### PR TITLE
Handle the `Pexp_send _` case

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -74,7 +74,7 @@ let would_force_break (c: Conf.t) s =
 let rec is_trivial c exp =
   match exp.pexp_desc with
   | Pexp_constant Pconst_string (s, None) -> not (would_force_break c s)
-  | Pexp_constant _ | Pexp_field _ | Pexp_send _ | Pexp_ident _ -> true
+  | Pexp_constant _ | Pexp_field _ | Pexp_ident _ | Pexp_send _ -> true
   | Pexp_construct (_, exp) -> Option.for_all exp ~f:(is_trivial c)
   | _ -> false
 
@@ -493,8 +493,8 @@ end = struct
     let ctx = Exp exp in
     match exp.pexp_desc with
     | Pexp_constant _ -> is_trivial c exp
-    | Pexp_array _ | Pexp_field _ | Pexp_send _ | Pexp_ident _
-     |Pexp_record _ | Pexp_tuple _ | Pexp_variant _
+    | Pexp_array _ | Pexp_field _ | Pexp_ident _ | Pexp_record _
+     |Pexp_send _ | Pexp_tuple _ | Pexp_variant _
      |Pexp_construct (_, None) ->
         true
     | Pexp_construct

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -74,7 +74,7 @@ let would_force_break (c: Conf.t) s =
 let rec is_trivial c exp =
   match exp.pexp_desc with
   | Pexp_constant Pconst_string (s, None) -> not (would_force_break c s)
-  | Pexp_constant _ | Pexp_field _ | Pexp_ident _ -> true
+  | Pexp_constant _ | Pexp_field _ | Pexp_send _ | Pexp_ident _ -> true
   | Pexp_construct (_, exp) -> Option.for_all exp ~f:(is_trivial c)
   | _ -> false
 
@@ -493,8 +493,8 @@ end = struct
     let ctx = Exp exp in
     match exp.pexp_desc with
     | Pexp_constant _ -> is_trivial c exp
-    | Pexp_array _ | Pexp_field _ | Pexp_ident _ | Pexp_record _
-     |Pexp_tuple _ | Pexp_variant _
+    | Pexp_array _ | Pexp_field _ | Pexp_send _ | Pexp_ident _
+     |Pexp_record _ | Pexp_tuple _ | Pexp_variant _
      |Pexp_construct (_, None) ->
         true
     | Pexp_construct
@@ -647,6 +647,7 @@ end = struct
       | Pexp_setfield (_, _, e0) when e0 == exp -> Some (LessMinus, Non)
       | Pexp_setinstvar _ -> Some (LessMinus, Non)
       | Pexp_field _ -> Some (Dot, Left)
+      | Pexp_send _ -> Some (HashOp, Left)
       | _ -> None )
     | {ctx= Exp _; ast= Pld _ | Top | Pat _ | Mty _ | Mod _ | Sig _ | Str _}
      |{ ctx= Pld _ | Top | Typ _ | Pat _ | Mty _ | Mod _ | Sig _ | Str _
@@ -712,6 +713,7 @@ end = struct
       | Pexp_setfield _ -> Some LessMinus
       | Pexp_setinstvar _ -> Some LessMinus
       | Pexp_field _ -> Some Dot
+      | Pexp_send _ -> Some HashOp
       | _ -> None )
     | Top | Pat _ | Mty _ | Mod _ | Sig _ | Str _ -> None
 

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -146,8 +146,8 @@ type prec =
   | InfixOp4
   | UMinus
   | Apply
-  | HashOp
   | Dot
+  | HashOp
   | High
   | Atomic
 
@@ -647,7 +647,7 @@ end = struct
       | Pexp_setfield (_, _, e0) when e0 == exp -> Some (LessMinus, Non)
       | Pexp_setinstvar _ -> Some (LessMinus, Non)
       | Pexp_field _ -> Some (Dot, Left)
-      | Pexp_send _ -> Some (HashOp, Left)
+      | Pexp_send _ -> Some (HashOp, Non)
       | _ -> None )
     | {ctx= Exp _; ast= Pld _ | Top | Pat _ | Mty _ | Mod _ | Sig _ | Str _}
      |{ ctx= Pld _ | Top | Typ _ | Pat _ | Mty _ | Mod _ | Sig _ | Str _

--- a/src/Ast.mli
+++ b/src/Ast.mli
@@ -66,8 +66,8 @@ type prec =
   | InfixOp4
   | UMinus
   | Apply
-  | HashOp
   | Dot
+  | HashOp
   | High
   | Atomic
 

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1397,8 +1397,14 @@ and fmt_expression c ?(box= true) ?eol ?parens ?ext ({ast= exp} as xexp) =
             $ fmt "@ done" )
         $ fmt_atrs )
   | Pexp_unreachable -> fmt "."
+  | Pexp_send (exp, {txt; loc}) ->
+      Cmts.fmt loc
+      @@ hvbox 2
+           ( wrap_if parens "(" ")"
+               (fmt_expression c (sub_exp ~ctx exp) $ fmt "@,#" $ str txt)
+           $ fmt_atrs )
   | Pexp_new _ | Pexp_object _ | Pexp_override _ | Pexp_poly _
-   |Pexp_send _ | Pexp_setinstvar _ ->
+   |Pexp_setinstvar _ ->
       internal_error "classes not implemented" []
 
 


### PR DESCRIPTION
Just like the `Pexp_field _` one.
Cf. **@emillon**'s [comment][1] on #13.

```ocaml
  let f x = (x ()).contents

  let x obj = obj#hello ()

  let x obj_f = (obj_f ())#hello ()

  let f obj = obj#hello_some_pretty_long_one ~with_labels:true ()

  let f obj =
    obj#hello_some_pretty_long_one ~with_labels:true
      "desjd\n\
       dijsde\n" {md|
In **markdown**
|md}
```

[1]: https://github.com/ocaml-ppx/ocamlformat/issues/13#issuecomment-344237707