### PR TITLE
[HELP] Fix: Preserve position of comments in match (*cmt*) expr with

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2024,7 +2024,7 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
                    $ fmt_extension_suffix c ext
                    $ fmt_attributes c ~key:"@" pexp_attributes
                    $ fmt "@;<1 2>"
-                   $ fmt_expression ~eol:(fmt "") c (sub_exp ~ctx e0)
+                   $ fmt_expression ~eol:(fmt "@;<1 2>") c (sub_exp ~ctx e0)
                    $ fmt "@ with" )
                $ fmt "@ " $ fmt_cases c ctx cs ))
       | Some {pc_lhs; pc_guard; pc_rhs} ->
@@ -2042,9 +2042,9 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
                    ( str keyword
                    $ fmt_extension_suffix c ext
                    $ fmt_attributes c ~key:"@" pexp_attributes
-                   $ hvbox 0
-                       ( fmt "@;<1 -1>"
-                       $ fmt_expression ~eol:(fmt "") c (sub_exp ~ctx e0) )
+                   $ ( fmt "@;<1 2>"
+                     $ fmt_expression ~eol:(fmt "@;<1 0>") c
+                         (sub_exp ~ctx e0) )
                    $ fmt "@," )
                $ fmt "@;<0 -2>"
                $ hvbox 0

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2017,16 +2017,14 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
       in
       match compact with
       | None ->
-          let leading_cmt = Cmts.fmt_before c.cmts e0.pexp_loc in
           hvbox 0
             (wrap_fits_breaks_if ~space:false c.conf parens "(" ")"
-               ( leading_cmt
-               $ hvbox 0
+               ( hvbox 0
                    ( str keyword
                    $ fmt_extension_suffix c ext
                    $ fmt_attributes c ~key:"@" pexp_attributes
                    $ fmt "@;<1 2>"
-                   $ fmt_expression c (sub_exp ~ctx e0)
+                   $ fmt_expression ~eol:(fmt "") c (sub_exp ~ctx e0)
                    $ fmt "@ with" )
                $ fmt "@ " $ fmt_cases c ctx cs ))
       | Some {pc_lhs; pc_guard; pc_rhs} ->
@@ -2045,7 +2043,8 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
                    $ fmt_extension_suffix c ext
                    $ fmt_attributes c ~key:"@" pexp_attributes
                    $ hvbox 0
-                       (fmt "@;<1 -1>" $ fmt_expression c (sub_exp ~ctx e0))
+                       ( fmt "@;<1 -1>"
+                       $ fmt_expression ~eol:(fmt "") c (sub_exp ~ctx e0) )
                    $ fmt "@," )
                $ fmt "@;<0 -2>"
                $ hvbox 0

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -137,10 +137,12 @@ let () =
   ()
 
 let foo =
+  (* foo *)
   match (* comment about entire pattern matching *)
     e with k -> z
 
 let foo =
+  (* foo *)
   match (* comment about entire pattern matching *)
     e [@foo] with k -> z
 
@@ -157,6 +159,7 @@ let foo =
     e [@foo] with k -> z | fooooooooooooooooooooo -> foooooooooooooooooo
 
 let foo =
+  (* foo *)
   match (* foo *) (* fooooooooooooooo *)
     e (* foo *)  [@foo] with k -> z
  | foooooooooooooooooooo -> fooooooooooooooooo

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -136,21 +136,27 @@ let () =
   (* *)
   ()
 
-;;
-match (* comment about entire pattern matching *)
-      e with k -> z
-;;
-match (* comment about entire pattern matching *)
-      e [@foo] with k -> z
-;;
-match (* foo *) (* fooooooooooooooo *)
-  e (* foo *)  [@foo] with k -> z
-;;
-match (* comment about entire pattern matching *)
-      e with k -> z | foooooooooooooooooooooooooo -> foooooooooooooooooooooo
-;;
-match (* comment about entire pattern matching *)
-      e [@foo] with k -> z | fooooooooooooooooooooo -> foooooooooooooooooo
-;;
-match (* foo *) (* fooooooooooooooo *)
-  e (* foo *)  [@foo] with k -> z | foooooooooooooooooooo -> fooooooooooooooooo
+let foo =
+  match (* comment about entire pattern matching *)
+    e with k -> z
+
+let foo =
+  match (* comment about entire pattern matching *)
+    e [@foo] with k -> z
+
+let foo =
+  match (* foo *) (* fooooooooooooooo *)
+    e (* foo *)  [@foo] with k -> z
+
+let foo =
+  match (* comment about entire pattern matching *)
+    e with k -> z | foooooooooooooooooooooooooo -> foooooooooooooooooooooo
+
+let foo =
+  match (* comment about entire pattern matching *)
+    e [@foo] with k -> z | fooooooooooooooooooooo -> foooooooooooooooooo
+
+let foo =
+  match (* foo *) (* fooooooooooooooo *)
+    e (* foo *)  [@foo] with k -> z
+ | foooooooooooooooooooo -> fooooooooooooooooo

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -135,3 +135,22 @@ let () =
   
   (* *)
   ()
+
+;;
+match (* comment about entire pattern matching *)
+      e with k -> z
+;;
+match (* comment about entire pattern matching *)
+      e [@foo] with k -> z
+;;
+match (* foo *) (* fooooooooooooooo *)
+  e (* foo *)  [@foo] with k -> z
+;;
+match (* comment about entire pattern matching *)
+      e with k -> z | foooooooooooooooooooooooooo -> foooooooooooooooooooooo
+;;
+match (* comment about entire pattern matching *)
+      e [@foo] with k -> z | fooooooooooooooooooooo -> foooooooooooooooooo
+;;
+match (* foo *) (* fooooooooooooooo *)
+  e (* foo *)  [@foo] with k -> z | foooooooooooooooooooo -> fooooooooooooooooo

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -136,6 +136,8 @@ let () =
   (* *)
   ()
 
+let foo = (* foo *) match (* foo *) e with k -> z
+
 let foo =
   (* foo *)
   match (* comment about entire pattern matching *)

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -165,3 +165,9 @@ let foo =
   match (* foo *) (* fooooooooooooooo *)
     e (* foo *)  [@foo] with k -> z
  | foooooooooooooooooooo -> fooooooooooooooooo
+
+let foo =
+  match
+    (* each procedure has different scope: start names from id 0 *)
+    Ident.NameGenerator.reset ()
+  with _ -> x

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -174,6 +174,8 @@ let () =
   (*  *)
   ()
 
+let foo = (* foo *) match (* foo *) e with k -> z
+
 let foo =
   (* foo *)
   match (* comment about entire pattern matching *) e with k -> z

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -174,28 +174,27 @@ let () =
   (*  *)
   ()
 
-;;
-match (* comment about entire pattern matching *) e with k -> z
+let foo = match (* comment about entire pattern matching *) e with k -> z
 
-;;
-match (* comment about entire pattern matching *) (e [@foo]) with k -> z
+let foo =
+  match (* comment about entire pattern matching *) (e [@foo]) with k -> z
 
-;;
-match (* foo *)
-      (* fooooooooooooooo *) (e [@foo]) (* foo *) with k -> z
+let foo =
+  match (* foo *)
+        (* fooooooooooooooo *) (e [@foo]) (* foo *) with k -> z
 
-;;
-match (* comment about entire pattern matching *) e with
-| k -> z
-| foooooooooooooooooooooooooo -> foooooooooooooooooooooo
+let foo =
+  match (* comment about entire pattern matching *) e with
+  | k -> z
+  | foooooooooooooooooooooooooo -> foooooooooooooooooooooo
 
-;;
-match (* comment about entire pattern matching *) (e [@foo]) with
-| k -> z
-| fooooooooooooooooooooo -> foooooooooooooooooo
+let foo =
+  match (* comment about entire pattern matching *) (e [@foo]) with
+  | k -> z
+  | fooooooooooooooooooooo -> foooooooooooooooooo
 
-;;
-match (* foo *)
-      (* fooooooooooooooo *) (e [@foo]) (* foo *) with
-| k -> z
-| foooooooooooooooooooo -> fooooooooooooooooo
+let foo =
+  match (* foo *)
+        (* fooooooooooooooo *) (e [@foo]) (* foo *) with
+  | k -> z
+  | foooooooooooooooooooo -> fooooooooooooooooo

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -173,3 +173,29 @@ let () =
 
   (*  *)
   ()
+
+;;
+match (* comment about entire pattern matching *) e with k -> z
+
+;;
+match (* comment about entire pattern matching *) (e [@foo]) with k -> z
+
+;;
+match (* foo *)
+      (* fooooooooooooooo *) (e [@foo]) (* foo *) with k -> z
+
+;;
+match (* comment about entire pattern matching *) e with
+| k -> z
+| foooooooooooooooooooooooooo -> foooooooooooooooooooooo
+
+;;
+match (* comment about entire pattern matching *) (e [@foo]) with
+| k -> z
+| fooooooooooooooooooooo -> foooooooooooooooooo
+
+;;
+match (* foo *)
+      (* fooooooooooooooo *) (e [@foo]) (* foo *) with
+| k -> z
+| foooooooooooooooooooo -> fooooooooooooooooo

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -174,9 +174,12 @@ let () =
   (*  *)
   ()
 
-let foo = match (* comment about entire pattern matching *) e with k -> z
+let foo =
+  (* foo *)
+  match (* comment about entire pattern matching *) e with k -> z
 
 let foo =
+  (* foo *)
   match (* comment about entire pattern matching *) (e [@foo]) with k -> z
 
 let foo =
@@ -194,6 +197,7 @@ let foo =
   | fooooooooooooooooooooo -> foooooooooooooooooo
 
 let foo =
+  (* foo *)
   match (* foo *)
         (* fooooooooooooooo *) (e [@foo]) (* foo *) with
   | k -> z

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -204,3 +204,9 @@ let foo =
         (* fooooooooooooooo *) (e [@foo]) (* foo *) with
   | k -> z
   | foooooooooooooooooooo -> fooooooooooooooooo
+
+let foo =
+  match
+    (* each procedure has different scope: start names from id 0 *)
+    Ident.NameGenerator.reset ()
+  with _ -> x


### PR DESCRIPTION
Should fix issue #341 