### PR TITLE
Add options to format chars and break strings

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,2 @@
 margin 77
+break-string-literals never

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -60,28 +60,15 @@ let rec is_sugared_list exp =
   | _ -> false
 
 
-let looks_like_format str =
-  String.fold str ~init:(false, true) ~f:(fun (prev_is_at, acc) -> function
-    | '@' when prev_is_at -> (false, acc)
-    | '@' -> (true, acc)
-    | '\n' when prev_is_at -> (false, true && acc)
-    | '\n' -> (false, false)
-    | _ -> (false, acc) )
-  |> snd
-
-
 let would_force_break (c: Conf.t) s =
-  match c.break_string_literals with
-  | `Newlines ->
-      let n = String.length s in
-      let looks_like_format = lazy (looks_like_format s) in
-      let rec would_force_break_ i =
-        i < n
-        && ( Char.equal s.[i] '\n' && not (Lazy.force looks_like_format)
-           || would_force_break_ (i + 1) )
-      in
-      would_force_break_ 0
-  | _ -> false
+  let contains_internal_newline s =
+    match String.rindex s '\n' with
+    | None -> false
+    | Some i when i = String.length s - 1 -> false
+    | _ -> true
+  in
+  Poly.equal c.break_string_literals `Newlines
+  && contains_internal_newline s
 
 
 let rec is_trivial c exp =

--- a/src/Ast.mli
+++ b/src/Ast.mli
@@ -14,10 +14,6 @@
 open Migrate_ast
 open Parsetree
 
-val looks_like_format : string -> bool
-(** Holds of strings where all newline chars are escaped with '@', except
-    possibly the last char. *)
-
 val is_prefix : expression -> bool
 (** Holds of prefix symbol expressions. *)
 

--- a/src/Ast.mli
+++ b/src/Ast.mli
@@ -14,6 +14,10 @@
 open Migrate_ast
 open Parsetree
 
+val looks_like_format : string -> bool
+(** Holds of strings where all newline chars are escaped with '@', except
+    possibly the last char. *)
+
 val is_prefix : expression -> bool
 (** Holds of prefix symbol expressions. *)
 

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -169,7 +169,7 @@ let escape_chars =
              [ ("hexadecimal", `Hexadecimal)
              ; ("decimal", `Decimal)
              ; ("minimal", `Minimal) ])
-          `Minimal
+          default
       & info ["escape-chars"] ~doc ~env)
 
 
@@ -182,7 +182,7 @@ let break_string_literals =
   mk ~default
     Arg.(
       value
-      & opt (enum [("newlines", `Newlines); ("never", `Never)]) `Newlines
+      & opt (enum [("newlines", `Newlines); ("never", `Never)]) default
       & info ["break-string-literals"] ~doc ~env)
 
 

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -157,7 +157,7 @@ let sparse =
 
 let escape_chars =
   let doc =
-    "How to escape chars. Can be set in a config file with a `escape-chars {hexadecimal,octal,minimal}` line."
+    "How to escape chars. Can be set in a config file with a `escape-chars {hexadecimal,decimal,minimal}` line."
   in
   let env = Arg.env_var "OCAMLFORMAT_ESCAPE_CHARS" in
   let default = `Minimal in
@@ -167,7 +167,7 @@ let escape_chars =
       & opt
           (enum
              [ ("hexadecimal", `Hexadecimal)
-             ; ("octal", `Octal)
+             ; ("decimal", `Decimal)
              ; ("minimal", `Minimal) ])
           `Minimal
       & info ["escape-chars"] ~doc ~env)
@@ -220,7 +220,7 @@ type t =
   { margin: int
   ; sparse: bool
   ; max_iters: int
-  ; escape_chars: [`Hexadecimal | `Minimal | `Octal]
+  ; escape_chars: [`Hexadecimal | `Minimal | `Decimal]
   ; break_string_literals: [`Newlines | `Never] }
 
 let update conf name value =
@@ -233,7 +233,7 @@ let update conf name value =
         escape_chars=
           ( match value with
           | "hexadecimal" -> `Hexadecimal
-          | "octal" -> `Octal
+          | "decimal" -> `Decimal
           | "minimal" -> `Minimal
           | other ->
               user_error

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -160,7 +160,7 @@ let escape_chars =
     "How to escape chars. Can be set in a config file with a `escape-chars {hexadecimal,octal,minimal}` line."
   in
   let env = Arg.env_var "OCAMLFORMAT_ESCAPE_CHARS" in
-  let default = `Hexadecimal in
+  let default = `Minimal in
   mk ~default
     Arg.(
       value
@@ -169,7 +169,7 @@ let escape_chars =
              [ ("hexadecimal", `Hexadecimal)
              ; ("octal", `Octal)
              ; ("minimal", `Minimal) ])
-          `Hexadecimal
+          `Minimal
       & info ["escape-chars"] ~doc ~env)
 
 
@@ -178,11 +178,11 @@ let break_string_literals =
     "Break string literals. Can be set in a config file with a `break-string-literals {never,newlines}` line."
   in
   let env = Arg.env_var "OCAMLFORMAT_BREAK_STRING_LITERALS" in
-  let default = `New_lines in
+  let default = `Newlines in
   mk ~default
     Arg.(
       value
-      & opt (enum [("newlines", `New_lines); ("never", `Never)]) `New_lines
+      & opt (enum [("newlines", `Newlines); ("never", `Never)]) `Newlines
       & info ["break-string-literals"] ~doc ~env)
 
 
@@ -221,7 +221,7 @@ type t =
   ; sparse: bool
   ; max_iters: int
   ; escape_chars: [`Hexadecimal | `Minimal | `Octal]
-  ; break_string_literals: [`New_lines | `Never] }
+  ; break_string_literals: [`Newlines | `Never] }
 
 let update conf name value =
   match name with
@@ -236,17 +236,20 @@ let update conf name value =
           | "octal" -> `Octal
           | "minimal" -> `Minimal
           | other ->
-              Printf.ksprintf failwith "Unknown escape-chars value: %S"
-                other ) }
+              user_error
+                (Printf.sprintf "Unknown escape-chars value: %S" other)
+                [] ) }
   | "break-string-literals" ->
       { conf with
         break_string_literals=
           ( match value with
           | "never" -> `Never
-          | "newlines" -> `New_lines
+          | "newlines" -> `Newlines
           | other ->
-              Printf.ksprintf failwith
-                "Unknown break-string-literals value: %S" other ) }
+              user_error
+                (Printf.sprintf "Unknown break-string-literals value: %S"
+                   other)
+                [] ) }
   | "version" when not !no_version_check ->
       if String.equal Version.version value then conf
       else

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -16,8 +16,11 @@ type t =
   ; sparse: bool  (** Generate more sparsely formatted code if true. *)
   ; max_iters: int
         (** Fail if output of formatting does not stabilize within
-            [max_iters] iterations. *)
-  }
+      [max_iters] iterations. *)
+  ; escape_chars: [`Hexadecimal | `Minimal | `Octal]
+        (** How to escape characters (literals and within strings). *)
+  ; break_string_literals: [`Never | `New_lines]
+        (** How to potentially break string literals into new lines. *) }
 
 type 'a input = {kind: 'a; name: string; file: string; conf: t}
 

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -16,10 +16,10 @@ type t =
   ; sparse: bool  (** Generate more sparsely formatted code if true. *)
   ; max_iters: int
         (** Fail if output of formatting does not stabilize within
-      [max_iters] iterations. *)
+            [max_iters] iterations. *)
   ; escape_chars: [`Hexadecimal | `Minimal | `Octal]
         (** How to escape characters (literals and within strings). *)
-  ; break_string_literals: [`Never | `New_lines]
+  ; break_string_literals: [`Never | `Newlines]
         (** How to potentially break string literals into new lines. *) }
 
 type 'a input = {kind: 'a; name: string; file: string; conf: t}

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -17,7 +17,7 @@ type t =
   ; max_iters: int
         (** Fail if output of formatting does not stabilize within
             [max_iters] iterations. *)
-  ; escape_chars: [`Hexadecimal | `Minimal | `Octal]
+  ; escape_chars: [`Hexadecimal | `Minimal | `Decimal]
         (** How to escape characters (literals and within strings). *)
   ; break_string_literals: [`Never | `Newlines]
         (** How to potentially break string literals into new lines. *) }

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -305,9 +305,9 @@ let rec fmt_longident (li: Longident.t) =
 
 let fmt_constant (c: Conf.t) const =
   let is_printable char_code = 0x20 <= char_code && char_code <= 0x7E in
-  let is_not_term_friendly char_code =
+  let is_control_code char_code =
     (* See discussion on PR #70 *)
-    char_code < 4 || char_code = 0x7F
+    char_code < 0x20 || char_code = 0x7F
   in
   let escape_char chr =
     let code = Char.to_int chr in
@@ -316,7 +316,7 @@ let fmt_constant (c: Conf.t) const =
         str (Char.escaped chr)
     | _ when is_printable code -> char chr
     | `Hexadecimal -> str (Printf.sprintf "\\x%02x" code)
-    | `Minimal when is_not_term_friendly code ->
+    | `Minimal when is_control_code code ->
         str (Printf.sprintf "\\x%02x" code)
     | `Minimal -> char chr
     | `Decimal -> str (Char.escaped chr)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -328,16 +328,13 @@ let fmt_constant (c: Conf.t) const =
   | Pconst_char c -> wrap "'" "'" @@ escape_char c
   | Pconst_string (s, delim) ->
       let escape_literal string =
-        let looks_like_format = lazy (Ast.looks_like_format string) in
         vbox 0
           ( String.foldi string ~init:(false, fmt "") ~f:
               (fun index (freshline, prev) ch ->
                 match (ch, c.break_string_literals) with
                 | ' ', _ when freshline -> (false, prev $ str "\\ ")
                 | '"', _ -> (false, prev $ str "\\\"")
-                | '\n', `Newlines
-                  when not (Lazy.force looks_like_format)
-                       && index <> String.length string - 1 ->
+                | '\n', `Newlines when index <> String.length string - 1 ->
                     (true, prev $ fmt "\\n\\@;<1000 0>")
                 | other, _ -> (false, prev $ escape_char other) )
           |> snd )

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -305,6 +305,10 @@ let rec fmt_longident (li: Longident.t) =
 
 let fmt_constant (c: Conf.t) const =
   let is_printable char_code = 0x20 <= char_code && char_code <= 0x7E in
+  let is_not_term_friendly char_code =
+    (* See discussion on PR #70 *)
+    char_code < 4 || char_code = 0x7F
+  in
   let escape_char chr =
     let code = Char.to_int chr in
     match c.Conf.escape_chars with
@@ -312,6 +316,8 @@ let fmt_constant (c: Conf.t) const =
         str (Char.escaped chr)
     | _ when is_printable code -> char chr
     | `Hexadecimal -> str (Printf.sprintf "\\x%02x" code)
+    | `Minimal when is_not_term_friendly code ->
+        str (Printf.sprintf "\\x%02x" code)
     | `Minimal -> char chr
     | `Octal -> str (Char.escaped chr)
   in

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -319,7 +319,7 @@ let fmt_constant (c: Conf.t) const =
     | `Minimal when is_not_term_friendly code ->
         str (Printf.sprintf "\\x%02x" code)
     | `Minimal -> char chr
-    | `Octal -> str (Char.escaped chr)
+    | `Decimal -> str (Char.escaped chr)
   in
   match const with
   | Pconst_integer (lit, suf) | Pconst_float (lit, suf) ->


### PR DESCRIPTION
Cf. issues #10, #11.

```
--break-string-literals=VAL (absent=newlines or
OCAMLFORMAT_BREAK_STRING_LITERALS env)
    Break string literals. Can be set in a config file with a
    `break-string-literals {never,newlines}` line.

--escape-chars=VAL (absent=hexadecimal or OCAMLFORMAT_ESCAPE_CHARS
env)
    How to escape chars. Can be set in a config file with a
    `escape-chars {hexadecimal,octal,minimal}` line.
```

I used `Cmdliner.Term.enum`s to leave space for future improvements, like
detecting UTF-8? or breaking long lines after spaces (or `/` for URIs) ….
Or when OCaml gets the string literals *literally* in the parse tree we can add
a `keep` option.

**⁂**

To play with it one can use/modify this script:

```bash
cat > /tmp/tt.ml <<'EOF'
module Test = struct
let x = "hello\nworldœd\
d→\n\
\t« »\
\ deij\n jl\\dsle ldjsellkj dse\n\x42 dsleij djlekjdsliejj ASEDE1092"

let _ = ('a', '\\', '\n', '\x00')
end
EOF
cat /tmp/tt.ml
testopt () {
    echo "=============== Test $1"
    _build/default/src/ocamlformat.exe --debug \
                                       --escape-chars $1 \
                                       --break-string $2 /tmp/tt.ml > /tmp/tt_$1.ml
    if [ $? -ne 0 ] ; then
        echo "ERROR: "
        cat /tmp/tt.1.ml
    fi
    cat /tmp/tt_$1.ml
    ocaml /tmp/tt_$1.ml
}
testopt min  nev
testopt hex  nev
testopt oct  nev
testopt min  new
testopt hex  new
testopt oct  new
```