### PR TITLE
Align (all) infix operators (if break)

### DIFF
--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -147,6 +147,22 @@ let escape_strings =
           default
       & info ["escape-strings"] ~doc ~env)
 
+let break_infix =
+  let doc =
+    "Break sequence of infix operators. Can be set in a config file with a \
+     `break-infix {wrap,fit-or-vertical}` line. `wrap` will group simple \
+     expressions and try to format them in a single line."
+  in
+  let env = Arg.env_var "OCAMLFORMAT_BREAK_INFIX" in
+  let default = `Wrap in
+  mk ~default
+    Arg.(
+      value
+      & opt
+          (enum [("wrap", `Wrap); ("fit-or-vertical", `Fit_or_vertical)])
+          default
+      & info ["break-infix"] ~doc ~env)
+
 let if_then_else =
   let doc =
     "If-then-else formatting. Can be set in a config file with an \
@@ -319,6 +335,7 @@ type t =
   ; doc_comments: [`Before | `After]
   ; parens_tuple: [`Always | `Multi_line_only]
   ; if_then_else: [`Compact | `Keyword_first]
+  ; break_infix: [`Wrap | `Fit_or_vertical]
   ; ocp_indent_compat: bool }
 
 let update conf name value =
@@ -345,6 +362,16 @@ let update conf name value =
           | other ->
               user_error
                 (Printf.sprintf "Unknown if-then-else value: %S" other)
+                [] ) }
+  | "break-infix" ->
+      { conf with
+        break_infix=
+          ( match value with
+          | "wrap" -> `Wrap
+          | "fit-or-vertical" -> `Fit_or_vertical
+          | other ->
+              user_error
+                (Printf.sprintf "Unknown break-infix value: %S" other)
                 [] ) }
   | "escape-chars" ->
       { conf with
@@ -432,6 +459,7 @@ let conf name =
     ; doc_comments= !doc_comments
     ; parens_tuple= !parens_tuple
     ; if_then_else= !if_then_else
+    ; break_infix= !break_infix
     ; ocp_indent_compat= !ocp_indent_compat }
     (Filename.dirname (to_absolute name))
 

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -27,6 +27,7 @@ type t = private
   ; doc_comments: [`Before | `After]
   ; parens_tuple: [`Always | `Multi_line_only]
   ; if_then_else: [`Compact | `Keyword_first]
+  ; break_infix: [`Wrap | `Fit_or_vertical]
   ; ocp_indent_compat: bool  (** Try to indent like ocp-indent *) }
 
 type 'a input = {kind: 'a; name: string; file: string; conf: t}

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1023,12 +1023,15 @@ and fmt_expression c ?(box= true) ?epi ?eol ?parens ?ext
                  (if parens then "@ )" else "")) )
     in
     let op_args_grouped =
-      List.group op_args ~break:(fun (_, (_, args1)) (_, (_, args2)) ->
-          let exists_not_simple args =
-            List.exists args ~f:(fun (_, arg) ->
-                not (is_simple c.conf width arg) )
-          in
-          exists_not_simple args1 || exists_not_simple args2 )
+      match c.conf.break_infix with
+      | `Wrap ->
+          List.group op_args ~break:(fun (_, (_, args1)) (_, (_, args2)) ->
+              let exists_not_simple args =
+                List.exists args ~f:(fun (_, arg) ->
+                    not (is_simple c.conf width arg) )
+              in
+              exists_not_simple args1 || exists_not_simple args2 )
+      | `Fit_or_vertical -> List.map ~f:(fun x -> [x]) op_args
     in
     hvbox 0 (list_fl op_args_grouped fmt_op_arg_group $ fmt_atrs)
   in

--- a/test/failing/align_infix.ml
+++ b/test/failing/align_infix.ml
@@ -1,5 +1,0 @@
-let sum_of_squares num =
-  num + 1 
-  |> List.range 0 
-  |> List.map ~f:square
-  |> List.fold_left ~init:0 ~f:( + )

--- a/test/passing/align_infix.ml
+++ b/test/passing/align_infix.ml
@@ -1,3 +1,5 @@
 let sum_of_squares num =
-  num + 1 |> List.range 0 |> List.map ~f:square
+  num + 1
+  |> List.range 0
+  |> List.map ~f:square
   |> List.fold_left ~init:0 ~f:( + )

--- a/test/passing/align_infix.ml.opts
+++ b/test/passing/align_infix.ml.opts
@@ -1,0 +1,1 @@
+--break-infix fit-or-vertical


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/69.

I personally find the code more readable this way. Feedback welcome. 