### PR TITLE
Colon instead of arrow before type for GADT constructors with no arguments

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1393,9 +1393,12 @@ and fmt_constructor_arguments c ctx pre args =
 
 and fmt_constructor_arguments_result c ctx args res =
   let pre : _ format = if Option.is_none res then " of@ " else ": " in
+  let before_type : _ format =
+    match args with Pcstr_tuple [] -> ": " | _ -> "-> "
+  in
   fmt_constructor_arguments c ctx pre args
   $ opt res (fun typ ->
-        fmt " " $ fmt "-> " $ fmt_core_type c (sub_typ ~ctx typ) )
+        fmt " " $ fmt before_type $ fmt_core_type c (sub_typ ~ctx typ) )
 
 
 and fmt_type_extension c ctx te =


### PR DESCRIPTION
Fixes #39

Tested on `type t = A : t` as well as more complex GADTs, which will make it to `infer.git` sooner or later.