### PR TITLE
Handle `Pexp_new` case (#13)

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1409,8 +1409,12 @@ and fmt_expression c ?(box= true) ?eol ?parens ?ext ({ast= exp} as xexp) =
            ( wrap_if parens "(" ")"
                (fmt_expression c (sub_exp ~ctx exp) $ fmt "@,#" $ str txt)
            $ fmt_atrs )
-  | Pexp_new _ | Pexp_object _ | Pexp_override _ | Pexp_poly _
-   |Pexp_setinstvar _ ->
+  | Pexp_new {txt; loc} ->
+      Cmts.fmt loc
+      @@ hvbox 2
+           ( wrap_if parens "(" ")" (fmt "new@ " $ fmt_longident txt)
+           $ fmt_atrs )
+  | Pexp_object _ | Pexp_override _ | Pexp_poly _ | Pexp_setinstvar _ ->
       internal_error "classes not implemented" []
 
 


### PR DESCRIPTION
Seems like a simple case.

```
let x = new Objects.one ~hello:true ()
let x = (new Objects.one) ~hello:true ()
```

become

```ocaml
let x = new Objects.one ~hello:true ()

let x = new Objects.one ~hello:true ()
```

Together with #72 I got to make `ocamlformat` succeed on some `js_of_ocaml-ppx`-heavy code of mine:

```ocaml
sprintf "Date: %s"
      (Js.to_string (new%js Js.date_now)##toString)
```

becomes

```ocaml
    sprintf "Date: %s" (Js.to_string [%js new Js.date_now] ## toString)
```

I didn't manage to test the `Lapply` case of:

```ocaml
type t =
  Longident.t =
    Lident of label
  | Ldot of Longident.t * label
  | Lapply of Longident.t * Longident.t
```

UTop seems to syntax-err when there is a functor application in the module path (?)






