### PR TITLE
change formatting of let module/open/exception/pats

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1358,15 +1358,21 @@ and fmt_expression c ?(box= true) ?epi ?eol ?parens ?ext
         $ fmt_atrs )
   | Pexp_open (flag, {txt}, e0) ->
       let override = Poly.(flag = Override) in
+      let force_break_if =
+        match e0.pexp_desc with
+        | Pexp_let _ | Pexp_extension _ | Pexp_letexception _
+         |Pexp_letmodule _ | Pexp_open _ ->
+            true
+        | _ -> override
+      in
       let force_fit_if =
         match xexp.ctx with
-        | Exp {pexp_desc= Pexp_apply _ | Pexp_construct _} -> not override
+        | Exp {pexp_desc= Pexp_apply _ | Pexp_construct _} ->
+            not force_break_if
         | _ -> false
       in
-      let fits_breaks = fits_breaks ~force_fit_if ~force_break_if:override
-      and fits_breaks_if =
-        fits_breaks_if ~force_fit_if ~force_break_if:override
-      in
+      let fits_breaks = fits_breaks ~force_fit_if ~force_break_if
+      and fits_breaks_if = fits_breaks_if ~force_fit_if ~force_break_if in
       let opn, cls =
         let can_skip_parens =
           match e0.pexp_desc with

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1335,7 +1335,7 @@ and fmt_expression c ?(box= true) ?epi ?eol ?parens ?ext
                 ( fmt_exception ~pre:(fmt "let exception@ ") c ": " ctx
                     ext_cstr
                 $ fmt "@ in" )
-            $ fmt "@ " $ fmt_expression c (sub_exp ~ctx exp) )
+            $ fmt "@;<1000 0>" $ fmt_expression c (sub_exp ~ctx exp) )
         $ fmt_atrs )
   | Pexp_letmodule (name, pmod, exp) ->
       let {pmod_desc; pmod_attributes} = pmod in
@@ -1354,7 +1354,7 @@ and fmt_expression c ?(box= true) ?epi ?eol ?parens ?ext
                 ( fmt_module c keyword name xargs (Some xbody) true xmty
                     (List.append pmod_attributes me.pmod_attributes)
                 $ fmt " in" )
-            $ fmt "@ " $ fmt_expression c (sub_exp ~ctx exp) )
+            $ fmt "@;<1000 0>" $ fmt_expression c (sub_exp ~ctx exp) )
         $ fmt_atrs )
   | Pexp_open (flag, {txt}, e0) ->
       let override = Poly.(flag = Override) in
@@ -1387,7 +1387,8 @@ and fmt_expression c ?(box= true) ?epi ?eol ?parens ?ext
         ( fits_breaks_if parens "" "("
         $ fits_breaks "" (if override then "let open! " else "let open ")
         $ fmt_longident txt $ fits_breaks opn " in"
-        $ fmt_or_k force_fit_if (fmt "@;<0 2>") (fits_breaks "" "@ ")
+        $ fmt_or_k force_fit_if (fmt "@;<0 2>")
+            (fits_breaks "" "@;<1000 0>")
         $ fmt_expression c (sub_exp ~ctx e0) $ fits_breaks cls ""
         $ fits_breaks_if parens "" ")" $ fmt_atrs )
   | Pexp_match (e0, cs) | Pexp_try (e0, cs) -> (

--- a/test/passing/let_in_constr.ml
+++ b/test/passing/let_in_constr.ml
@@ -1,1 +1,4 @@
-let _ = Some (let open! List in 1)
+let _ =
+  Some
+    (let open! List in
+    1)

--- a/test/passing/letopen.ml
+++ b/test/passing/letopen.ml
@@ -1,13 +1,22 @@
 let _ = Some_module.Submodule.(a + b)
 
 let _ =
-  let open Some_module.Submodule in AAAAAAAAAAAAAAAAAAAAAAAAAAAA.(a + b)
+  let open Some_module.Submodule in
+  AAAAAAAAAAAAAAAAAAAAAAAAAAAA.(a + b)
 
-let _ = let open Some_module.Submodule in let module A = MMMMMM in a + b
+let _ =
+  let open Some_module.Submodule in
+  let module A = MMMMMM in
+  a + b + c
 
-let _ = let open Some_module.Submodule in let exception A of int in a + b
+let _ =
+  let open Some_module.Submodule in
+  let exception A of int in
+  a + b
 
-let _ = let open Some_module.Submodule in [%except {| result |}]
+let _ =
+  let open Some_module.Submodule in
+  [%except {| result |}]
 
 let _ =
   let open Some_module.Submodule in

--- a/test/passing/letopen.ml
+++ b/test/passing/letopen.ml
@@ -1,0 +1,20 @@
+let _ = Some_module.Submodule.(a + b)
+
+let _ =
+  let open Some_module.Submodule in AAAAAAAAAAAAAAAAAAAAAAAAAAAA.(a + b)
+
+let _ = let open Some_module.Submodule in let module A = MMMMMM in a + b
+
+let _ = let open Some_module.Submodule in let exception A of int in a + b
+
+let _ = let open Some_module.Submodule in [%except {| result |}]
+
+let _ =
+  let open Some_module.Submodule in
+  [%except {| loooooooooooooooooooooooooong result |}]
+
+let _ =
+  let open Some_module.Submodule in
+  let x = a + b in
+  let y = f x in
+  y

--- a/test/passing/module_type.ml
+++ b/test/passing/module_type.ml
@@ -4,7 +4,9 @@ end
 
 let get = failwith "TODO"
 
-let foo () = let module X = (val (get : (module S))) in X.x ()
+let foo () =
+  let module X = (val (get : (module S))) in
+  X.x ()
 
 module type S = sig
   


### PR DESCRIPTION
- force break after `let ... in`
- use long form for pexp_open if followed by a let keyword or a ppx extensions 