### PR TITLE
Improve: make gen_version.sh more portable

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -12,7 +12,7 @@ Jbuild_plugin.V1.send
 (rule
  (targets Version.ml)
  (deps (universe))
- (action (run bash %%{dep:../tools/gen_version.sh} Version.ml))
+ (action (run sh %%{dep:../tools/gen_version.sh} Version.ml))
  (mode fallback))
 
 (ocamllex Literal_lexer)

--- a/tools/gen_version.sh
+++ b/tools/gen_version.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 ######################################################################
 #                                                                    #
 #                            OCamlFormat                             #
@@ -15,18 +13,19 @@
 
 FILE="$1"
 
-if [[ ! -z "$2" ]]; then
+if test -n "$2"; then
     # second arg passed when called from ocamlformat.opam
     VERSION="$2"
 else
     # second arg omitted when called from src/dune
-    if [[ ! "%%VERSION%%" == "%%"*"%%" ]]; then
-        # file has been watermarked when building distrib archive
-        VERSION="%%VERSION%%"
-    else
-        # file has not been watermarked when building in dev git tree
-        VERSION=$(git describe --tags --dirty --always)
-    fi
+    case "%%VERSION%%" in
+        "%%"*"%%")
+            # file has not been watermarked when building in dev git tree
+            VERSION=$(git describe --tags --dirty --always);;
+        *)
+            # file has been watermarked when building distrib archive
+            VERSION="%%VERSION%%";;
+    esac
 fi
 
 echo "let version = \"$VERSION\"" > $FILE


### PR DESCRIPTION
Should fix issue #470
It should not have a negative impact on the release procedure.