### PR TITLE
Improve comments formatting

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -1239,7 +1239,7 @@ end = struct
     prec_ast ast
     >>| fun prec_ast ->
     let cmp = Poly.compare prec_ctx prec_ast in
-    if cmp < 0 then (* ast higher precedence than context: no parens *)
+    if cmp < 0 (* ast higher precedence than context: no parens *) then
       false
     else if cmp > 0 then (* context higher prec than ast: add parens *)
       true

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3530,9 +3530,7 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
   let fmt_cmts_before =
     Cmts.fmt_before c.cmts ~epi:(fmt "\n@\n") ~eol:(fmt "\n@\n")
       ~adj:(fmt "@\n") si.pstr_loc
-  and fmt_cmts_after =
-    Cmts.fmt_after c.cmts ~pro:(fmt "\n@\n") si.pstr_loc
-  in
+  and fmt_cmts_after = Cmts.fmt_after c.cmts ?pro:None si.pstr_loc in
   wrap_k fmt_cmts_before fmt_cmts_after
   @@
   match si.pstr_desc with

--- a/test/passing/comments_in_types.ml
+++ b/test/passing/comments_in_types.ml
@@ -1,0 +1,25 @@
+type t1 =
+  S.s                           (* comment attached to t1 *)
+type t2 =
+  s                             (* comment attached to t2 *)
+type t3 =
+    S                           (* comment attached to t3 *)
+type t4 =
+  | S                                   (* comment attached to t4 *)
+
+
+
+(* comment attached to the list *)
+let _ =
+  [ x
+  ; y
+  ]
+
+
+type t5 = int              (*  comment attached to t5 *)
+
+type t6 = X of int (*  comment attached to X *)  | Y of float   (* comment attached to Y *)
+	    | Q of int    (* comment attached to X *) | P of string (* comment attached to P *)
+	    | W
+(* comment attached to N *)
+	    | N of char             (* comment attached to t6 *)

--- a/test/passing/comments_in_types.ml.ref
+++ b/test/passing/comments_in_types.ml.ref
@@ -1,0 +1,27 @@
+type t1 = S.s
+(* comment attached to t1 *)
+
+type t2 = s
+(* comment attached to t2 *)
+
+type t3 = S
+(* comment attached to t3 *)
+
+type t4 = S
+(* comment attached to t4 *)
+
+(* comment attached to the list *)
+let _ = [x; y]
+
+type t5 = int
+(* comment attached to t5 *)
+
+type t6 =
+  | X of int (* comment attached to X *)
+  | Y of float (* comment attached to Y *)
+  | Q of int (* comment attached to X *)
+  | P of string (* comment attached to P *)
+  | W
+  (* comment attached to N *)
+  | N of char
+(* comment attached to t6 *)


### PR DESCRIPTION
Some improvements on the formatting of comments.
Some comments were attached to the wrong piece of code (next one instead of previous one), and the formatting added unnecessary linebreaks.
A new regression test has been added: passing/comments_in_types.ml
