### PR TITLE
parents for nested constructors in pattern.

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -816,7 +816,8 @@ end = struct
      |Exp {pexp_desc= Pexp_let _}, Ppat_exception _
      |( Exp {pexp_desc= Pexp_fun _}
       , (Ppat_construct _ | Ppat_lazy _ | Ppat_tuple _ | Ppat_variant _) ) ->
-        true
+       true
+    | Pat {ppat_desc=(Ppat_construct _ | Ppat_variant _); _}, (Ppat_construct (_, Some _) | Ppat_variant (_, Some _)) -> true
     | _ -> false
 
 

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -78,7 +78,7 @@ let may_force_break (c: Conf.t) s =
 
 let rec is_trivial c exp =
   match exp.pexp_desc with
-  | Pexp_constant Pconst_string (s, None) -> not (may_force_break c s)
+  | Pexp_constant (Pconst_string (s, None)) -> not (may_force_break c s)
   | Pexp_constant _ | Pexp_field _ | Pexp_ident _ | Pexp_send _ -> true
   | Pexp_construct (_, exp) -> Option.for_all exp ~f:(is_trivial c)
   | _ -> false
@@ -293,7 +293,7 @@ end = struct
       || Option.exists ptype_manifest ~f
     in
     match ctx with
-    | Pld PTyp t1 -> assert (typ == t1)
+    | Pld (PTyp t1) -> assert (typ == t1)
     | Pld _ -> assert false
     | Typ ctx -> (
       match ctx.ptyp_desc with
@@ -360,7 +360,7 @@ end = struct
 
   let check_pat {ctx; ast= pat} =
     match ctx with
-    | Pld PPat (p1, _) -> assert (p1 == pat)
+    | Pld (PPat (p1, _)) -> assert (p1 == pat)
     | Pld _ -> assert false
     | Typ _ -> assert false
     | Pat ctx -> (
@@ -422,7 +422,7 @@ end = struct
 
   let check_exp {ctx; ast= exp} =
     match ctx with
-    | Pld PPat (_, Some e1) -> assert (e1 == exp)
+    | Pld (PPat (_, Some e1)) -> assert (e1 == exp)
     | Pld _ -> assert false
     | Exp ctx -> (
         let f eI = eI == exp in
@@ -751,7 +751,7 @@ end = struct
     | {ast= {ptyp_desc= Ptyp_package _}} -> true
     | _ ->
       match ambig_prec (sub_ast ~ctx (Typ typ)) with
-      | Some Some true -> true
+      | Some (Some true) -> true
       | _ -> false
 
 
@@ -816,8 +816,10 @@ end = struct
      |Exp {pexp_desc= Pexp_let _}, Ppat_exception _
      |( Exp {pexp_desc= Pexp_fun _}
       , (Ppat_construct _ | Ppat_lazy _ | Ppat_tuple _ | Ppat_variant _) ) ->
-       true
-    | Pat {ppat_desc=(Ppat_construct _ | Ppat_variant _); _}, (Ppat_construct (_, Some _) | Ppat_variant (_, Some _)) -> true
+        true
+    | ( Pat {ppat_desc= Ppat_construct _ | Ppat_variant _; _}
+      , (Ppat_construct (_, Some _) | Ppat_variant (_, Some _)) ) ->
+        true
     | _ -> false
 
 
@@ -962,7 +964,7 @@ end = struct
           in
           match ambig_prec (sub_ast ~ctx (Exp exp)) with
           | None -> false (* ctx not apply *)
-          | Some Some true -> true (* exp is apply and ambig *)
+          | Some (Some true) -> true (* exp is apply and ambig *)
           | _ ->
               if is_right_infix_arg pexp_desc exp then is_sequence exp
               else exposed Non_apply exp )

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -416,7 +416,7 @@ let dedup_cmts map_ast ast comments =
         , PStr
             [ { pstr_desc=
                   Pstr_eval
-                    ( { pexp_desc= Pexp_constant Pconst_string (doc, None)
+                    ( { pexp_desc= Pexp_constant (Pconst_string (doc, None))
                       ; pexp_loc }
                     , [] ) } ] ) ->
           docs := Set.add !docs ("*" ^ doc, pexp_loc) ;

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -433,7 +433,7 @@ let doc_atrs atrs =
                 [ { pstr_desc=
                       Pstr_eval
                         ( { pexp_desc=
-                              Pexp_constant Pconst_string (doc, None)
+                              Pexp_constant (Pconst_string (doc, None))
                           ; pexp_loc= loc
                           ; pexp_attributes= [] }
                         , [] ) } ] ) ) ->
@@ -469,7 +469,7 @@ let rec fmt_attribute c pre = function
     , PStr
         [ { pstr_desc=
               Pstr_eval
-                ( { pexp_desc= Pexp_constant Pconst_string (doc, None)
+                ( { pexp_desc= Pexp_constant (Pconst_string (doc, None))
                   ; pexp_attributes= [] }
                 , [] ) } ] ) ->
       fmt_or (String.equal txt "ocaml.text") "@ " " " $ fmt "(**" $ str doc

--- a/src/Normalize.ml
+++ b/src/Normalize.ml
@@ -25,7 +25,7 @@ let mapper =
       , PStr
           [ { pstr_desc=
                 Pstr_eval
-                  ( { pexp_desc= Pexp_constant Pconst_string (doc, None)
+                  ( { pexp_desc= Pexp_constant (Pconst_string (doc, None))
                     ; pexp_loc
                     ; pexp_attributes }
                   , [] )
@@ -69,7 +69,7 @@ let mapper =
           ; pexp_loc
           ; pexp_attributes= atrs0 }
         , [ ( _
-            , { pexp_desc= Pexp_constant Pconst_integer (lit, suf)
+            , { pexp_desc= Pexp_constant (Pconst_integer (lit, suf))
               ; pexp_attributes= atrs1 } ) ] ) ->
         m.expr m
           (Exp.constant ~loc:pexp_loc ~attrs:(atrs0 @ atrs1)

--- a/src/Reason.ml
+++ b/src/Reason.ml
@@ -50,7 +50,7 @@ let mapper cmts =
         , PStr
             [ { pstr_desc=
                   Pstr_eval
-                    ( {pexp_desc= Pexp_constant Pconst_string (txt, None)}
+                    ( {pexp_desc= Pexp_constant (Pconst_string (txt, None))}
                     , [] ) } ] ) ->
           Set.mem cmts ("*" ^ txt)
       | _ -> false


### PR DESCRIPTION
I dislike the (valid) pattern syntax `Some Some None` because it breaks symmetry between pattern and expression.
The PR adds parenthesises around nested constructor.   
 