### PR TITLE
Formatting of %ext on if/while/for/match/try/;

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -410,6 +410,8 @@ end = struct
         | Pexp_construct
             ({txt= Lident "::"}, Some {pexp_desc= Pexp_tuple [e1; e2]}) ->
             assert (e1 == exp || e2 == exp)
+        | Pexp_extension (_, PStr [{pstr_desc= Pstr_eval (e, _)}]) ->
+            assert (e == exp)
         | Pexp_constant _ | Pexp_extension _ | Pexp_ident _ | Pexp_new _
          |Pexp_object _ | Pexp_pack _ | Pexp_unreachable ->
             assert false
@@ -856,6 +858,7 @@ end = struct
          |Pexp_construct
             ({txt= Lident "::"}, Some {pexp_desc= Pexp_tuple [_; e]})
          |Pexp_construct (_, Some e)
+         |Pexp_extension (_, PStr [{pstr_desc= Pstr_eval (e, _)}])
          |Pexp_fun (_, _, _, e)
          |Pexp_ifthenelse (_, e, None)
          |Pexp_ifthenelse (_, _, Some e)

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -67,6 +67,11 @@ let list xs sep pp fs =
   Format.pp_print_list ~pp_sep (fun fs x -> pp x fs) fs xs
 
 
+let list_k xs pp_sep pp fs =
+  let pp_sep fs () = pp_sep fs in
+  Format.pp_print_list ~pp_sep (fun fs x -> pp x fs) fs xs
+
+
 (** Conditional formatting ----------------------------------------------*)
 
 let fmt_if_k cnd k fs = if cnd then k fs

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -58,6 +58,10 @@ val list_pn : 'a list -> (?prev:'a -> 'a -> ?next:'a -> t) -> t
 (** Format a list using provided function for the elements, which is passed
     the previous and next elements, if any. *)
 
+val list_k : 'a list -> t -> ('a -> t) -> t
+(** Format a list using the first function for the separators between
+    elements. *)
+
 (** Conditional formatting ----------------------------------------------*)
 
 val fmt_if : bool -> s -> t


### PR DESCRIPTION
This is not ready to merge yet because:

1. There is a large chunk of code commented out because it generates incorrectly formatted code with this change.  I haven't had a chance to find out why yet.
2. No formatting has been applied to the new code. **EDIT:** Formatting has been applied.
3. It should really have some tests.

I'm pushing this out for feedback on better ways to handle this.

This PR adds sugared formatting of: `if%ext`, `while%ext`, `for%ext`, `match%ext` and `try%ext`.  This covers the syntax covered by Lwt's ppx, for example.

Some example formatting with this PR:
```ocaml
let () =
  if%ext true then () else () ;
  if%ext true then () else if true then () else () ;
  let%ext x = () in
  for%ext i = 1 to 10 do () done ;
  while%ext false do () done ;
  match%ext x with _ -> ()


let () =
  let%ext x = () in
  try%ext x with _ -> ()


let () =
  if%ext true then () else () ;
  if%ext true then () else if true then () else () ;
  if%ext true then () else ()


let () =
  (match%ext x with _ -> ()) ;
  match%ext x with _ -> ()


let () =
  () ;
  () ;%ext
  () ;
  () ;%ext ()
```
  