### PR TITLE
Use original filename when given in error messages.

### DIFF
--- a/src/Reason.ml
+++ b/src/Reason.ml
@@ -20,7 +20,7 @@ type 'a reason_data =
     [input_channel]. It is expected to have the given [magic_number] and is
     assumed to be the output of `refmt --print=binary_reason` where `refmt`
     has been compiled with the same version of `ocaml` as `ocamlformat`. *)
-let input ast_magic input_name ic =
+let input ast_magic ~input_name ic =
   Location.input_name := input_name ;
   let (magic, _, (ast: 'a), comments, _, _) : 'a reason_data =
     Caml.Marshal.from_channel ic

--- a/src/Reason.mli
+++ b/src/Reason.mli
@@ -15,13 +15,15 @@ open Migrate_ast
 open Parsetree
 
 val input_impl :
-  string -> In_channel.t -> structure * (string * Location.t) list
+  input_name:string -> In_channel.t
+  -> structure * (string * Location.t) list
 (** Reads a serialized structure from an input channel. It is assumed to be
     the output of `refmt --print=binary_reason` where `refmt` has been
     compiled with the same version of `ocaml` as `ocamlformat`. *)
 
 val input_intf :
-  string -> In_channel.t -> signature * (string * Location.t) list
+  input_name:string -> In_channel.t
+  -> signature * (string * Location.t) list
 (** Reads a serialized signature from an input channel. It is assumed to be
     the output of `refmt --print=binary_reason` where `refmt` has been
     compiled with the same version of `ocaml` as `ocamlformat`. *)

--- a/src/Translation_unit.mli
+++ b/src/Translation_unit.mli
@@ -11,11 +11,12 @@
 
 (** Operations on translation units. *)
 type 'a t =
-  { input: string -> In_channel.t -> 'a * (string * Location.t) list
+  { input:
+      input_name:string -> In_channel.t -> 'a * (string * Location.t) list
   ; init_cmts: string -> 'a -> (string * Location.t) list -> unit
   ; fmt: Conf.t -> 'a -> Fmt.t
   ; parse:
-      ?warn:bool -> string -> string -> In_channel.t
+      ?warn:bool -> input_name:string -> In_channel.t
       -> 'a * (string * Location.t) list
   ; equal:
       'a * (string * Location.t) list -> 'a * (string * Location.t) list
@@ -28,7 +29,7 @@ type 'a t =
 type x = XUnit: 'a t -> x
 
 val parse :
-  (Lexing.lexbuf -> 'a) -> ?warn:bool -> string -> string -> In_channel.t
+  (Lexing.lexbuf -> 'a) -> ?warn:bool -> input_name:string -> In_channel.t
   -> 'a * (string * Location.t) list
 (** [parse parse_ast ~warn input_name input_file input_channel] parses the
     contents of [input_channel] assuming it corresponds to [input_name] for
@@ -38,7 +39,8 @@ val parse :
     otherwise only enabled. *)
 
 val parse_print :
-  x -> Conf.t -> string -> string -> In_channel.t -> string option -> unit
+  x -> Conf.t -> input_name:string -> input_file:string -> In_channel.t
+  -> string option -> unit
 (** [parse_print xunit conf input_name input_file input_channel output_file]
     parses the contents of [input_channel], using [input_name] for error
     messages, and referring to the contents of [input_file] to improve

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -15,7 +15,7 @@
 let impl : _ Translation_unit.t =
   let parse = Translation_unit.parse Migrate_ast.Parse.implementation in
   { parse
-  ; input= parse Location.none.loc_start.pos_fname
+  ; input= (fun ~input_name ic -> parse ~input_name ic)
   ; init_cmts= Cmts.init_impl
   ; fmt= Fmt_ast.fmt_structure
   ; equal= (fun (ast1, _) (ast2, _) -> Normalize.equal_impl ast1 ast2)
@@ -28,7 +28,7 @@ let impl : _ Translation_unit.t =
 let intf : _ Translation_unit.t =
   let parse = Translation_unit.parse Migrate_ast.Parse.interface in
   { parse
-  ; input= parse Location.none.loc_start.pos_fname
+  ; input= (fun ~input_name ic -> parse ~input_name ic)
   ; init_cmts= Cmts.init_intf
   ; fmt= Fmt_ast.fmt_signature
   ; equal= (fun (ast1, _) (ast2, _) -> Normalize.equal_intf ast1 ast2)
@@ -54,7 +54,11 @@ let xunit_of_kind : _ -> Translation_unit.x = function
                Translation_unit.parse_print (xunit_of_kind kind) conf name
                  file ic (Some file) ) )
    | In_out
-       ({kind= (`Impl | `Intf) as kind; file= input_file; conf}, output_file) ->
+       ( { kind= (`Impl | `Intf) as kind
+         ; file= input_file
+         ; name= input_name
+         ; conf }
+       , output_file ) ->
        In_channel.with_file input_file ~f:(fun ic ->
-           Translation_unit.parse_print (xunit_of_kind kind) conf input_file
-             input_file ic output_file )
+           Translation_unit.parse_print (xunit_of_kind kind) conf
+             ~input_name ~input_file ic output_file )

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -15,7 +15,7 @@
 let impl : _ Translation_unit.t =
   let parse = Translation_unit.parse Migrate_ast.Parse.implementation in
   { parse
-  ; input= (fun ~input_name ic -> parse ~input_name ic)
+  ; input= parse ?warn:None
   ; init_cmts= Cmts.init_impl
   ; fmt= Fmt_ast.fmt_structure
   ; equal= (fun (ast1, _) (ast2, _) -> Normalize.equal_impl ast1 ast2)
@@ -28,7 +28,7 @@ let impl : _ Translation_unit.t =
 let intf : _ Translation_unit.t =
   let parse = Translation_unit.parse Migrate_ast.Parse.interface in
   { parse
-  ; input= (fun ~input_name ic -> parse ~input_name ic)
+  ; input= parse ?warn:None
   ; init_cmts= Cmts.init_intf
   ; fmt= Fmt_ast.fmt_signature
   ; equal= (fun (ast1, _) (ast2, _) -> Normalize.equal_intf ast1 ast2)


### PR DESCRIPTION
```
$ jbuilder exec src/ocamlformat.exe -- /tmp/tmp.1234.ml --name '/path/to/original_file.ml'
File "/path/to/original_file.ml", line 6, characters 4-7:
Error: Syntax error
```

Without the patch this is reporting:
```
$ jbuilder exec src/ocamlformat.exe -- /tmp/tmp.1234.ml --name '/path/to/original_file.ml'
File "/tmp/tmp.1234.ml", line 6, characters 4-7:
Error: Syntax error
```