### PR TITLE
Improve: disable ocamlformat if no dot ocamlformat in the project

### DIFF
--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -219,6 +219,7 @@ function."
                    ocamlformat-command nil (list :file errorfile) nil
                    (append margin-args
                      (list
+                       "--inside-project-only"
                        "--name" buffer-file-name
                        "--output" outputfile bufferfile))))
              (progn

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -219,7 +219,6 @@ function."
                    ocamlformat-command nil (list :file errorfile) nil
                    (append margin-args
                      (list
-                       "--inside-project-only"
                        "--name" buffer-file-name
                        "--output" outputfile bufferfile))))
              (progn

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -183,6 +183,9 @@ OPTIONS
        --impl
            Parse file with unrecognized extension as an implementation.
 
+       --inside-project-only
+           TODO
+
        --intf
            Parse file with unrecognized extension as an interface.
 

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -184,7 +184,8 @@ OPTIONS
            Parse file with unrecognized extension as an implementation.
 
        --inside-project-only
-           TODO
+           Do not read .ocamlformat config files outside the project. If no
+           config file is found, disable ocamlformat.
 
        --intf
            Parse file with unrecognized extension as an interface.

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -222,6 +222,9 @@ OPTIONS
        --use-file
            Parse file with unrecognized extension as a use_file.
 
+       --verbose
+           Print config
+
        --version
            Show version information.
 

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -216,14 +216,14 @@ OPTIONS
            configuration. default sets each option to its default value.
            janestreet is the profile used at JaneStreet. 
 
+       --print-config
+           Print config
+
        -q, --quiet
            Quiet. May be set in .ocamlformat.
 
        --use-file
            Parse file with unrecognized extension as a use_file.
-
-       --verbose
-           Print config
 
        --version
            Show version information.

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -169,6 +169,12 @@ OPTIONS
            Aggregate options. Options are specified as a comma-separated list
            of pairs: option=VAL,...,option=VAL.
 
+       --disable-outside-project
+           Do not read .ocamlformat config files outside the current project.
+           The project root of an input file is taken to be the nearest
+           ancestor directory that contains a .git or .hg or dune-project
+           file. If no config file is found, formatting is disabled.
+
        -g, --debug
            Generate debugging output.
 
@@ -182,10 +188,6 @@ OPTIONS
 
        --impl
            Parse file with unrecognized extension as an implementation.
-
-       --inside-project-only
-           Do not read .ocamlformat config files outside the project. If no
-           config file is found, disable ocamlformat.
 
        --intf
            Parse file with unrecognized extension as an interface.

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -832,7 +832,7 @@ let output =
       & info ["o"; "output"] ~doc ~docs ~docv)
 
 let print_config =
-  let doc = "Print config" in
+  let doc = "Print config." in
   let default = false in
   mk ~default Arg.(value & flag & info ["print-config"] ~doc ~docs)
 

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -292,10 +292,10 @@ end = struct
           if inline && not allow_inline then
             Some (Error (`Misplaced (name, value)))
           else
-            match update config (parse value) with
-            | config ->
+            match parse value with
+            | packed_value ->
                 if verbose then log_update ~from ~name ~value ;
-                Some (Ok config)
+                Some (Ok (update config packed_value))
             | exception _ -> Some (Error (`Bad_value (name, value)))
         else None )
     |> Option.value ~default:(Error (`Unknown (name, value)))
@@ -725,7 +725,7 @@ let comment_check =
       {conf with comment_check= x} )
 
 let disable_outside_project =
-  let withness =
+  let witness =
     String.concat ~sep:" or "
       (List.map project_root_witness ~f:(fun name ->
            Format.sprintf "$(b,%s)" name ))
@@ -736,7 +736,7 @@ let disable_outside_project =
        project. The project root of an input file is taken to be the \
        nearest ancestor directory that contains a %s file. If no config \
        file is found, formatting is disabled."
-      withness
+      witness
   in
   let default = false in
   mk ~default
@@ -1104,8 +1104,8 @@ let build_config ~filename =
       in
       Format.eprintf
         "File %S:@\n\
-         Warning: Ocamlformat disabled because [--inside-project-only] was \
-         given and %s@\n\
+         Warning: Ocamlformat disabled because [--disable-outside-project] \
+         was given and %s@\n\
          %!"
         filename reason ) ;
     {conf with disable= true} )

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -764,7 +764,10 @@ let inputs =
     Arg.(value & pos_all file_or_dash default & info [] ~doc ~docv ~docs)
 
 let inside_project_only =
-  let doc = "TODO" in
+  let doc =
+    "Do not read .ocamlformat config files outside the project. If no \
+     config file is found, disable ocamlformat."
+  in
   let default = false in
   mk ~default Arg.(value & flag & info ["inside-project-only"] ~doc ~docs)
 

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -310,7 +310,7 @@ end = struct
       | Some x ->
           let config = update config x in
           if verbose then
-            log_update ~from:`Config ~name ~value:(to_string x) ;
+            log_update ~from:`Commandline ~name ~value:(to_string x) ;
           config
     in
     List.fold !store ~init:config ~f:on_pack

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -115,10 +115,12 @@ module C : sig
 
   val default : 'a t -> 'a
 
-  val update_using_cmdline : config -> config
+  val update_using_cmdline : config -> verbose:bool -> config
 
   val update :
        config:config
+    -> verbose:bool
+    -> from:[`File of string * int | `Config | `Commandline | `Attribute]
     -> name:string
     -> value:string
     -> inline:bool
@@ -137,6 +139,7 @@ end = struct
     ; update: config -> 'a -> config
     ; allow_inline: bool
     ; cmdline_get: unit -> 'a option
+    ; to_string: 'a -> string
     ; default: 'a }
 
   type 'a option_decl =
@@ -199,6 +202,10 @@ end = struct
     in
     let docv = generated_choice_docv ~all in
     let opt_names = List.map all ~f:(fun (x, y, _) -> (x, y)) in
+    let to_string v' =
+      List.find_map_exn all ~f:(fun (str, v, _) ->
+          if Poly.equal v v' then Some str else None )
+    in
     let docs = section_name section in
     let term =
       Arg.(
@@ -219,7 +226,9 @@ end = struct
     in
     let r = mk ~default:None term in
     let cmdline_get () = !r in
-    let opt = {names; parse; update; cmdline_get; allow_inline; default} in
+    let opt =
+      {names; parse; update; cmdline_get; allow_inline; default; to_string}
+    in
     store := Pack opt :: !store ;
     opt
 
@@ -238,8 +247,11 @@ end = struct
     let term = Arg.(value & flag & info names_for_cmdline ~doc ~docs) in
     let parse = Bool.of_string in
     let r = mk ~default term in
+    let to_string = Bool.to_string in
     let cmdline_get () = if !r then Some (not invert_flag) else None in
-    let opt = {names; parse; update; cmdline_get; allow_inline; default} in
+    let opt =
+      {names; parse; update; cmdline_get; allow_inline; default; to_string}
+    in
     store := Pack opt :: !store ;
     opt
 
@@ -253,30 +265,55 @@ end = struct
     in
     let parse = Int.of_string in
     let r = mk ~default:None term in
+    let to_string = Int.to_string in
     let cmdline_get () = !r in
-    let opt = {names; parse; update; cmdline_get; allow_inline; default} in
+    let opt =
+      {names; parse; update; cmdline_get; allow_inline; default; to_string}
+    in
     store := Pack opt :: !store ;
     opt
 
-  let update ~config ~name ~value ~inline =
+  let log_update ~from ~name ~value =
+    match from with
+    | `Attribute -> ()
+    | (`File _ | `Config | `Commandline) as from ->
+        let from =
+          match from with
+          | `File (file, lnum) -> Format.sprintf " (%s:%d)" file lnum
+          | `Config -> " (Environment variable or --config)"
+          | `Commandline -> " (command line)"
+        in
+        Format.eprintf "%s=%s%s\n%!" name value from
+
+  let update ~config ~verbose ~from ~name ~value ~inline =
     List.find_map !store
       ~f:(fun (Pack {names; parse; update; allow_inline}) ->
         if List.exists names ~f:(String.equal name) then
           if inline && not allow_inline then
             Some (Error (`Misplaced (name, value)))
           else
-            try Some (Ok (update config (parse value))) with _ ->
-              Some (Error (`Bad_value (name, value)))
+            try
+              let config = update config (parse value) in
+              if verbose then log_update ~from ~name ~value ;
+              Some (Ok config)
+            with _ -> Some (Error (`Bad_value (name, value)))
         else None )
     |> Option.value ~default:(Error (`Unknown (name, value)))
 
   let default {default} = default
 
-  let update_using_cmdline conf =
-    let on_pack conf (Pack {cmdline_get; update}) =
-      match cmdline_get () with None -> conf | Some x -> update conf x
+  let update_using_cmdline config ~verbose =
+    let on_pack config (Pack {names; cmdline_get; update; to_string}) =
+      let name = List.hd_exn names in
+      match cmdline_get () with
+      | None -> config
+      | Some x ->
+          let config = update config x in
+          if verbose then
+            log_update ~from:`Config ~name ~value:(to_string x) ;
+          config
     in
-    List.fold !store ~init:conf ~f:on_pack
+    List.fold !store ~init:config ~f:on_pack
 end
 
 let info =
@@ -726,6 +763,11 @@ let inputs =
   mk ~default
     Arg.(value & pos_all file_or_dash default & info [] ~doc ~docv ~docs)
 
+let inside_project_only =
+  let doc = "TODO" in
+  let default = false in
+  mk ~default Arg.(value & flag & info ["inside-project-only"] ~doc ~docs)
+
 let kind : [`Impl | `Intf | `Use_file] ref =
   let doc =
     "Parse file with unrecognized extension as an implementation."
@@ -764,17 +806,17 @@ let output =
       & opt (some string) default
       & info ["o"; "output"] ~doc ~docs ~docv)
 
+let print_config =
+  let doc = "Print config" in
+  let default = false in
+  mk ~default Arg.(value & flag & info ["verbose"] ~doc ~docs)
+
 let no_version_check =
   let doc =
     "Do no check version matches the one specified in .ocamlformat."
   in
   let default = false in
   mk ~default Arg.(value & flag & info ["no-version-check"] ~doc ~docs)
-
-let inside_project_only =
-  let doc = "TODO" in
-  let default = false in
-  mk ~default Arg.(value & flag & info ["inside-project-only"] ~doc ~docs)
 
 let config =
   let doc =
@@ -846,7 +888,7 @@ let janestreet_profile =
   ; wrap_fun_args= false
   ; module_item_spacing= `Compact }
 
-let _profile =
+let (_profile : t option C.t) =
   let doc =
     "Preset profiles which set $(i,all) options, overriding lower priority \
      configuration."
@@ -880,7 +922,7 @@ let validate () =
 ;;
 parse info validate
 
-let parse_line config ~from s =
+let parse_line config ~verbose ~from s =
   let update ~config ~from ~name ~value =
     let name = String.strip name in
     let value = String.strip value in
@@ -889,8 +931,10 @@ let parse_line config ~from s =
         if String.equal Version.version value || !no_version_check then
           Ok config
         else Error (`Bad_value (value, name))
-    | name, `File _ -> C.update ~config ~name ~value ~inline:false
-    | name, `Attribute -> C.update ~config ~name ~value ~inline:true
+    | name, (`File _ | `Config | `Commandline) ->
+        C.update ~config ~verbose ~from ~name ~value ~inline:false
+    | name, `Attribute ->
+        C.update ~config ~verbose ~from ~name ~value ~inline:true
   in
   let s =
     match String.index s '#' with
@@ -934,20 +978,23 @@ let rec collect_files ~dir acc =
     let filename = Filename.concat dir ".ocamlformat" in
     if Caml.Sys.file_exists filename then filename :: acc else acc
   in
-  if is_project_root dir && !inside_project_only then acc
+  if is_project_root dir && !inside_project_only then (acc, Some dir)
   else
     let dir' = Filename.dirname dir in
     if (not (String.equal dir dir')) && Caml.Sys.file_exists dir then
       collect_files ~dir:dir' acc
-    else acc
+    else if !inside_project_only then ([], None)
+    else (acc, None)
 
-let read_config_file conf filename =
+let read_config_file ~verbose conf filename =
   try
     In_channel.with_file filename ~f:(fun ic ->
         let c, errors, _ =
           In_channel.fold_lines ic ~init:(conf, [], 1)
             ~f:(fun (conf, errors, num) line ->
-              match parse_line conf ~from:(`File (filename, num)) line with
+              match
+                parse_line conf ~verbose ~from:(`File (filename, num)) line
+              with
               | Ok conf -> (conf, errors, Int.succ num)
               | Error e -> (conf, e :: errors, Int.succ num) )
         in
@@ -969,9 +1016,11 @@ let read_config_file conf filename =
 let to_absolute file =
   Filename.(if is_relative file then concat (Unix.getcwd ()) file else file)
 
-let update_using_env conf =
+let update_using_env ~verbose conf =
   let f (config, errors) (name, value) =
-    match C.update ~config ~name ~value ~inline:false with
+    match
+      C.update ~config ~verbose ~from:`Config ~name ~value ~inline:false
+    with
     | Ok c -> (c, errors)
     | Error e -> (config, e :: errors)
   in
@@ -1003,28 +1052,48 @@ let kind_of fname =
   | ".mlt" -> `Use_file
   | _ -> !kind
 
-let update_using_xdg =
+let xdg_config =
   match Caml.Sys.getenv_opt "XDG_CONFIG_HOME" with
   | Some xdg_config_home ->
       let filename =
         Filename.concat xdg_config_home "ocamlformat/.ocamlformat"
       in
-      Staged.stage (fun conf -> read_config_file conf filename)
-  | None -> Staged.stage (fun conf -> conf)
+      if Caml.Sys.file_exists filename then Some filename else None
+  | None -> None
 
 let build_config ~filename =
-  let files =
+  let files, project_root =
     collect_files ~dir:(Filename.dirname (to_absolute filename)) []
   in
-  if !inside_project_only && List.is_empty files then
-    {default with disable= true}
-  else
-    let read_config_files conf =
-      List.fold files ~init:conf ~f:read_config_file
-    in
-    default
-    |> Staged.unstage update_using_xdg
-    |> read_config_files |> update_using_env |> C.update_using_cmdline
+  let files =
+    match (xdg_config, !inside_project_only) with
+    | None, _ | Some _, true -> files
+    | Some f, false -> f :: files
+  in
+  let verbose = !print_config in
+  let conf =
+    List.fold files ~init:default ~f:(read_config_file ~verbose)
+    |> update_using_env ~verbose
+    |> C.update_using_cmdline ~verbose
+  in
+  if !inside_project_only && List.is_empty files then (
+    ( if not conf.quiet then
+      let reason =
+        match project_root with
+        | Some root ->
+            Printf.sprintf
+              "no [.ocamlformat] was found within the project (root: %s)"
+              root
+        | None -> "no project root was found"
+      in
+      Format.eprintf
+        "File %S:\n\
+         Warning: Ocamlformat disabled because [--inside-project-only] was \
+         given and %s\n\
+         %!"
+        filename reason ) ;
+    {conf with disable= true} )
+  else conf
 
 let action =
   if !inplace then
@@ -1048,4 +1117,4 @@ let action =
 
 and debug = !debug
 
-let parse_line_in_attribute = parse_line ~from:`Attribute
+let parse_line_in_attribute = parse_line ~from:`Attribute ~verbose:false

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -221,8 +221,8 @@ end = struct
       | Some v -> Ok v
       | None ->
           Error
-            (Printf.sprintf "Invalid value %S, expecting %s" s
-               ( List.map all ~f:(fun (s, _, _) -> s)
+            (Printf.sprintf "Invalid value '%s', expecting %s" s
+               ( List.map all ~f:(fun (s, _, _) -> Format.sprintf "'%s'" s)
                |> String.concat ~sep:" or " ))
     in
     let r = mk ~default:None term in
@@ -249,7 +249,8 @@ end = struct
     let parse s =
       try Ok (Bool.of_string s) with _ ->
         Error
-          (Format.sprintf "invalid value %S, expecting 'true' or 'false'" s)
+          (Format.sprintf "invalid value '%s', expecting 'true' or 'false'"
+             s)
     in
     let r = mk ~default term in
     let to_string = Bool.to_string in
@@ -270,7 +271,7 @@ end = struct
     in
     let parse s =
       try Ok (Int.of_string s) with _ ->
-        Error (Format.sprintf "invalid value %S, expecting an integer" s)
+        Error (Format.sprintf "invalid value '%s', expecting an integer" s)
     in
     let r = mk ~default:None term in
     let to_string = Int.to_string in

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -809,7 +809,7 @@ let output =
 let print_config =
   let doc = "Print config" in
   let default = false in
-  mk ~default Arg.(value & flag & info ["verbose"] ~doc ~docs)
+  mk ~default Arg.(value & flag & info ["print-config"] ~doc ~docs)
 
 let no_version_check =
   let doc =
@@ -1071,6 +1071,8 @@ let build_config ~filename =
     | Some f, false -> f :: files
   in
   let verbose = !print_config in
+  if verbose then
+    Option.iter project_root ~f:(Format.eprintf "project-root=%s\n%!") ;
   let conf =
     List.fold files ~init:default ~f:(read_config_file ~verbose)
     |> update_using_env ~verbose

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -28,8 +28,8 @@ type t =
   ; indicate_nested_or_patterns: bool
   ; infix_precedence: [`Indent | `Parens]
   ; leading_nested_match_parens: bool
-  ; let_binding_spacing: [`Compact | `Sparse | `Double_semicolon]
   ; let_and: [`Compact | `Sparse]
+  ; let_binding_spacing: [`Compact | `Sparse | `Double_semicolon]
   ; let_open: [`Preserve | `Auto | `Short | `Long]
   ; margin: int
   ; max_iters: int

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -31,8 +31,8 @@ type t =
   ; indicate_nested_or_patterns: bool
   ; infix_precedence: [`Indent | `Parens]
   ; leading_nested_match_parens: bool
-  ; let_binding_spacing: [`Compact | `Sparse | `Double_semicolon]
   ; let_and: [`Compact | `Sparse]
+  ; let_binding_spacing: [`Compact | `Sparse | `Double_semicolon]
   ; let_open: [`Preserve | `Auto | `Short | `Long]
   ; margin: int  (** Format code to fit within [margin] columns. *)
   ; max_iters: int

--- a/test/passing/option.ml.ref
+++ b/test/passing/option.ml.ref
@@ -9,10 +9,10 @@ Warning 47: illegal payload for attribute 'ocamlformat'.
 Invalid format "string expected"
 File "passing/option.ml", line 28, characters 3-14:
 Warning 47: illegal payload for attribute 'ocamlformat'.
-Invalid value for if-then-else: "bad"
+Invalid value for if-then-else: "Invalid value 'bad', expecting 'compact' or 'keyword-first'"
 File "passing/option.ml", line 39, characters 14-25:
 Warning 47: illegal payload for attribute 'ocamlformat'.
-Invalid value for if-then-else: "bad"
+Invalid value for if-then-else: "Invalid value 'bad', expecting 'compact' or 'keyword-first'"
 let[@ocamlformat "if-then-else=keyword-first"] _ =
   if b
   then e

--- a/test/passing/verbose1.ml.opts
+++ b/test/passing/verbose1.ml.opts
@@ -1,0 +1,1 @@
+--print-config --doc-comments=before --config="doc-comments=before"

--- a/test/passing/verbose1.ml.ref
+++ b/test/passing/verbose1.ml.ref
@@ -1,4 +1,3 @@
-margin=90 (/home/hugo/.ocamlformat:6)
 margin=77 ({CWD}/.ocamlformat:1)
 wrap-comments=true ({CWD}/.ocamlformat:2)
 doc-comments=before (Environment variable or --config)

--- a/test/passing/verbose1.ml.ref
+++ b/test/passing/verbose1.ml.ref
@@ -1,6 +1,6 @@
 margin=90 (/home/hugo/.ocamlformat:6)
-margin=77 (/home/hugo/l/ocamlformat/.ocamlformat:1)
-wrap-comments=true (/home/hugo/l/ocamlformat/.ocamlformat:2)
+margin=77 ({CWD}/.ocamlformat:1)
+wrap-comments=true ({CWD}/.ocamlformat:2)
 doc-comments=before (Environment variable or --config)
 doc-comments=before (Environment variable or --config)
 

--- a/test/passing/verbose1.ml.ref
+++ b/test/passing/verbose1.ml.ref
@@ -1,0 +1,6 @@
+margin=90 (/home/hugo/.ocamlformat:6)
+margin=77 (/home/hugo/l/ocamlformat/.ocamlformat:1)
+wrap-comments=true (/home/hugo/l/ocamlformat/.ocamlformat:2)
+doc-comments=before (Environment variable or --config)
+doc-comments=before (Environment variable or --config)
+

--- a/test/passing/verbose1.ml.ref
+++ b/test/passing/verbose1.ml.ref
@@ -1,5 +1,5 @@
 margin=77 ({CWD}/.ocamlformat:1)
 wrap-comments=true ({CWD}/.ocamlformat:2)
 doc-comments=before (Environment variable or --config)
-doc-comments=before (Environment variable or --config)
+doc-comments=before (command line)
 

--- a/test/passing/verbose2.ml.opts
+++ b/test/passing/verbose2.ml.opts
@@ -1,1 +1,1 @@
---inside-project-only --print-config --doc-comments=before --config="doc-comments=before"
+--disable-outside-project --print-config --doc-comments=before --config="doc-comments=before"

--- a/test/passing/verbose2.ml.opts
+++ b/test/passing/verbose2.ml.opts
@@ -1,0 +1,1 @@
+--inside-project-only --print-config --doc-comments=before --config="doc-comments=before"

--- a/test/passing/verbose2.ml.ref
+++ b/test/passing/verbose2.ml.ref
@@ -1,0 +1,6 @@
+project-root=/home/hugo/l/ocamlformat
+margin=77 (/home/hugo/l/ocamlformat/.ocamlformat:1)
+wrap-comments=true (/home/hugo/l/ocamlformat/.ocamlformat:2)
+doc-comments=before (Environment variable or --config)
+doc-comments=before (Environment variable or --config)
+

--- a/test/passing/verbose2.ml.ref
+++ b/test/passing/verbose2.ml.ref
@@ -2,5 +2,5 @@ project-root={CWD}
 margin=77 ({CWD}/.ocamlformat:1)
 wrap-comments=true ({CWD}/.ocamlformat:2)
 doc-comments=before (Environment variable or --config)
-doc-comments=before (Environment variable or --config)
+doc-comments=before (command line)
 

--- a/test/passing/verbose2.ml.ref
+++ b/test/passing/verbose2.ml.ref
@@ -1,6 +1,6 @@
-project-root=/home/hugo/l/ocamlformat
-margin=77 (/home/hugo/l/ocamlformat/.ocamlformat:1)
-wrap-comments=true (/home/hugo/l/ocamlformat/.ocamlformat:2)
+project-root={CWD}
+margin=77 ({CWD}/.ocamlformat:1)
+wrap-comments=true ({CWD}/.ocamlformat:2)
 doc-comments=before (Environment variable or --config)
 doc-comments=before (Environment variable or --config)
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -87,12 +87,13 @@ done
 
 TMP=$(mktemp -d /tmp/ocamlformat-test.XXXXX)
 trap "rm -rf /tmp/ocamlformat-${TMP#/tmp/ocamlformat-}" EXIT
+CWD=$(dirname $(pwd))
 
 ocamlformat() {
     [ $# -eq 1 ]
     opts=$(cat $1.opts 2>/dev/null || true)
     tmpfile=$TMP/$(basename $1)
-    OCAMLFORMAT=max-iters=2 bash -c "(\"$OCAMLFORMAT\" $opts \"$1\" || true) 2>&1" > $tmpfile
+    OCAMLFORMAT=max-iter=2 bash -c "(\"$OCAMLFORMAT\" $opts \"$1\" || true) 2>&1" | sed "s#${CWD}#{CWD}#" > $tmpfile
 }
 
 reffile() {

--- a/test/test.sh
+++ b/test/test.sh
@@ -93,7 +93,7 @@ ocamlformat() {
     [ $# -eq 1 ]
     opts=$(cat $1.opts 2>/dev/null || true)
     tmpfile=$TMP/$(basename $1)
-    OCAMLFORMAT=max-iter=2 bash -c "(\"$OCAMLFORMAT\" $opts \"$1\" || true) 2>&1" | sed "s#${CWD}#{CWD}#" > $tmpfile
+    OCAMLFORMAT=max-iters=2 bash -c "(\"$OCAMLFORMAT\" $opts \"$1\" || true) 2>&1" | sed "s#${CWD}#{CWD}#" > $tmpfile
 }
 
 reffile() {


### PR DESCRIPTION
The PR adds a way to not reformat files that live in a "project" that doesn't contain a `.ocamlformat` file.