### PR TITLE
Fix: Sanitize docstring check

### DIFF
--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -147,6 +147,9 @@ OPTIONS (CODE FORMATTING STYLE)
            Control whether or not to indicate nested or-pattern using
            indentation.
 
+       --no-parse-docstrings
+           Parse and format docstrings.
+
        --no-wrap-fun-args
            Style for function call and function definition.
 

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -581,18 +581,7 @@ let remaining_comments t =
 
 let diff x y =
   let norm z =
-    let f (txt, _) =
-      match Octavius.parse (Lexing.from_string txt) with
-      | Ok parsed ->
-          Fmt_odoc.fmt parsed Format.str_formatter ;
-          Format.flush_str_formatter ()
-      | Error _ ->
-          (* normalize consecutive whitespace chars to a single space *)
-          String.concat ~sep:" "
-            (List.filter ~f:(Fn.non String.is_empty)
-               (String.split_on_chars txt
-                  ~on:['\t'; '\n'; '\011'; '\012'; '\r'; ' ']))
-    in
+    let f (txt, _) = Normalize.docstring txt in
     Set.of_list
       (module String)
       (List.map ~f (List.dedup_and_sort ~compare:Poly.compare z))

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -579,9 +579,9 @@ let remaining_comments t =
     ; get t.cmts_within "within"
     ; get t.cmts_after "after" ]
 
-let diff x y =
+let diff c x y =
   let norm z =
-    let f (txt, _) = Normalize.docstring txt in
+    let f (txt, _) = Normalize.docstring c txt in
     Set.of_list
       (module String)
       (List.map ~f (List.dedup_and_sort ~compare:Poly.compare z))

--- a/src/Cmts.mli
+++ b/src/Cmts.mli
@@ -123,7 +123,8 @@ val remaining_comments : t -> (Location.t * string * string * Sexp.t) list
 (** Returns comments that have not been formatted yet. *)
 
 val diff :
-     (string * Location.t) list
+     Conf.t
+  -> (string * Location.t) list
   -> (string * Location.t) list
   -> (string, string) Either.t Sequence.t
 (** Difference between two lists of comments. *)

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -39,6 +39,7 @@ type t =
   ; module_item_spacing: [`Compact | `Sparse]
   ; ocp_indent_compat: bool
   ; parens_tuple: [`Always | `Multi_line_only]
+  ; parse_docstrings: bool
   ; quiet: bool
   ; sequence_style: [`Separator | `Terminator]
   ; type_decl: [`Compact | `Sparse]
@@ -830,6 +831,13 @@ module Formatting = struct
       (fun conf x -> {conf with parens_tuple= x})
       (fun conf -> conf.parens_tuple)
 
+  let parse_docstrings =
+    let doc = "Parse and format docstrings." in
+    let names = ["parse-docstrings"] in
+    C.flag ~default:true ~names ~doc ~section
+      (fun conf x -> {conf with parse_docstrings= x})
+      (fun conf -> conf.parse_docstrings)
+
   let sequence_style =
     let doc = "Style of sequence." in
     let names = ["sequence-style"] in
@@ -1119,6 +1127,7 @@ let default_profile =
   ; module_item_spacing= C.default Formatting.module_item_spacing
   ; ocp_indent_compat= C.default Formatting.ocp_indent_compat
   ; parens_tuple= C.default Formatting.parens_tuple
+  ; parse_docstrings= C.default Formatting.parse_docstrings
   ; quiet= C.default quiet
   ; sequence_style= C.default Formatting.sequence_style
   ; type_decl= C.default Formatting.type_decl
@@ -1188,6 +1197,7 @@ let janestreet_profile =
   ; module_item_spacing= `Compact
   ; ocp_indent_compat= false
   ; parens_tuple= `Multi_line_only
+  ; parse_docstrings= true
   ; quiet= default_profile.quiet
   ; sequence_style= `Terminator
   ; type_decl= `Sparse

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -44,6 +44,7 @@ type t =
   ; module_item_spacing: [`Compact | `Sparse]
   ; ocp_indent_compat: bool  (** Try to indent like ocp-indent *)
   ; parens_tuple: [`Always | `Multi_line_only]
+  ; parse_docstrings: bool
   ; quiet: bool
   ; sequence_style: [`Separator | `Terminator]
   ; type_decl: [`Compact | `Sparse]

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -607,7 +607,9 @@ let fmt_docstring c ?(standalone = false) ?pro ?epi doc =
         | _, false -> false
       in
       let try_parse str_cmt =
-        if c.conf.parse_docstrings then (
+        if not c.conf.parse_docstrings then
+          (if c.conf.wrap_comments then fill_text else str) str_cmt
+        else
           match Octavius.parse (Lexing.from_string str_cmt) with
           | Error _ ->
               (if c.conf.wrap_comments then fill_text else str) str_cmt
@@ -623,8 +625,7 @@ let fmt_docstring c ?(standalone = false) ?pro ?epi doc =
               in
               fmt_if (space_i 0) " "
               $ Fmt_odoc.fmt parsed
-              $ fmt_if (space_i (String.length str_cmt - 1)) " " )
-        else (if c.conf.wrap_comments then fill_text else str) str_cmt
+              $ fmt_if (space_i (String.length str_cmt - 1)) " "
       in
       Cmts.fmt c.cmts loc
       @@ vbox_if (Option.is_none pro) 0

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -607,22 +607,24 @@ let fmt_docstring c ?(standalone = false) ?pro ?epi doc =
         | _, false -> false
       in
       let try_parse str_cmt =
-        match Octavius.parse (Lexing.from_string str_cmt) with
-        | Error _ ->
-            (if c.conf.wrap_comments then fill_text else str) str_cmt
-        | Ok parsed ->
-            if Conf.debug then (
-              Octavius.print Caml.Format.str_formatter parsed ;
-              Caml.Format.eprintf "%s%!"
-                (Caml.Format.flush_str_formatter ()) ) ;
-            let space_i i =
-              let spaces = ['\t'; '\n'; '\011'; '\012'; '\r'; ' '] in
-              let is_space = List.mem ~equal:Char.equal spaces in
-              0 <= i && i < String.length str_cmt && is_space str_cmt.[i]
-            in
-            fmt_if (space_i 0) " "
-            $ Fmt_odoc.fmt parsed
-            $ fmt_if (space_i (String.length str_cmt - 1)) " "
+        if c.conf.parse_docstrings then (
+          match Octavius.parse (Lexing.from_string str_cmt) with
+          | Error _ ->
+              (if c.conf.wrap_comments then fill_text else str) str_cmt
+          | Ok parsed ->
+              if Conf.debug then (
+                Octavius.print Caml.Format.str_formatter parsed ;
+                Caml.Format.eprintf "%s%!"
+                  (Caml.Format.flush_str_formatter ()) ) ;
+              let space_i i =
+                let spaces = ['\t'; '\n'; '\011'; '\012'; '\r'; ' '] in
+                let is_space = List.mem ~equal:Char.equal spaces in
+                0 <= i && i < String.length str_cmt && is_space str_cmt.[i]
+              in
+              fmt_if (space_i 0) " "
+              $ Fmt_odoc.fmt parsed
+              $ fmt_if (space_i (String.length str_cmt - 1)) " " )
+        else (if c.conf.wrap_comments then fill_text else str) str_cmt
       in
       Cmts.fmt c.cmts loc
       @@ vbox_if (Option.is_none pro) 0

--- a/src/Normalize.ml
+++ b/src/Normalize.ml
@@ -27,7 +27,7 @@ let docstring c s =
   else
     match Octavius.parse (Lexing.from_string s) with
     | Ok parsed ->
-        Format_.asprintf "%a@!" (fun fs x -> Fmt_odoc.fmt x fs) parsed
+        Format_.asprintf "%a%!" (fun fs x -> Fmt_odoc.fmt x fs) parsed
     | Error _ -> basic_normalize s
 
 let make_mapper c ~ignore_doc_comment =

--- a/src/Normalize.ml
+++ b/src/Normalize.ml
@@ -23,12 +23,12 @@ let docstring c s =
       (List.filter ~f:(Fn.non String.is_empty)
          (String.split_on_chars s ~on:['\t'; '\n'; '\011'; '\012'; '\r'; ' ']))
   in
-  if c.Conf.parse_docstrings then
+  if not c.Conf.parse_docstrings then basic_normalize s
+  else
     match Octavius.parse (Lexing.from_string s) with
     | Ok parsed ->
         Format_.asprintf "%a@!" (fun fs x -> Fmt_odoc.fmt x fs) parsed
     | Error _ -> basic_normalize s
-  else basic_normalize s
 
 let make_mapper c ~ignore_doc_comment =
   (* remove locations *)

--- a/src/Normalize.ml
+++ b/src/Normalize.ml
@@ -19,8 +19,7 @@ open Ast_helper
 let docstring s =
   match Octavius.parse (Lexing.from_string s) with
   | Ok parsed ->
-      Fmt_odoc.fmt parsed Format_.str_formatter ;
-      Format_.flush_str_formatter ()
+      Format_.asprintf "%a@!" (fun fs x -> Fmt_odoc.fmt x fs) parsed
   | Error _ ->
       (* normalize consecutive whitespace chars to a single space *)
       String.concat ~sep:" "

--- a/src/Normalize.ml
+++ b/src/Normalize.ml
@@ -291,11 +291,15 @@ let docstrings_use_file c s =
   in
   !docstrings
 
+type docstring_error =
+  | Moved of Location.t * Location.t * string
+  | Unstable of Location.t * string
+
 let moved_docstrings c get_docstrings s1 s2 =
   let d1 = get_docstrings c s1 in
   let d2 = get_docstrings c s2 in
   let equal (_, x) (_, y) = String.equal (docstring c x) (docstring c y) in
-  let unstable x = `Unstable x in
+  let unstable (x, y) = Unstable (x, y) in
   match List.zip d1 d2 with
   | None ->
       (* We only return the ones that are not in both lists. *)
@@ -312,7 +316,7 @@ let moved_docstrings c get_docstrings s1 s2 =
       let both, l1 =
         List.partition_map l1 ~f:(fun x ->
             match List.find l2 ~f:(equal x) with
-            | Some (l, s) -> `Fst (`Moved (fst x, l, s))
+            | Some (l, s) -> `Fst (Moved (fst x, l, s))
             | None -> `Snd x )
       in
       let l2 = List.filter l2 ~f:(fun x -> not (List.mem ~equal l1 x)) in

--- a/src/Normalize.mli
+++ b/src/Normalize.mli
@@ -45,26 +45,18 @@ val equal_use_file :
 val mapper : Conf.t -> Ast_mapper.mapper
 (** Ast_mapper for normalization transformations. *)
 
+type docstring_error =
+  | Moved of Location.t * Location.t * string
+  | Unstable of Location.t * string
+
 val moved_docstrings_impl :
-     Conf.t
-  -> structure
-  -> structure
-  -> [ `Moved of Location.t * Location.t * string
-     | `Unstable of Location.t * string ]
-     list
+  Conf.t -> structure -> structure -> docstring_error list
 
 val moved_docstrings_intf :
-     Conf.t
-  -> signature
-  -> signature
-  -> [ `Moved of Location.t * Location.t * string
-     | `Unstable of Location.t * string ]
-     list
+  Conf.t -> signature -> signature -> docstring_error list
 
 val moved_docstrings_use_file :
      Conf.t
   -> toplevel_phrase list
   -> toplevel_phrase list
-  -> [ `Moved of Location.t * Location.t * string
-     | `Unstable of Location.t * string ]
-     list
+  -> docstring_error list

--- a/src/Normalize.mli
+++ b/src/Normalize.mli
@@ -14,6 +14,9 @@
 open Migrate_ast
 open Parsetree
 
+val docstring : string -> string
+(** Normalize a docstring. *)
+
 val impl : structure -> structure
 (** Normalize a structure. *)
 

--- a/src/Normalize.mli
+++ b/src/Normalize.mli
@@ -49,16 +49,22 @@ val moved_docstrings_impl :
      Conf.t
   -> structure
   -> structure
-  -> (Location.t * Location.t * string) list
+  -> [ `Moved of Location.t * Location.t * string
+     | `Unstable of Location.t * string ]
+     list
 
 val moved_docstrings_intf :
      Conf.t
   -> signature
   -> signature
-  -> (Location.t * Location.t * string) list
+  -> [ `Moved of Location.t * Location.t * string
+     | `Unstable of Location.t * string ]
+     list
 
 val moved_docstrings_use_file :
      Conf.t
   -> toplevel_phrase list
   -> toplevel_phrase list
-  -> (Location.t * Location.t * string) list
+  -> [ `Moved of Location.t * Location.t * string
+     | `Unstable of Location.t * string ]
+     list

--- a/src/Normalize.mli
+++ b/src/Normalize.mli
@@ -14,41 +14,51 @@
 open Migrate_ast
 open Parsetree
 
-val docstring : string -> string
+val docstring : Conf.t -> string -> string
 (** Normalize a docstring. *)
 
-val impl : structure -> structure
+val impl : Conf.t -> structure -> structure
 (** Normalize a structure. *)
 
-val intf : signature -> signature
+val intf : Conf.t -> signature -> signature
 (** Normalize a signature. *)
 
-val use_file : toplevel_phrase list -> toplevel_phrase list
+val use_file : Conf.t -> toplevel_phrase list -> toplevel_phrase list
 (** Normalize a use_file. *)
 
-val equal_impl : ignore_doc_comments:bool -> structure -> structure -> bool
+val equal_impl :
+  ignore_doc_comments:bool -> Conf.t -> structure -> structure -> bool
 (** Compare structures for equality up to normalization. *)
 
-val equal_intf : ignore_doc_comments:bool -> signature -> signature -> bool
+val equal_intf :
+  ignore_doc_comments:bool -> Conf.t -> signature -> signature -> bool
 (** Compare signatures for equality up to normalization. *)
 
 val equal_use_file :
      ignore_doc_comments:bool
+  -> Conf.t
   -> toplevel_phrase list
   -> toplevel_phrase list
   -> bool
 (** Compare use_file for equality up to normalization. *)
 
-val mapper : Ast_mapper.mapper
+val mapper : Conf.t -> Ast_mapper.mapper
 (** Ast_mapper for normalization transformations. *)
 
 val moved_docstrings_impl :
-  structure -> structure -> (Location.t * Location.t * string) list
+     Conf.t
+  -> structure
+  -> structure
+  -> (Location.t * Location.t * string) list
 
 val moved_docstrings_intf :
-  signature -> signature -> (Location.t * Location.t * string) list
+     Conf.t
+  -> signature
+  -> signature
+  -> (Location.t * Location.t * string) list
 
 val moved_docstrings_use_file :
-     toplevel_phrase list
+     Conf.t
+  -> toplevel_phrase list
   -> toplevel_phrase list
   -> (Location.t * Location.t * string) list

--- a/src/Reason.mli
+++ b/src/Reason.mli
@@ -51,10 +51,14 @@ val moved_docstrings_impl :
      Conf.t
   -> structure with_comments
   -> structure with_comments
-  -> (Location.t * Location.t * string) list
+  -> [ `Moved of Location.t * Location.t * string
+     | `Unstable of Location.t * string ]
+     list
 
 val moved_docstrings_intf :
      Conf.t
   -> signature with_comments
   -> signature with_comments
-  -> (Location.t * Location.t * string) list
+  -> [ `Moved of Location.t * Location.t * string
+     | `Unstable of Location.t * string ]
+     list

--- a/src/Reason.mli
+++ b/src/Reason.mli
@@ -51,14 +51,10 @@ val moved_docstrings_impl :
      Conf.t
   -> structure with_comments
   -> structure with_comments
-  -> [ `Moved of Location.t * Location.t * string
-     | `Unstable of Location.t * string ]
-     list
+  -> Normalize.docstring_error list
 
 val moved_docstrings_intf :
      Conf.t
   -> signature with_comments
   -> signature with_comments
-  -> [ `Moved of Location.t * Location.t * string
-     | `Unstable of Location.t * string ]
-     list
+  -> Normalize.docstring_error list

--- a/src/Reason.mli
+++ b/src/Reason.mli
@@ -25,14 +25,15 @@ val input_intf : Conf.t -> In_channel.t -> signature with_comments
     the output of `refmt --print=binary_reason` where `refmt` has been
     compiled with the same version of `ocaml` as `ocamlformat`. *)
 
-val norm_impl : structure with_comments -> structure
+val norm_impl : Conf.t -> structure with_comments -> structure
 (** Normalize a structure. *)
 
-val norm_intf : signature with_comments -> signature
+val norm_intf : Conf.t -> signature with_comments -> signature
 (** Normalize a signature. *)
 
 val equal_impl :
      ignore_doc_comments:bool
+  -> Conf.t
   -> structure with_comments
   -> structure with_comments
   -> bool
@@ -40,17 +41,20 @@ val equal_impl :
 
 val equal_intf :
      ignore_doc_comments:bool
+  -> Conf.t
   -> signature with_comments
   -> signature with_comments
   -> bool
 (** Compare signatures for equality up to normalization. *)
 
 val moved_docstrings_impl :
-     structure with_comments
+     Conf.t
+  -> structure with_comments
   -> structure with_comments
   -> (Location.t * Location.t * string) list
 
 val moved_docstrings_intf :
-     signature with_comments
+     Conf.t
+  -> signature with_comments
   -> signature with_comments
   -> (Location.t * Location.t * string) list

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -26,14 +26,16 @@ type 'a t =
   ; parse: Lexing.lexbuf -> 'a
   ; equal:
          ignore_doc_comments:bool
+      -> Conf.t
       -> 'a with_comments
       -> 'a with_comments
       -> bool
   ; moved_docstrings:
-         'a with_comments
+         Conf.t
+      -> 'a with_comments
       -> 'a with_comments
       -> (Location.t * Location.t * string) list
-  ; normalize: 'a with_comments -> 'a
+  ; normalize: Conf.t -> 'a with_comments -> 'a
   ; printast: Caml.Format.formatter -> 'a -> unit }
 
 (** Existential package of a type of translation unit and its operations. *)
@@ -170,14 +172,14 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
           if
             (* Ast not preserved ? *)
             not
-              (xunit.equal ~ignore_doc_comments:(not conf.comment_check) old
-                 new_)
+              (xunit.equal ~ignore_doc_comments:(not conf.comment_check)
+                 conf old new_)
           then (
-            dump xunit dir base ".old" ".ast" (xunit.normalize old) ;
-            dump xunit dir base ".new" ".ast" (xunit.normalize new_) ;
+            dump xunit dir base ".old" ".ast" (xunit.normalize conf old) ;
+            dump xunit dir base ".new" ".ast" (xunit.normalize conf new_) ;
             if not Conf.debug then Unix.unlink tmp ;
-            if xunit.equal ~ignore_doc_comments:true old new_ then
-              let docstrings = xunit.moved_docstrings old new_ in
+            if xunit.equal ~ignore_doc_comments:true conf old new_ then
+              let docstrings = xunit.moved_docstrings conf old new_ in
               internal_error (`Doc_comment docstrings)
                 [("output file", String.sexp_of_t tmp)]
             else internal_error `Ast [("output file", String.sexp_of_t tmp)] ) ;
@@ -188,7 +190,7 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
             | l ->
                 let l = List.map l ~f:(fun (l, n, _t, _s) -> (l, n)) in
                 internal_error (`Comment_dropped l) [] ) ;
-            let diff_cmts = Cmts.diff comments new_.comments in
+            let diff_cmts = Cmts.diff conf comments new_.comments in
             if not (Sequence.is_empty diff_cmts) then (
               dump xunit dir base ".old" ".ast" old.ast ;
               dump xunit dir base ".new" ".ast" new_.ast ;

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -34,9 +34,7 @@ type 'a t =
          Conf.t
       -> 'a with_comments
       -> 'a with_comments
-      -> [ `Moved of Location.t * Location.t * string
-         | `Unstable of Location.t * string ]
-         list
+      -> Normalize.docstring_error list
   ; normalize: Conf.t -> 'a with_comments -> 'a
   ; printast: Caml.Format.formatter -> 'a -> unit }
 
@@ -48,9 +46,7 @@ exception Warning50 of (Location.t * Warnings.t) list
 exception
   Internal_error of
     [ `Ast
-    | `Doc_comment of [ `Moved of Location.t * Location.t * string
-                      | `Unstable of Location.t * string ]
-                      list
+    | `Doc_comment of Normalize.docstring_error list
     | `Comment
     | `Comment_dropped of (Location.t * string) list ]
     * (string * Sexp.t) list
@@ -321,7 +317,7 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
           ( match m with
           | `Doc_comment l when not conf.Conf.quiet ->
               List.iter l ~f:(function
-                | `Moved (loc_before, loc_after, msg) ->
+                | Normalize.Moved (loc_before, loc_after, msg) ->
                     if Location.compare loc_before Location.none = 0 then
                       Caml.Format.eprintf
                         "%!@{<loc>%a@}:@,@{<error>Error@}: Docstring (** \
@@ -342,7 +338,7 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
                          %!"
                         Location.print_loc loc_before (String.strip msg)
                         Location.print_loc loc_after
-                | `Unstable (loc, s) ->
+                | Normalize.Unstable (loc, s) ->
                     Caml.Format.eprintf
                       "%!@{<loc>%a@}:@,@{<error>Error@}: Formatting of (** \
                        %s *) is unstable (e.g. parses as a list or not \

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -345,9 +345,10 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
                 | `Unstable (loc, s) ->
                     Caml.Format.eprintf
                       "%!@{<loc>%a@}:@,@{<error>Error@}: Formatting of (** \
-                       %s *) is unstable, please tighten up this comment \
-                       in the source or disable the formatting using the \
-                       option --no-parse-docstrings.\n\
+                       %s *) is unstable (e.g. parses as a list or not \
+                       depending on the margin), please tighten up this \
+                       comment in the source or disable the formatting \
+                       using the option --no-parse-docstrings.\n\
                        %!"
                       Location.print_loc loc (String.strip s) )
           | `Comment_dropped l when not conf.Conf.quiet ->

--- a/src/Translation_unit.mli
+++ b/src/Translation_unit.mli
@@ -28,9 +28,7 @@ type 'a t =
          Conf.t
       -> 'a with_comments
       -> 'a with_comments
-      -> [ `Moved of Location.t * Location.t * string
-         | `Unstable of Location.t * string ]
-         list
+      -> Normalize.docstring_error list
   ; normalize: Conf.t -> 'a with_comments -> 'a
   ; printast: Caml.Format.formatter -> 'a -> unit }
 

--- a/src/Translation_unit.mli
+++ b/src/Translation_unit.mli
@@ -20,14 +20,16 @@ type 'a t =
   ; parse: Lexing.lexbuf -> 'a
   ; equal:
          ignore_doc_comments:bool
+      -> Conf.t
       -> 'a with_comments
       -> 'a with_comments
       -> bool
   ; moved_docstrings:
-         'a with_comments
+         Conf.t
+      -> 'a with_comments
       -> 'a with_comments
       -> (Location.t * Location.t * string) list
-  ; normalize: 'a with_comments -> 'a
+  ; normalize: Conf.t -> 'a with_comments -> 'a
   ; printast: Caml.Format.formatter -> 'a -> unit }
 
 (** Existential package of a type of translation unit and its operations. *)

--- a/src/Translation_unit.mli
+++ b/src/Translation_unit.mli
@@ -28,7 +28,9 @@ type 'a t =
          Conf.t
       -> 'a with_comments
       -> 'a with_comments
-      -> (Location.t * Location.t * string) list
+      -> [ `Moved of Location.t * Location.t * string
+         | `Unstable of Location.t * string ]
+         list
   ; normalize: Conf.t -> 'a with_comments -> 'a
   ; printast: Caml.Format.formatter -> 'a -> unit }
 

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -11,12 +11,13 @@
 
 (** OCamlFormat *)
 
-let normalize norm {Translation_unit.ast; _} = norm ast
+let normalize norm c {Translation_unit.ast; _} = norm c ast
 
-let equal eq ~ignore_doc_comments a b =
-  eq ~ignore_doc_comments a.Translation_unit.ast b.Translation_unit.ast
+let equal eq ~ignore_doc_comments c a b =
+  eq ~ignore_doc_comments c a.Translation_unit.ast b.Translation_unit.ast
 
-let moved_docstrings f a b = f a.Translation_unit.ast b.Translation_unit.ast
+let moved_docstrings f c a b =
+  f c a.Translation_unit.ast b.Translation_unit.ast
 
 (** Operations on implementation files. *)
 let impl : _ Translation_unit.t =

--- a/test/passing/print_config.ml.ref
+++ b/test/passing/print_config.ml.ref
@@ -6,6 +6,7 @@ wrap-fun-args=true
 wrap-comments=true (file ../.ocamlformat:2)
 type-decl=compact
 sequence-style=separator
+parse-docstrings=true
 parens-tuple=always
 ocp-indent-compat=false
 module-item-spacing=sparse (file passing/dir1/dir2/.ocamlformat:1)

--- a/test/passing/verbose1.ml.ref
+++ b/test/passing/verbose1.ml.ref
@@ -6,6 +6,7 @@ wrap-fun-args=true
 wrap-comments=true (file ../.ocamlformat:2)
 type-decl=compact
 sequence-style=separator
+parse-docstrings=true
 parens-tuple=always
 ocp-indent-compat=false
 module-item-spacing=sparse

--- a/test/passing/verbose2.ml.ref
+++ b/test/passing/verbose2.ml.ref
@@ -6,6 +6,7 @@ wrap-fun-args=true
 wrap-comments=true (file ../.ocamlformat:2)
 type-decl=compact
 sequence-style=separator
+parse-docstrings=true
 parens-tuple=always
 ocp-indent-compat=false
 module-item-spacing=sparse


### PR DESCRIPTION
- Fixing the Not_found exception
- Factorize the normalize function

It doesn't fix the case when the formatting changes the docstring, e.g. on test/code/infer/infer/src/IR/Exp.ml we get the error: 

```
Error: Docstring (** Checks whether an expression denotes a location by pointer arithmetic.
Currently, catches array - indexing expressions such as a [i] only. *) added.
```

That can be fixed by modifying the `-` into `--`.