### PR TITLE
Fix: parens with lazy pat (fix #199)

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -1294,6 +1294,7 @@ end = struct
               ( Ppat_construct _ | Ppat_exception _ | Ppat_tuple _
               | Ppat_variant _ ) }
       , Ppat_or _ )
+     |Pat {ppat_desc= Ppat_lazy _}, Ppat_tuple _
      |Pat {ppat_desc= Ppat_tuple _}, Ppat_tuple _
      |Pat {ppat_desc= Ppat_lazy _}, Ppat_lazy _
      |Exp {pexp_desc= Pexp_fun _}, Ppat_or _
@@ -1308,6 +1309,7 @@ end = struct
      |( Exp {pexp_desc= Pexp_fun _}
       , (Ppat_construct _ | Ppat_lazy _ | Ppat_tuple _ | Ppat_variant _) ) ->
         true
+    | (Str _ | Exp _), Ppat_lazy _ -> true
     | ( Pat {ppat_desc= Ppat_construct _ | Ppat_variant _; _}
       , (Ppat_construct (_, Some _) | Ppat_variant (_, Some _)) ) ->
         true

--- a/test/passing/lazy.ml
+++ b/test/passing/lazy.ml
@@ -1,0 +1,8 @@
+let (lazy a) = lazy 1
+
+let (lazy (a, b)) = lazy (1, 2)
+
+let () =
+  let (lazy a) = lazy 1 in
+  let (lazy (a, b)) = lazy (1, 2) in
+  ()


### PR DESCRIPTION
follow the same logic as https://github.com/ocaml-ppx/ocamlformat/pull/151.