### PR TITLE
Improve: main loop and error reporting

### DIFF
--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -820,11 +820,12 @@ let parse_line config ~from s =
     | [name; value], `File (filename, lnum) ->
         (* tolerate space separated [var value] to compatibility with older
            config file format *)
-        Format.eprintf
-          "File %S, line %d:\n\
-           Warning: Using deprecated ocamlformat config syntax.\n\
-           Please use `%s = %s`\n"
-          filename lnum name value ;
+        if not config.quiet then
+          Format.eprintf
+            "File %S, line %d:\n\
+             Warning: Using deprecated ocamlformat config syntax.\n\
+             Please use `%s = %s`\n"
+            filename lnum name value ;
         update ~config ~from ~name ~value
     (* special case for disable/enable *)
     | ["enable"], _ -> update ~config ~from ~name:"disable" ~value:"false"

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -85,7 +85,8 @@ let update_config c l =
               Format.sprintf "Invalid value for %s: %S" name value
         in
         let w = Warnings.Attribute_payload (txt, reason error) in
-        !Location.warning_printer loc Caml.Format.err_formatter w ;
+        if not c.conf.quiet then
+          !Location.warning_printer loc Caml.Format.err_formatter w ;
         c
   in
   List.fold ~init:c l ~f:update_one

--- a/test/passing/error4.ml.ref
+++ b/test/passing/error4.ml.ref
@@ -2,8 +2,6 @@ File "passing/error4.ml", line 2, characters 0-13:
 Warning 50: ambiguous documentation comment
 File "passing/error4.ml", line 3, characters 8-16:
 Warning 50: unattached documentation comment (ignored)
-File "passing/error4.ml", line 5, characters 8-16:
-Warning 50: unattached documentation comment (ignored)
 (** a or b *)
 let a = ()
 

--- a/test/passing/option.ml.ref
+++ b/test/passing/option.ml.ref
@@ -13,21 +13,6 @@ Invalid value for if-then-else: "bad"
 File "passing/option.ml", line 39, characters 14-25:
 Warning 47: illegal payload for attribute 'ocamlformat'.
 Invalid value for if-then-else: "bad"
-File "passing/option.ml", line 63, characters 4-15:
-Warning 47: illegal payload for attribute 'ocamlformat'.
-margin not allowed here
-File "passing/option.ml", line 8, characters 5-21:
-Warning 47: illegal payload for attribute 'ocamlformat.typo'.
-Invalid format "unknown suffix \"typo\""
-File "passing/option.ml", line 14, characters 5-16:
-Warning 47: illegal payload for attribute 'ocamlformat'.
-Invalid format "string expected"
-File "passing/option.ml", line 20, characters 5-16:
-Warning 47: illegal payload for attribute 'ocamlformat'.
-Invalid value for if-then-else: "bad"
-File "passing/option.ml", line 29, characters 7-18:
-Warning 47: illegal payload for attribute 'ocamlformat'.
-Invalid value for if-then-else: "bad"
 let[@ocamlformat "if-then-else=keyword-first"] _ =
   if b
   then e


### PR DESCRIPTION
- do not print warnings in quiet mode
- do not print warnings after the first iteration but in debug mode (a regular user should not care about warnings triggered while trying to reach a fix-point)  
- do not override input_name after the first iteration so that one get meaningful location in debug mode.  
- report different error/bug when doc comments are moved and when ast has changed.