### PR TITLE
Various changes

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -784,10 +784,9 @@ end = struct
     | ( (Exp {pexp_desc= Pexp_let _} | Str {pstr_desc= Pstr_value _})
       , Ppat_constraint (_, {ptyp_desc= Ptyp_poly _}) ) ->
         false
-    | _, Ppat_unpack _
+    | Pat _, Ppat_constraint _
+     |_, Ppat_unpack _
      |_, Ppat_constraint ({ppat_desc= Ppat_unpack _}, _)
-     |( Pat {ppat_desc= Ppat_construct _ | Ppat_record _ | Ppat_variant _}
-      , Ppat_constraint _ )
      |( Pat
           { ppat_desc=
               ( Ppat_alias _ | Ppat_array _ | Ppat_constraint _
@@ -806,7 +805,7 @@ end = struct
               ( Ppat_construct _ | Ppat_exception _ | Ppat_tuple _
               | Ppat_variant _ ) }
       , Ppat_or _ )
-     |Pat {ppat_desc= Ppat_tuple _}, (Ppat_constraint _ | Ppat_tuple _)
+     |Pat {ppat_desc= Ppat_tuple _}, Ppat_tuple _
      |Pat {ppat_desc= Ppat_lazy _}, Ppat_lazy _
      |Exp {pexp_desc= Pexp_fun _}, Ppat_or _
      |( (Exp {pexp_desc= Pexp_let _} | Str {pstr_desc= Pstr_value _})

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -947,7 +947,8 @@ end = struct
         when e0 == exp && is_prefix ident ->
           (* don't put parens around [!e] in [{ !e with a; b }] *)
           false
-      | Pexp_record (_, Some ({pexp_desc= Pexp_apply _} as e0))
+      | Pexp_record
+          (_, Some ({pexp_desc= Pexp_apply _ | Pexp_sequence _} as e0))
         when e0 == exp ->
           true
       | Pexp_sequence

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -768,6 +768,7 @@ end = struct
                 ({txt= Lident "::"}, Some {ppat_desc= Ppat_tuple [_; _]}) }
       , inner ) -> (
       match inner with
+      | Ppat_construct ({txt= Lident "::"}, _) -> true
       | Ppat_construct _ | Ppat_variant _ -> false
       | _ -> true )
     | ( Pat {ppat_desc= Ppat_construct _}

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -706,7 +706,9 @@ end = struct
       | Pexp_apply _ -> Some Apply
       | Pexp_assert _ | Pexp_lazy _ | Pexp_for _
        |Pexp_variant (_, Some _)
-       |Pexp_while _ ->
+       |Pexp_while _ | Pexp_new _
+       |Pexp_extension
+          (_, PStr [{pstr_desc= Pstr_eval ({pexp_desc= Pexp_new _}, _)}]) ->
           Some Apply
       | Pexp_setfield _ -> Some LessMinus
       | Pexp_setinstvar _ -> Some LessMinus

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -659,10 +659,10 @@ and fmt_row_field c ctx = function
       let doc, atrs = doc_atrs atrs in
       hvbox 0
         ( Cmts.fmt c.cmts loc @@ (fmt "`" $ str txt)
-        $ fmt_attributes c ~key:"@" atrs (fmt "")
         $ fmt_if (not (const && List.is_empty typs)) " of "
         $ fmt_if (const && not (List.is_empty typs)) " & "
         $ list typs "@ & " (sub_typ ~ctx >> fmt_core_type c)
+        $ fmt_attributes c ~key:"@" atrs (fmt "")
         $ fmt_docstring c ~pro:(fmt "@;<2 0>") doc )
   | Rinherit typ -> fmt_core_type c (sub_typ ~ctx typ)
 

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2254,8 +2254,9 @@ and fmt_with_constraint c ctx = function
       $ fmt_type_declaration c ctx ~fmt_name:(fmt_longident txt) td
   | Pwith_module ({txt= m1}, {txt= m2}) ->
       fmt " module " $ fmt_longident m1 $ fmt " = " $ fmt_longident m2
-  | Pwith_typesubst (_, td) ->
-      fmt " type " $ fmt_type_declaration c ~eq:":=" ctx td
+  | Pwith_typesubst ({txt}, td) ->
+      fmt " type "
+      $ fmt_type_declaration c ~eq:":=" ctx ~fmt_name:(fmt_longident txt) td
   | Pwith_modsubst ({txt= m1}, {txt= m2}) ->
       fmt " module " $ fmt_longident m1 $ fmt " := " $ fmt_longident m2
 

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2694,11 +2694,14 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
       $ ( hovbox 4
             ( str keyword
             $ fmt_extension_suffix c ext
-            $ fmt_attributes c ~key:"@" atrs (fmt "")
+            $ fmt_if_k (Option.is_some in_)
+                (fmt_attributes c ~key:"@" atrs (fmt ""))
             $ fmt " " $ fmt_pattern c xpat $ fmt "@ " $ fmt_fun_args c xargs
             $ Option.call ~f:fmt_cstr )
         $ fmt "=" )
       $ fmt_body c xbody
+      $ fmt_if_k (Option.is_none in_)
+          (fmt_attributes c ~key:"@@" atrs (fmt ""))
       $ Cmts.fmt_after c.cmts pvb_loc
       $ (match in_ with Some in_ -> in_ indent | None -> Fn.const ())
       $ Option.call ~f:epi )

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1834,7 +1834,9 @@ and fmt_type_declaration c ?(pre= "") ?(suf= ("" : _ format)) ?(brk= suf)
                     fmt_if (not first) "@,; "
                     $ fmt_label_declaration c ctx x
                     $ fmt_if (last && exposed_right_typ x.pld_type) " " )))
-    | Ptype_open -> fmt_manifest ~priv mfst $ fmt " = .."
+    | Ptype_open ->
+        fmt_manifest ~priv:Public mfst
+        $ fmt " =" $ fmt_private_flag priv $ fmt " .."
   in
   let fmt_cstrs cstrs =
     fmt_if_k

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -23,3 +23,9 @@ val foo : int
   [@@warning "-32"]
   [@@warning "-99"]
   [@@some long comment]
+
+type t = [`A of int[@default] | `B of (float[@default])]
+
+let f x =
+  let[@something] e = 1 in
+  e[@@inline always]

--- a/test/passing/gadt.ml
+++ b/test/passing/gadt.ml
@@ -11,3 +11,9 @@ type (_, _, _, _, _) gadt =
       ('a, 'b, long_name * long_name2, 't, 'u) gadt
       * ('b, 'c, 'v, 'u, 'k) gadt2
       -> ('a, 'c, long_name * 'k, 't, 'v) gadt
+
+type _ t = ..
+
+type _ t += A : int | B: int -> int
+
+type t = A: (int -> int) -> int

--- a/test/passing/list.ml
+++ b/test/passing/list.ml
@@ -10,3 +10,7 @@ let f x =
   -> true
 
 let f x = match x with P [{xxxxxx}; {yyyyyyyy}] -> true
+
+let x = (x :: y) :: z
+
+let x = match x with (x :: y) :: z -> ()

--- a/test/passing/list_pattern.ml
+++ b/test/passing/list_pattern.ml
@@ -2,3 +2,5 @@ let _ = match x with Atom x -> x | List [Atom x; Atom y] -> x ^ y
 
 let _ =
   match x with Atom x -> x | List (Atom x :: Atom y :: rest) -> x ^ y
+
+let _ = match x with (x :: y) :: z -> true

--- a/test/passing/module_type.ml
+++ b/test/passing/module_type.ml
@@ -16,4 +16,6 @@ type t = (module S)
 
 type 'a monoid_a = (module Monoid with type t = 'a)
 
+type 'a monoid_a = (module Monoid with type F.t = 'a)
+
 let sumi (type a) ((module A): a monoid_a) (n: a) = A.mappend n A.mempty

--- a/test/passing/new.ml
+++ b/test/passing/new.ml
@@ -1,3 +1,15 @@
 let x = new Objects.one ~hello:true ()
 
-let _ = sprintf "Date: %s" (Js.to_string new%js Js.date_now ## toString)
+let _ = sprintf "Date: %s" (Js.to_string (new%js Js.date_now) ## toString)
+
+let _ = f (new test) a b
+
+let _ = f (new test x) a b
+
+let _ = f (new test (new test a b) c) a b
+
+let _ = f (new%js test) a b
+
+let _ = f (new%js test x) a b
+
+let _ = f (new%js test (new%js test a b) c) a b

--- a/test/passing/record.ml
+++ b/test/passing/record.ml
@@ -11,3 +11,9 @@ let _ =
     with
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   ; b= c }
+
+let _ = {(a : t) with a; b; c}
+
+let _ = {(f a) with a; b; c}
+
+let _ = {(a ; a) with a; b; c}

--- a/test/passing/type_annotations.ml
+++ b/test/passing/type_annotations.ml
@@ -1,1 +1,11 @@
 let f = match None with (_: int option) -> true
+
+let f (x: int) : int = e
+
+let f (x as y: int) : int = e
+
+let f ((x: int) as y) : int = e
+
+let f ((x: int): int) = e
+
+let _ = match x with exception (e: exn) -> true | _ -> false

--- a/test/passing/variants.ml
+++ b/test/passing/variants.ml
@@ -1,3 +1,17 @@
 type t = A of (int * int) * int
 
+type t = A of int * int
+
+type t = A of (int * int)
+
 let _ = match x with Some (Some None) -> t
+
+type t = ..
+
+type t = private ..
+
+type t = u = private ..
+
+type t += A
+
+type t += B = A


### PR DESCRIPTION
Based on top of https://github.com/ocaml-ppx/ocamlformat/pull/171
- add parens around nested constraint
- add parens around constraint inside aliases
- improve formatting of `new c x y`
- add parens around constraint in exception pat
- add parens around nested ( :: ) in pats
- fix extensible gadt
- fix attribute in let bindings
- fix [S with type lident = ty]
- fix attribute on polymorphic variant
- fix private on extensible variants 