### PR TITLE
Apply no transformation on empty files or files with only comments

### DIFF
--- a/src/Translation_unit.mli
+++ b/src/Translation_unit.mli
@@ -21,6 +21,7 @@ type 'a t =
       'a * (string * Location.t) list -> 'a * (string * Location.t) list
       -> bool
   ; normalize: 'a * (string * Location.t) list -> 'a
+  ; no_translation: 'a -> bool
   ; printast: Caml.Format.formatter -> 'a -> unit }
 
 (** Existential package of a type of translation unit and its operations. *)

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -20,6 +20,7 @@ let impl : _ Translation_unit.t =
   ; fmt= Fmt_ast.fmt_structure
   ; equal= (fun (ast1, _) (ast2, _) -> Normalize.equal_impl ast1 ast2)
   ; normalize= (fun (ast, _) -> Normalize.impl ast)
+  ; no_translation= List.is_empty
   ; printast= Migrate_ast.Printast.implementation }
 
 
@@ -32,6 +33,7 @@ let intf : _ Translation_unit.t =
   ; fmt= Fmt_ast.fmt_signature
   ; equal= (fun (ast1, _) (ast2, _) -> Normalize.equal_intf ast1 ast2)
   ; normalize= (fun (ast, _) -> Normalize.intf ast)
+  ; no_translation= List.is_empty
   ; printast= Migrate_ast.Printast.interface }
 
 


### PR DESCRIPTION
The current behavior is to drop the comments, and then failing due to detecting ast changes.

Instead we can apply no translation and preserve the input file as is.

Empty files do come in practice, as an empty mli for a main.exe gives you warnings for unused values in the main.ml.

A more refine behavior would be to process the comments if any.  This is left as future work.