### PR TITLE
Fix formatting of types with ocp-indent-compat=true

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -797,7 +797,7 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
       in
       let xt1N = sugar_arrow_typ c xtyp in
       hvbox_if box
-        (if c.conf.ocp_indent_compat then -2 else 0)
+        (if Option.is_some pro && c.conf.ocp_indent_compat then -2 else 0)
         ( ( match pro with
           | Some pro when c.conf.ocp_indent_compat ->
               fits_breaks ""

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -774,7 +774,7 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
   $
   let doc, atrs = doc_atrs ptyp_attributes in
   Cmts.fmt c.cmts ptyp_loc
-  @@ ( if List.is_empty atrs then fun k -> Fn.id k
+  @@ ( if List.is_empty atrs then Fn.id
      else fun k -> wrap "(" ")" (k $ fmt_attributes c ~key:"@" atrs) )
   @@
   let parens = parenze_typ xtyp in

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -796,8 +796,7 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
         | Optional l -> fmt "?" $ str l $ fmt ":"
       in
       let xt1N = sugar_arrow_typ c xtyp in
-      hvbox_if box
-        (if c.conf.ocp_indent_compat then -2 else 0)
+      hvbox_if box 0
         ( ( match pro with
           | Some pro when c.conf.ocp_indent_compat ->
               fits_breaks ""

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -766,10 +766,10 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
   let {ptyp_desc; ptyp_attributes; ptyp_loc} = typ in
   update_config_maybe_disabled c ptyp_loc ptyp_attributes
   @@ fun c ->
-  ( match pro with
-  | Some pro when c.conf.ocp_indent_compat ->
+  ( match (ptyp_desc, pro) with
+  | Ptyp_arrow _, Some pro when c.conf.ocp_indent_compat ->
       fmt_if space_before_pro "@;<1 0>" $ str pro $ fmt " "
-  | Some pro -> fmt_if space_before_pro " " $ str pro $ fmt "@ "
+  | _, Some pro -> fmt_if space_before_pro " " $ str pro $ fmt "@ "
   | _ -> fmt "" )
   $
   let doc, atrs = doc_atrs ptyp_attributes in

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -760,24 +760,23 @@ and fmt_payload c ctx pld =
             fmt " when " $ fmt_expression c (sub_exp ~ctx exp) )
 
 and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
-    ({ast= typ} as xtyp) =
-  protect (Typ typ)
-  @@
+    ?(space_before_pro = true) ({ast= typ} as xtyp) =
   let {ptyp_desc; ptyp_attributes; ptyp_loc} = typ in
-  update_config_maybe_disabled c ptyp_loc ptyp_attributes
+  let parens = parenze_typ xtyp in
+  protect (Typ typ)
+  @@ update_config_maybe_disabled c ptyp_loc ptyp_attributes
   @@ fun c ->
-  ( match (ptyp_desc, pro) with
-  | Ptyp_arrow _, Some _ when c.conf.ocp_indent_compat -> fmt "@,"
-  | _, Some pro -> str pro $ fmt "@ "
+  ( match pro with
+  | Some pro when c.conf.ocp_indent_compat ->
+      fmt_if space_before_pro "@;<1 0>" $ str pro $ fmt " "
+  | Some pro -> fmt_if space_before_pro " " $ str pro $ fmt "@ "
   | _ -> fmt "" )
   $
   let doc, atrs = doc_atrs ptyp_attributes in
-  Cmts.fmt c.cmts ptyp_loc
-  @@ ( if List.is_empty atrs then Fn.id
+  ( Cmts.fmt c.cmts ptyp_loc
+  @@ ( if List.is_empty atrs then fun k -> Fn.id k
      else fun k -> wrap "(" ")" (k $ fmt_attributes c ~key:"@" atrs) )
-  @@
-  let parens = parenze_typ xtyp in
-  ( hvbox_if box 0
+  @@ hvbox_if box 0
   @@ wrap_if
        (match typ.ptyp_desc with Ptyp_tuple _ -> false | _ -> parens)
        "(" ")"
@@ -795,12 +794,12 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
         | Optional l -> fmt "?" $ str l $ fmt ":"
       in
       let xt1N = sugar_arrow_typ c xtyp in
-      hvbox_if box 0
+      hvbox_if box
+        (if c.conf.ocp_indent_compat then -2 else 0)
         ( ( match pro with
           | Some pro when c.conf.ocp_indent_compat ->
-              str pro
-              $ fits_breaks " "
-                  (String.make (Int.max 1 (3 - String.length pro)) ' ')
+              fits_breaks ""
+                (String.make (Int.max 1 (2 - String.length pro)) ' ')
           | _ -> fits_breaks "" "   " )
         $ list xt1N "@ -> " (fun (lI, xtI) ->
               hvbox 0 (arg_label lI $ fmt_core_type c xtI) ) )
@@ -2606,7 +2605,8 @@ and fmt_class_field c ctx (cf : class_field) =
                   ~after:e.pexp_loc ) ;
             ( [ fmt "@ : " $ fmt "type "
                 $ list args "@ " (fun name -> fmt_str_loc c name)
-              ; fmt_core_type c ~pro:"." (sub_typ ~ctx t) ]
+              ; fmt_core_type c ~pro:"." ~space_before_pro:false
+                  (sub_typ ~ctx t) ]
             , fmt "@;<1 2>="
             , fmt "@ " $ fmt_expression c (sub_exp ~ctx e) )
         | None ->
@@ -2824,7 +2824,6 @@ and fmt_value_description c ctx vd =
         ( str pre $ fmt " "
         $ Cmts.fmt c.cmts loc
             (wrap_if (is_symbol_id txt) "( " " )" (str txt))
-        $ fmt " "
         $ fmt_core_type c ~pro:":" (sub_typ ~ctx pval_type)
         $ list_fl pval_prim (fun ~first ~last:_ s ->
               fmt_if first "@ =" $ fmt " \"" $ str s $ fmt "\"" ) )
@@ -4011,7 +4010,8 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
                 Cmts.relocate c.cmts ~src:body.pexp_loc ~before:exp.pexp_loc
                   ~after:exp.pexp_loc ;
                 ( Some
-                    (fmt "@ " $ fmt_core_type c ~pro:":" (sub_typ ~ctx typ))
+                    ( fmt "@;<0 -1>"
+                    $ fmt_core_type c ~pro:":" (sub_typ ~ctx typ) )
                 , sub_exp ~ctx exp )
             | _ -> (None, xbody)
           in

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -761,10 +761,10 @@ and fmt_payload c ctx pld =
 
 and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
     ?(space_before_pro = true) ({ast= typ} as xtyp) =
-  let {ptyp_desc; ptyp_attributes; ptyp_loc} = typ in
-  let parens = parenze_typ xtyp in
   protect (Typ typ)
-  @@ update_config_maybe_disabled c ptyp_loc ptyp_attributes
+  @@
+  let {ptyp_desc; ptyp_attributes; ptyp_loc} = typ in
+  update_config_maybe_disabled c ptyp_loc ptyp_attributes
   @@ fun c ->
   ( match pro with
   | Some pro when c.conf.ocp_indent_compat ->
@@ -773,10 +773,12 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
   | _ -> fmt "" )
   $
   let doc, atrs = doc_atrs ptyp_attributes in
-  ( Cmts.fmt c.cmts ptyp_loc
+  Cmts.fmt c.cmts ptyp_loc
   @@ ( if List.is_empty atrs then fun k -> Fn.id k
      else fun k -> wrap "(" ")" (k $ fmt_attributes c ~key:"@" atrs) )
-  @@ hvbox_if box 0
+  @@
+  let parens = parenze_typ xtyp in
+  ( hvbox_if box 0
   @@ wrap_if
        (match typ.ptyp_desc with Ptyp_tuple _ -> false | _ -> parens)
        "(" ")"

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -796,7 +796,8 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
         | Optional l -> fmt "?" $ str l $ fmt ":"
       in
       let xt1N = sugar_arrow_typ c xtyp in
-      hvbox_if box 0
+      hvbox_if box
+        (if c.conf.ocp_indent_compat then -2 else 0)
         ( ( match pro with
           | Some pro when c.conf.ocp_indent_compat ->
               fits_breaks ""

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -760,7 +760,7 @@ and fmt_payload c ctx pld =
             fmt " when " $ fmt_expression c (sub_exp ~ctx exp) )
 
 and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
-    ?(space_before_pro = true) ({ast= typ} as xtyp) =
+    ?(pro_space = true) ({ast= typ} as xtyp) =
   protect (Typ typ)
   @@
   let {ptyp_desc; ptyp_attributes; ptyp_loc} = typ in
@@ -768,8 +768,8 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
   @@ fun c ->
   ( match (ptyp_desc, pro) with
   | Ptyp_arrow _, Some pro when c.conf.ocp_indent_compat ->
-      fmt_if space_before_pro "@;<1 0>" $ str pro $ fmt " "
-  | _, Some pro -> fmt_if space_before_pro " " $ str pro $ fmt "@ "
+      fmt_if pro_space "@;<1 0>" $ str pro $ fmt " "
+  | _, Some pro -> fmt_if pro_space " " $ str pro $ fmt "@ "
   | _ -> fmt "" )
   $
   let doc, atrs = doc_atrs ptyp_attributes in
@@ -2607,8 +2607,8 @@ and fmt_class_field c ctx (cf : class_field) =
                   ~after:e.pexp_loc ) ;
             ( [ fmt "@ : " $ fmt "type "
                 $ list args "@ " (fun name -> fmt_str_loc c name)
-              ; fmt_core_type c ~pro:"." ~space_before_pro:false
-                  (sub_typ ~ctx t) ]
+              ; fmt_core_type c ~pro:"." ~pro_space:false (sub_typ ~ctx t)
+              ]
             , fmt "@;<1 2>="
             , fmt "@ " $ fmt_expression c (sub_exp ~ctx e) )
         | None ->

--- a/test/passing/ocp_indent_compat.ml
+++ b/test/passing/ocp_indent_compat.ml
@@ -1,0 +1,55 @@
+[@@@ocamlformat "ocp-indent-compat=true"]
+
+(* Bad: unboxing the function type *)
+external i : (int -> float[@unboxed]) = "i" "i_nat"
+
+module type M = sig
+  val action : action
+  (** Formatting action: input type and source, and output destination. *)
+
+  val doc_atrs
+    :  (string Location.loc * payload) list
+    -> (string Location.loc * bool) list option
+       * (string Location.loc * payload) list
+
+  val transl_modtype_longident
+    (* from Typemod *)
+    : (Location.t -> Env.t -> Longident.t -> Path.t) ref
+
+  val transl_modtype_longident
+    (* foooooooooo fooooooooooooo foooooooooooo foooooooooooooo
+       foooooooooooooo foooooooooooo *)
+    : (Location.t -> Env.t -> Longident.t -> Path.t) ref
+
+  val imported_sets_of_closures_table
+    : Simple_value_approx.function_declarations option
+      Set_of_closures_id.Tbl.t
+end
+
+[@@@ocamlformat "ocp-indent-compat=false"]
+
+module type M = sig
+  val transl_modtype_longident
+    (* from Typemod *) :
+    (Location.t -> Env.t -> Longident.t -> Path.t) ref
+
+  val transl_modtype_longident
+    (* foooooooooo fooooooooooooo foooooooooooo foooooooooooooo
+       foooooooooooooo foooooooooooo *) :
+    (Location.t -> Env.t -> Longident.t -> Path.t) ref
+
+  val imported_sets_of_closures_table :
+    Simple_value_approx.function_declarations option
+    Set_of_closures_id.Tbl.t
+end
+
+let array_fold_transf (f : numbering -> 'a -> numbering * 'b) n
+    (a : 'a array) : numbering * 'b array =
+  match Array.length a with 0 -> (n, [||]) | 1 -> x
+
+let to_clambda_function (id, (function_decl : Flambda.function_declaration))
+    : Clambda.ufunction =
+  (* All that we need in the environment, for translating one closure from a
+     closed set of closures, is the substitutions for variables bound to the
+     various closures in the set. Such closures will always be ... *)
+  x

--- a/test/passing/ocp_indent_compat.ml
+++ b/test/passing/ocp_indent_compat.ml
@@ -9,8 +9,8 @@ module type M = sig
 
   val doc_atrs
     :  (string Location.loc * payload) list
-    -> (string Location.loc * bool) list option
-       * (string Location.loc * payload) list
+      -> (string Location.loc * bool) list option
+         * (string Location.loc * payload) list
 
   val transl_modtype_longident
     (* from Typemod *)

--- a/test/passing/ocp_indent_compat.ml
+++ b/test/passing/ocp_indent_compat.ml
@@ -9,8 +9,8 @@ module type M = sig
 
   val doc_atrs
     :  (string Location.loc * payload) list
-      -> (string Location.loc * bool) list option
-         * (string Location.loc * payload) list
+    -> (string Location.loc * bool) list option
+       * (string Location.loc * payload) list
 
   val transl_modtype_longident
     (* from Typemod *)

--- a/test/passing/ocp_indent_compat.ml
+++ b/test/passing/ocp_indent_compat.ml
@@ -24,6 +24,15 @@ module type M = sig
   val imported_sets_of_closures_table
     : Simple_value_approx.function_declarations option
       Set_of_closures_id.Tbl.t
+
+  type 'a option_decl =
+       names:string list
+    -> doc:string
+    -> section:[`Formatting | `Operational]
+    -> ?allow_inline:bool
+    -> (config -> 'a -> config)
+    -> (config -> 'a)
+    -> 'a t
 end
 
 [@@@ocamlformat "ocp-indent-compat=false"]

--- a/test/passing/ocp_indent_compat.ml
+++ b/test/passing/ocp_indent_compat.ml
@@ -13,17 +13,17 @@ module type M = sig
        * (string Location.loc * payload) list
 
   val transl_modtype_longident
-    (* from Typemod *)
-    : (Location.t -> Env.t -> Longident.t -> Path.t) ref
+    (* from Typemod *) :
+    (Location.t -> Env.t -> Longident.t -> Path.t) ref
 
   val transl_modtype_longident
     (* foooooooooo fooooooooooooo foooooooooooo foooooooooooooo
-       foooooooooooooo foooooooooooo *)
-    : (Location.t -> Env.t -> Longident.t -> Path.t) ref
+       foooooooooooooo foooooooooooo *) :
+    (Location.t -> Env.t -> Longident.t -> Path.t) ref
 
-  val imported_sets_of_closures_table
-    : Simple_value_approx.function_declarations option
-      Set_of_closures_id.Tbl.t
+  val imported_sets_of_closures_table :
+    Simple_value_approx.function_declarations option
+    Set_of_closures_id.Tbl.t
 
   type 'a option_decl =
        names:string list


### PR DESCRIPTION
This fix is needed for PR #524 (error on js_source.ml with `ocp-indent-compat=true`).