### PR TITLE
[WIP] Improve: use metaquot

### DIFF
--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -31,6 +31,7 @@ depends: [
   "fpath"
   "ocaml-migrate-parsetree" {>= "1.0.10"}
   "octavius"
+  "ppx_tools_versioned"
   "stdio"
 ]
 synopsis: "Auto-formatter for OCaml code"

--- a/ocamlformat_reason.opam
+++ b/ocamlformat_reason.opam
@@ -29,6 +29,7 @@ depends: [
   "fpath"
   "ocaml-migrate-parsetree" {>= "1.0.6"}
   "octavius"
+  "ppx_tools_versioned"
   "reason" {= "1.13.4"}
   "stdio"
   "lwt" {< "3.1.0"} (* ocamlformat does not need lwt, but reason requires utop requires lwt, so exclude 3.1.0 since it does not build *)

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -383,15 +383,16 @@ let rec is_trivial c exp =
       is_trivial c e1
   | _ -> false
 
+let is_doc = function
+  | {Location.txt= "ocaml.doc" | "ocaml.text"}, _ -> false
+  | _ -> true
+
 let has_trailing_attributes_exp {pexp_desc; pexp_attributes} =
   match pexp_desc with
   | Pexp_fun _ | Pexp_function _ | Pexp_ifthenelse _ | Pexp_match _
    |Pexp_newtype _ | Pexp_try _ ->
       false
-  | _ ->
-      List.exists pexp_attributes ~f:(function
-        | {Location.txt= "ocaml.doc" | "ocaml.text"}, _ -> false
-        | _ -> true )
+  | _ -> List.exists pexp_attributes ~f:is_doc
 
 let has_trailing_attributes_pat {ppat_desc; ppat_attributes} =
   match ppat_desc with
@@ -401,22 +402,13 @@ let has_trailing_attributes_pat {ppat_desc; ppat_attributes} =
    |Ppat_record _ | Ppat_array _ | Ppat_type _ | Ppat_unpack _
    |Ppat_extension _ | Ppat_open _ | Ppat_interval _ ->
       false
-  | _ ->
-      List.exists ppat_attributes ~f:(function
-        | {Location.txt= "ocaml.doc" | "ocaml.text"}, _ -> false
-        | _ -> true )
+  | _ -> List.exists ppat_attributes ~f:is_doc
 
-let has_trailing_attributes_mty {pmty_desc; pmty_attributes} =
-  match pmty_desc with _ ->
-    List.exists pmty_attributes ~f:(function
-      | {Location.txt= "ocaml.doc" | "ocaml.text"}, _ -> false
-      | _ -> true )
+let has_trailing_attributes_mty {pmty_attributes} =
+  List.exists pmty_attributes ~f:is_doc
 
-let has_trailing_attributes_mod {pmod_desc; pmod_attributes} =
-  match pmod_desc with _ ->
-    List.exists pmod_attributes ~f:(function
-      | {Location.txt= "ocaml.doc" | "ocaml.text"}, _ -> false
-      | _ -> true )
+let has_trailing_attributes_mod {pmod_attributes} =
+  List.exists pmod_attributes ~f:is_doc
 
 (** Ast terms of various forms. *)
 module T = struct

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -1345,8 +1345,8 @@ end = struct
       | _ -> false
     in
     let constructor_cxt_prec_of_inner = function
-      | {ptyp_desc= Ptyp_arrow _} -> Some (Apply, Non)
-      | {ptyp_desc= Ptyp_tuple _} -> Some (InfixOp3, Non)
+      | [%type: [%t? _] -> [%t? _]] -> Some (Apply, Non)
+      | [%type: [%t? _] * [%t? _]] -> Some (InfixOp3, Non)
       | _ -> None
     in
     match ctx with

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -159,14 +159,9 @@ let is_sequence exp =
       true
   | _ -> false
 
-let rec is_sugared_list exp =
-  match exp.pexp_desc with
-  | Pexp_construct ({txt= Lident "[]"}, None) -> true
-  | Pexp_construct
-      ( {txt= Lident "::"}
-      , Some
-          { pexp_desc= Pexp_tuple [_; ({pexp_attributes= []} as tl)]
-          ; pexp_attributes= [] } ) ->
+let rec is_sugared_list = function
+  | [%expr []] -> true
+  | [%expr [%e? _] :: [%e? tl]] when List.is_empty tl.pexp_attributes ->
       is_sugared_list tl
   | _ -> false
 

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2160,20 +2160,9 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
       hvbox 2
         (wrap_fits_breaks_if ~space:false c.conf parens "(" ")"
            (fmt "lazy@ " $ fmt_expression c (sub_exp ~ctx e) $ fmt_atrs))
-  | Pexp_extension
-      ( ext
-      , PStr
-          [ ( { pstr_desc=
-                  Pstr_eval
-                    ( ( { pexp_desc=
-                            ( Pexp_while _ | Pexp_for _ | Pexp_match _
-                            | Pexp_try _ | Pexp_let _ | Pexp_ifthenelse _
-                            | Pexp_sequence _ | Pexp_new _
-                            | Pexp_letmodule _ | Pexp_object _
-                            | Pexp_function _ )
-                        ; pexp_attributes= [] } as e1 )
-                    , _ ) } as str ) ] )
+  | Pexp_extension (ext, PStr [([%stri [%e? e1]] as str)])
     when List.is_empty pexp_attributes
+         && List.is_empty e1.pexp_attributes
          && ( Poly.(c.conf.extension_sugar = `Always)
             || Source.extension_using_sugar ~name:ext ~payload:e1 ) ->
       hvbox 0

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1508,17 +1508,14 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
       in
       Cmts.relocate c.cmts ~src:pexp_loc ~before:ident.loc ~after:ident.loc ;
       fmt_index_op c ctx ~parens op s indices ~set:e
-  | Pexp_apply
-      ( { pexp_desc= Pexp_ident {txt= Lident ":="; loc}
-        ; pexp_attributes= []
-        ; pexp_loc }
-      , [(Nolabel, r); (Nolabel, v)] )
+  | Pexp_apply (([%expr ( := )] as ident), [(Nolabel, r); (Nolabel, v)])
     when is_simple c.conf width (sub_exp ~ctx r) ->
-      Cmts.relocate c.cmts ~src:pexp_loc ~before:loc ~after:loc ;
+      Cmts.relocate c.cmts ~src:pexp_loc ~before:ident.pexp_loc
+        ~after:ident.pexp_loc ;
       wrap_if parens "(" ")"
         (hovbox 0
            ( fmt_expression c (sub_exp ~ctx r)
-           $ Cmts.fmt c.cmts loc (fmt " :=@;<1 2>")
+           $ Cmts.fmt c.cmts ident.pexp_loc (fmt " :=@;<1 2>")
            $ hvbox 2 (fmt_expression c (sub_exp ~ctx v)) ))
   | Pexp_apply
       ( { pexp_desc=

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1763,7 +1763,7 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?ext
                  | [] -> fmt ""
                  | locs -> list locs "" (Cmts.fmt_before c.cmts)
                in
-               let fmt_op = match i with 0 -> fmt "" | _ -> fmt "::" in
+               let fmt_op = fmt_if (i > 0) "::" in
                (fmt_cmts, (fmt_op, [(Nolabel, arg)])) )) )
   | Pexp_construct (({txt= Lident "::"} as lid), Some arg) ->
       wrap_if parens "(" ")"
@@ -2284,9 +2284,7 @@ and fmt_class_structure c ~ctx ?ext self_ fields =
         (c, (i, c)) )
   in
   let cmts_after_self =
-    match fields with
-    | [] -> Cmts.fmt_after c.cmts self_.ppat_loc
-    | _ -> fmt ""
+    fmt_if_k (List.is_empty fields) (Cmts.fmt_after c.cmts self_.ppat_loc)
   in
   let self_ =
     match self_ with
@@ -2330,9 +2328,7 @@ and fmt_class_signature c ~ctx ~parens ?ext self_ fields =
         (c, (i, c)) )
   in
   let cmts_after_self =
-    match fields with
-    | [] -> Cmts.fmt_after c.cmts self_.ptyp_loc
-    | _ -> fmt ""
+    fmt_if_k (List.is_empty fields) (Cmts.fmt_after c.cmts self_.ptyp_loc)
   in
   let self_ =
     match self_ with

--- a/src/Migrate_ast.ml
+++ b/src/Migrate_ast.ml
@@ -10,21 +10,21 @@
  **********************************************************************)
 
 include (
-  Ast_407 :
+  Ast_406 :
     module type of struct
-      include Ast_407
+      include Ast_406
     end
-    with module Location := Ast_407.Location )
+    with module Location := Ast_406.Location )
 
 module Parse = struct
   open Migrate_parsetree
 
-  let implementation = Parse.implementation Versions.ocaml_407
+  let implementation = Parse.implementation Versions.ocaml_406
 
-  let interface = Parse.interface Versions.ocaml_407
+  let interface = Parse.interface Versions.ocaml_406
 
   let use_file lexbuf =
-    List.filter (Parse.use_file Versions.ocaml_407 lexbuf)
+    List.filter (Parse.use_file Versions.ocaml_406 lexbuf)
       ~f:(fun (p : Parsetree.toplevel_phrase) ->
         match p with
         | Ptop_def [] -> false
@@ -32,7 +32,7 @@ module Parse = struct
 end
 
 let to_current =
-  Migrate_parsetree.Versions.(migrate ocaml_407 ocaml_current)
+  Migrate_parsetree.Versions.(migrate ocaml_406 ocaml_current)
 
 module Printast = struct
   open Printast
@@ -114,7 +114,7 @@ module Position = struct
 end
 
 module Location = struct
-  include Ast_407.Location
+  include Ast_406.Location
   module Format = Format_
 
   let fmt fs {loc_start; loc_end; loc_ghost} =

--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,7 @@
 
 let preprocess =
   match Jbuild_plugin.V1.context with
-  | "coverage" -> "(preprocess (pps bisect_ppx))"
+  | "coverage" -> "bisect_ppx"
   | _ -> ""
 
 ;; Jbuild_plugin.V1.send @@ Format.sprintf "
@@ -17,8 +17,8 @@ let preprocess =
 (executables
  (names ocamlformat ocamlformat_reason)
  (flags (:standard -open Import))
- %s
- (libraries cmdliner format_ fpath import ocaml-migrate-parsetree octavius unix))
+ (preprocess (pps ppxlib.metaquot %s))
+ (libraries cmdliner format_ fpath import ocaml-migrate-parsetree octavius ppx_tools_versioned.metaquot_403 unix))
 
 (rule
   (targets ocamlformat.1)

--- a/src/dune
+++ b/src/dune
@@ -18,7 +18,7 @@ let preprocess =
  (names ocamlformat ocamlformat_reason)
  (flags (:standard -open Import))
  (preprocess (pps ppx_tools_versioned.metaquot_406 %s))
- (libraries cmdliner core format_ fpath import ocaml-migrate-parsetree octavius ppx_tools_versioned unix))
+ (libraries cmdliner format_ fpath import ocaml-migrate-parsetree octavius ppx_tools_versioned unix))
 
 (rule
   (targets ocamlformat.1)

--- a/src/dune
+++ b/src/dune
@@ -17,8 +17,8 @@ let preprocess =
 (executables
  (names ocamlformat ocamlformat_reason)
  (flags (:standard -open Import))
- (preprocess (pps ppxlib.metaquot %s))
- (libraries cmdliner format_ fpath import ocaml-migrate-parsetree octavius ppx_tools_versioned.metaquot_403 unix))
+ (preprocess (pps ppx_tools_versioned.metaquot_406 %s))
+ (libraries cmdliner core format_ fpath import ocaml-migrate-parsetree octavius ppx_tools_versioned unix))
 
 (rule
   (targets ocamlformat.1)


### PR DESCRIPTION
in progress

- downgrading `Migrate_ast` to work with `Ast_406` instead of `Ast_407` because there is no `metaquot_407`
- patterns can't (always) be rewritten with `metaquot` if they contain `as`
- I am simplifying several code chunks as I encounter them