### PR TITLE
Handle the case `Ptyp_object _` (#13)

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -303,8 +303,12 @@ end = struct
               | Rtag (_, _, _, t1N) -> List.exists t1N ~f
               | Rinherit t1 -> typ == t1 ) )
       | Ptyp_package (_, it1N) -> assert (List.exists it1N ~f:snd_f)
-      | Ptyp_object _ | Ptyp_class _ ->
-          internal_error "objects not implemented" [] )
+      | Ptyp_object (fields, _) ->
+          assert (
+            List.exists fields ~f:(function
+              | Otag (_, _, t1) -> typ == t1
+              | Oinherit t1 -> typ == t1 ) )
+      | Ptyp_class _ -> internal_error "objects not implemented" [] )
     | Pat ctx -> (
       match ctx.ppat_desc with
       | Ppat_constraint (_, t1) -> assert (typ == t1)


### PR DESCRIPTION
The following cases work well:

```ocaml
type t =
  < hello: string  (** some doc *)
  ; world: int
  ; more: int * float
  ; make: int
  ; it: string
  ; long: float [@default 42.] >
[@@deriving make]

type 'a u = <hello: string  (** more doc *) ; world: int ; .. > as 'a

type 'a v = < .. > as 'a

let x : unit -> <bouh: string ; .. > = fun () -> assert false

let lookup_obj : < .. > -> (< .. > as 'a) list -> 'a = fun _ -> assert false
```

Then, the new "`Oinherit`" syntax-case
(added last summer https://github.com/ocaml/ocaml/pull/1118)

It works with OCaml 4.06.1, but fails to parse with `ocamlformat` for some reason I don't understand:

```ocaml
type with_inherit = < stuff: int; t>
```

```
File "/tmp/tt.ml", line 1, characters 35-36:
Error: Syntax error
```




