### PR TITLE
Improve: no parens for trailing 'not'

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -1594,10 +1594,10 @@ end = struct
     | Pld _, {pexp_desc= Pexp_tuple _} -> false
     | Str {pstr_desc= Pstr_eval _}, {pexp_desc= Pexp_tuple _} -> false
     | Cl {pcl_desc= Pcl_apply _}, {pexp_desc= Pexp_apply _} -> true
-    | ( Exp {pexp_desc= Pexp_apply (op, (Nolabel, _) :: (Nolabel, _) :: _)}
+    | ( Exp {pexp_desc= Pexp_apply (op, (Nolabel, _) :: (Nolabel, e1) :: _)}
       , { pexp_desc=
             Pexp_apply ({pexp_desc= Pexp_ident {txt= Lident "not"}}, _) } )
-      when is_infix op ->
+      when is_infix op && not (e1 == exp) ->
         true
     | Exp {pexp_desc}, _ -> (
       match pexp_desc with

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -215,7 +215,7 @@ end = struct
     List.find_map !store
       ~f:(fun (Pack {names; parse; update; allow_inline}) ->
         if List.exists names ~f:(String.equal name) then
-          if inline && (not allow_inline) then
+          if inline && not allow_inline then
             Some (Error (`Misplaced (name, value)))
           else
             try Some (Ok (update config (parse value))) with _ ->

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -351,8 +351,7 @@ let sugar_sequence c width xexp =
     | Pexp_sequence (e1, e2) ->
         Cmts.relocate c.cmts ~src:pexp_loc ~before:e1.pexp_loc
           ~after:e2.pexp_loc ;
-        if
-          (not allow_attribute) && (not (List.is_empty exp.pexp_attributes))
+        if (not allow_attribute) && not (List.is_empty exp.pexp_attributes)
         then [xexp]
         else if Ast.exposed_right_exp Ast.Let_match e1 then
           [sub_exp ~ctx e1; sub_exp ~ctx e2]
@@ -364,7 +363,7 @@ let sugar_sequence c width xexp =
   in
   List.group (sugar_sequence_ xexp) ~break:(fun xexp1 xexp2 ->
       (not (is_simple c.conf width xexp1))
-      || (not (is_simple c.conf width xexp2)) )
+      || not (is_simple c.conf width xexp2) )
 
 (* The sugar is different when used with the [functor] keyword. The syntax
    M(A : A)(B : B) cannot handle [_] as module name. *)
@@ -373,8 +372,7 @@ let rec sugar_functor_type c ~for_functor_kw ({ast= mty} as xmty) =
   match mty with
   | {pmty_desc= Pmty_functor (arg, arg_mty, body); pmty_loc; pmty_attributes}
     when for_functor_kw
-         || List.is_empty pmty_attributes
-            && (not (String.equal arg.txt "_")) ->
+         || (List.is_empty pmty_attributes && not (String.equal arg.txt "_")) ->
       let arg =
         if String.equal "*" arg.txt then {arg with txt= ""} else arg
       in
@@ -396,8 +394,7 @@ let rec sugar_functor c ~for_functor_kw ({ast= me} as xme) =
   match me with
   | {pmod_desc= Pmod_functor (arg, arg_mt, body); pmod_loc; pmod_attributes}
     when for_functor_kw
-         || List.is_empty pmod_attributes
-            && (not (String.equal arg.txt "_")) ->
+         || (List.is_empty pmod_attributes && not (String.equal arg.txt "_")) ->
       let arg =
         if String.equal "*" arg.txt then {arg with txt= ""} else arg
       in
@@ -812,7 +809,7 @@ and fmt_row_field c ctx = function
       hvbox 0
         ( Cmts.fmt c.cmts loc @@ (fmt "`" $ str txt)
         $ fmt_if (not (const && List.is_empty typs)) " of "
-        $ fmt_if (const && (not (List.is_empty typs))) " & "
+        $ fmt_if (const && not (List.is_empty typs)) " & "
         $ list typs "@ & " (sub_typ ~ctx >> fmt_core_type c)
         $ fmt_attributes c ~key:"@" atrs
         $ fmt_docstring c ~pro:(fmt "@;<2 0>") doc )
@@ -994,7 +991,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
             (List.group xpats ~break:(fun {ast= p1} {ast= p2} ->
                  break_cases_level c > 0
                  || (not (is_simple p1))
-                 || (not (is_simple p2)) ))
+                 || not (is_simple p2) ))
             (fun ~first:first_grp ~last:_ xpat_grp ->
               list_fl xpat_grp (fun ~first ~last xpat ->
                   let pro =
@@ -1280,7 +1277,7 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
       if c.conf.wrap_fun_args then
         List.group all ~break:(fun (_, a1) (_, a2) ->
             (not (is_simple c.conf width (sub_exp ~ctx a1)))
-            || (not (is_simple c.conf width (sub_exp ~ctx a2))) )
+            || not (is_simple c.conf width (sub_exp ~ctx a2)) )
       else List.map all ~f:(fun x -> [x])
     in
     list_fl groups (fun ~first:first_grp ~last:last_grp args ->
@@ -1582,7 +1579,7 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
         $ fits_breaks_if paren_body ")" "@ )" )
   | Pexp_constant const ->
       wrap_if
-        (parens || (not (List.is_empty pexp_attributes)))
+        (parens || not (List.is_empty pexp_attributes))
         "(" ")"
         (fmt_constant c ~loc:pexp_loc ?epi const $ fmt_atrs)
   | Pexp_constraint
@@ -1687,7 +1684,7 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
         $ hvbox 0 (fmt_cases c ctx cs) )
   | Pexp_ident {txt; loc} ->
       let wrap, wrap_ident =
-        if is_symbol exp && (not (List.is_empty pexp_attributes)) then
+        if is_symbol exp && not (List.is_empty pexp_attributes) then
           (wrap_if true "( " " )", true)
         else if is_symbol exp then (wrap_if parens "( " " )", false)
         else (wrap_if parens "(" ")", false)
@@ -1744,7 +1741,7 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
                     $ fmt_if (not last) "@ " )))
   | Pexp_let (rec_flag, bindings, body) ->
       wrap_if
-        (parens || (not (List.is_empty pexp_attributes)))
+        (parens || not (List.is_empty pexp_attributes))
         "(" ")"
         (vbox 0
            ( hvbox 0
@@ -1764,7 +1761,7 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
   | Pexp_letexception (ext_cstr, exp) ->
       hvbox 0
         ( wrap_if
-            (parens || (not (List.is_empty pexp_attributes)))
+            (parens || not (List.is_empty pexp_attributes))
             "(" ")"
             ( hvbox 0
                 ( fmt_exception ~pre:(fmt "let exception@ ") c (fmt ": ")
@@ -1790,7 +1787,7 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
       in
       hvbox 0
         ( wrap_if
-            (parens || (not (List.is_empty pexp_attributes)))
+            (parens || not (List.is_empty pexp_attributes))
             "(" ")"
             ( hvbox 2
                 ( fmt_module c keyword name xargs (Some xbody) true xmty []
@@ -2304,7 +2301,7 @@ and fmt_class_expr c ?eol ?(box = true) ({ast= exp} as xexp) =
     $ list_fl
         (List.group a1N ~break:(fun (_, a1) (_, a2) ->
              (not (is_simple c.conf width (sub_exp ~ctx a1)))
-             || (not (is_simple c.conf width (sub_exp ~ctx a2))) ))
+             || not (is_simple c.conf width (sub_exp ~ctx a2)) ))
         (fun ~first:first_grp ~last:last_grp args ->
           list_pn args (fun ?prev (lbl, arg) ?next ->
               let ({ast} as xarg) = sub_exp ~ctx arg in
@@ -2909,7 +2906,7 @@ and fmt_module_type c ({ast= mty} as xmty) =
       }
   | Pmty_signature s ->
       let empty =
-        List.is_empty s && (not (Cmts.has_within c.cmts pmty_loc))
+        List.is_empty s && not (Cmts.has_within c.cmts pmty_loc)
       in
       let doc, atrs = doc_atrs pmty_attributes in
       let before = Cmts.fmt_before c.cmts pmty_loc in
@@ -3030,7 +3027,7 @@ and fmt_signature c ctx itms =
           | Psig_module {pmd_type= {pmty_desc= Pmty_alias _}} -> true
           | _ -> false
         in
-        (not (is_simple itmI)) || (not (is_simple itmJ)) )
+        (not (is_simple itmI)) || not (is_simple itmJ) )
   in
   let fmt_grp itms =
     list itms "@\n" (fun (i, c) ->
@@ -3495,7 +3492,7 @@ and fmt_module_expr c ({ast= m} as xmod) =
             $ fmt_attributes c ~pre:(fmt " ") ~key:"@" atrs ) }
   | Pmod_structure sis ->
       let empty =
-        List.is_empty sis && (not (Cmts.has_within c.cmts pmod_loc))
+        List.is_empty sis && not (Cmts.has_within c.cmts pmod_loc)
       in
       let doc, atrs = doc_atrs pmod_attributes in
       let before = Cmts.fmt_before c.cmts pmod_loc in
@@ -3642,7 +3639,7 @@ and fmt_structure c ctx itms =
         in
         has_doc itmI || has_doc itmJ
         || (not (is_simple itmI))
-        || (not (is_simple itmJ)) )
+        || not (is_simple itmJ) )
   in
   let fmt_grp ~last:last_grp itms =
     list_fl itms (fun ~first ~last (itm, c) ->

--- a/src/Source.ml
+++ b/src/Source.ml
@@ -135,7 +135,7 @@ let tokens_between t ?(filter = fun _ -> true) ~(from : Location.t)
 let contains_IN_token_between t ~(from : Location.t) ~(upto : Location.t) =
   let filter = function Parser.IN -> true | _ -> false in
   Source_code_position.ascending from.loc_start upto.loc_start < 0
-  && (not (List.is_empty (tokens_between t ~from ~upto ~filter)))
+  && not (List.is_empty (tokens_between t ~from ~upto ~filter))
 
 let is_long_pexp_open source {Parsetree.pexp_desc} =
   match pexp_desc with

--- a/test/passing/infix_precedence.ml
+++ b/test/passing/infix_precedence.ml
@@ -7,6 +7,6 @@ let dolore_tempor_in_duis duis_esse esse =
               Qui.Occaecat.Enim.do_commodo_dolore esse_magna
           | _ -> false ))
      && Occaecat.sed_aliqua duis_esse <> PariAtur.Aliquip
-     && (not
-           (Adipisicing.magna_tempor_ipsum_elit_nisi duis_esse
-              Adipisicing.loremipSumDolorsi)) )
+     && not
+          (Adipisicing.magna_tempor_ipsum_elit_nisi duis_esse
+             Adipisicing.loremipSumDolorsi) )


### PR DESCRIPTION
refines https://github.com/ocaml-ppx/ocamlformat/pull/275