### PR TITLE
Improve char escaping to ascii / uniform hexa / utf8

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -62,7 +62,7 @@ let rec is_sugared_list exp =
 
 let would_force_break (c: Conf.t) s =
   let contains_internal_newline s =
-    match String.rindex s '\n' with
+    match String.index s '\n' with
     | None -> false
     | Some i when i = String.length s - 1 -> false
     | _ -> true

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -17,8 +17,10 @@ type t =
   ; max_iters: int
         (** Fail if output of formatting does not stabilize within
             [max_iters] iterations. *)
-  ; escape_chars: [`Hexadecimal | `Minimal | `Decimal]
-        (** How to escape characters (literals and within strings). *)
+  ; escape_chars: [`Decimal | `Hexadecimal | `Preserve]
+        (** Escape encoding for chars literals. *)
+  ; escape_strings: [`Decimal | `Hexadecimal | `Preserve]
+        (** Escape encoding for string literals. *)
   ; break_string_literals: [`Never | `Newlines]
         (** How to potentially break string literals into new lines. *) }
 

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -59,7 +59,7 @@ val list_pn : 'a list -> (?prev:'a -> 'a -> ?next:'a -> t) -> t
     the previous and next elements, if any. *)
 
 val list_k : 'a list -> t -> ('a -> t) -> t
-(** Format a list using the first function for the separators between
+(** Format a list using the format thunk for the separators between
     elements. *)
 
 (** Conditional formatting ----------------------------------------------*)


### PR DESCRIPTION
The lower-128 chars are escaped as standard by Char.escaped