### PR TITLE
use sugar syntax to avoid repeating record field name in Pexp_constraint

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1385,6 +1385,11 @@ and fmt_expression c ?(box= true) ?epi ?eol ?parens ?ext
         match f.pexp_desc with
         | Pexp_ident {txt= txt'; loc} when field_alias txt txt' ->
             Cmts.fmt c loc @@ cbox 2 (fmt_longident txt)
+        | Pexp_constraint
+            (({pexp_desc= Pexp_ident {txt= txt'; loc}} as e), t)
+          when field_alias txt txt' ->
+            Cmts.fmt c loc @@ fmt_expression c (sub_exp ~ctx:(Exp f) e)
+            $ fmt " : " $ fmt_core_type c (sub_typ ~ctx:(Exp f) t)
         | _ ->
             cbox 2
               ( fmt_longident txt $ fmt "=@ "


### PR DESCRIPTION
Some sugar was added to the parser at some point for constrained field in records:

That is one can write:
```
[%sexp { x : int; y : string }]
```
Instead of:
```
[%sexp { x = (x : int); y = (y : string) }]
```
Recognize this case, and produce it.