### PR TITLE
Improve: spacing of module unpack

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3140,11 +3140,12 @@ and fmt_module_expr c ({ast= m} as xmod) =
             $ fmt_docstring c ~epi:(fmt "@,") doc )
       ; bdy=
           Cmts.fmt c.cmts pmod_loc
-          @@ wrap_fits_breaks "(" ")"
-               ( fmt "val "
-               $ fmt_expression c (sub_exp ~ctx e1)
-               $ fmt "@;<1 2>: "
-               $ fmt_package_type c ctx pty )
+          @@ hvbox 2
+               (wrap_fits_breaks "(" ")"
+                  ( fmt "val "
+                  $ fmt_expression c (sub_exp ~ctx e1)
+                  $ fmt "@;<1 2>: "
+                  $ fmt_package_type c ctx pty ))
       ; epi=
           Some
             ( Cmts.fmt_after c.cmts pmod_loc
@@ -3158,8 +3159,9 @@ and fmt_module_expr c ({ast= m} as xmod) =
             $ fmt_docstring c ~epi:(fmt "@,") doc )
       ; bdy=
           Cmts.fmt c.cmts pmod_loc
-          @@ wrap_fits_breaks "(" ")"
-               (fmt "val " $ fmt_expression c (sub_exp ~ctx e1))
+          @@ hvbox 2
+               (wrap_fits_breaks "(" ")"
+                  (fmt "val " $ fmt_expression c (sub_exp ~ctx e1)))
       ; epi=
           Some
             ( Cmts.fmt_after c.cmts pmod_loc

--- a/test/passing/module_attributes.ml
+++ b/test/passing/module_attributes.ml
@@ -12,4 +12,7 @@ include M (N) [@warning "item"] [@@warning "structure"]
 
 include [%ext] [@warning "item"] [@@warning "structure"]
 
-include ( val M ) [@warning "item"] [@@warning "structure"]
+include (val M) [@warning "item"] [@@warning "structure"]
+
+include ( val Aaaaaaaaaaaaaaaa.Bbbbbbbbbbbbbbbb.Cccccccccccccccc.
+              Dddddddddddddddd ) [@warning "item"] [@@warning "structure"]


### PR DESCRIPTION
An alternative to #227, by adding a missing box instead of unconditionally removing space, so that multi-line unpacked modules still get the right space.