### PR TITLE
Improve: option --diff to display the diff without overwriting the file

### DIFF
--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -206,6 +206,9 @@ OPTIONS
            Aggregate options. Options are specified as a comma-separated list
            of pairs: option=VAL,...,option=VAL.
 
+       --diff
+           Print the diff.
+
        --disable-outside-detected-project
            Do not read .ocamlformat config files outside the current project.
            The project root of an input file is taken to be the nearest

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -31,6 +31,7 @@ depends: [
   "fpath"
   "ocaml-migrate-parsetree" {>= "1.0.10"}
   "octavius"
+  "patdiff"
   "stdio"
 ]
 synopsis: "Auto-formatter for OCaml code"

--- a/ocamlformat_reason.opam
+++ b/ocamlformat_reason.opam
@@ -29,6 +29,7 @@ depends: [
   "fpath"
   "ocaml-migrate-parsetree" {>= "1.0.6"}
   "octavius"
+  "patdiff"
   "reason" {= "1.13.4"}
   "stdio"
   "lwt" {< "3.1.0"} (* ocamlformat does not need lwt, but reason requires utop requires lwt, so exclude 3.1.0 since it does not build *)

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -63,6 +63,9 @@ type action =
           or stdout if None. *)
   | Inplace of [`Impl | `Intf | `Use_file] input list
       (** Format in-place, overwriting input file(s). *)
+  | Diff of [`Impl | `Intf | `Use_file] input
+      (** Print the diff after the formatting the input file (or [-] for
+          stdin) of given kind to stdout. *)
 
 val action : action
 (** Formatting action: input type and source, and output destination. *)

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -165,7 +165,7 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
           Out_channel.output_string stdout fmted ;
           Unix.unlink tmp ;
           Ok
-      | In_out _, Some ofile -> Unix.rename tmp ofile ; Ok
+      | (In_out _ | Diff _), Some ofile -> Unix.rename tmp ofile ; Ok
       | Inplace _, Some ofile when i > 1 -> Unix.rename tmp ofile ; Ok
       | Inplace _, Some _ -> Unix.unlink tmp ; Ok )
     else
@@ -253,7 +253,7 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
     | _ when conf.disable ->
         ( match (Conf.action, ofile) with
         | _, None -> Out_channel.output_string stdout source_txt
-        | In_out _, Some ofile ->
+        | (In_out _ | Diff _), Some ofile ->
             Out_channel.write_all ofile ~data:source_txt
         | Inplace _, _ -> () ) ;
         Ok

--- a/src/dune
+++ b/src/dune
@@ -18,7 +18,7 @@ let preprocess =
  (names ocamlformat ocamlformat_reason)
  (flags (:standard -open Import))
  %s
- (libraries cmdliner format_ fpath import ocaml-migrate-parsetree octavius unix))
+ (libraries cmdliner format_ fpath import ocaml-migrate-parsetree octavius patdiff.lib unix))
 
 (rule
   (targets ocamlformat.1)

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -123,3 +123,56 @@ match Conf.action with
   | Ok -> Caml.exit 0
   | Unstable _ | Ocamlformat_bug _ | Invalid_source _ | User_error _ ->
       Caml.exit 1 )
+| Diff
+    { kind= (`Impl | `Intf | `Use_file) as kind
+    ; file= "-"
+    ; name= input_name
+    ; conf } -> (
+    let file, oc =
+      Filename.open_temp_file "ocamlformat" (Filename.basename input_name)
+    in
+    let output_file =
+      Filename.temp_file "ocamlformat" (Filename.basename input_name)
+    in
+    In_channel.iter_lines stdin ~f:(fun s ->
+        Out_channel.output_string oc s ;
+        Out_channel.newline oc ) ;
+    Out_channel.close oc ;
+    let result =
+      In_channel.with_file file ~f:(fun ic ->
+          Translation_unit.parse_print (xunit_of_kind kind) conf ~input_name
+            ~input_file:file ic (Some output_file) )
+    in
+    Unix.unlink file ;
+    match result with
+    | Ok ->
+        let config = Patdiff_lib.Configuration.get_config () in
+        let old_file = file in
+        let new_file = output_file in
+        ignore
+          (Patdiff_lib.Compare_core.diff_files config ~old_file ~new_file) ;
+        Caml.exit 0
+    | Unstable _ | Ocamlformat_bug _ | Invalid_source _ | User_error _ ->
+        Caml.exit 1 )
+| Diff
+    { kind= (`Impl | `Intf | `Use_file) as kind
+    ; file= input_file
+    ; name= input_name
+    ; conf } -> (
+    let output_file =
+      Filename.temp_file "ocamlformat" (Filename.basename input_name)
+    in
+    match
+      In_channel.with_file input_file ~f:(fun ic ->
+          Translation_unit.parse_print (xunit_of_kind kind) conf ~input_name
+            ~input_file ic (Some output_file) )
+    with
+    | Ok ->
+        let config = Patdiff_lib.Configuration.get_config () in
+        let old_file = input_file in
+        let new_file = output_file in
+        ignore
+          (Patdiff_lib.Compare_core.diff_files config ~old_file ~new_file) ;
+        Caml.exit 0
+    | Unstable _ | Ocamlformat_bug _ | Invalid_source _ | User_error _ ->
+        Caml.exit 1 )


### PR DESCRIPTION
Relying on [patdiff](https://github.com/janestreet/patdiff) for now, not sure adding a new dep is a good thing.

Is this what you had in mind @pascutto ?