### PR TITLE
Improve: Support reading file from stdin

### DIFF
--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -674,7 +674,7 @@ let inputs =
   in
   let doc =
     "Input files. At least one is required, and exactly one without \
-     --inplace. If - is passed, will read from stdin."
+     $(b,--inplace). If $(b,-) is passed, will read from stdin."
   in
   let default = [] in
   mk ~default
@@ -894,11 +894,6 @@ type 'a input = {kind: 'a; name: string; file: string; conf: t}
 type action =
   | In_out of [`Impl | `Intf | `Use_file] input * string option
   | Inplace of [`Impl | `Intf | `Use_file] input list
-  | Stdin of
-      { kind: [`Impl | `Intf | `Use_file]
-      ; name: string
-      ; conf: t
-      ; output_file: string option }
 
 let kind_of fname =
   match Filename.extension fname with
@@ -921,17 +916,6 @@ let action =
            ; conf= build_config ~filename:file } ))
   else
     match !inputs with
-    | ["-"] ->
-        let name =
-          match !name with
-          | None -> impossible "checked by validate"
-          | Some name -> name
-        in
-        Stdin
-          { kind= kind_of name
-          ; name
-          ; conf= build_config ~filename:name
-          ; output_file= !output }
     | [input_file] ->
         let name = Option.value !name ~default:input_file in
         In_out

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -930,7 +930,7 @@ let action =
         Stdin
           { kind= kind_of name
           ; name
-          ; conf= read_config ~filename:name config
+          ; conf= build_config ~filename:name
           ; output_file= !output }
     | [input_file] ->
         let name = Option.value !name ~default:input_file in

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -45,14 +45,19 @@ type t =
   ; wrap_comments: bool  (** Wrap comments at margin. *)
   ; wrap_fun_args: bool }
 
-type 'a input =
-  {kind: 'a; name: string; file: [`Tmp | `Input] * string; conf: t}
+type 'a input = {kind: 'a; name: string; file: string; conf: t}
 
 type action =
   | In_out of [`Impl | `Intf | `Use_file] input * string option
       (** Format input file of given kind to output file, or stdout if None. *)
   | Inplace of [`Impl | `Intf | `Use_file] input list
       (** Format in-place, overwriting input file(s). *)
+  | Stdin of
+      { kind: [`Impl | `Intf | `Use_file]
+      ; name: string
+      ; conf: t
+      ; output_file: string option }
+      (** Format stdin of given kind to an output file, or stdout if None. *)
 
 val action : action
 (** Formatting action: input type and source, and output destination. *)

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -45,7 +45,8 @@ type t =
   ; wrap_comments: bool  (** Wrap comments at margin. *)
   ; wrap_fun_args: bool }
 
-type 'a input = {kind: 'a; name: string; file: string; conf: t}
+type 'a input =
+  {kind: 'a; name: string; file: [`Tmp | `Input] * string; conf: t}
 
 type action =
   | In_out of [`Impl | `Intf | `Use_file] input * string option

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -49,15 +49,10 @@ type 'a input = {kind: 'a; name: string; file: string; conf: t}
 
 type action =
   | In_out of [`Impl | `Intf | `Use_file] input * string option
-      (** Format input file of given kind to output file, or stdout if None. *)
+      (** Format input file (or [-] for stdin) of given kind to output file,
+          or stdout if None. *)
   | Inplace of [`Impl | `Intf | `Use_file] input list
       (** Format in-place, overwriting input file(s). *)
-  | Stdin of
-      { kind: [`Impl | `Intf | `Use_file]
-      ; name: string
-      ; conf: t
-      ; output_file: string option }
-      (** Format stdin of given kind to an output file, or stdout if None. *)
 
 val action : action
 (** Formatting action: input type and source, and output destination. *)

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -142,8 +142,7 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
           Out_channel.output_string stdout fmted ;
           Unix.unlink tmp ;
           Ok
-      | In_out _, Some ofile | Stdin _, Some ofile ->
-          Unix.rename tmp ofile ; Ok
+      | In_out _, Some ofile -> Unix.rename tmp ofile ; Ok
       | Inplace _, Some ofile when i > 1 -> Unix.rename tmp ofile ; Ok
       | Inplace _, Some _ -> Unix.unlink tmp ; Ok )
     else
@@ -206,7 +205,7 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
     | _ when conf.disable ->
         ( match (Conf.action, ofile) with
         | _, None -> Out_channel.output_string stdout source_txt
-        | In_out _, Some ofile | Stdin _, Some ofile ->
+        | In_out _, Some ofile ->
             Out_channel.write_all ofile ~data:source_txt
         | Inplace _, _ -> () ) ;
         Ok

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -142,7 +142,8 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
           Out_channel.output_string stdout fmted ;
           Unix.unlink tmp ;
           Ok
-      | In_out _, Some ofile -> Unix.rename tmp ofile ; Ok
+      | In_out _, Some ofile | Stdin _, Some ofile ->
+          Unix.rename tmp ofile ; Ok
       | Inplace _, Some ofile when i > 1 -> Unix.rename tmp ofile ; Ok
       | Inplace _, Some _ -> Unix.unlink tmp ; Ok )
     else
@@ -205,7 +206,7 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
     | _ when conf.disable ->
         ( match (Conf.action, ofile) with
         | _, None -> Out_channel.output_string stdout source_txt
-        | In_out _, Some ofile ->
+        | In_out _, Some ofile | Stdin _, Some ofile ->
             Out_channel.write_all ofile ~data:source_txt
         | Inplace _, _ -> () ) ;
         Ok

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -78,11 +78,12 @@ match Conf.action with
           | Unstable _ | Ocamlformat_bug _ | Invalid_source _ -> false )
     then Caml.exit 0
     else Caml.exit 1
-| Stdin
-    { kind= (`Impl | `Intf | `Use_file) as kind
-    ; name= input_name
-    ; conf
-    ; output_file } -> (
+| In_out
+    ( { kind= (`Impl | `Intf | `Use_file) as kind
+      ; file= "-"
+      ; name= input_name
+      ; conf }
+    , output_file ) -> (
     let file, oc =
       Filename.open_temp_file "ocamlformat" (Filename.basename input_name)
     in

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -66,7 +66,7 @@ match Conf.action with
 | Inplace inputs ->
     let results : Translation_unit.result list =
       List.map inputs
-        ~f:(fun {Conf.kind; name= input_name; file= input_file; conf} ->
+        ~f:(fun {Conf.kind; name= input_name; file= _, input_file; conf} ->
           In_channel.with_file input_file ~f:(fun ic ->
               Translation_unit.parse_print (xunit_of_kind kind) conf
                 ~input_name ~input_file ic (Some input_file) ) )
@@ -84,10 +84,17 @@ match Conf.action with
       ; name= input_name
       ; conf }
     , output_file ) -> (
-  match
-    In_channel.with_file input_file ~f:(fun ic ->
-        Translation_unit.parse_print (xunit_of_kind kind) conf ~input_name
-          ~input_file ic output_file )
-  with
-  | Ok -> Caml.exit 0
-  | Unstable _ | Ocamlformat_bug _ | Invalid_source _ -> Caml.exit 1 )
+    let after, input_file =
+      match input_file with
+      | `Tmp, tmp_file -> ((fun () -> Caml.Sys.remove tmp_file), tmp_file)
+      | `Input, input_file -> (Fn.id, input_file)
+    in
+    let result =
+      In_channel.with_file input_file ~f:(fun ic ->
+          Translation_unit.parse_print (xunit_of_kind kind) conf ~input_name
+            ~input_file ic output_file )
+    in
+    after () ;
+    match result with
+    | Ok -> Caml.exit 0
+    | Unstable _ | Ocamlformat_bug _ | Invalid_source _ -> Caml.exit 1 )

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -90,11 +90,13 @@ match Conf.action with
         Out_channel.output_string oc s ;
         Out_channel.newline oc ) ;
     Out_channel.close oc ;
-    match
+    let result =
       In_channel.with_file file ~f:(fun ic ->
           Translation_unit.parse_print (xunit_of_kind kind) conf ~input_name
             ~input_file:file ic output_file )
-    with
+    in
+    Unix.unlink file ;
+    match result with
     | Ok -> Caml.exit 0
     | Unstable _ | Ocamlformat_bug _ | Invalid_source _ -> Caml.exit 1 )
 | In_out

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -86,7 +86,7 @@ match Conf.action with
     , output_file ) -> (
     let after, input_file =
       match input_file with
-      | `Tmp, tmp_file -> ((fun () -> Caml.Sys.remove tmp_file), tmp_file)
+      | `Tmp, tmp_file -> ((fun () -> Unix.unlink tmp_file), tmp_file)
       | `Input, input_file -> (Fn.id, input_file)
     in
     let result =

--- a/src/ocamlformat_reason.ml
+++ b/src/ocamlformat_reason.ml
@@ -41,18 +41,11 @@ let xunit_of_kind : _ -> Translation_unit.x = function
 ;;
 match Conf.action with
 | In_out
-    ( { kind= (`Impl | `Intf) as kind
-      ; name= input_name
-      ; file= input_file
-      ; conf }
+    ( {kind= (`Impl | `Intf) as kind; file= "-"; name= input_name; conf}
     , output_file ) ->
-    Translation_unit.parse_print (xunit_of_kind kind) conf ~input_name
-      ~input_file In_channel.stdin output_file
 | In_out ({kind= `Use_file}, _) ->
-    user_error "Cannot convert toplevel Reason file" []
+    user_error "Cannot convert Reason code with --use-file" []
 | Inplace _ -> user_error "Cannot convert Reason code with --inplace" []
-| Stdin {kind= (`Impl | `Intf) as kind; name= input_name; conf; output_file}
-  ->
     let file, oc =
       Filename.open_temp_file "ocamlformat" (Filename.basename input_name)
     in
@@ -66,3 +59,11 @@ match Conf.action with
             ~input_file:file ic output_file )
     in
     Unix.unlink file ; result
+| In_out
+    ( { kind= (`Impl | `Intf) as kind
+      ; name= input_name
+      ; file= input_file
+      ; conf }
+    , output_file ) ->
+    Translation_unit.parse_print (xunit_of_kind kind) conf ~input_name
+      ~input_file In_channel.stdin output_file

--- a/src/ocamlformat_reason.ml
+++ b/src/ocamlformat_reason.ml
@@ -43,9 +43,6 @@ match Conf.action with
 | In_out
     ( {kind= (`Impl | `Intf) as kind; file= "-"; name= input_name; conf}
     , output_file ) ->
-| In_out ({kind= `Use_file}, _) ->
-    user_error "Cannot convert Reason code with --use-file" []
-| Inplace _ -> user_error "Cannot convert Reason code with --inplace" []
     let file, oc =
       Filename.open_temp_file "ocamlformat" (Filename.basename input_name)
     in
@@ -59,6 +56,9 @@ match Conf.action with
             ~input_file:file ic output_file )
     in
     Unix.unlink file ; result
+| In_out ({kind= `Use_file; _}, _) ->
+    user_error "Cannot convert Reason code with --use-file" []
+| Inplace _ -> user_error "Cannot convert Reason code with --inplace" []
 | In_out
     ( { kind= (`Impl | `Intf) as kind
       ; name= input_name

--- a/src/ocamlformat_reason.ml
+++ b/src/ocamlformat_reason.ml
@@ -43,7 +43,7 @@ match Conf.action with
 | In_out
     ( { kind= (`Impl | `Intf) as kind
       ; name= input_name
-      ; file= _, input_file
+      ; file= input_file
       ; conf }
     , output_file ) ->
     Translation_unit.parse_print (xunit_of_kind kind) conf ~input_name
@@ -51,3 +51,18 @@ match Conf.action with
 | In_out ({kind= `Use_file}, _) ->
     user_error "Cannot convert toplevel Reason file" []
 | Inplace _ -> user_error "Cannot convert Reason code with --inplace" []
+| Stdin {kind= (`Impl | `Intf) as kind; name= input_name; conf; output_file}
+  ->
+    let file, oc =
+      Filename.open_temp_file "ocamlformat" (Filename.basename input_name)
+    in
+    In_channel.iter_lines stdin ~f:(fun s ->
+        Out_channel.output_string oc s ;
+        Out_channel.newline oc ) ;
+    Out_channel.close oc ;
+    let result =
+      In_channel.with_file file ~f:(fun ic ->
+          Translation_unit.parse_print (xunit_of_kind kind) conf ~input_name
+            ~input_file:file ic output_file )
+    in
+    Unix.unlink file ; result

--- a/src/ocamlformat_reason.ml
+++ b/src/ocamlformat_reason.ml
@@ -43,7 +43,7 @@ match Conf.action with
 | In_out
     ( { kind= (`Impl | `Intf) as kind
       ; name= input_name
-      ; file= input_file
+      ; file= _, input_file
       ; conf }
     , output_file ) ->
     Translation_unit.parse_print (xunit_of_kind kind) conf ~input_name


### PR DESCRIPTION
Hi! Great project! I have a somewhat strange OCaml dev environment, and ocamlformat not supporting stdin input files was causing me problems.

I made small changes to support this new feature:
1. SRC files list can be empty (if so, go to read from stdin mode)
2. If so, you must pass a name (so we know if it's Impl, Intf, etc)
3. In the stdin case, I make a tmp file and mark it to be cleaned up after we're done

I was able to reuse the existing action variants, but I had to change the type of the `file` field in the record slightly. Let me know if you think this should be done some other way! Thanks!