### PR TITLE
Improve: remove more spaces inside parenthesized multiline constructs

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -948,13 +948,13 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
       let parens =
         parens || Poly.(c.conf.parens_tuple_patterns = `Always)
       in
-      let wrap =
+      let wrap_multiline =
         if c.conf.indicate_multiline_delimiters then
           wrap_if_breaks "( " "@ )"
         else wrap_if_breaks "(" ")"
       in
       hvbox 0
-        (wrap
+        (wrap_multiline
            (wrap_if_fits_and parens "(" ")"
               (list pats "@,, " (sub_pat ~ctx >> fmt_pattern c))))
   | Ppat_construct (lid, None) -> (

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -948,8 +948,13 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
       let parens =
         parens || Poly.(c.conf.parens_tuple_patterns = `Always)
       in
+      let wrap =
+        if c.conf.indicate_multiline_delimiters then
+          wrap_if_breaks "( " "@ )"
+        else wrap_if_breaks "(" ")"
+      in
       hvbox 0
-        (wrap_if_breaks "( " "@ )"
+        (wrap
            (wrap_if_fits_and parens "(" ")"
               (list pats "@,, " (sub_pat ~ctx >> fmt_pattern c))))
   | Ppat_construct (lid, None) -> (
@@ -1324,7 +1329,9 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
           let very_last = last_grp && last in
           fmt_if_k very_first
             (fits_breaks_if parens_or_nested "("
-               (if parens_or_forced then "( " else ""))
+               ( if parens_or_forced then
+                 if c.conf.indicate_multiline_delimiters then "( " else "("
+               else "" ))
           $ fmt_cmts
           $ fmt_if_k first
               (open_hovbox (if first_grp && parens then -2 else 0))
@@ -1332,7 +1339,10 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
           $ fmt_if_k last close_box
           $ fmt_or_k very_last
               (fits_breaks_if parens_or_nested ")"
-                 (if parens_or_forced then "@ )" else ""))
+                 ( if parens_or_forced then
+                   if c.conf.indicate_multiline_delimiters then "@ )"
+                   else "@,)"
+                 else "" ))
               (break_unless_newline 1 0) )
     in
     let op_args_grouped =
@@ -1582,7 +1592,8 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
                              | Pexp_fun _ | Pexp_function _ -> Some false
                              | _ -> None )
                            xbody )
-                   $ fits_breaks ")" "@ )" )
+                   $ fmt_or_k c.conf.indicate_multiline_delimiters
+                       (fits_breaks ")" "@ )") (fits_breaks ")" "@,)") )
                $ fmt_atrs ))
       | ( lbl
         , ( { pexp_desc= Pexp_function [{pc_lhs; pc_guard= None; pc_rhs}]
@@ -1611,7 +1622,8 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
                        $ fmt "@ ->" )
                    $ fmt "@ "
                    $ cbox 0 (fmt_expression c (sub_exp ~ctx pc_rhs))
-                   $ fits_breaks ")" " )"
+                   $ fmt_or_k c.conf.indicate_multiline_delimiters
+                       (fits_breaks ")" " )") (fmt ")")
                    $ Cmts.fmt_after c.cmts pexp_loc )
                $ fmt_atrs ))
       | (lbl, ({pexp_desc= Pexp_function cs; pexp_loc} as eN)) :: rev_e1N
@@ -1629,7 +1641,9 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
                       $ fmt_label lbl ":" $ fmt "(function"
                       $ fmt_attributes c ~pre:(fmt " ") ~key:"@"
                           eN.pexp_attributes ))
-               $ fmt "@ " $ fmt_cases c ctx'' cs $ fits_breaks ")" " )"
+               $ fmt "@ " $ fmt_cases c ctx'' cs
+               $ fmt_or_k c.conf.indicate_multiline_delimiters
+                   (fits_breaks ")" " )") (fmt ")")
                $ Cmts.fmt_after c.cmts pexp_loc
                $ fmt_atrs ))
       | _ ->
@@ -1653,7 +1667,9 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
               ( hvbox 2
                   ( fmt_or paren_body "assert (@," "assert@ "
                   $ fmt_expression c ~parens:false (sub_exp ~ctx e0) )
-              $ fits_breaks_if paren_body ")" "@ )"
+              $ fmt_or_k c.conf.indicate_multiline_delimiters
+                  (fits_breaks_if paren_body ")" "@ )")
+                  (fits_breaks_if paren_body ")" "@,)")
               $ fmt_atrs )))
   | Pexp_constant const ->
       wrap_if
@@ -1727,7 +1743,9 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
   | Pexp_construct (({txt= Lident "::"} as lid), Some arg) ->
       wrap_if parens "(" ")"
         ( hvbox 2
-            ( wrap "( " " )" (fmt_longident_loc c lid)
+            ( fmt_or_k c.conf.indicate_multiline_delimiters
+                (wrap "( " " )" (fmt_longident_loc c lid))
+                (wrap "(" ")" (fmt_longident_loc c lid))
             $ fmt "@ "
             $ fmt_expression c (sub_exp ~ctx arg) )
         $ fmt_atrs )
@@ -1763,7 +1781,9 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
                 $ fmt "@ " )
             $ fmt "->" )
           $ fmt_body c ?ext xbody )
-        $ fits_breaks_if parens ")" "@ )" )
+        $ fmt_or_k c.conf.indicate_multiline_delimiters
+            (fits_breaks_if parens ")" "@ )")
+            (fits_breaks_if parens ")" "@,)") )
   | Pexp_function cs ->
       wrap_if parens "(" ")"
         ( hvbox 2
@@ -1775,7 +1795,7 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
   | Pexp_ident {txt; loc} ->
       let wrap, wrap_ident =
         if is_symbol exp && not (List.is_empty pexp_attributes) then
-          (wrap_if true "( " " )", true)
+          (wrap "( " " )", true)
         else if is_symbol exp then (wrap_if parens "( " " )", false)
         else (wrap_if parens "(" ")", false)
       in
@@ -1814,7 +1834,9 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
                           $ fmt_if parens_bch " (" $ fmt "@ "
                           $ fmt_expression c ~box:false ~parens:false xbch
                           )
-                      $ fmt_if parens_bch " )" )
+                      $ fmt_if parens_bch
+                          ( if c.conf.indicate_multiline_delimiters then " )"
+                          else ")" ) )
                     $ fmt_if (not last) "@ "
                 | `Keyword_first ->
                     opt xcnd (fun xcnd ->
@@ -1830,7 +1852,10 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
                         ( fmt_or (Option.is_some xcnd) "then" "else"
                         $ fmt_if parens_bch " (" $ fmt "@ "
                         $ fmt_expression c ~box:false ~parens:false xbch
-                        $ fmt_if parens_bch " )" )
+                        $ fmt_if parens_bch
+                            ( if c.conf.indicate_multiline_delimiters then
+                              " )"
+                            else ")" ) )
                     $ fmt_if (not last) "@ " )))
   | Pexp_let (rec_flag, bindings, body) ->
       wrap_if
@@ -1997,7 +2022,9 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
                    $ fmt "@ ->" $ fmt_if parens_here " (" )
                $ fmt "@ "
                $ cbox 0 (fmt_expression c ?parens:parens_for_exp xpc_rhs)
-               $ fmt_if parens_here " )" )) )
+               $ fmt_if parens_here
+                   ( if c.conf.indicate_multiline_delimiters then " )"
+                   else ")" ) )) )
   | Pexp_pack me ->
       let {opn; pro; psp; bdy; cls; esp; epi} =
         fmt_module_expr c (sub_mod ~ctx me)
@@ -2098,7 +2125,9 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
       let wrap =
         if parens then wrap_fits_breaks c.conf "(" ")"
         else if no_parens_if_break then Fn.id
-        else wrap_if_breaks "( " "@ )"
+        else if c.conf.indicate_multiline_delimiters then
+          wrap_if_breaks "( " "@ )"
+        else wrap_if_breaks "(" ")"
       in
       hvbox 0
         (wrap (list es "@,, " (sub_exp ~ctx >> fmt_expression c)) $ fmt_atrs)
@@ -2465,7 +2494,9 @@ and fmt_class_expr c ?eol ?(box = true) ({ast= exp} as xexp) =
             $ fmt "->" )
           $ close_box $ fmt "@ "
           $ fmt_class_expr c ~eol:(fmt "@;<1000 0>") xbody )
-        $ fits_breaks_if parens ")" "@ )" )
+        $ fmt_or_k c.conf.indicate_multiline_delimiters
+            (fits_breaks_if parens ")" "@ )")
+            (fits_breaks_if parens ")" "@,)") )
   | Pcl_apply (e0, e1N1) ->
       wrap_if parens "(" ")" (hvbox 2 (fmt_args_grouped e0 e1N1) $ fmt_atrs)
   | Pcl_let (rec_flag, bindings, body) ->
@@ -2731,7 +2762,9 @@ and fmt_cases c ctx cs =
             | true, true, true -> fmt " (@;<1 4>" )
           $ hovbox 0
               ( hovbox 0 (fmt_expression c ?parens:parens_for_exp xrhs)
-              $ fmt_if parens_here "@ )" ) ) )
+              $ fmt_or_k c.conf.indicate_multiline_delimiters
+                  (fmt_if parens_here "@ )")
+                  (fmt_if parens_here "@,)") ) ) )
 
 and fmt_value_description c ctx vd =
   let { pval_name= {txt; loc}
@@ -3537,7 +3570,8 @@ and fmt_module_expr c ({ast= m} as xmod) =
             ( Option.call ~f:pro_e $ psp_e $ bdy_e $ esp_e
             $ Option.call ~f:epi_e $ fmt " :@ " $ Option.call ~f:pro_t
             $ psp_t $ bdy_t $ esp_t $ Option.call ~f:epi_t )
-          $ fits_breaks ")" " )"
+          $ fmt_or_k c.conf.indicate_multiline_delimiters
+              (fits_breaks ")" " )") (fmt ")")
       ; cls= close_box $ cls_e $ cls_t
       ; esp= fmt ""
       ; epi=

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -952,7 +952,7 @@ let id x = x
 let idb1 =
   (fun id ->
     let _ = id true in
-    id )
+    id)
     id
 ;;
 
@@ -1086,7 +1086,7 @@ let rec devariantize : type t. t ty -> variant -> t =
     List.iter2
       (fun (Field {label; field_type; set}) (lab, v) ->
         if label <> lab then raise VariantMismatch;
-        set builder (devariantize field_type v) )
+        set builder (devariantize field_type v))
       fields
       fl;
     of_builder builder
@@ -1298,7 +1298,7 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
        ; sum_inj =
            (fun (type c) ->
              (function Thd, Noarg -> `Nil | Ttl Thd, v -> `Cons v
-               : (noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist) )
+               : (noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist))
            (* One can also write the type annotation directly *) })
 ;;
 
@@ -1725,7 +1725,7 @@ let rec ins : type n. int -> n avl -> (n avl, n succ avl) sum =
         (match bal with
         | Less -> Inl (Node (Same, a, y, b))
         | Same -> Inr (Node (More, a, y, b))
-        | More -> rotr a y b) )
+        | More -> rotr a y b))
     else (
       match ins x b with
       | Inl b -> Inl (Node (bal, a, y, b) : n avl)
@@ -1733,7 +1733,7 @@ let rec ins : type n. int -> n avl -> (n avl, n succ avl) sum =
         (match bal with
         | More -> Inl (Node (Same, a, y, b) : n avl)
         | Same -> Inr (Node (Less, a, y, b) : n succ avl)
-        | Less -> rotl a y b) )
+        | Less -> rotl a y b))
 ;;
 
 let insert x (Avl t) = match ins x t with Inl t -> Avl t | Inr t -> Avl t
@@ -1745,11 +1745,11 @@ let rec del_min : type n. n succ avl -> int * (n avl, n succ avl) sum = function
     (match del_min l with
     | y, Inr l -> y, Inr (Node (bal, l, x, r))
     | y, Inl l ->
-      ( y
+      (y
       , (match bal with
         | Same -> Inr (Node (Less, l, x, r))
         | More -> Inl (Node (Same, l, x, r))
-        | Less -> rotl l x r) ))
+        | Less -> rotl l x r)))
 ;;
 
 type _ avl_del =
@@ -1771,7 +1771,7 @@ let rec del : type n. int -> n avl -> n avl_del =
         | Same, (z, Inl r) -> Dsame (Node (More, l, z, r))
         | Less, (z, Inl r) -> Ddecr (Eq, Node (Same, l, z, r))
         | More, (z, Inl r) ->
-          (match rotr l z r with Inl t -> Ddecr (Eq, t) | Inr t -> Dsame t)) )
+          (match rotr l z r with Inl t -> Ddecr (Eq, t) | Inr t -> Dsame t)))
     else if y < x
     then (
       match del y l with
@@ -1780,7 +1780,7 @@ let rec del : type n. int -> n avl -> n avl_del =
         (match bal with
         | Same -> Dsame (Node (Less, l, x, r))
         | More -> Ddecr (Eq, Node (Same, l, x, r))
-        | Less -> (match rotl l x r with Inl t -> Ddecr (Eq, t) | Inr t -> Dsame t)) )
+        | Less -> (match rotl l x r with Inl t -> Ddecr (Eq, t) | Inr t -> Dsame t)))
     else (
       match del y r with
       | Dsame r -> Dsame (Node (bal, l, x, r))
@@ -1788,7 +1788,7 @@ let rec del : type n. int -> n avl -> n avl_del =
         (match bal with
         | Same -> Dsame (Node (More, l, x, r))
         | Less -> Ddecr (Eq, Node (Same, l, x, r))
-        | More -> (match rotr l x r with Inl t -> Ddecr (Eq, t) | Inr t -> Dsame t)) )
+        | More -> (match rotr l x r with Inl t -> Ddecr (Eq, t) | Inr t -> Dsame t)))
 ;;
 
 let delete x (Avl t) = match del x t with Dsame t -> Avl t | Ddecr (_, t) -> Avl t
@@ -1932,7 +1932,7 @@ let rec assoc : type a. string -> a rep -> assoc list -> a =
   | Assoc (x', r', v) :: env ->
     if x = x'
     then (
-      match rep_equal r r' with None -> failwith ("Wrong type for " ^ x) | Some Eq -> v )
+      match rep_equal r r' with None -> failwith ("Wrong type for " ^ x) | Some Eq -> v)
     else assoc x r env
 ;;
 
@@ -2053,7 +2053,7 @@ let rec lookup : type e. string -> e ctx -> e checked =
     if s = name
     then Cok (Var l, t)
     else (
-      match lookup name rs with Cerror m -> Cerror m | Cok (v, t) -> Cok (Shift v, t) )
+      match lookup name rs with Cerror m -> Cerror m | Cok (v, t) -> Cok (Shift v, t))
 ;;
 
 let rec tc : type n e. n nat -> e ctx -> term -> e checked =
@@ -2974,7 +2974,7 @@ end
 module Z : sig
   type t [@@immediate]
 end = (
-  Y : X with type t = int )
+  Y : X with type t = int)
 
 [%%expect
 {|
@@ -3486,12 +3486,12 @@ let subst_lambda ~subst_rec ~free ~subst : _ lambda -> _ = function
     let used = free t in
     let used_expr =
       Subst.fold subst ~init:[] ~f:(fun ~key ~data acc ->
-          if Names.mem s used then data :: acc else acc )
+          if Names.mem s used then data :: acc else acc)
     in
     if List.exists used_expr ~f:(fun t -> Names.mem s (free t))
     then (
       let name = s ^ string_of_int (next_id ()) in
-      `Abs (name, subst_rec ~subst:(Subst.add ~key:s ~data:(`Var name) subst) t) )
+      `Abs (name, subst_rec ~subst:(Subst.add ~key:s ~data:(`Var name) subst) t))
     else map_lambda ~map_rec:(subst_rec ~subst:(Subst.remove s subst)) l
   | `App _ as l -> map_lambda ~map_rec:(subst_rec ~subst) l
 ;;
@@ -3723,12 +3723,12 @@ class ['a] lambda_ops (ops : ('a, 'a) #ops Lazy.t) =
         let used = !!free t in
         let used_expr =
           Subst.fold sub ~init:[] ~f:(fun ~key ~data acc ->
-              if Names.mem s used then data :: acc else acc )
+              if Names.mem s used then data :: acc else acc)
         in
         if List.exists used_expr ~f:(fun t -> Names.mem s (!!free t))
         then (
           let name = s ^ string_of_int (next_id ()) in
-          `Abs (name, !!subst ~sub:(Subst.add ~key:s ~data:(`Var name) sub) t) )
+          `Abs (name, !!subst ~sub:(Subst.add ~key:s ~data:(`Var name) sub) t))
         else self#map ~f:(!!subst ~sub:(Subst.remove s sub)) l
       | `App _ as l -> self#map ~f:(!!subst ~sub) l
 
@@ -3955,12 +3955,12 @@ let lambda_ops (ops : ('a, 'a) #ops Lazy.t) =
         let used = !!free t in
         let used_expr =
           Subst.fold sub ~init:[] ~f:(fun ~key ~data acc ->
-              if Names.mem s used then data :: acc else acc )
+              if Names.mem s used then data :: acc else acc)
         in
         if List.exists used_expr ~f:(fun t -> Names.mem s (!!free t))
         then (
           let name = s ^ string_of_int (next_id ()) in
-          `Abs (name, !!subst ~sub:(Subst.add ~key:s ~data:(`Var name) sub) t) )
+          `Abs (name, !!subst ~sub:(Subst.add ~key:s ~data:(`Var name) sub) t))
         else self#map ~f:(!!subst ~sub:(Subst.remove s sub)) l
       | `App _ as l -> self#map ~f:(!!subst ~sub) l
 
@@ -5311,7 +5311,7 @@ end = (
       end
 
       module N' = N
-    end )
+    end)
 
 ;;
 M2.N'.x
@@ -5352,7 +5352,7 @@ end = (
       end
 
       module C' = C
-    end )
+    end)
 
 ;;
 M2.C'.chr 66
@@ -5951,7 +5951,7 @@ class c (v : int) =
       (fun v ->
         object
           method v : string = v
-        end )
+        end)
         "42"
   end
 
@@ -6080,7 +6080,7 @@ class virtual ['a, 'cursor] storage_base =
           else (
             let a' = f cur#get count a in
             cur#incr ();
-            loop (count + 1) a' )
+            loop (count + 1) a')
         in
         loop 0 a0
 
@@ -6160,7 +6160,7 @@ module UText = struct
         set_buf buf (pos + (i lsl 2)) cur#get;
         cur#incr ()
       done;
-      set_buf buf (pos + ((init#len - 1) lsl 2)) cur#get )
+      set_buf buf (pos + ((init#len - 1) lsl 2)) cur#get)
   ;;
 
   let make_buf init =
@@ -7531,7 +7531,7 @@ module Bootstrap (MakeH : functor (Element : ORDERED) -> HEAP with module Elem =
         | BE.H (y, p1) ->
           let p2 = PrimH.deleteMin p in
           BE.H (y, PrimH.merge p1 p2)
-        | BE.E -> assert false )
+        | BE.E -> assert false)
   ;;
 end
 


### PR DESCRIPTION
Extends `indicate-multiline-delimiters` (reduces the diff on `core_kernel`).