### PR TITLE
Fix: comments attachment

### DIFF
--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -79,3 +79,9 @@ end
 let _ = f ~f:(fun a b -> c) (* comment *) ~f:(fun a b -> c)
 let _ = f (fun x -> g h) (* comment *) ~f:(fun a b -> c)
 let _ = f (g h) (* comment *) ~f:(fun a b -> c)
+
+
+
+let _ = f ((0 + 0) (* test *) + (1 * 1) (* test *))
+
+let _ = f ((1 * 1) (* test *) + (0 + 0) (* test *))

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -75,3 +75,7 @@ module type M = sig
     -> int
 
 end
+
+let _ = f ~f:(fun a b -> c) (* comment *) ~f:(fun a b -> c)
+let _ = f (fun x -> g h) (* comment *) ~f:(fun a b -> c)
+let _ = f (g h) (* comment *) ~f:(fun a b -> c)

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -73,3 +73,9 @@ match x with
 module type M = sig
   val f (* A list of [name], [count] pairs. *) : (string * int) list -> int
 end
+
+let _ = f ~f:(fun a b -> c) (* comment *) ~f:(fun a b -> c)
+
+let _ = f (fun x -> g h) (* comment *) ~f:(fun a b -> c)
+
+let _ = f (g h) (* comment *) ~f:(fun a b -> c)

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -79,3 +79,7 @@ let _ = f ~f:(fun a b -> c) (* comment *) ~f:(fun a b -> c)
 let _ = f (fun x -> g h) (* comment *) ~f:(fun a b -> c)
 
 let _ = f (g h) (* comment *) ~f:(fun a b -> c)
+
+let _ = f (0 + 0 (* test *) + (1 * 1) (* test *))
+
+let _ = f ((1 * 1) (* test *) + (0 + 0) (* test *))

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -1401,7 +1401,8 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
            (fun (type c) ->
              ( function Thd, Noarg -> `Nil | Ttl Thd, v -> `Cons v
                : (noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist )
-             (* One can also write the type annotation directly *) ) })
+             )
+           (* One can also write the type annotation directly *) })
 
 let v = variantize Enil (ty_list Int) (`Cons (1, `Cons (2, `Nil)))
 


### PR DESCRIPTION
```
let _ = f ~f:(fun a b -> c) (* comment *) ~f:(fun a b -> c)
```
would previously become
```
let _ = f ~f:(fun a b -> c (* comment *)) ~f:(fun a b -> c)
```

and 
```
let _ = f (0 + (1 * 1) (* test *))
```
would previously become
```
let _ = f (0 + (1 * 1 (* test *)))
```