### PR TITLE
Alternative formatting for string literals

### DIFF
--- a/src/Literal_lexer.mli
+++ b/src/Literal_lexer.mli
@@ -9,6 +9,6 @@
  *                                                                    *
  **********************************************************************)
 
-val string : [`Normalize_nl | `Preserve] -> Caml.Lexing.lexbuf -> string
+val string : [`Normalize | `Preserve] -> Caml.Lexing.lexbuf -> string
 
 val char : Caml.Lexing.lexbuf -> string

--- a/src/Literal_lexer.mll
+++ b/src/Literal_lexer.mll
@@ -40,12 +40,22 @@ and string_aux mode = parse
       { () }
   | '\\' newline ([' ' '\t'] *)
       { string_aux mode lexbuf }
-  | '\\' ['\\' '\'' '\"' 't' 'b' 'r' ' ']
+  | '\\' ['\\' '\'' '\"' 't' 'b' 'r']
       { store_string (Lexing.lexeme lexbuf);
+        string_aux mode lexbuf }
+  | "\\ "
+      { begin match mode with
+          | `Normalize -> store_string " "
+          | `Preserve -> store_string "\\ " end;
+        string_aux mode lexbuf }
+  | "\t"
+      { begin match mode with
+          | `Normalize -> store_string "\\t"
+          | `Preserve -> store_string "\t" end;
         string_aux mode lexbuf }
   | "\\n"
       { begin match mode with
-          | `Normalize_nl -> store_string "\n"
+          | `Normalize -> store_string "\n"
           | `Preserve -> store_string "\\n" end;
         string_aux mode lexbuf }
   | '\\' ['0'-'9'] ['0'-'9'] ['0'-'9']

--- a/src/Source.mli
+++ b/src/Source.mli
@@ -19,8 +19,7 @@ val string_between : t -> Location.t -> Location.t -> string option
 
 val string_at : t -> Location.t -> string
 
-val string_literal :
-  t -> [`Normalize_nl | `Preserve] -> Location.t -> string
+val string_literal : t -> [`Normalize | `Preserve] -> Location.t -> string
 
 val char_literal : t -> Location.t -> string
 

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -243,8 +243,8 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
         input_file
   | Unstable i ->
       Format.eprintf
-        "%s: Cannot process %S.\n  \
-         Please report this bug at \
+        "%s: Cannot process %S.\n\
+        \  Please report this bug at \
          https://github.com/ocaml-ppx/ocamlformat/issues.\n\
          %!"
         exe input_file ;
@@ -252,8 +252,8 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
         "  BUG: formatting did not stabilize after %i iterations.\n%!" i
   | Ocamlformat_bug exn -> (
       Format.eprintf
-        "%s: Cannot process %S.\n  \
-         Please report this bug at \
+        "%s: Cannot process %S.\n\
+        \  Please report this bug at \
          https://github.com/ocaml-ppx/ocamlformat/issues.\n\
          %!"
         exe input_file ;

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -3667,7 +3667,7 @@ let rec eval : lexpr -> _ = function
 let rec print = function
   | `Var id -> print_string id
   | `Abs (id, l) ->
-      print_string ("\ " ^ id ^ " . ") ;
+      print_string (" " ^ id ^ " . ") ;
       print l
   | `App (l1, l2) -> print l1 ; print_string " " ; print l2
   | `Num x -> print_int x
@@ -3885,7 +3885,7 @@ let lexpr = lazy_fix (new lexpr_ops)
 let rec print = function
   | `Var id -> print_string id
   | `Abs (id, l) ->
-      print_string ("\ " ^ id ^ " . ") ;
+      print_string (" " ^ id ^ " . ") ;
       print l
   | `App (l1, l2) -> print l1 ; print_string " " ; print l2
   | `Num x -> print_int x
@@ -4093,7 +4093,7 @@ let lexpr = lazy_fix lexpr_ops
 let rec print = function
   | `Var id -> print_string id
   | `Abs (id, l) ->
-      print_string ("\ " ^ id ^ " . ") ;
+      print_string (" " ^ id ^ " . ") ;
       print l
   | `App (l1, l2) -> print l1 ; print_string " " ; print l2
   | `Num x -> print_int x

--- a/test/passing/string.ml
+++ b/test/passing/string.ml
@@ -15,9 +15,19 @@ let _ =
    cccccccccccccccccc\n	\
    "
 
+let _ =
+  "aaaaaaaaaaaaaaaaaaaaaaaaa\n \
+   bbbbbbbbbbbbbbbbbbbbbbbbbb\n \
+   cccccccccccccccccc\n \
+   "
+
 let _ = ('\xff', '\255', '\n')
 
 let f = function '\xff'..'\255' -> ()
 
 
 let f ("test" [@test "test"]) = 2
+
+;;
+"@\n \
+ xxxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxx xxxxxxxx xxxxxxxxxxx"

--- a/test/passing/string.ml.ref
+++ b/test/passing/string.ml.ref
@@ -9,13 +9,24 @@ let f = function
 let _ = "\010\xFFa\o123\n\\\u{12345}aa🐪🐪🐪🐪🐪\n"
 
 let _ =
-  "aaaaaaaaaaaaaaaaaaaaaaaaa\n	\
-   bbbbbbbbbbbbbbbbbbbbbbbbbb\n	\
-   cccccccccccccccccc\n	\
-   "
+  "aaaaaaaaaaaaaaaaaaaaaaaaa\n\
+   \tbbbbbbbbbbbbbbbbbbbbbbbbbb\n\
+   \tcccccccccccccccccc\n\
+   \t"
+
+let _ =
+  "aaaaaaaaaaaaaaaaaaaaaaaaa\n\
+  \ bbbbbbbbbbbbbbbbbbbbbbbbbb\n\
+  \ cccccccccccccccccc\n\
+  \ "
 
 let _ = ('\xff', '\255', '\n')
 
 let f = function '\xff' .. '\255' -> ()
 
 let f ("test"[@test "test"]) = 2
+
+;;
+"@\n\
+\ xxxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxx \
+ xxxxxxxx xxxxxxxxxxx"


### PR DESCRIPTION
This new formatting aims at preserving the visual aspect of new lines and leading whitespaces.
For examples,
```
          "File %S, line %d:\n  \
           Warning: Using deprecated ocamlformat config syntax.\n\
```
would become 
```
          "File %S, line %d:\n
          \  Warning: Using deprecated ocamlformat config syntax.\n"
```