### PR TITLE
Improve: formatting of comments

### DIFF
--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -554,11 +554,15 @@ let fmt_within t ?(pro= Fmt.break_unless_newline 1 0)
     ?(epi= Fmt.break_unless_newline 1 0) =
   fmt_cmts t t.cmts_within ~pro ~epi ~eol:(Fmt.fmt "")
 
-let fmt t ?pro ?epi ?eol ?adj loc k =
+let fmt t ?pro ?epi ?eol ?adj loc =
+  (* remove the before comments from the map first *)
   let before = fmt_before t ?pro ?epi ?eol ?adj loc in
-  let inner = k in
-  let after = fmt_after t ?pro ?epi loc in
-  before $ inner $ after
+  (* remove the within comments from the map by accepting the continuation *)
+  fun k ->
+    (* delay the after comments until the within comments have been removed *)
+    let after = fmt_after t ?pro ?epi loc in
+    let inner = k in
+    before $ inner $ after
 
 let fmt_list t ?pro ?epi ?eol locs init =
   List.fold locs ~init ~f:(fun k loc -> fmt t ?pro ?epi ?eol loc @@ k)

--- a/test/passing/comment_breaking.ml
+++ b/test/passing/comment_breaking.ml
@@ -1,0 +1,8 @@
+let () =
+  foo aaaaaaaaaa bbbbbbbbbb cccccccccc |> (ignore : t -> _) ;
+  bar dddddddddd eeeeeeeeee ffffffffff |> (ignore : t -> _)
+
+let () =
+  (* this comment should not change breaking of the following line *)
+  foo aaaaaaaaaa bbbbbbbbbb cccccccccc |> (ignore : t -> _) ;
+  bar dddddddddd eeeeeeeeee ffffffffff |> (ignore : t -> _)


### PR DESCRIPTION
Ensure that comments are removed in before-within-after order as the
formatting code relies on. PR #223 happened to have the order
within-before-after, causing some regressions.