### PR TITLE
Style of functions and applications

### DIFF
--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -298,8 +298,8 @@ end
     column of the first location is not greater than that of the second
     location. *)
 let is_adjacent t (l1 : Location.t) (l2 : Location.t) =
-  Option.value_map (Source.string_between t.source l1 l2) ~default:false ~f:
-    (fun btw ->
+  Option.value_map (Source.string_between t.source l1 l2) ~default:false
+    ~f:(fun btw ->
       match String.strip btw with
       | "" -> true
       | "|" ->

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -16,7 +16,7 @@ type t =
   ; break_infix: [`Wrap | `Fit_or_vertical]
   ; break_string_literals: [`Newlines | `Never | `Wrap]
         (** How to potentially break string literals into new lines. *)
-  ; no_comment_check: bool
+  ; comment_check: bool
   ; doc_comments: [`Before | `After]
   ; escape_chars: [`Decimal | `Hexadecimal | `Preserve]
         (** Escape encoding for chars literals. *)
@@ -36,7 +36,8 @@ type t =
   ; parens_tuple: [`Always | `Multi_line_only]
   ; quiet: bool
   ; type_decl: [`Compact | `Sparse]
-  ; wrap_comments: bool  (** Wrap comments at margin. *) }
+  ; wrap_comments: bool  (** Wrap comments at margin. *)
+  ; wrap_fun_args: bool }
 
 type 'a input = {kind: 'a; name: string; file: string; conf: t}
 

--- a/src/Migrate_ast.ml
+++ b/src/Migrate_ast.ml
@@ -19,8 +19,8 @@ module Parse = struct
   let interface = Parse.interface Versions.ocaml_407
 
   let use_file lexbuf =
-    List.filter (Parse.use_file Versions.ocaml_407 lexbuf) ~f:
-      (fun (p : Parsetree.toplevel_phrase) ->
+    List.filter (Parse.use_file Versions.ocaml_407 lexbuf)
+      ~f:(fun (p : Parsetree.toplevel_phrase) ->
         match p with
         | Ptop_def [] -> false
         | Ptop_def (_ :: _) | Ptop_dir _ -> true )

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -78,7 +78,7 @@ let parse parse_ast (conf : Conf.t) ic =
   (Location.warning_printer :=
      fun loc fmt warn ->
        match warn with
-       | Warnings.Bad_docstring _ when not conf.no_comment_check ->
+       | Warnings.Bad_docstring _ when conf.comment_check ->
            w50 := (loc, warn) :: !w50
        | _ -> if not conf.quiet then warning_printer loc fmt warn) ;
   try
@@ -153,7 +153,7 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
           if
             (* Ast not preserved ? *)
             not
-              (xunit.equal ~ignore_doc_comments:conf.no_comment_check old
+              (xunit.equal ~ignore_doc_comments:(not conf.comment_check) old
                  new_)
           then (
             dump xunit dir base ".old" ".ast" (xunit.normalize old) ;
@@ -162,7 +162,7 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
             internal_error "formatting changed ast"
               [("output file", String.sexp_of_t tmp)] ) ;
           (* Comments not preserved ? *)
-          if not conf.no_comment_check then (
+          if conf.comment_check then (
             ( match Cmts.remaining_comments cmts_t with
             | [] -> ()
             | l -> internal_error "formatting lost comments" l ) ;

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -68,8 +68,8 @@ Caml.at_exit (Format_.pp_print_flush Format_.err_formatter)
 match Conf.action with
 | Inplace inputs -> (
   match
-    List.filter_map inputs ~f:
-      (fun {Conf.kind; name= input_name; file= input_file; conf} ->
+    List.filter_map inputs
+      ~f:(fun {Conf.kind; name= input_name; file= input_file; conf} ->
         match
           In_channel.with_file input_file ~f:(fun ic ->
               Translation_unit.parse_print (xunit_of_kind kind) conf

--- a/test/passing/fun_decl.ml
+++ b/test/passing/fun_decl.ml
@@ -1,0 +1,94 @@
+[@@@ocamlformat "wrap-fun-args=false"]
+
+class t =
+  object
+    method meth
+          aaaaaaaaaaa
+          bbbbbbbbbbbbbb
+          ccccccccccccccccccc
+          ddddddddddddddddddddd
+          eeeeeeeeeeeeeee =
+      body
+  end
+
+let func
+    aaaaaaaaaaa
+    bbbbbbbbbbbbbb
+    ccccccccccccccccccc
+    ddddddddddddddddddddd
+    eeeeeeeeeeeeeee =
+  body
+
+let rec func
+    aaaaaaaaaaa
+    bbbbbbbbbbbbbb
+    ccccccccccccccccccc
+    ddddddddddddddddddddd
+    eeeeeeeeeeeeeee =
+  body
+
+let to_loc_trace
+    ?(desc_of_source=
+      fun source ->
+        let callsite = Source.call_site source in
+        Format.asprintf
+          "return from %a"
+          Typ.Procname.pp
+          (CallSite.pname callsite))
+    ?(source_should_nest= fun _ -> true)
+    ?(desc_of_sink=
+      fun sink ->
+        let callsite = Sink.call_site sink in
+        Format.asprintf
+          "call to %a"
+          Typ.Procname.pp
+          (CallSite.pname callsite))
+    ?(sink_should_nest= fun _ -> true)
+    (passthroughs, sources, sinks) =
+  ()
+
+let translate_captured
+    { Clang_ast_t.lci_captured_var
+    ; lci_init_captured_vardecl
+    ; lci_capture_this
+    ; lci_capture_kind }
+    ((trans_results_acc, captured_vars_acc) as acc) =
+  ()
+
+[@@@ocamlformat "wrap-fun-args=true"]
+
+class t =
+  object
+    method meth aaaaaaaaaaa bbbbbbbbbbbbbb ccccccccccccccccccc
+        ddddddddddddddddddddd eeeeeeeeeeeeeee =
+      body
+  end
+
+let func aaaaaaaaaaa bbbbbbbbbbbbbb ccccccccccccccccccc
+    ddddddddddddddddddddd eeeeeeeeeeeeeee =
+  body
+
+let rec func aaaaaaaaaaa bbbbbbbbbbbbbb ccccccccccccccccccc
+    ddddddddddddddddddddd eeeeeeeeeeeeeee =
+  body
+
+let to_loc_trace
+    ?(desc_of_source=
+      fun source ->
+        let callsite = Source.call_site source in
+        Format.asprintf "return from %a" Typ.Procname.pp
+          (CallSite.pname callsite)) ?(source_should_nest= fun _ -> true)
+    ?(desc_of_sink=
+      fun sink ->
+        let callsite = Sink.call_site sink in
+        Format.asprintf "call to %a" Typ.Procname.pp
+          (CallSite.pname callsite)) ?(sink_should_nest= fun _ -> true)
+    (passthroughs, sources, sinks) =
+  ()
+
+let translate_captured
+    { Clang_ast_t.lci_captured_var
+    ; lci_init_captured_vardecl
+    ; lci_capture_this
+    ; lci_capture_kind } ((trans_results_acc, captured_vars_acc) as acc) =
+  ()

--- a/test/passing/issue289.ml
+++ b/test/passing/issue289.ml
@@ -1,0 +1,99 @@
+[@@@ocamlformat "wrap-fun-args=false"]
+
+let foo =
+  let open Gql in
+  [ field
+      "id"
+      ~doc:"Toy ID."
+      ~args:[]
+      ~typ:(non_null guid)
+      ~resolve:(function _ctx -> x.id )
+  ; field "id" ~doc:"Toy ID." ~args:[] ~typppp ~resolve:(function _ctx ->
+        x.id )
+  ; field
+      "id"
+      ~doc:"Toy ID."
+      ~args:[]
+      ~typ:(non_null guid)
+      ~resolve:(function
+        | A -> x.id
+        | B -> c )
+  ; field "id" ~doc:"Toy ID." ~args:[] ~resolve:(function
+        | A -> x.id
+        | B -> c )
+  ; field
+      "id"
+      ~doc:"Toy ID."
+      ~args:[]
+      ~typppppppppppppppppppp
+      ~resolve:(function
+        | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
+        | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
+  ; field "id" ~doc:"Toy ID." ~args:[] ~resolve:(function
+        | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
+        | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
+  ; field
+      "id"
+      ~doc:"Toy ID."
+      ~args:[]
+      ~typ:(non_null guid)
+      ~resolve:(fun _ctx x -> x.id )
+  ; field
+      "name"
+      ~doc:"Toy name."
+      ~args:[]
+      ~typ:(non_null string)
+      ~resolve:(fun _ctx x -> x.name )
+  ; field
+      "description"
+      ~doc:"Toy description."
+      ~args:[]
+      ~typ:string
+      ~resolve:(fun _ctx x -> x.description |> Util.option_of_string )
+  ; field
+      "type"
+      ~doc:"Toy type. Possible values are: car, animal, train."
+      ~args:[]
+      ~typ:(non_null toy_type_enum)
+      ~resolve:(fun _ctx x -> x.toy_type )
+  ; field
+      "createdAt"
+      ~doc:"Date created."
+      ~args:[]
+      ~typ:(non_null Scalar.date_time)
+      ~resolve:(fun _ctx x -> x.created_at ) ]
+
+[@@@ocamlformat "wrap-fun-args=true"]
+
+let foo =
+  let open Gql in
+  [ field "id" ~doc:"Toy ID." ~args:[] ~typ:(non_null guid)
+        ~resolve:(function _ctx -> x.id )
+  ; field "id" ~doc:"Toy ID." ~args:[] ~typppp ~resolve:(function _ctx ->
+        x.id )
+  ; field "id" ~doc:"Toy ID." ~args:[] ~typ:(non_null guid)
+      ~resolve:(function
+      | A -> x.id
+      | B -> c )
+  ; field "id" ~doc:"Toy ID." ~args:[] ~resolve:(function
+      | A -> x.id
+      | B -> c )
+  ; field "id" ~doc:"Toy ID." ~args:[] ~typppppppppppppppppppp
+      ~resolve:(function
+      | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
+      | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
+  ; field "id" ~doc:"Toy ID." ~args:[] ~resolve:(function
+      | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
+      | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
+  ; field "id" ~doc:"Toy ID." ~args:[] ~typ:(non_null guid)
+      ~resolve:(fun _ctx x -> x.id )
+  ; field "name" ~doc:"Toy name." ~args:[] ~typ:(non_null string)
+      ~resolve:(fun _ctx x -> x.name )
+  ; field "description" ~doc:"Toy description." ~args:[] ~typ:string
+      ~resolve:(fun _ctx x -> x.description |> Util.option_of_string )
+  ; field "type" ~doc:"Toy type. Possible values are: car, animal, train."
+      ~args:[] ~typ:(non_null toy_type_enum) ~resolve:(fun _ctx x ->
+        x.toy_type )
+  ; field "createdAt" ~doc:"Date created." ~args:[]
+      ~typ:(non_null Scalar.date_time) ~resolve:(fun _ctx x -> x.created_at
+    ) ]

--- a/test/passing/let_binding.ml
+++ b/test/passing/let_binding.ml
@@ -101,3 +101,12 @@ module Let_and_sparse = struct
     and y = 2 in
     3
 end
+
+let f aaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbb
+    cccccccccccccccccccccccc dddddddddddddddddd eeeeeeeeeeeeee =
+  ()
+
+let _ =
+ fun aaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccc
+     dddddddddddddddddd eeeeeeeeeeeeee ->
+  ()

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -1491,9 +1491,9 @@ let ty_abc : (([`A of int | `B of string | `C] as 'a), 'e) ty =
          ; ("B", TCarg (Ttl Thd, String))
          ; ("C", TCnoarg (Ttl (Ttl Thd))) ]
 
-       method inj
-         : type c.    (int -> string -> noarg -> unit, c) ty_sel * c
-                   -> [`A of int | `B of string | `C] =
+       method inj : type c.
+              (int -> string -> noarg -> unit, c) ty_sel * c
+           -> [`A of int | `B of string | `C] =
          function
          | Thd, v -> `A v | Ttl Thd, v -> `B v | Ttl (Ttl Thd), Noarg -> `C
     end)
@@ -1514,9 +1514,8 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
           method cases =
             [("Nil", TCnoarg Thd); ("Cons", TCarg (Ttl Thd, tcons))]
 
-          method inj
-            : type c.    (noarg -> a * a vlist -> unit, c) ty_sel * c
-                      -> a vlist =
+          method inj : type c.
+              (noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist =
             function Thd, Noarg -> `Nil | Ttl Thd, v -> `Cons v
        end))
 


### PR DESCRIPTION
I usually find it easier to read code when things are either on a single line or on a single column.
This PR tries to apply that logic to applications and functions.

This PR also fixes a bug where label would be totally disconnected from their value.
e.g.
```ocaml
let _ = 
  call something ~f:
    fun x -> x
```