### PR TITLE
Improve: Better error with location when comment dropped

### DIFF
--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -563,7 +563,9 @@ let remaining_comments t =
     Hashtbl.to_alist t
     |> List.concat_map ~f:(fun (ast_loc, cmts) ->
            List.map cmts ~f:(fun (cmt_txt, cmt_loc) ->
-               ( before_after
+               ( cmt_loc
+               , cmt_txt
+               , before_after
                , let open Sexp in
                  List
                    [ List [Atom "ast_loc"; Location.sexp_of_t ast_loc]

--- a/src/Cmts.mli
+++ b/src/Cmts.mli
@@ -119,7 +119,7 @@ val has_within : t -> Location.t -> bool
 val has_after : t -> Location.t -> bool
 (** [has_after t loc] holds if [t] contains some comment after [loc]. *)
 
-val remaining_comments : t -> (string * Sexp.t) list
+val remaining_comments : t -> (Location.t * string * string * Sexp.t) list
 (** Returns comments that have not been formatted yet. *)
 
 val diff :


### PR DESCRIPTION
Should improve the situation for issue #17 
Though raising an error only gives information about the first dropped comment, maybe it is better to use warnings and have a message about all dropped comments?