### PR TITLE
Write extension on the let at toplevel: e.g. let%expect_test _

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -470,8 +470,11 @@ let rec fmt_attribute c pre = function
            (wrap "[" "]" (str pre $ str txt $ fmt_payload c (Pld pld) pld))
 
 
-and fmt_extension c ctx key ({txt}, pld) =
-  wrap "[" "]" (str key $ str txt $ fmt_payload c ctx pld)
+and fmt_extension c ctx key (({txt} as ext), pld) =
+  match pld with
+  | PStr [({pstr_desc= Pstr_value _; _} as si)] ->
+      fmt_structure_item c ~sep:"" ~last:true ~ext (sub_str ~ctx si)
+  | _ -> wrap "[" "]" (str key $ str txt $ fmt_payload c ctx pld)
 
 
 and fmt_attributes c pre ~key attrs suf =
@@ -2191,7 +2194,7 @@ and fmt_structure c ?(sep= "") ctx itms =
          fmt_if (not first) "\n@\n" $ fmt_grp ~last grp ))
 
 
-and fmt_structure_item c ~sep ~last:last_item {ctx; ast= si} =
+and fmt_structure_item c ~sep ~last:last_item ?ext {ctx; ast= si} =
   protect (Str si)
   @@
   let at_top = Poly.(ctx = Top) in
@@ -2250,7 +2253,9 @@ and fmt_structure_item c ~sep ~last:last_item {ctx; ast= si} =
   | Pstr_value (rec_flag, bindings) ->
       hvbox 0
         (list_fl bindings (fun ~first ~last binding ->
-             fmt_value_binding c ~rec_flag ~first ctx binding
+             fmt_value_binding c ~rec_flag ~first
+               ?ext:(if first then ext else None)
+               ctx binding
                ~epi:(fits_breaks ~force_fit_if:last_item "" "\n")
              $ fmt_if (not last) "\n@\n" ))
   | Pstr_modtype mtd -> fmt_module_type_declaration c ctx mtd


### PR DESCRIPTION
Opening the discussion to change:
```
[%expect_test
 let _ = ...
]
```
into:
```
let%expect_test _ = ...
```

Seems it would fit nicely with the new ppx_let style, let%bind, let%map, etc.

Example [here](https://github.com/janestreet/core/blob/9f38c7fc8b9b2121b7934f575fb3af73db5c2a4c/test/src/cidr_tests.ml)