### PR TITLE
Don't execute shell scripts directly in build

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -9,7 +9,7 @@ let preprocess =
 (rule
  (targets Version.ml)
  (deps (universe))
- (action (run ../tools/gen_version.sh Version.ml))
+ (action (run sh %%{dep:../tools/gen_version.sh} Version.ml))
  (mode fallback))
 
 (ocamllex (modules Literal_lexer))


### PR DESCRIPTION
Windows Dune doesn't (yet) understand `#!` scripts. It may well do around the same as opam 2.1 gains the same ability... in the meantime, it's now called via sh (the `%{dep:...}` addition is necessary since Dune only adds dependencies on the first argument of `(run`)

While I'm not averse to CLAs - this is a tiny change, if it really requires a CLA, would someone who's already signed one be so kind as to remark this commit as their own?