### PR TITLE
`>]` is invalid.

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -225,6 +225,12 @@ and Requires_sub_terms : sig
 
   val exposed : cls -> expression -> bool
 
+  type ltgt = LT | GT
+
+  val typ_exposed_left : ltgt -> core_type -> bool
+
+  val typ_exposed_right : ltgt -> core_type -> bool
+
   val prec_ast : T.t -> prec option
 
   val parenze_typ : core_type In_ctx.xt -> bool
@@ -971,6 +977,20 @@ end = struct
           | _ ->
               if is_right_infix_arg pexp_desc exp then is_sequence exp
               else exposed Non_apply exp )
+    | _ -> false
+
+  type ltgt = LT | GT
+
+  let rec typ_exposed_left c typ =
+    match (typ.ptyp_desc, c) with
+    | Ptyp_arrow (_, t, _), _ -> typ_exposed_left c t
+    | Ptyp_object _, LT -> true
+    | _ -> false
+
+  let rec typ_exposed_right c typ =
+    match (typ.ptyp_desc, c) with
+    | Ptyp_arrow (_, _, t), _ -> typ_exposed_right c t
+    | Ptyp_object _, GT -> true
     | _ -> false
 end
 

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -984,12 +984,14 @@ end = struct
   let rec typ_exposed_left c typ =
     match (typ.ptyp_desc, c) with
     | Ptyp_arrow (_, t, _), _ -> typ_exposed_left c t
+    | Ptyp_tuple l, _ -> typ_exposed_left c (List.hd_exn l)
     | Ptyp_object _, LT -> true
     | _ -> false
 
   let rec typ_exposed_right c typ =
     match (typ.ptyp_desc, c) with
     | Ptyp_arrow (_, _, t), _ -> typ_exposed_right c t
+    | Ptyp_tuple l, _ -> typ_exposed_right c (List.last_exn l)
     | Ptyp_object _, GT -> true
     | _ -> false
 end

--- a/src/Ast.mli
+++ b/src/Ast.mli
@@ -107,6 +107,12 @@ val is_simple : Conf.t -> (expression xt -> int) -> expression xt -> bool
 (** Holds of "simple" expressions: constants and constructor and function
     applications of other simple expressions. *)
 
+type ltgt = LT | GT
+
+val typ_exposed_left : ltgt -> core_type -> bool
+
+val typ_exposed_right : ltgt -> core_type -> bool
+
 (** 'Classes' of expressions which are parenthesized differently. *)
 type cls = Let_match | Match | Non_apply | Sequence | Then | ThenElse
 

--- a/src/Ast.mli
+++ b/src/Ast.mli
@@ -107,16 +107,14 @@ val is_simple : Conf.t -> (expression xt -> int) -> expression xt -> bool
 (** Holds of "simple" expressions: constants and constructor and function
     applications of other simple expressions. *)
 
-type ltgt = LT | GT
+val exposed_left_typ : core_type -> bool
 
-val typ_exposed_left : ltgt -> core_type -> bool
-
-val typ_exposed_right : ltgt -> core_type -> bool
+val exposed_right_typ : core_type -> bool
 
 (** 'Classes' of expressions which are parenthesized differently. *)
 type cls = Let_match | Match | Non_apply | Sequence | Then | ThenElse
 
-val exposed : cls -> expression -> bool
+val exposed_right_exp : cls -> expression -> bool
 (** [exposed cls exp] holds if there is a right-most subexpression of [exp]
     which is of class [cls] and is not parenthesized. *)
 

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -602,14 +602,13 @@ and fmt_core_type c ?(box= true) ?pro ({ast= typ} as xtyp) =
   | Ptyp_variant (rfs, flag, lbls) ->
       let row_fields rfs = list rfs "@ | " (fmt_row_field c ctx) in
       let protect_token =
-        match (lbls, rfs) with
-        | _, [] -> false
-        | None, l -> (
-          match List.last_exn l with
-          | Rinherit _ -> false
-          | Rtag (_, _, _, [x]) -> typ_exposed_right GT x
-          | Rtag (_, _, _, _) -> false )
-        | Some _, _ -> false
+        match List.last rfs with
+        | None -> false
+        | Some (Rinherit _) -> false
+        | Some (Rtag (_, _, _, l)) ->
+          match List.last l with
+          | None -> false
+          | Some x -> typ_exposed_right GT x
       in
       hvbox 0
         ( fits_breaks "[" "["
@@ -626,7 +625,7 @@ and fmt_core_type c ?(box= true) ?pro ({ast= typ} as xtyp) =
   | Ptyp_object ([], Closed) -> fmt "< >"
   | Ptyp_object (fields, closedness) ->
       hvbox 0
-        (wrap_fits_breaks "<" ">"
+        (wrap "< " " >"
            ( list fields "@ ; " (function
                | Otag (lab_loc, attrs, typ) ->
                    (* label loc * attributes * core_type -> object_field *)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -603,7 +603,7 @@ and fmt_core_type c ?(box= true) ?pro ({ast= typ} as xtyp) =
       let row_fields rfs = list rfs "@ | " (fmt_row_field c ctx) in
       let protect_token =
         match (lbls, rfs) with
-        | _, [] -> impossible "not produced by parser"
+        | _, [] -> false
         | None, l -> (
           match List.last_exn l with
           | Rinherit _ -> false

--- a/test/passing/object_type.ml
+++ b/test/passing/object_type.ml
@@ -18,3 +18,15 @@ type z = < > t
 let x : unit -> <bouh: string ; .. > = fun () -> assert false
 
 let lookup_obj : < .. > -> (< .. > as 'a) list -> 'a = fun _ -> assert false
+
+let _ = [%ext : <a ; b> ]
+
+let _ = (x [@att : <a ; b> ])
+
+type t = [`A of <a ; b> ]
+
+type t = {a: < >; b: int}
+
+type t = {b: int; a: < > }
+
+type 'a u = [< `A | `B of < > > `B] as 'a

--- a/test/passing/object_type.ml
+++ b/test/passing/object_type.ml
@@ -25,6 +25,8 @@ let _ = (x [@att : <a ; b> ])
 
 type t = [`A of <a ; b> ]
 
+type t = private [> ]
+
 type t = {a: < >; b: int}
 
 type t = {b: int; a: < > }

--- a/test/passing/object_type.ml
+++ b/test/passing/object_type.ml
@@ -7,7 +7,7 @@ type t =
   ; long: float [@default 42.] >
 [@@deriving make]
 
-type 'a u = < hello: string  (** more doc *) ; world: int ; ..  > as 'a
+type 'a u = < hello: string  (** more doc *) ; world: int ; .. > as 'a
 
 type 'a v = < .. > as 'a
 
@@ -15,7 +15,7 @@ type 'a w = (< .. > as 'a) -> 'a
 
 type z = < > t
 
-let x : unit -> < bouh: string ; ..  > = fun () -> assert false
+let x : unit -> < bouh: string ; .. > = fun () -> assert false
 
 let lookup_obj : < .. > -> (< .. > as 'a) list -> 'a = fun _ -> assert false
 

--- a/test/passing/object_type.ml
+++ b/test/passing/object_type.ml
@@ -7,7 +7,7 @@ type t =
   ; long: float [@default 42.] >
 [@@deriving make]
 
-type 'a u = <hello: string  (** more doc *) ; world: int ; .. > as 'a
+type 'a u = < hello: string  (** more doc *) ; world: int ; ..  > as 'a
 
 type 'a v = < .. > as 'a
 
@@ -15,20 +15,24 @@ type 'a w = (< .. > as 'a) -> 'a
 
 type z = < > t
 
-let x : unit -> <bouh: string ; .. > = fun () -> assert false
+let x : unit -> < bouh: string ; ..  > = fun () -> assert false
 
 let lookup_obj : < .. > -> (< .. > as 'a) list -> 'a = fun _ -> assert false
 
-let _ = [%ext : <a ; b> ]
+let _ = [%ext : < a ; b > ]
 
-let _ = (x [@att : <a ; b> ])
+let _ = (x [@att : < a ; b > ])
 
-type t = [`A of <a ; b> ]
+type t = [`A of < a ; b > ]
 
 type t = private [> ]
+
+type t = < a: < > >
 
 type t = {a: < >; b: int}
 
 type t = {b: int; a: < > }
 
-type 'a u = [< `A | `B of < > > `B] as 'a
+type 'a u = [< `A | `B of < > > `B ] as 'a
+
+type t = [`A of int * < > ]


### PR DESCRIPTION
- `[%ext: < .. >]`
- ```type t = [`A of <a; b>]]```

I've tried a few fix but I'm not happy. Do you have any suggestion ?