### PR TITLE
Improve: break in type declaration for variant and record

### DIFF
--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -163,6 +163,20 @@ let break_infix =
           default
       & info ["break-infix"] ~doc ~env)
 
+let type_decl =
+  let doc =
+    "Style of type declaration. Can be set in a config file with a \
+     `break-infix {wrap,fit-or-vertical}` line. `wrap` will group simple \
+     expressions and try to format them in a single line."
+  in
+  let env = Arg.env_var "OCAMLFORMAT_TYPE_DECL" in
+  let default = `Auto in
+  mk ~default
+    Arg.(
+      value
+      & opt (enum [("sparse", `Sparse); ("auto", `Auto)]) default
+      & info ["type-decl"] ~doc ~env)
+
 let if_then_else =
   let doc =
     "If-then-else formatting. Can be set in a config file with an \
@@ -358,6 +372,7 @@ type t =
   ; if_then_else: [`Compact | `Keyword_first]
   ; infix_precedence: [`Indent | `Parens]
   ; break_infix: [`Wrap | `Fit_or_vertical]
+  ; type_decl: [`Sparse | `Auto]
   ; ocp_indent_compat: bool
   ; quiet: bool
   ; no_comment_check: bool }
@@ -406,6 +421,16 @@ let update conf name value =
           | other ->
               user_error
                 (Printf.sprintf "Unknown break-infix value: %S" other)
+                [] ) }
+  | "type-doc" ->
+      { conf with
+        type_decl=
+          ( match value with
+          | "sparse" -> `Sparse
+          | "auto" -> `Auto
+          | other ->
+              user_error
+                (Printf.sprintf "Unknown type-decl value: %S" other)
                 [] ) }
   | "escape-chars" ->
       { conf with
@@ -495,6 +520,7 @@ let conf name =
     ; if_then_else= !if_then_else
     ; infix_precedence= !infix_precedence
     ; break_infix= !break_infix
+    ; type_decl= !type_decl
     ; ocp_indent_compat= !ocp_indent_compat
     ; quiet= !quiet
     ; no_comment_check= !no_comment_check }

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -166,15 +166,16 @@ let break_infix =
 let type_decl =
   let doc =
     "Style of type declaration. Can be set in a config file with a \
-     `break-infix {wrap,fit-or-vertical}` line. `wrap` will group simple \
-     expressions and try to format them in a single line."
+     `type-decl {compact,sparse}` line. `compact` will try to format \
+     constructors and records definition in a single line. `sparse` will \
+     always break between constructors and record fields."
   in
   let env = Arg.env_var "OCAMLFORMAT_TYPE_DECL" in
-  let default = `Auto in
+  let default = `Compact in
   mk ~default
     Arg.(
       value
-      & opt (enum [("sparse", `Sparse); ("auto", `Auto)]) default
+      & opt (enum [("compact", `Compact); ("sparse", `Sparse)]) default
       & info ["type-decl"] ~doc ~env)
 
 let if_then_else =
@@ -372,7 +373,7 @@ type t =
   ; if_then_else: [`Compact | `Keyword_first]
   ; infix_precedence: [`Indent | `Parens]
   ; break_infix: [`Wrap | `Fit_or_vertical]
-  ; type_decl: [`Sparse | `Auto]
+  ; type_decl: [`Compact | `Sparse]
   ; ocp_indent_compat: bool
   ; quiet: bool
   ; no_comment_check: bool }
@@ -426,8 +427,8 @@ let update conf name value =
       { conf with
         type_decl=
           ( match value with
+          | "compact" -> `Compact
           | "sparse" -> `Sparse
-          | "auto" -> `Auto
           | other ->
               user_error
                 (Printf.sprintf "Unknown type-decl value: %S" other)

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -29,6 +29,7 @@ type t = private
   ; if_then_else: [`Compact | `Keyword_first]
   ; infix_precedence: [`Indent | `Parens]
   ; break_infix: [`Wrap | `Fit_or_vertical]
+  ; type_decl: [`Sparse | `Auto]
   ; ocp_indent_compat: bool  (** Try to indent like ocp-indent *)
   ; quiet: bool
   ; no_comment_check: bool }

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -29,7 +29,7 @@ type t = private
   ; if_then_else: [`Compact | `Keyword_first]
   ; infix_precedence: [`Indent | `Parens]
   ; break_infix: [`Wrap | `Fit_or_vertical]
-  ; type_decl: [`Sparse | `Auto]
+  ; type_decl: [`Compact | `Sparse]
   ; ocp_indent_compat: bool  (** Try to indent like ocp-indent *)
   ; quiet: bool
   ; no_comment_check: bool }

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2478,7 +2478,7 @@ and fmt_type_declaration c ?(pre= "") ?(suf= ("" : _ format)) ?(brk= suf)
                     fmt_if (not first)
                       ( match c.conf.type_decl with
                       | `Sparse -> "@;<1000 0>; "
-                      | `Auto -> "@,; " )
+                      | `Compact -> "@,; " )
                     $ fmt_label_declaration c ctx x
                     $ fmt_if (last && exposed_right_typ x.pld_type) " " )))
     | Ptype_open ->
@@ -2548,7 +2548,9 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
   in
   let doc, atrs = doc_atrs pcd_attributes in
   fmt_if (not first)
-    (match c.conf.type_decl with `Sparse -> "@;<1000 0>" | `Auto -> "@ ")
+    ( match c.conf.type_decl with
+    | `Sparse -> "@;<1000 0>"
+    | `Compact -> "@ " )
   $ Cmts.fmt_before c.cmts pcd_loc
   $ Cmts.fmt_before c.cmts loc
   $ fmt_or_k first (if_newline "| ") (fmt "| ")

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -583,7 +583,8 @@ and fmt_payload c ctx pld =
       $ opt exp (fun exp ->
             fmt " when " $ fmt_expression c (sub_exp ~ctx exp) )
 
-and fmt_core_type c ?(box= true) ?pro ({ast= typ} as xtyp) =
+and fmt_core_type c ?(box= true) ?(in_type_declaration= false) ?pro
+    ({ast= typ} as xtyp) =
   protect (Typ typ)
   @@
   let {ptyp_desc; ptyp_attributes; ptyp_loc} = typ in
@@ -650,7 +651,12 @@ and fmt_core_type c ?(box= true) ?pro ({ast= typ} as xtyp) =
       let row_fields rfs =
         match rfs with
         | [] -> Cmts.fmt_within c.cmts ~pro:(fmt "") ptyp_loc
-        | _ -> list rfs "@ | " (fmt_row_field c ctx)
+        | _ ->
+            list rfs
+              ( if in_type_declaration && Poly.(c.conf.type_decl = `Sparse)
+              then "@;<1000 0>| "
+              else "@ | " )
+              (fmt_row_field c ctx)
       in
       let protect_token =
         match List.last rfs with
@@ -2448,7 +2454,7 @@ and fmt_type_declaration c ?(pre= "") ?(suf= ("" : _ format)) ?(brk= suf)
   let fmt_manifest ~priv manifest =
     opt manifest (fun typ ->
         fmt " " $ str eq $ fmt_private_flag priv $ fmt "@ "
-        $ fmt_core_type c (sub_typ ~ctx typ) )
+        $ fmt_core_type c ~in_type_declaration:true (sub_typ ~ctx typ) )
   in
   let fmt_manifest_kind mfst priv kind =
     match kind with
@@ -2469,7 +2475,10 @@ and fmt_type_declaration c ?(pre= "") ?(suf= ("" : _ format)) ?(brk= suf)
         $ hvbox 0
             (wrap_fits_breaks "{" "}"
                (list_fl lbl_decls (fun ~first ~last x ->
-                    fmt_if (not first) "@,; "
+                    fmt_if (not first)
+                      ( match c.conf.type_decl with
+                      | `Sparse -> "@;<1000 0>; "
+                      | `Auto -> "@,; " )
                     $ fmt_label_declaration c ctx x
                     $ fmt_if (last && exposed_right_typ x.pld_type) " " )))
     | Ptype_open ->
@@ -2538,7 +2547,8 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
     cstr_decl
   in
   let doc, atrs = doc_atrs pcd_attributes in
-  fmt_if (not first) "@ "
+  fmt_if (not first)
+    (match c.conf.type_decl with `Sparse -> "@;<1000 0>" | `Auto -> "@ ")
   $ Cmts.fmt_before c.cmts pcd_loc
   $ Cmts.fmt_before c.cmts loc
   $ fmt_or_k first (if_newline "| ") (fmt "| ")

--- a/test/passing/types.ml
+++ b/test/passing/types.ml
@@ -9,3 +9,7 @@ type uu += A of (int as 'a)
 type uu += B of 'a * (< leq: 'a > as 'a)
 
 let _ = ignore Async_unix.Fd.(([stdin (); stdout (); stderr ()] : t list))
+
+type t = {a: int; b: int}
+
+type t = [`A | `B]

--- a/test/passing/types_sparse.ml
+++ b/test/passing/types_sparse.ml
@@ -1,0 +1,25 @@
+type uu =
+  | A of int
+  | B of (< leq: 'a > as 'a)
+
+type uu =
+  | A of int
+  | B of (< leq: 'a > as 'a) * 'a
+
+type uu =
+  | A of (int as 'a)
+  | B of 'a * (< leq: 'a > as 'a)
+
+type uu += A of (int as 'a)
+
+type uu += B of 'a * (< leq: 'a > as 'a)
+
+let _ = ignore Async_unix.Fd.(([stdin (); stdout (); stderr ()] : t list))
+
+type t =
+  { a: int
+  ; b: int }
+
+type t =
+  [ `A
+  | `B ]

--- a/test/passing/types_sparse.ml.opts
+++ b/test/passing/types_sparse.ml.opts
@@ -1,0 +1,1 @@
+--type-decl sparse


### PR DESCRIPTION
I could add an option to configure that but I'd only do it if some people prefer the old behavior.