### PR TITLE
Add parens around module value types in signatures

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -546,7 +546,8 @@ and fmt_core_type c ?(box= true) ({ast= typ} as xtyp) =
            (list t1N "@,, " (sub_typ ~ctx >> fmt_core_type c))
       $ fmt "@ " $ fmt_longident txt
   | Ptyp_extension ext -> hvbox 2 (fmt_extension c ctx "%" ext)
-  | Ptyp_package pty -> hvbox 0 (fmt "module@ " $ fmt_package_type c ctx pty)
+  | Ptyp_package pty ->
+      hvbox 0 (wrap "(" ")" (fmt "module@ " $ fmt_package_type c ctx pty))
   | Ptyp_poly (a1N, t) ->
       hovbox_if box 0
         ( list a1N "@ " (fun {txt} -> fmt "'" $ str txt) $ fmt ".@ "


### PR DESCRIPTION
Fixes #107 