### PR TITLE
Improve: formatting of or-patterns in try expressions

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1027,7 +1027,8 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
       let nested =
         match ctx0 with
         | Pat {ppat_desc= Ppat_or _} -> true
-        | Exp {pexp_desc= Pexp_match _ | Pexp_function _} -> true
+        | Exp {pexp_desc= Pexp_match _ | Pexp_try _ | Pexp_function _} ->
+            true
         | _ -> false
       in
       let xpats = sugar_or_pat c xpat in

--- a/test/passing/try_with_or_pattern.ml
+++ b/test/passing/try_with_or_pattern.ml
@@ -1,0 +1,5 @@
+let[@ocamlformat "break-cases=all"] _ =
+  try () with
+  | End_of_file
+  | Not_found ->
+      ()


### PR DESCRIPTION
Fixes #489

I think the issue was that or-patterns in Pexp_try context weren't picked as nested or-patterns.

I wrote a test case first and then tried to make it pass. As I'm not really familiar with the codebase yet it mostly felt like randomly swapping boolean values until it worked so I might be missing something.

As for #498 the `tools/test_branch.sh` still fails (even on master). I'll try to find some time to figure this out if I can.