### PR TITLE
Fix compatibility with ocaml 4.03

### DIFF
--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -220,6 +220,13 @@ let rec read_conf_files conf dir =
 let to_absolute file =
   Filename.(if is_relative file then concat (Unix.getcwd ()) file else file)
 
+let ends_with (str: string) (ext: string) =
+  try
+    let len = String.length ext in
+    let str = String.sub str (String.length str - len) len in
+    String.equal str ext
+  with Invalid_argument _ ->
+    false
 
 let conf name =
   read_conf_files {margin= !margin; sparse= !sparse; max_iters= !max_iters}
@@ -233,10 +240,9 @@ type action =
   | Inplace of [`Impl | `Intf] input list
 
 let kind_of fname =
-  match Filename.extension fname with
-  | ".ml" -> `Impl
-  | ".mli" -> `Intf
-  | _ -> !kind
+  if ends_with fname ".ml" then `Impl
+  else if ends_with fname ".mli" then `Intf
+  else !kind
 
 
 let action =

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -51,11 +51,16 @@ let dump xunit dir base suf ext ast =
     xunit.printast (Caml.Format.formatter_of_out_channel oc) ast ;
     Out_channel.close oc
 
+let split_extension filename =
+  let root = Filename.chop_extension filename in
+  let root_length = String.length root in
+  let ext_length = String.length filename - root_length in
+  let ext = String.sub filename root_length ext_length in
+  root, ext
 
 let parse_print (XUnit xunit) (conf: Conf.t) iname ifile ic ofile =
   let dir = Filename.dirname ofile in
-  let base = Filename.(remove_extension (basename ofile)) in
-  let ext = Filename.extension ofile in
+  let base, ext = split_extension (Filename.basename ofile) in
   (* iterate until formatting stabilizes *)
   let rec parse_print_ i source ifile ic =
     Format.pp_print_flush Format.err_formatter () ;
@@ -127,4 +132,3 @@ let parse_print (XUnit xunit) (conf: Conf.t) iname ifile ic ofile =
   | Syntaxerr.Error _ as exc ->
       Location.report_exception Caml.Format.err_formatter exc ;
       Caml.exit 1
-

--- a/src/format/jbuild
+++ b/src/format/jbuild
@@ -29,8 +29,7 @@ let ocamlopt_flags =
   (flags
    (-safe-string -strict-formats -strict-sequence -principal
     -w +a-4-6-9-40-41-42-44-45-48@50-21
-    -short-paths -bin-annot -keep-docs -keep-locs
-    -unboxed-types))
+    -short-paths -bin-annot -keep-docs -keep-locs))
   (ocamlc_flags (%s))
   (ocamlopt_flags (%s))
   (libraries ())))

--- a/src/import/jbuild
+++ b/src/import/jbuild
@@ -29,8 +29,7 @@ let ocamlopt_flags =
   (flags
    (-safe-string -strict-formats -strict-sequence -principal
     -w +a-4-6-9-40-41-42-44-45-48@50
-    -short-paths -bin-annot -keep-docs -keep-locs
-    -unboxed-types))
+    -short-paths -bin-annot -keep-docs -keep-locs))
   (ocamlc_flags (%s))
   (ocamlopt_flags (%s))
   (libraries (base stdio))))

--- a/src/jbuild
+++ b/src/jbuild
@@ -30,7 +30,7 @@ let ocamlopt_flags =
    (-w +a-4-6-9-40-41-42-44-45-48@50
     -strict-formats -strict-sequence -principal
     -short-paths -bin-annot -keep-docs -keep-locs
-    -safe-string -unboxed-types
+    -safe-string
     -open Import))
   (ocamlc_flags (%s))
   (ocamlopt_flags (%s))


### PR DESCRIPTION
Fixes #7 

Removes uses of `Filename.extension` and `Filename.remove_extension` which were added in ocaml 4.04, and the `-unboxed-types` flag.