### PR TITLE
Improve: option 'parens-ite'

### DIFF
--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -154,6 +154,10 @@ OPTIONS (CODE FORMATTING STYLE)
            Attempt to generate output which does not change (much) when
            post-processing with ocp-indent.
 
+       --parens-ite
+           Uses parentheses around if-then-else branches that spread across
+           multiple lines.
+
        --parens-tuple={always|multi-line-only}
            Parens tuples. always always uses parentheses around tuples.
            multi-line-only mode will try to skip parens for single-line

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -1953,7 +1953,8 @@ end = struct
     in
     let rec ifthenelse pexp_desc =
       match pexp_desc with
-      | Pexp_extension (_, PStr [{pstr_desc= Pstr_eval (e, _)}]) ->
+      | Pexp_extension (ext, PStr [{pstr_desc= Pstr_eval (e, _)}])
+        when Source.extension_using_sugar ~name:ext ~payload:e ->
           ifthenelse e.pexp_desc
       | Pexp_let _ | Pexp_match _ | Pexp_try _ -> true
       | _ -> false

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -38,6 +38,7 @@ type t =
   ; max_iters: int
   ; module_item_spacing: [`Compact | `Sparse]
   ; ocp_indent_compat: bool
+  ; parens_ite: bool
   ; parens_tuple: [`Always | `Multi_line_only]
   ; quiet: bool
   ; sequence_style: [`Separator | `Terminator]
@@ -814,6 +815,16 @@ module Formatting = struct
       (fun conf x -> {conf with ocp_indent_compat= x})
       (fun conf -> conf.ocp_indent_compat)
 
+  let parens_ite =
+    let doc =
+      "Uses parentheses around if-then-else branches that spread across \
+       multiple lines."
+    in
+    let names = ["parens-ite"] in
+    C.flag ~default:false ~names ~doc ~section
+      (fun conf x -> {conf with parens_ite= x})
+      (fun conf -> conf.parens_ite)
+
   let parens_tuple =
     let doc = "Parens tuples." in
     let names = ["parens-tuple"] in
@@ -1118,6 +1129,7 @@ let default_profile =
   ; max_iters= C.default max_iters
   ; module_item_spacing= C.default Formatting.module_item_spacing
   ; ocp_indent_compat= C.default Formatting.ocp_indent_compat
+  ; parens_ite= C.default Formatting.parens_ite
   ; parens_tuple= C.default Formatting.parens_tuple
   ; quiet= C.default quiet
   ; sequence_style= C.default Formatting.sequence_style
@@ -1187,6 +1199,7 @@ let janestreet_profile =
   ; max_iters= default_profile.max_iters
   ; module_item_spacing= `Compact
   ; ocp_indent_compat= false
+  ; parens_ite= true
   ; parens_tuple= `Multi_line_only
   ; quiet= default_profile.quiet
   ; sequence_style= `Terminator

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -43,6 +43,7 @@ type t =
             [max_iters] iterations. *)
   ; module_item_spacing: [`Compact | `Sparse]
   ; ocp_indent_compat: bool  (** Try to indent like ocp-indent *)
+  ; parens_ite: bool
   ; parens_tuple: [`Always | `Multi_line_only]
   ; quiet: bool
   ; sequence_style: [`Separator | `Terminator]

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -1716,14 +1716,14 @@ let rec ins : type n. int -> n avl -> (n avl, n succ avl) sum =
     if x = y
     then Inl t
     else if x < y
-    then
+    then (
       match ins x a with
       | Inl a -> Inl (Node (bal, a, y, b))
       | Inr a ->
         (match bal with
         | Less -> Inl (Node (Same, a, y, b))
         | Same -> Inr (Node (More, a, y, b))
-        | More -> rotr a y b)
+        | More -> rotr a y b) )
     else (
       match ins x b with
       | Inl b -> Inl (Node (bal, a, y, b) : n avl)
@@ -1760,7 +1760,7 @@ let rec del : type n. int -> n avl -> n avl_del =
   | Leaf -> Dsame Leaf
   | Node (bal, l, x, r) ->
     if x = y
-    then
+    then (
       match r with
       | Leaf -> (match bal with Same -> Ddecr (Eq, l) | More -> Ddecr (Eq, l))
       | Node _ ->
@@ -1769,16 +1769,16 @@ let rec del : type n. int -> n avl -> n avl_del =
         | Same, (z, Inl r) -> Dsame (Node (More, l, z, r))
         | Less, (z, Inl r) -> Ddecr (Eq, Node (Same, l, z, r))
         | More, (z, Inl r) ->
-          (match rotr l z r with Inl t -> Ddecr (Eq, t) | Inr t -> Dsame t))
+          (match rotr l z r with Inl t -> Ddecr (Eq, t) | Inr t -> Dsame t)) )
     else if y < x
-    then
+    then (
       match del y l with
       | Dsame l -> Dsame (Node (bal, l, x, r))
       | Ddecr (Eq, l) ->
         (match bal with
         | Same -> Dsame (Node (Less, l, x, r))
         | More -> Ddecr (Eq, Node (Same, l, x, r))
-        | Less -> (match rotl l x r with Inl t -> Ddecr (Eq, t) | Inr t -> Dsame t))
+        | Less -> (match rotl l x r with Inl t -> Ddecr (Eq, t) | Inr t -> Dsame t)) )
     else (
       match del y r with
       | Dsame r -> Dsame (Node (bal, l, x, r))
@@ -1929,8 +1929,8 @@ let rec assoc : type a. string -> a rep -> assoc list -> a =
   | [] -> raise Not_found
   | Assoc (x', r', v) :: env ->
     if x = x'
-    then
-      match rep_equal r r' with None -> failwith ("Wrong type for " ^ x) | Some Eq -> v
+    then (
+      match rep_equal r r' with None -> failwith ("Wrong type for " ^ x) | Some Eq -> v )
     else assoc x r env
 ;;
 
@@ -3487,9 +3487,9 @@ let subst_lambda ~subst_rec ~free ~subst : _ lambda -> _ = function
           if Names.mem s used then data :: acc else acc )
     in
     if List.exists used_expr ~f:(fun t -> Names.mem s (free t))
-    then
+    then (
       let name = s ^ string_of_int (next_id ()) in
-      `Abs (name, subst_rec ~subst:(Subst.add ~key:s ~data:(`Var name) subst) t)
+      `Abs (name, subst_rec ~subst:(Subst.add ~key:s ~data:(`Var name) subst) t) )
     else map_lambda ~map_rec:(subst_rec ~subst:(Subst.remove s subst)) l
   | `App _ as l -> map_lambda ~map_rec:(subst_rec ~subst) l
 ;;
@@ -3724,9 +3724,9 @@ class ['a] lambda_ops (ops : ('a, 'a) #ops Lazy.t) =
               if Names.mem s used then data :: acc else acc )
         in
         if List.exists used_expr ~f:(fun t -> Names.mem s (!!free t))
-        then
+        then (
           let name = s ^ string_of_int (next_id ()) in
-          `Abs (name, !!subst ~sub:(Subst.add ~key:s ~data:(`Var name) sub) t)
+          `Abs (name, !!subst ~sub:(Subst.add ~key:s ~data:(`Var name) sub) t) )
         else self#map ~f:(!!subst ~sub:(Subst.remove s sub)) l
       | `App _ as l -> self#map ~f:(!!subst ~sub) l
 
@@ -3956,9 +3956,9 @@ let lambda_ops (ops : ('a, 'a) #ops Lazy.t) =
               if Names.mem s used then data :: acc else acc )
         in
         if List.exists used_expr ~f:(fun t -> Names.mem s (!!free t))
-        then
+        then (
           let name = s ^ string_of_int (next_id ()) in
-          `Abs (name, !!subst ~sub:(Subst.add ~key:s ~data:(`Var name) sub) t)
+          `Abs (name, !!subst ~sub:(Subst.add ~key:s ~data:(`Var name) sub) t) )
         else self#map ~f:(!!subst ~sub:(Subst.remove s sub)) l
       | `App _ as l -> self#map ~f:(!!subst ~sub) l
 
@@ -6075,10 +6075,10 @@ class virtual ['a, 'cursor] storage_base =
         let rec loop count a =
           if count >= self#len
           then a
-          else
+          else (
             let a' = f cur#get count a in
             cur#incr ();
-            loop (count + 1) a'
+            loop (count + 1) a' )
         in
         loop 0 a0
 
@@ -6152,13 +6152,13 @@ module UText = struct
   let init_buf buf pos init =
     if init#len = 0
     then ()
-    else
+    else (
       let cur = init#first in
       for i = 0 to init#len - 2 do
         set_buf buf (pos + (i lsl 2)) cur#get;
         cur#incr ()
       done;
-      set_buf buf (pos + ((init#len - 1) lsl 2)) cur#get
+      set_buf buf (pos + ((init#len - 1) lsl 2)) cur#get )
   ;;
 
   let make_buf init =

--- a/test/passing/print_config.ml.ref
+++ b/test/passing/print_config.ml.ref
@@ -7,6 +7,7 @@ wrap-comments=true (file ../.ocamlformat:2)
 type-decl=compact
 sequence-style=separator
 parens-tuple=always
+parens-ite=false
 ocp-indent-compat=false
 module-item-spacing=sparse (file passing/dir1/dir2/.ocamlformat:1)
 margin=77 (file ../.ocamlformat:1)

--- a/test/passing/verbose1.ml.ref
+++ b/test/passing/verbose1.ml.ref
@@ -7,6 +7,7 @@ wrap-comments=true (file ../.ocamlformat:2)
 type-decl=compact
 sequence-style=separator
 parens-tuple=always
+parens-ite=false
 ocp-indent-compat=false
 module-item-spacing=sparse
 margin=77 (file ../.ocamlformat:1)

--- a/test/passing/verbose2.ml.ref
+++ b/test/passing/verbose2.ml.ref
@@ -7,6 +7,7 @@ wrap-comments=true (file ../.ocamlformat:2)
 type-decl=compact
 sequence-style=separator
 parens-tuple=always
+parens-ite=false
 ocp-indent-compat=false
 module-item-spacing=sparse
 margin=77 (file ../.ocamlformat:1)


### PR DESCRIPTION
From JS fork (https://github.com/janestreet/ocamlformat/commit/0f0289d6fc36177655fb7d21c41c7d55bc700364)
PR open for discussion.
For the moment the option is not used, to read options from Ast.parenze_exp would require to rewrite a big part of the code, is that really what we want?
We could also adopt this new behavior as default.