### PR TITLE
Improve: two open lines following multiline definition only with --sparse

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -21,12 +21,10 @@ let is_prefix_id i =
   | "!=" -> false
   | _ -> match i.[0] with '!' | '?' | '~' -> true | _ -> false
 
-
 let is_prefix exp =
   match exp.pexp_desc with
   | Pexp_ident {txt= Lident i} -> is_prefix_id i
   | _ -> false
-
 
 let is_infix_id i =
   match (i.[0], i) with
@@ -39,12 +37,10 @@ let is_infix_id i =
       true
   | _ -> false
 
-
 let is_infix e =
   match e.pexp_desc with
   | Pexp_ident {txt= Lident i} -> is_infix_id i
   | _ -> false
-
 
 let is_symbol_id i = is_prefix_id i || is_infix_id i
 
@@ -55,14 +51,12 @@ let is_symbol e = is_prefix e || is_infix e
 let is_sequence exp =
   match exp.pexp_desc with Pexp_sequence _ -> true | _ -> false
 
-
 let rec is_sugared_list exp =
   match exp.pexp_desc with
   | Pexp_construct ({txt= Lident "[]"}, None) -> true
   | Pexp_construct ({txt= Lident "::"}, Some {pexp_desc= Pexp_tuple [_; tl]}) ->
       is_sugared_list tl
   | _ -> false
-
 
 let may_force_break (c: Conf.t) s =
   let contains_internal_newline s =
@@ -75,14 +69,12 @@ let may_force_break (c: Conf.t) s =
   | `Newlines -> contains_internal_newline s
   | _ -> false
 
-
 let rec is_trivial c exp =
   match exp.pexp_desc with
   | Pexp_constant (Pconst_string (s, None)) -> not (may_force_break c s)
   | Pexp_constant _ | Pexp_field _ | Pexp_ident _ | Pexp_send _ -> true
   | Pexp_construct (_, exp) -> Option.for_all exp ~f:(is_trivial c)
   | _ -> false
-
 
 let has_trailing_attributes {pexp_desc; pexp_attributes} =
   match pexp_desc with
@@ -91,7 +83,6 @@ let has_trailing_attributes {pexp_desc; pexp_attributes} =
       List.exists pexp_attributes ~f:(function
         | {Location.txt= "ocaml.doc" | "ocaml.text"}, _ -> false
         | _ -> true )
-
 
 (** Ast terms of various forms. *)
 module T = struct
@@ -178,7 +169,6 @@ let assoc_of_prec = function
   | High -> Non
   | Atomic -> Non
 
-
 (** Term-in-context, [{ctx; ast}] records that [ast] is (considered to be)
     an immediate sub-term of [ctx] as assumed by the operations in
     [Requires_sub_terms]. *)
@@ -251,13 +241,11 @@ end = struct
   let dump fs ctx ast =
     Format.fprintf fs "ast: %a@\nctx: %a@\n" T.dump ast T.dump ctx
 
-
   let fail ctx ast exc =
     let bt = Caml.Printexc.get_backtrace () in
     dump Format.err_formatter ctx ast ;
     Format.eprintf "%s" bt ;
     raise exc
-
 
   (** Predicates to check the claimed sub-term relation. *)
 
@@ -354,10 +342,8 @@ end = struct
       | _ -> assert false )
     | Top -> assert false
 
-
   let check_typ ({ctx; ast= typ} as xtyp) =
     try check_typ xtyp with exc -> fail ctx (Typ typ) exc
-
 
   let check_pat {ctx; ast= pat} =
     match ctx with
@@ -416,10 +402,8 @@ end = struct
       | _ -> assert false )
     | Top -> assert false
 
-
   let check_pat ({ctx; ast= pat} as xpat) =
     try check_pat xpat with exc -> fail ctx (Pat pat) exc
-
 
   let check_exp {ctx; ast= exp} =
     match ctx with
@@ -494,10 +478,8 @@ end = struct
     | Mod {pmod_desc= Pmod_unpack e1} -> assert (e1 == exp)
     | Mod _ | Top | Typ _ | Pat _ | Mty _ | Sig _ -> assert false
 
-
   let check_exp ({ctx; ast= exp} as xexp) =
     try check_exp xexp with exc -> fail ctx (Exp exp) exc
-
 
   let rec is_simple (c: Conf.t) width ({ast= exp} as xexp) =
     let ctx = Exp exp in
@@ -517,7 +499,6 @@ end = struct
         is_trivial c e0 && List.for_all e1N ~f:(snd >> is_trivial c)
         && width xexp * 3 < c.margin
     | _ -> false
-
 
   (** [prec_ctx {ctx; ast}] is the precedence of the context of [ast] within
       [ctx], where [ast] is an immediate sub-term (modulo syntactic sugar)
@@ -650,7 +631,6 @@ end = struct
       ; ast= Pld _ | Top | Pat _ | Exp _ | Mty _ | Mod _ | Sig _ | Str _ } ->
         None
 
-
   (** [prec_ast ast] is the precedence of [ast]. Meaningful for binary
       operators, otherwise returns [None]. *)
   let prec_ast = function
@@ -714,7 +694,6 @@ end = struct
       | _ -> None )
     | Top | Pat _ | Mty _ | Mod _ | Sig _ | Str _ -> None
 
-
   (** [ambig_prec {ctx; ast}] holds when [ast] is ambiguous in its context
       [ctx], indicating that [ast] should be parenthesized. Meaningful for
       binary operators, otherwise returns [None] if [ctx] has no precedence
@@ -735,7 +714,6 @@ end = struct
     else (* which child and assoc conflict: add parens *)
       true
 
-
   (** [parenze_typ {ctx; ast}] holds when type [ast] should be parenthesized
       in context [ctx]. *)
   let parenze_typ ({ctx; ast= typ} as xtyp) =
@@ -746,7 +724,6 @@ end = struct
       match ambig_prec (sub_ast ~ctx (Typ typ)) with
       | Some (Some true) -> true
       | _ -> false
-
 
   (** [parenze_pat {ctx; ast}] holds when pattern [ast] should be
       parenthesized in context [ctx]. *)
@@ -819,7 +796,6 @@ end = struct
         true
     | _ -> false
 
-
   (** Check if an exp is a prefix op that is not fully applied *)
   let is_displaced_prefix_op {ctx; ast= exp} =
     match (ctx, exp.pexp_desc) with
@@ -828,7 +804,6 @@ end = struct
         false
     | _, Pexp_ident {txt= Lident i} when is_prefix_id i -> true
     | _ -> false
-
 
   (** Check if an exp is an infix op that is not fully applied *)
   let is_displaced_infix_op {ctx; ast= exp} =
@@ -839,7 +814,6 @@ end = struct
         false
     | _, Pexp_ident {txt= Lident i} when is_infix_id i -> true
     | _ -> false
-
 
   (** 'Classes' of expressions which are parenthesized differently. *)
   type cls = Let_match | Match | Non_apply | Sequence | Then | ThenElse
@@ -858,7 +832,6 @@ end = struct
       , (Let_match | Non_apply) ) ->
         true
     | _ -> false
-
 
   (** [exposed cls exp] holds if there is a right-most subexpression of
       [exp] which satisfies [mem_cls cls] and is not parenthesized. *)

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -56,7 +56,6 @@ end = struct
            else None ))
       ancestor
 
-
   (* Add elements in decreasing width order to construct tree from roots to
      leaves. That is, when adding an interval to a partially constructed
      tree, it will already contain all wider intervals, so the new
@@ -74,7 +73,6 @@ end = struct
         | None -> tree.roots <- elt :: tree.roots ) ;
     { tree with
       tbl= Hashtbl.map tree.tbl ~f:(List.sort ~compare:Poly.compare) }
-
 
   let children {tbl} elt = Option.value ~default:[] (Hashtbl.find tbl elt)
 
@@ -103,10 +101,8 @@ module Position = struct
     if pos_lnum = -1 then Format.fprintf fs "[%d]" pos_cnum
     else Format.fprintf fs "[%d,%d+%d]" pos_lnum pos_bol (pos_cnum - pos_bol)
 
-
   let compare p1 p2 =
     if phys_equal p1 p2 then 0 else Int.compare p1.pos_cnum p2.pos_cnum
-
 
   let distance p1 p2 = p2.pos_cnum - p1.pos_cnum
 end
@@ -118,7 +114,6 @@ module Location = struct
     Format.fprintf fs "(%a..%a)%s" Position.fmt loc_start Position.fmt
       loc_end
       (if loc_ghost then " ghost" else "")
-
 
   let to_string x = Format.asprintf "%a" fmt x
 
@@ -227,14 +222,12 @@ end = struct
       List.equal ~equal:Poly.equal (Map.to_alist smap) (Map.to_alist emap)
     )
 
-
   let is_empty (smap, _) = Map.is_empty smap
 
   let of_list cmts =
     List.fold cmts ~init:empty ~f:(fun (smap, emap) cmt ->
         let _, loc = cmt in
         (Map.add_multi smap loc cmt, Map.add_multi emap loc cmt) )
-
 
   let to_list (smap, _) = List.concat (Map.data smap)
 
@@ -245,7 +238,6 @@ end = struct
     with
     | `Ok smap, `Ok emap -> (smap, emap)
     | _ -> internal_error "overlapping key ranges" []
-
 
   let split (smap, emap) (loc: Location.t) =
     let addo m kvo =
@@ -284,7 +276,6 @@ let string_between (l1: Location.t) (l2: Location.t) =
     (* can happen e.g. if comment is within a parenthesized expression *)
     None
 
-
 let begins_line (l: Location.t) =
   let rec begins_line_ cnum =
     cnum = 0
@@ -297,7 +288,6 @@ let begins_line (l: Location.t) =
   in
   begins_line_ l.loc_start.pos_cnum
 
-
 let ends_line (l: Location.t) =
   let rec ends_line_ cnum =
     match !source.[cnum] with
@@ -306,7 +296,6 @@ let ends_line (l: Location.t) =
     | _ -> false
   in
   ends_line_ l.loc_end.pos_cnum
-
 
 (** Heuristic to determine if two locations should be considered "adjacent".
     Holds if there is only whitespace between the locations, or if there is
@@ -321,7 +310,6 @@ let is_adjacent (l1: Location.t) (l2: Location.t) =
           begins_line l1
           && Position.column l1.loc_start <= Position.column l2.loc_start
       | _ -> false )
-
 
 (** Heuristic to choose between placing a comment after the previous loc or
     before the next loc. Places comment after prev loc only if they are
@@ -338,7 +326,6 @@ let partition_after_prev_or_before_next ~prev cmts ~next =
         (CmtSet.of_list after, CmtSet.of_list (List.concat befores))
     | [] -> impossible "by parent match" )
   | _ -> (CmtSet.empty, cmts)
-
 
 let cmts_before = Hashtbl.Poly.create ()
 
@@ -367,7 +354,6 @@ let add_cmts ?prev ?next tbl loc cmts =
             Location.fmt loc Location.fmt cmt_loc (String.escaped btw_prev)
             cmt_txt (String.escaped btw_next) ) ;
     Hashtbl.add_exn tbl loc cmtl )
-
 
 (** Traverse the location tree from locs, find the deepest location that
     contains each comment, intersperse comments between that location's
@@ -406,7 +392,6 @@ let rec place loc_tree ?prev_loc locs cmts =
           List.iter (CmtSet.to_list cmts) ~f:(fun (txt, _) ->
               Format.eprintf "lost: %s@\n" txt )
 
-
 (** Remove comments that duplicate docstrings (or other comments). *)
 let dedup_cmts map_ast ast comments =
   let of_ast map_ast ast =
@@ -429,7 +414,6 @@ let dedup_cmts map_ast ast comments =
   in
   Set.(to_list (diff (of_list (module Cmt) comments) (of_ast map_ast ast)))
 
-
 let docs_memo = Hashtbl.Poly.create ()
 
 (** Remember all docstrings that have been formatted, to avoid duplication
@@ -438,7 +422,6 @@ let doc_is_dup doc =
   match Hashtbl.add docs_memo ~key:doc ~data:() with
   | `Ok -> false
   | `Duplicate -> true
-
 
 (** Initialize global state and place comments. *)
 let init map_ast loc_of_ast src asts comments_n_docstrings =
@@ -458,7 +441,6 @@ let init map_ast loc_of_ast src asts comments_n_docstrings =
     let locs = List.map asts ~f:loc_of_ast in
     let cmts = CmtSet.of_list comments in
     place loc_tree locs cmts )
-
 
 let init_impl = init map_structure (fun {Parsetree.pstr_loc} -> pstr_loc)
 
@@ -480,7 +462,6 @@ let relocate ~src ~before ~after =
   update_multi cmts_after src after ~f:(fun src_cmts dst_cmts ->
       List.append dst_cmts src_cmts )
 
-
 let remove = ref true
 
 let preserve f x =
@@ -488,7 +469,6 @@ let preserve f x =
   remove := false ;
   f () x ;
   remove := save
-
 
 let split_asterisk_prefixed (txt, {Location.loc_start}) =
   let len = Position.column loc_start + 3 in
@@ -517,7 +497,6 @@ let split_asterisk_prefixed (txt, {Location.loc_start}) =
   in
   split_asterisk_prefixed_ 0
 
-
 let fmt_cmt (c: Conf.t) cmt =
   let open Fmt in
   if not c.wrap_comments then wrap "(*" "*)" (str (fst cmt))
@@ -534,7 +513,6 @@ let fmt_cmt (c: Conf.t) cmt =
                 | "", None -> fmt ")"
                 | _, None -> str line $ fmt "*)"
                 | _, Some _ -> str line $ fmt "@,*" ) )
-
 
 (** Find, remove, and format comments for loc. *)
 let fmt_cmts c ?pro ?epi ?(eol= Fmt.fmt "@\n") ?(adj= eol) tbl loc =
@@ -557,24 +535,19 @@ let fmt_cmts c ?pro ?epi ?(eol= Fmt.fmt "@\n") ?(adj= eol) tbl loc =
     ( Option.call ~f:pro $ vbox 0 (list cmts "@ " (fmt_cmt c))
     $ fmt_or_k eol_cmt (fmt_or_k adj_cmt adj eol) (Option.call ~f:epi) )
 
-
 let fmt_before c ?pro ?(epi= Fmt.break_unless_newline 1 0) ?eol ?adj =
   fmt_cmts c cmts_before ?pro ~epi ?eol ?adj
 
-
 let fmt_after c ?(pro= Fmt.break_unless_newline 1 0) ?epi =
   fmt_cmts c cmts_after ~pro ?epi ~eol:(Fmt.fmt "")
-
 
 let fmt c ?pro ?epi ?eol ?adj loc =
   Fmt.wrap_k
     (fmt_before c ?pro ?epi ?eol ?adj loc)
     (fmt_after c ?pro ?epi loc)
 
-
 let fmt_list c ?pro ?epi ?eol locs init =
   List.fold locs ~init ~f:(fun k loc -> fmt c ?pro ?epi ?eol loc @@ k)
-
 
 (** check if any comments have not been formatted *)
 let final_check () =
@@ -592,7 +565,6 @@ let final_check () =
     internal_error "formatting lost comments"
       (Hashtbl.fold cmts_before ~f:(f "before")
          ~init:(Hashtbl.fold cmts_after ~f:(f "after") ~init:[]))
-
 
 let diff x y =
   let norm z =

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -43,7 +43,6 @@ end = struct
     let Arg (trm, set) = List.fold_right ~f:pair args ~init in
     Term.app (Term.const set) trm
 
-
   let args : arg list ref = ref []
 
   let mk ~default arg =
@@ -51,7 +50,6 @@ end = struct
     let set x = var := x in
     args := Arg (arg, set) :: !args ;
     var
-
 
   let parse info validate =
     match Term.eval (Term.(ret (const validate $ tuple !args)), info) with
@@ -68,7 +66,6 @@ let info =
     [`S "DESCRIPTION"; `P "$(tname) automatically formats OCaml code."]
   in
   Term.info "ocamlformat" ~version:Version.version ~doc ~man
-
 
 let break_string_literals =
   let doc =
@@ -90,13 +87,11 @@ let break_string_literals =
           default
       & info ["break-string-literals"] ~doc ~env)
 
-
 let debug =
   let doc = "Generate debugging output." in
   let env = Arg.env_var "OCAMLFORMAT_DEBUG" in
   let default = false in
   mk ~default Arg.(value & flag & info ["g"; "debug"] ~doc ~env)
-
 
 let escape_chars =
   let doc =
@@ -120,7 +115,6 @@ let escape_chars =
           default
       & info ["escape-chars"] ~doc ~env)
 
-
 let escape_strings =
   let doc =
     "Escape encoding for string literals. Can be set in a config file with \
@@ -140,12 +134,10 @@ let escape_strings =
           default
       & info ["escape-strings"] ~doc ~env)
 
-
 let inplace =
   let doc = "Format in-place, overwriting input file(s)." in
   let default = false in
   mk ~default Arg.(value & flag & info ["i"; "inplace"] ~doc)
-
 
 let inputs =
   let docv = "SRC" in
@@ -156,7 +148,6 @@ let inputs =
   let default = [] in
   mk ~default Arg.(value & pos_all file default & info [] ~doc ~docv)
 
-
 let kind : [`Impl | `Intf] ref =
   let doc =
     "Parse file with unrecognized extension as an implementation."
@@ -166,7 +157,6 @@ let kind : [`Impl | `Intf] ref =
   let intf = (`Intf, Arg.info ["intf"] ~doc) in
   let default = `Impl in
   mk ~default Arg.(value & vflag default [impl; intf])
-
 
 let margin =
   let docv = "COLS" in
@@ -179,7 +169,6 @@ let margin =
   mk ~default
     Arg.(value & opt int default & info ["m"; "margin"] ~doc ~docv ~env)
 
-
 let max_iters =
   let docv = "N" in
   let doc =
@@ -190,7 +179,6 @@ let max_iters =
   let default = 10 in
   mk ~default
     Arg.(value & opt int default & info ["n"; "max-iters"] ~doc ~docv ~env)
-
 
 let name =
   let docv = "NAME" in
@@ -205,7 +193,6 @@ let name =
   mk ~default
     Arg.(value & opt (some string) default & info ["name"] ~doc ~docv)
 
-
 let output =
   let docv = "DST" in
   let doc =
@@ -217,7 +204,6 @@ let output =
     Arg.(
       value & opt (some string) default & info ["o"; "output"] ~doc ~docv)
 
-
 let sparse =
   let doc =
     "Generate more sparsely formatted code. Can be set in a config file \
@@ -227,14 +213,12 @@ let sparse =
   let default = false in
   mk ~default Arg.(value & flag & info ["sparse"] ~doc ~env)
 
-
 let no_version_check =
   let doc =
     "Do no check version matches the one specified in .ocamlformat."
   in
   let default = false in
   mk ~default Arg.(value & flag & info ["no-version-check"] ~doc)
-
 
 let no_warn_error =
   let doc =
@@ -244,7 +228,6 @@ let no_warn_error =
   in
   let default = false in
   mk ~default Arg.(value & flag & info ["no-warn-error"] ~doc)
-
 
 let wrap_comments =
   let doc =
@@ -258,7 +241,6 @@ let wrap_comments =
   let default = false in
   mk ~default Arg.(value & flag & info ["wrap-comments"] ~doc ~env)
 
-
 let validate () =
   if List.is_empty !inputs then
     `Error (false, "Must specify at least one input file.")
@@ -269,7 +251,6 @@ let validate () =
   else if not !inplace && List.length !inputs > 1 then
     `Error (false, "Must specify only one input file without --inplace")
   else `Ok ()
-
 
 ;; parse info validate
 
@@ -331,7 +312,6 @@ let update conf name value =
   | "wrap-comments" -> {conf with wrap_comments= Bool.of_string value}
   | _ -> conf
 
-
 let rec read_conf_files conf dir =
   let dir' = Filename.dirname dir in
   if not (String.equal dir dir') && Caml.Sys.file_exists dir then
@@ -347,10 +327,8 @@ let rec read_conf_files conf dir =
     with Sys_error _ -> conf
   else conf
 
-
 let to_absolute file =
   Filename.(if is_relative file then concat (Unix.getcwd ()) file else file)
-
 
 let conf name =
   read_conf_files
@@ -363,7 +341,6 @@ let conf name =
     ; wrap_comments= !wrap_comments }
     (Filename.dirname (to_absolute name))
 
-
 type 'a input = {kind: 'a; name: string; file: string; conf: t}
 
 type action =
@@ -375,7 +352,6 @@ let kind_of fname =
   | ".ml" -> `Impl
   | ".mli" -> `Intf
   | _ -> !kind
-
 
 let action =
   if !inplace then

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -23,7 +23,6 @@ let set_margin n fs =
   Format.pp_set_margin fs n ;
   Format.pp_set_max_indent fs (n - 1)
 
-
 (** Break hints and format strings --------------------------------------*)
 
 let break n o fs = Format.pp_print_break fs n o
@@ -54,23 +53,19 @@ let list_pn x1N (pp: ?prev:_ -> _ -> ?next:_ -> _ -> unit) fs =
       in
       list_pn_ fs x1 x2N
 
-
 let list_fl xs pp fs =
   list_pn xs
     (fun ?prev x ?next fs ->
       pp ~first:(Option.is_none prev) ~last:(Option.is_none next) x fs )
     fs
 
-
 let list xs sep pp fs =
   let pp_sep fs () = Format.fprintf fs sep in
   Format.pp_print_list ~pp_sep (fun fs x -> pp x fs) fs xs
 
-
 let list_k xs pp_sep pp fs =
   let pp_sep fs () = pp_sep fs in
   Format.pp_print_list ~pp_sep (fun fs x -> pp x fs) fs xs
-
 
 (** Conditional formatting ----------------------------------------------*)
 
@@ -90,7 +85,6 @@ let break_unless_newline n o fs = Format.pp_print_or_newline fs n o "" ""
 
 let or_newline fits breaks fs =
   Format.pp_print_or_newline fs 1 0 fits breaks
-
 
 (** Conditional on immediately preceding a line break -------------------*)
 
@@ -119,10 +113,8 @@ let fits_breaks ?(force_fit_if= false) ?(force_break_if= false) fits breaks
     Format.pp_print_string fs b )
   else Format.pp_print_fits_or_breaks fs fits n o b
 
-
 let fits_breaks_if ?force_fit_if ?force_break_if cnd fits breaks fs =
   if cnd then fits_breaks ?force_fit_if ?force_break_if fits breaks fs
-
 
 (** Wrapping ------------------------------------------------------------*)
 
@@ -130,7 +122,6 @@ let wrap_if_k cnd pre suf k fs =
   if cnd then pre fs ;
   k fs ;
   if cnd then suf fs
-
 
 let wrap_k x = wrap_if_k true x
 
@@ -141,18 +132,15 @@ and wrap pre suf = wrap_k (fmt pre) (fmt suf)
 let wrap_if_breaks pre suf k fs =
   fits_breaks "" pre fs ; k fs ; fits_breaks "" suf fs
 
-
 let wrap_if_fits_and cnd pre suf k fs =
   fits_breaks_if cnd pre "" fs ;
   k fs ;
   fits_breaks_if cnd suf "" fs
 
-
 let wrap_fits_breaks_if cnd pre suf k fs =
   fits_breaks_if cnd pre (pre ^ " ") fs ;
   k fs ;
   fits_breaks_if cnd suf ("@ " ^ suf) fs
-
 
 let wrap_fits_breaks x = wrap_fits_breaks_if true x
 

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -34,7 +34,6 @@ let protect =
         first := false ) ;
       raise exc
 
-
 let rec sugar_arrow_typ ({ast= typ} as xtyp) =
   let ctx = Typ typ in
   let {ptyp_desc; ptyp_loc} = typ in
@@ -44,7 +43,6 @@ let rec sugar_arrow_typ ({ast= typ} as xtyp) =
       (l, sub_typ ~ctx t1) :: sugar_arrow_typ (sub_typ ~ctx t2)
   | _ -> [(Nolabel, xtyp)]
 
-
 let rec sugar_or_pat ({ast= pat} as xpat) =
   let ctx = Pat pat in
   match pat with
@@ -52,7 +50,6 @@ let rec sugar_or_pat ({ast= pat} as xpat) =
       Cmts.relocate ~src:ppat_loc ~before:pat1.ppat_loc ~after:pat2.ppat_loc ;
       sugar_or_pat (sub_pat ~ctx pat1) @ sugar_or_pat (sub_pat ~ctx pat2)
   | _ -> [xpat]
-
 
 type arg_kind =
   | Val of arg_label * pattern xt * expression xt option
@@ -90,7 +87,6 @@ let sugar_fun pat xexp =
   | Some {ppat_attributes} when not (List.is_empty ppat_attributes) ->
       ([], xexp)
   | _ -> sugar_fun_ xexp
-
 
 let sugar_infix prec xexp =
   let assoc = Option.value_map prec ~default:Non ~f:assoc_of_prec in
@@ -136,7 +132,6 @@ let sugar_infix prec xexp =
   in
   sugar_infix_ None (Nolabel, xexp)
 
-
 let rec sugar_list_pat pat =
   let ctx = Pat pat in
   let {ppat_desc; ppat_loc= src} = pat in
@@ -153,7 +148,6 @@ let rec sugar_list_pat pat =
         Some (([src; loc; ppat_loc], sub_pat ~ctx hd) :: xtl, nil_loc)
     | None -> None )
   | _ -> None
-
 
 let sugar_list_exp exp =
   let rec sugar_list_exp_ exp =
@@ -178,7 +172,6 @@ let sugar_list_exp exp =
   assert (Bool.equal (Option.is_some r) (is_sugared_list exp)) ;
   r
 
-
 let sugar_infix_cons xexp =
   let rec sugar_infix_cons_ ({ast= exp} as xexp) =
     let ctx = Exp exp in
@@ -196,7 +189,6 @@ let sugar_infix_cons xexp =
   in
   sugar_infix_cons_ xexp
 
-
 let rec sugar_ite ({ast= exp} as xexp) =
   let ctx = Exp exp in
   let {pexp_desc; pexp_loc} = exp in
@@ -209,7 +201,6 @@ let rec sugar_ite ({ast= exp} as xexp) =
       Cmts.relocate ~src:pexp_loc ~before:cnd.pexp_loc ~after:thn.pexp_loc ;
       [(Some (sub_exp ~ctx cnd), sub_exp ~ctx thn)]
   | _ -> [(None, xexp)]
-
 
 let sugar_sequence c width xexp =
   let rec sugar_sequence_ ({ast= exp} as xexp) =
@@ -229,7 +220,6 @@ let sugar_sequence c width xexp =
   List.group (sugar_sequence_ xexp) ~break:(fun xexp1 xexp2 ->
       not (is_simple c width xexp1) || not (is_simple c width xexp2) )
 
-
 let rec sugar_functor_type ({ast= mty} as xmty) =
   let ctx = Mty mty in
   match mty with
@@ -240,7 +230,6 @@ let rec sugar_functor_type ({ast= mty} as xmty) =
       let xargs, xbody = sugar_functor_type (sub_mty ~ctx body) in
       ((arg, Option.map arg_mty ~f:(sub_mty ~ctx)) :: xargs, xbody)
   | _ -> ([], xmty)
-
 
 let rec sugar_functor ?mt ({ast= me} as xme) =
   let ctx = Mod me in
@@ -274,7 +263,6 @@ let rec sugar_functor ?mt ({ast= me} as xme) =
           ((arg, xarg_mt) :: xargs, xbody_me, xbody_mt) )
   | _ -> ([], xme, mt)
 
-
 type block =
   { opn: Fmt.t
   ; pro: Fmt.t option
@@ -293,7 +281,6 @@ let empty =
   ; esp= Fn.const ()
   ; epi= None }
 
-
 (* In several places, naked newlines (i.e. not "@\n") are used to avoid
    trailing space in open lines. *)
 (* In several places, a break such as "@;<1000 0>" is used to force the
@@ -309,7 +296,6 @@ let rec fmt_longident (li: Longident.t) =
         $ wrap_if (is_symbol_id id) "( " " )" (str id) )
   | Lapply (li1, li2) ->
       cbox 0 (fmt_longident li1 $ wrap "(" ")" (fmt_longident li2))
-
 
 let fmt_constant (c: Conf.t) ?epi const =
   let fmt_char_escaped chr =
@@ -423,12 +409,10 @@ let fmt_constant (c: Conf.t) ?epi const =
       | Some delim, _ ->
           str ("{" ^ delim ^ "|") $ str s $ str ("|" ^ delim ^ "}")
 
-
 let fmt_variance = function
   | Covariant -> fmt "+"
   | Contravariant -> fmt "-"
   | Invariant -> fmt ""
-
 
 let doc_atrs atrs =
   let doc, rev_atrs =
@@ -449,7 +433,6 @@ let doc_atrs atrs =
   in
   (doc, List.rev rev_atrs)
 
-
 let fmt_docstring (c: Conf.t) ?pro ?epi doc =
   opt doc (fun (({txt; loc} as doc), floating) ->
       let epi =
@@ -466,10 +449,8 @@ let fmt_docstring (c: Conf.t) ?pro ?epi doc =
              $ (if c.wrap_comments then fill_text else str) txt $ fmt "*)"
              $ Option.call ~f:epi ) ) )
 
-
 let fmt_extension_suffix c ext =
   opt ext (fun {txt; loc} -> str "%" $ Cmts.fmt c loc (str txt))
-
 
 let rec fmt_attribute c pre = function
   | ( {txt= ("ocaml.doc" | "ocaml.text") as txt}
@@ -486,19 +467,16 @@ let rec fmt_attribute c pre = function
       @@ hvbox 2
            (wrap "[" "]" (str pre $ str txt $ fmt_payload c (Pld pld) pld))
 
-
 and fmt_extension c ctx key (({txt} as ext), pld) =
   match pld with
   | PStr [({pstr_desc= Pstr_value _; _} as si)] ->
       fmt_structure_item c ~sep:"" ~last:true ~ext (sub_str ~ctx si)
   | _ -> wrap "[" "]" (str key $ str txt $ fmt_payload c ctx pld)
 
-
 and fmt_attributes c pre ~key attrs suf =
   list_fl attrs (fun ~first ~last atr ->
       fmt_or_k first (pre $ open_hvbox 0) (fmt "@ ")
       $ fmt_attribute c key atr $ fmt_if_k last (close_box $ suf) )
-
 
 and fmt_payload c ctx pld =
   protect (Pld pld)
@@ -512,7 +490,6 @@ and fmt_payload c ctx pld =
       fmt "@ ? " $ fmt_pattern c (sub_pat ~ctx pat)
       $ opt exp (fun exp ->
             fmt " when " $ fmt_expression c (sub_exp ~ctx exp) )
-
 
 and fmt_core_type c ?(box= true) ({ast= typ} as xtyp) =
   protect (Typ typ)
@@ -605,14 +582,12 @@ and fmt_core_type c ?(box= true) ({ast= typ} as xtyp) =
   )
   $ fmt_docstring c ~pro:(fmt "@ ") doc
 
-
 and fmt_package_type c ctx ({txt}, cnstrs) =
   hvbox 0
     ( fmt_longident txt
     $ list_fl cnstrs (fun ~first ~last:_ ({txt}, typ) ->
           fmt_or first " with type " " and type " $ fmt_longident txt
           $ fmt " = " $ fmt_core_type c (sub_typ ~ctx typ) ) )
-
 
 and fmt_row_field c ctx = function
   | Rtag ({txt; loc}, atrs, const, typs) ->
@@ -625,7 +600,6 @@ and fmt_row_field c ctx = function
         $ list typs "@ & " (sub_typ ~ctx >> fmt_core_type c)
         $ fmt_docstring c ~pro:(fmt "@;<2 0>") doc )
   | Rinherit typ -> fmt_core_type c (sub_typ ~ctx typ)
-
 
 and fmt_pattern (c: Conf.t) ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
   protect (Pat pat)
@@ -791,7 +765,6 @@ and fmt_pattern (c: Conf.t) ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
         ( fmt_longident txt $ fmt ".(" $ fmt_pattern c (sub_pat ~ctx pat)
         $ fmt ")" )
 
-
 and fmt_fun_args c args =
   let fmt_fun_arg = function
     | Val (Nolabel, xpat, None) -> fmt_pattern c xpat
@@ -855,7 +828,6 @@ and fmt_fun_args c args =
   in
   fmt_if_k (not (List.is_empty args)) (list args "@ " fmt_fun_arg $ fmt "@ ")
 
-
 and fmt_body c ({ast= body} as xbody) =
   let ctx = Exp body in
   match body with
@@ -865,7 +837,6 @@ and fmt_body c ({ast= body} as xbody) =
       $ close_box $ fmt "@ " $ fmt_cases c ctx cs
   | _ ->
       close_box $ fmt "@ " $ fmt_expression c ~eol:(fmt "@;<1000 0>") xbody
-
 
 and fmt_expression c ?(box= true) ?epi ?eol ?parens ?ext
     ({ast= exp} as xexp) =
@@ -1599,7 +1570,6 @@ and fmt_expression c ?(box= true) ?epi ?eol ?parens ?ext
   | Pexp_object _ | Pexp_override _ | Pexp_poly _ | Pexp_setinstvar _ ->
       internal_error "classes not implemented" []
 
-
 and fmt_cases (c: Conf.t) ctx cs =
   list_fl cs (fun ~first ~last:_ {pc_lhs; pc_guard; pc_rhs} ->
       let xrhs = sub_exp ~ctx pc_rhs in
@@ -1647,7 +1617,6 @@ and fmt_cases (c: Conf.t) ctx cs =
               ( hovbox 0 (fmt_expression c ~parens:false xrhs)
               $ fmt_if paren_body "@ )" ) ) )
 
-
 and fmt_value_description c ctx vd =
   let {pval_name= {txt}; pval_type; pval_prim; pval_attributes} = vd in
   let pre = if List.is_empty pval_prim then "val" else "external" in
@@ -1661,7 +1630,6 @@ and fmt_value_description c ctx vd =
     $ fmt_attributes c (fmt "@;<2 2>") ~key:"@@" atrs (fmt "")
     $ fmt_docstring c ~pro:(fmt "@\n") doc )
 
-
 and fmt_tydcl_params c ctx params =
   fmt_if_k
     (not (List.is_empty params))
@@ -1672,7 +1640,6 @@ and fmt_tydcl_params c ctx params =
            (list params "@,, " (fun (ty, vc) ->
                 fmt_variance vc $ fmt_core_type c (sub_typ ~ctx ty) ))
        $ fmt " " ))
-
 
 and fmt_private_flag flag = fmt_if Poly.(flag = Private) "@ private"
 
@@ -1734,7 +1701,6 @@ and fmt_type_declaration c ?(pre= "") ?(suf= ("" : _ format)) ?(brk= suf)
            $ fmt_attributes c (fmt "@ ") ~key:"@@" atrs (fmt "") ) )
   $ fmt brk
 
-
 and fmt_label_declaration c ctx lbl_decl =
   let {pld_mutable; pld_name= {txt; loc}; pld_type; pld_loc; pld_attributes} =
     lbl_decl
@@ -1749,7 +1715,6 @@ and fmt_label_declaration c ctx lbl_decl =
            $ fmt_core_type c (sub_typ ~ctx pld_type) )
        $ fmt_docstring c ~pro:(fmt "@;<2 0>") doc
        $ fmt_attributes c (fmt " ") ~key:"@" atrs (fmt "") )
-
 
 and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
   let {pcd_name= {txt; loc}; pcd_args; pcd_res; pcd_attributes; pcd_loc} =
@@ -1767,7 +1732,6 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
   $ Cmts.fmt_after c ?pro:None ~epi:(fmt "@ ") loc
   $ Cmts.fmt_after c ?pro:None ~epi:(fmt "@ ") pcd_loc
 
-
 and fmt_constructor_arguments c ctx pre args =
   match args with
   | Pcstr_tuple [] -> fmt ""
@@ -1778,7 +1742,6 @@ and fmt_constructor_arguments c ctx pre args =
       $ wrap_fits_breaks "{" "}"
           (list lds "@,; " (fmt_label_declaration c ctx))
 
-
 and fmt_constructor_arguments_result c ctx args res =
   let pre : _ format = if Option.is_none res then " of@ " else ":@ " in
   let before_type : _ format =
@@ -1787,7 +1750,6 @@ and fmt_constructor_arguments_result c ctx args res =
   fmt_constructor_arguments c ctx pre args
   $ opt res (fun typ ->
         fmt "@ " $ fmt before_type $ fmt_core_type c (sub_typ ~ctx typ) )
-
 
 and fmt_type_extension c ctx te =
   let { ptyext_params
@@ -1811,7 +1773,6 @@ and fmt_type_extension c ctx te =
             ) )
     $ fmt_attributes c (fmt "@ ") ~key:"@@" atrs (fmt "") )
 
-
 and fmt_exception ~pre c sep ctx te =
   let atrs, te =
     (* This won't be needed once https://github.com/ocaml/ocaml/pull/1705 is
@@ -1833,7 +1794,6 @@ and fmt_exception ~pre c sep ctx te =
     ( fmt_docstring c ~epi:(fmt "@,") doc
     $ hvbox 2 (pre $ fmt_extension_constructor c sep ctx te)
     $ fmt_attributes c (fmt "@ ") ~key:"@@" atrs (fmt "") )
-
 
 and fmt_extension_constructor c sep ctx ec =
   let {pext_name= {txt}; pext_kind; pext_attributes} = ec in
@@ -1859,7 +1819,6 @@ and fmt_extension_constructor c sep ctx ec =
          |Pext_decl (_, Some _) ->
             fmt " " )
     $ fmt_docstring c ~pro:(fmt "@;<2 0>") doc )
-
 
 and fmt_module_type c {ast= mt} =
   let ctx = Mty mt in
@@ -1914,7 +1873,6 @@ and fmt_module_type c {ast= mt} =
   | Pmty_extension ext -> {empty with bdy= fmt_extension c ctx "%" ext}
   | Pmty_alias {txt} -> {empty with bdy= fmt_longident txt}
 
-
 and fmt_signature c ctx itms =
   let grps =
     List.group itms ~break:(fun itmI itmJ ->
@@ -1930,7 +1888,6 @@ and fmt_signature c ctx itms =
     list itms "@\n" (sub_sig ~ctx >> fmt_signature_item c)
   in
   hvbox 0 (list grps "\n@;<1000 0>" fmt_grp)
-
 
 and fmt_signature_item c {ast= si} =
   protect (Sig si)
@@ -1990,7 +1947,6 @@ and fmt_signature_item c {ast= si} =
   | Psig_value vd -> fmt_value_description c ctx vd
   | Psig_class _ | Psig_class_type _ ->
       internal_error "classes not implemented" []
-
 
 and fmt_module c ?epi keyword name xargs xbody colon xmty attributes =
   let {txt= name; loc} = name in
@@ -2060,7 +2016,6 @@ and fmt_module c ?epi keyword name xargs xbody colon xmty attributes =
     $ fmt_attributes c (fmt "@ ") ~key:"@@" atrs (fmt "")
     $ Option.call ~f:epi )
 
-
 and fmt_module_declaration c ctx ~rec_flag ~first pmd =
   let {pmd_name; pmd_type; pmd_attributes} = pmd in
   let keyword =
@@ -2072,13 +2027,11 @@ and fmt_module_declaration c ctx ~rec_flag ~first pmd =
   in
   fmt_module c keyword pmd_name xargs None colon (Some xmty) pmd_attributes
 
-
 and fmt_module_type_declaration c ctx pmtd =
   let {pmtd_name; pmtd_type; pmtd_attributes} = pmtd in
   fmt_module c "module type" pmtd_name [] None false
     (Option.map pmtd_type ~f:(sub_mty ~ctx))
     pmtd_attributes
-
 
 and fmt_open_description c {popen_lid; popen_override; popen_attributes} =
   let doc, atrs = doc_atrs popen_attributes in
@@ -2086,7 +2039,6 @@ and fmt_open_description c {popen_lid; popen_override; popen_attributes} =
   $ fmt_if Poly.(popen_override = Override) "!" $ fmt " "
   $ fmt_longident popen_lid.txt
   $ fmt_attributes c (fmt " ") ~key:"@@" atrs (fmt "")
-
 
 and fmt_with_constraint c ctx = function
   | Pwith_type ({txt}, td) ->
@@ -2099,12 +2051,10 @@ and fmt_with_constraint c ctx = function
   | Pwith_modsubst ({txt= m1}, {txt= m2}) ->
       fmt " module " $ fmt_longident m1 $ fmt " := " $ fmt_longident m2
 
-
 and maybe_generative c ~ctx m =
   match m with
   | {pmod_desc= Pmod_structure []; _} -> empty
   | _ -> fmt_module_expr c (sub_mod ~ctx m)
-
 
 and fmt_module_expr c {ast= m} =
   let ctx = Mod m in
@@ -2283,7 +2233,6 @@ and fmt_module_expr c {ast= m} =
   | Pmod_extension x1 ->
       {empty with bdy= Cmts.fmt c pmod_loc @@ fmt_extension c ctx "%" x1}
 
-
 and fmt_structure c ?(sep= "") ctx itms =
   let grps =
     List.group itms ~break:(fun itmI itmJ ->
@@ -2335,7 +2284,6 @@ and fmt_structure c ?(sep= "") ctx itms =
   hvbox 0
     (list_fl grps (fun ~first ~last grp ->
          fmt_if (not first) "\n@\n" $ fmt_grp ~last grp ))
-
 
 and fmt_structure_item (c: Conf.t) ~sep ~last:last_item ?ext {ctx; ast= si} =
   protect (Str si)
@@ -2409,7 +2357,6 @@ and fmt_structure_item (c: Conf.t) ~sep ~last:last_item ?ext {ctx; ast= si} =
       $ fmt_attributes c (fmt " ") ~key:"@@" atrs (fmt "")
   | Pstr_class _ | Pstr_class_type _ ->
       internal_error "classes not implemented" []
-
 
 and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
   let {pvb_pat; pvb_expr; pvb_attributes; pvb_loc} = binding in
@@ -2493,7 +2440,6 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
       $ (match in_ with Some in_ -> in_ indent | None -> Fn.const ())
       $ Option.call ~f:epi )
 
-
 and fmt_module_binding c ?epi ~rec_flag ~first ctx pmb =
   let {pmb_name; pmb_expr; pmb_attributes} = pmb in
   let keyword =
@@ -2507,7 +2453,6 @@ and fmt_module_binding c ?epi ~rec_flag ~first ctx pmb =
   let xargs, xbody, xmty = sugar_functor ?mt (sub_mod ~ctx me) in
   fmt_module c ?epi keyword pmb_name xargs (Some xbody) true xmty
     (List.append pmb_attributes me.pmod_attributes)
-
 
 (** Entry points *)
 

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2337,7 +2337,7 @@ and fmt_structure c ?(sep= "") ctx itms =
          fmt_if (not first) "\n@\n" $ fmt_grp ~last grp ))
 
 
-and fmt_structure_item c ~sep ~last:last_item ?ext {ctx; ast= si} =
+and fmt_structure_item (c: Conf.t) ~sep ~last:last_item ?ext {ctx; ast= si} =
   protect (Str si)
   @@
   let at_top = Poly.(ctx = Top) in
@@ -2398,7 +2398,9 @@ and fmt_structure_item c ~sep ~last:last_item ?ext {ctx; ast= si} =
              fmt_value_binding c ~rec_flag ~first
                ?ext:(if first then ext else None)
                ctx binding
-               ~epi:(fits_breaks ~force_fit_if:last_item "" "\n")
+               ?epi:
+                 (Option.some_if c.sparse
+                    (fits_breaks ~force_fit_if:last_item "" "\n"))
              $ fmt_if (not last) "\n@\n" ))
   | Pstr_modtype mtd -> fmt_module_type_declaration c ctx mtd
   | Pstr_extension (ext, atrs) ->

--- a/src/Normalize.ml
+++ b/src/Normalize.ml
@@ -133,7 +133,6 @@ let mapper =
   { Ast_mapper.default_mapper with
     location; attribute; attributes; expr; pat; value_binding }
 
-
 let impl = map_structure mapper
 
 let intf = map_signature mapper

--- a/src/Reason.ml
+++ b/src/Reason.ml
@@ -29,7 +29,6 @@ let input ast_magic ~input_name ic =
     (ast, List.map comments ~f:(fun (txt, _, loc) -> (txt, loc)))
   else user_error "input not a serialized translation unit" []
 
-
 let input_impl = input Config.ast_impl_magic_number
 
 let input_intf = input Config.ast_intf_magic_number
@@ -115,7 +114,6 @@ let mapper cmts =
         | _ -> true ))
   in
   {Normalize.mapper with attributes; pat; expr; structure; signature}
-
 
 let norm_impl (ast, cmts) = map_structure (mapper cmts) ast
 

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -44,7 +44,6 @@ let parse parse_ast ?(warn= Conf.warn_error) ~input_name ic =
   let comments = Lexer.comments () in
   (ast, comments)
 
-
 (** Debug: dump internal ast representation to file. *)
 let dump xunit dir base suf ext ast =
   if Conf.debug then (
@@ -52,7 +51,6 @@ let dump xunit dir base suf ext ast =
     let oc = Out_channel.create tmp in
     xunit.printast (Caml.Format.formatter_of_out_channel oc) ast ;
     Out_channel.close oc )
-
 
 let parse_print (XUnit xunit) (conf: Conf.t) ~input_name:iname
     ~input_file:ifile ic ofile =

--- a/src/import/Import.ml
+++ b/src/import/Import.ml
@@ -30,10 +30,8 @@ let impossible msg = failwith msg
 let internal_error msg kvs =
   Error.raise_s (Sexp.message ("Internal Error: " ^ msg) kvs)
 
-
 let user_error msg kvs =
   Error.raise_s (Sexp.message ("User Error: " ^ msg) kvs)
-
 
 let check f x =
   assert (

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -23,7 +23,6 @@ let impl : _ Translation_unit.t =
   ; no_translation= List.is_empty
   ; printast= Migrate_ast.Printast.implementation }
 
-
 (** Operations on interface files. *)
 let intf : _ Translation_unit.t =
   let parse = Translation_unit.parse Migrate_ast.Parse.interface in
@@ -36,12 +35,10 @@ let intf : _ Translation_unit.t =
   ; no_translation= List.is_empty
   ; printast= Migrate_ast.Printast.interface }
 
-
 (** Select translation unit type and operations based on kind. *)
 let xunit_of_kind : _ -> Translation_unit.x = function
   | `Impl -> XUnit impl
   | `Intf -> XUnit intf
-
 
 ;; Caml.at_exit (Format.pp_print_flush Format.err_formatter)
 

--- a/src/ocamlformat_reason.ml
+++ b/src/ocamlformat_reason.ml
@@ -23,7 +23,6 @@ let reason_impl : _ Translation_unit.t =
   ; no_translation= List.is_empty
   ; printast= Migrate_ast.Printast.implementation }
 
-
 (** Operations on binary serialized Reason interfaces. *)
 let reason_intf : _ Translation_unit.t =
   let parse = Translation_unit.parse Migrate_ast.Parse.interface in
@@ -36,12 +35,10 @@ let reason_intf : _ Translation_unit.t =
   ; no_translation= List.is_empty
   ; printast= Migrate_ast.Printast.interface }
 
-
 (** Select translation unit type and operations based on kind. *)
 let xunit_of_kind : _ -> Translation_unit.x = function
   | `Impl -> XUnit reason_impl
   | `Intf -> XUnit reason_intf
-
 
 ;; match Conf.action with
    | In_out

--- a/test/passing/extensions.ml
+++ b/test/passing/extensions.ml
@@ -2,7 +2,6 @@ let () =
   [%ext expr] ;
   ()
 
-
 let _ = (match%ext x with () -> ()) [@attr y]
 
 val f : compare:[%compare : 'a] -> sexp_of:[%sexp_of : 'a] -> t

--- a/test/passing/first_class_module.ml
+++ b/test/passing/first_class_module.ml
@@ -19,7 +19,6 @@ let () =
   (* error here *)
   ()
 
-
 module type S = sig
   val x : int
 end

--- a/test/passing/kw_extentions.ml
+++ b/test/passing/kw_extentions.ml
@@ -2,13 +2,11 @@ let _ =
   let%lwt foo = Lwt.return 1 in
   Lwt.return_unit
 
-
 let _ =
   let%lwt foo = Lwt.return 1 in
   let%lwt bar = Lwt.return 1 in
   let%lwt baz = Lwt.return 1 in
   Lwt.return_unit
-
 
 let () =
   if%ext true then () else () ;
@@ -18,22 +16,18 @@ let () =
   while%ext false do () done ;
   match%ext x with _ -> ()
 
-
 let () =
   let%ext x = () in
   try%ext x with _ -> ()
-
 
 let () =
   if%ext true then () else () ;
   if%ext true then () else if true then () else () ;
   if%ext true then () else ()
 
-
 let () =
   (match%ext x with _ -> ()) ;
   match%ext x with _ -> ()
-
 
 let () =
   () ;
@@ -41,11 +35,9 @@ let () =
   () ;
   () ;%ext ()
 
-
 let _ =
   let%ext () = () and () = () in
   ()
-
 
 let () = f (fun () -> ()) ;%ext f ()
 

--- a/test/passing/list.ml
+++ b/test/passing/list.ml
@@ -9,5 +9,4 @@ let f x =
          :: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz)
   -> true
 
-
 let f x = match x with P [{xxxxxx}; {yyyyyyyy}] -> true

--- a/test/passing/record.ml
+++ b/test/passing/record.ml
@@ -6,7 +6,6 @@ let _ =
   { !looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
     with a; b= c }
 
-
 let _ =
   { !looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
     with


### PR DESCRIPTION
Generating two open lines following multi-line function definitions only if an option is set is easy. This PR reuses `--sparse`. Generating no open lines following single-line definitions is harder, I expect mostly as some work is needed to avoid ambiguous docstring attachment and the current implementation relies on always having an open line following a definition.