### PR TITLE
Improve: shorter output of regtests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Once OCamlFormat has been built, run `make test` to check for regressions.
 
 The first step of `make test` is to ensure that invoking OCamlFormat on its own source code produces the same source code (you can run `make fixpoint` to only check this). If OCamlFormat is not integrated with the editor you use, you should run `make fmt` to reformat all OCamlFormat source files.
 
-The second part of `make test` is to ensure the test suite passes, the test report is displayed in the terminal and you should only get `[PASSED]` (in green) and `[FAILED]` (in orange). You should not get any result in red nor any `[REGRESSION]`.
+The second part of `make test` is to ensure the test suite passes, the test report is displayed in the terminal and you should only get `[FAILED] [BASELINE]` (in orange) results. You should not get any result in red nor any `[REGRESSION]`.
 
 ## Contributor License Agreement ("CLA")
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -155,7 +155,7 @@ for f in ${FAILING[@]}; do
         cp $TMP/$base failing-output/
         if [ -n "$GIT" ]; then $GIT add failing-output/$base; fi
     elif diff -q $TMP/$base failing-output/$base >/dev/null; then
-        printf "\e[33m[FAILED] [LEGACY]\e[m      %s\n" $name
+        printf "\e[33m[FAILED] [BASELINE]\e[m    %s\n" $name
         if [ -n "$GIT" ] && ! is_file_on_git failing-output/$base; then
             $GIT add failing-output/$base; fi
     else

--- a/test/test.sh
+++ b/test/test.sh
@@ -155,7 +155,7 @@ for f in ${FAILING[@]}; do
         cp $TMP/$base failing-output/
         if [ -n "$GIT" ]; then $GIT add failing-output/$base; fi
     elif diff -q $TMP/$base failing-output/$base >/dev/null; then
-        printf "\e[33m[FAILED]\e[m               %s\n" $name
+        printf "\e[33m[FAILED] [LEGACY]\e[m      %s\n" $name
         if [ -n "$GIT" ] && ! is_file_on_git failing-output/$base; then
             $GIT add failing-output/$base; fi
     else

--- a/test/test.sh
+++ b/test/test.sh
@@ -119,13 +119,11 @@ CHANGES=()
 for f in ${PASSING[@]}; do
     base=$(basename $f)
     name=${base%.*}
-    printf "%-12s\t\t[RUNNING]\n" $name
+    printf "[RUNNING]              %s\n" $name
     ocamlformat $f
-    if diff -q "$(reffile "$f")" $TMP/$base >/dev/null; then
-        printf "\033[1A\033[2K"
-    else
-        printf "\033[1A\033[2K"
-        printf "%-12s\t\t\e[31m[FAILED]\e[m \e[41m\e[30m[REGRESSION]\e[m\n" $name
+    printf "\033[1A\033[2K"
+    if ! diff -q "$(reffile "$f")" $TMP/$base >/dev/null; then
+        printf "\e[31m[FAILED]\e[m \e[41m\e[30m[REGRESSION]\e[m  %s\n" $name
         if [ -n "$ACCEPT" ]; then
 	    cp $TMP/$base "$(reffile "$f")"
         elif [ -n "$UPDATE" ]; then
@@ -143,19 +141,21 @@ done
 for f in ${FAILING[@]}; do
     base=$(basename $f)
     name=${base%.*}
+    printf "[RUNNING]              %s\n" $name
     ocamlformat $f
+    printf "\033[1A\033[2K"
     if diff -q $(reffile $f) $TMP/$base >/dev/null; then
-        printf "%-12s\t\e[32m[PASSED]\e[m \e[42m\e[30m[PROGRESSION]\e[m\n" $name
+        printf "\e[32m[PASSED]\e[m \e[42m\e[30m[PROGRESSION]\e[m %s\n" $name
         if [ -n "$UPDATE" ]; then
             $GIT mv -f $f* passing/
             $GIT rm -f failing-output/$base
         fi
     elif [ ! -e failing-output/$base ]; then
-        printf "%-12s\t\e[33m[FAILED]\e[m \e[43m\e[30m[NEW]\e[m\n" $name
+        printf "\e[33m[FAILED]\e[m \e[43m\e[30m[NEW]\e[m         %s\n" $name
         cp $TMP/$base failing-output/
         if [ -n "$GIT" ]; then $GIT add failing-output/$base; fi
     elif diff -q $TMP/$base failing-output/$base >/dev/null; then
-        printf "%-12s\t\e[33m[FAILED]\e[m\n" $name
+        printf "\e[33m[FAILED]\e[m               %s\n" $name
         if [ -n "$GIT" ] && ! is_file_on_git failing-output/$base; then
             $GIT add failing-output/$base; fi
     else
@@ -166,7 +166,7 @@ for f in ${FAILING[@]}; do
             $(reffile $f) $TMP/$base \
             |wc -l)
         progress=$((refcount - curcount))
-        printf "%-12s\t\e[33m[FAILED]\e[m \e[%dm\e[30m[CHANGE: %+d]\e[m\n" \
+        printf "\e[33m[FAILED]\e[m \e[%dm\e[30m[CHANGE: %+d]\e[m %s\n" \
             $name \
             $(if [ $progress -gt 0 ]; then echo 42; \
               elif [ $progress -eq 0 ]; then echo 43; \

--- a/test/test.sh
+++ b/test/test.sh
@@ -119,10 +119,12 @@ CHANGES=()
 for f in ${PASSING[@]}; do
     base=$(basename $f)
     name=${base%.*}
+    printf "%-12s\t\t[RUNNING]\n" $name
     ocamlformat $f
     if diff -q "$(reffile "$f")" $TMP/$base >/dev/null; then
-        printf "%-12s\t\t\e[32m[PASSED]\e[m\n" $name
+        printf "\033[1A\033[2K"
     else
+        printf "\033[1A\033[2K"
         printf "%-12s\t\t\e[31m[FAILED]\e[m \e[41m\e[30m[REGRESSION]\e[m\n" $name
         if [ -n "$ACCEPT" ]; then
 	    cp $TMP/$base "$(reffile "$f")"


### PR DESCRIPTION
The goal is to flood less the terminal:
- the current test is displayed, until it is completed
- if there is a regression (orange/red), the result sticks
- otherwise, nothing is printed

Let's say some tests are broken, we only see:
```running regtests with ../_build/dev/src/ocamlformat.exe
[FAILED] [REGRESSION]  attributes
[FAILED] [REGRESSION]  comment_in_empty
[FAILED] [REGRESSION]  comment_in_modules
[FAILED] [REGRESSION]  comments
[FAILED] [REGRESSION]  exceptions
[FAILED] [REGRESSION]  first_class_module
[FAILED] [REGRESSION]  functor
[FAILED] [REGRESSION]  js_source
[FAILED] [REGRESSION]  module_type
[FAILED] [REGRESSION]  object
[FAILED] [REGRESSION]  shortcut_ext_attr
[FAILED] [REGRESSION]  skip
[FAILED] [REGRESSION]  source
[FAILED] [REGRESSION]  module_item_spacing
[FAILED] [REGRESSION]  recmod
[FAILED] [LEGACY]      list_and_comments
Makefile:157: recipe for target 'regtests' failed
```