### PR TITLE
Revise formatting of compact single case matches

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -1614,10 +1614,9 @@ end = struct
       parenthesized in context [ctx]. *)
   let parenze_cty ({ctx; ast= cty} as xcty) =
     assert (check_cty xcty ; true) ;
-    match xcty with _ -> (
-      match ambig_prec (sub_ast ~ctx (Cty cty)) with
-      | Some (Some true) -> true
-      | _ -> false )
+    match ambig_prec (sub_ast ~ctx (Cty cty)) with
+    | Some (Some true) -> true
+    | _ -> false
 
   (** [parenze_mty {ctx; ast}] holds when module type [ast] should be
       parenthesized in context [ctx]. *)
@@ -2095,11 +2094,10 @@ end = struct
       parenthesized in context [ctx]. *)
   and parenze_cl ({ctx; ast= cl} as xcl) =
     assert (check_cl xcl ; true) ;
-    match xcl with _ -> (
-      match ambig_prec (sub_ast ~ctx (Cl cl)) with
-      | None -> false
-      | Some (Some true) -> true
-      | _ -> exposed_right_cl Non_apply cl )
+    match ambig_prec (sub_ast ~ctx (Cl cl)) with
+    | None -> false
+    | Some (Some true) -> true
+    | _ -> exposed_right_cl Non_apply cl
 
   let rec exposed_left_typ typ =
     match typ.ptyp_desc with

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -305,7 +305,8 @@ end = struct
     let docs = section_name section in
     let term = Arg.(value & flag & info names_for_cmdline ~doc ~docs) in
     let parse s =
-      try Ok (Bool.of_string s) with _ ->
+      try Ok (Bool.of_string s)
+      with _ ->
         Error
           (Format.sprintf "invalid value '%s', expecting 'true' or 'false'"
              s)
@@ -336,7 +337,8 @@ end = struct
       Arg.(value & opt (some int) None & info names ~doc ~docs ~docv)
     in
     let parse s =
-      try Ok (Int.of_string s) with _ ->
+      try Ok (Int.of_string s)
+      with _ ->
         Error (Format.sprintf "invalid value '%s', expecting an integer" s)
     in
     let r = mk ~default:None term in

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -100,8 +100,8 @@ let fits_breaks ?(force_fit_if = false) ?(force_break_if = false) fits
       let b = String.sub breaks ~pos:2 ~len:(len - 2) in
       match breaks.[1] with
       | ';' -> (
-        try Scanf.sscanf breaks "@;<%d %d>%s" (fun x y z -> (x, y, z)) with
-        | Scanf.Scan_failure _ | End_of_file -> (1, 0, b) )
+        try Scanf.sscanf breaks "@;<%d %d>%s" (fun x y z -> (x, y, z))
+        with Scanf.Scan_failure _ | End_of_file -> (1, 0, b) )
       | ',' -> (0, 0, b)
       | ' ' -> (1, 0, b)
       | _ -> (0, Int.min_value, breaks)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -44,7 +44,8 @@ let empty =
 let protect =
   let first = ref true in
   fun ast pp fs ->
-    try pp fs with exc ->
+    try pp fs
+    with exc ->
       if !first && Conf.debug then (
         let bt = Caml.Printexc.get_backtrace () in
         Format.pp_print_flush fs () ;

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2075,16 +2075,18 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?(indent_wrap = 0) ?ext
         | _ -> impossible "previous match"
       in
       let compact =
-        match cs with
-        | []
-         |_ :: _ :: _
-         |[ { pc_lhs=
-                { ppat_desc=
-                    Ppat_or _ | Ppat_alias ({ppat_desc= Ppat_or _}, _) } }
-          ] ->
+        match exp.pexp_desc with
+        | Pexp_try
+            ( _
+            , [ { pc_lhs=
+                    { ppat_desc=
+                        Ppat_or _ | Ppat_alias ({ppat_desc= Ppat_or _}, _)
+                    } } ] )
+          when Poly.(c.conf.break_cases = `All) ->
             None
-        | [x] ->
-            if Poly.(c.conf.single_case = `Compact) then Some x else None
+        | Pexp_try (_, [x]) when Poly.(c.conf.single_case = `Compact) ->
+            Some x
+        | _ -> None
       in
       match compact with
       | None ->
@@ -2118,18 +2120,20 @@ and fmt_expression c ?(box = true) ?epi ?eol ?parens ?(indent_wrap = 0) ?ext
                    $ hvbox 0
                        (fmt "@;<1 -1>" $ fmt_expression c (sub_exp ~ctx e0))
                    $ fmt "@," )
-               $ fmt "@;<0 -2>"
+               $ break_unless_newline 1 (-2)
                $ hvbox 0
-                   ( break_unless_newline 1 0 $ fmt "with@ " $ leading_cmt
-                   $ hvbox 0
-                       ( fmt_pattern c ~pro:(if_newline "| ")
-                           (sub_pat ~ctx pc_lhs)
-                       $ opt pc_guard (fun g ->
-                             fmt "@ when "
-                             $ fmt_expression c (sub_exp ~ctx g) ) )
-                   $ fmt "@ ->" $ fmt_if parens_here " (" )
-               $ fmt "@ "
-               $ cbox 0 (fmt_expression c ?parens:parens_for_exp xpc_rhs)
+                   ( hvbox 0
+                       ( fmt "with@ " $ leading_cmt
+                       $ hvbox 0
+                           ( fmt_pattern c ~pro:(if_newline "| ")
+                               (sub_pat ~ctx pc_lhs)
+                           $ opt pc_guard (fun g ->
+                                 fmt "@ when "
+                                 $ fmt_expression c (sub_exp ~ctx g) )
+                           $ fmt "@ ->" $ fmt_if parens_here " (" ) )
+                   $ fmt "@;<1 2>"
+                   $ cbox 0
+                       (fmt_expression c ?parens:parens_for_exp xpc_rhs) )
                $ fmt_if parens_here
                    ( if c.conf.indicate_multiline_delimiters then " )"
                    else ")" ) )) )

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -53,15 +53,13 @@ match x with
 try f x
 with
 (* this comment is intended to refer to the entire case below *)
-| Caml.Not_found
--> ()
+| Caml.Not_found ->
+  ()
 
 ;;
-match x
-with
+match x with
 (* this comment is intended to refer to the entire case below *)
-| false
--> ()
+| false -> ()
 
 ;;
 match x with

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -3,10 +3,11 @@ let () = [%ext expr] ; ()
 let _ = ([%ext match x with () -> ()] [@attr y])
 
 let _ =
-  match%ext x with () ->
-    let y = [%test let x = y] in
-    let%test x = d in
-    d
+  match%ext x with
+  | () ->
+      let y = [%test let x = y] in
+      let%test x = d in
+      d
 
 val f : compare:[%compare: 'a] -> sexp_of:[%sexp_of: 'a] -> t
 

--- a/test/passing/infix_bind.ml
+++ b/test/passing/infix_bind.ml
@@ -132,20 +132,20 @@ let parens =
       close_box $ fmt "@ " $ fmt_expression c ~eol:(fmt "@;<1000 0>") xbody
 
 let parens =
-  match body
-  with {pexp_desc= Pexp_function cs; pexp_attributes; pexp_loc} -> (
-    update_config_maybe_disabled c pexp_loc pexp_attributes @@ function
-    | _ ->
-        fmt "@ "
-        $ Cmts.fmt c.cmts pexp_loc
-            (wrap_if parens "(" ")"
-               ( fmt "function"
-               $ fmt_extension_suffix c ext
-               $ fmt_attributes c ~key:"@" pexp_attributes
-               $ close_box $ fmt "@ " $ fmt_cases c ctx cs ))
-    | _ ->
-        close_box $ fmt "@ "
-        $ fmt_expression c ~eol:(fmt "@;<1000 0>") xbody )
+  match body with
+  | {pexp_desc= Pexp_function cs; pexp_attributes; pexp_loc} -> (
+      update_config_maybe_disabled c pexp_loc pexp_attributes @@ function
+      | _ ->
+          fmt "@ "
+          $ Cmts.fmt c.cmts pexp_loc
+              (wrap_if parens "(" ")"
+                 ( fmt "function"
+                 $ fmt_extension_suffix c ext
+                 $ fmt_attributes c ~key:"@" pexp_attributes
+                 $ close_box $ fmt "@ " $ fmt_cases c ctx cs ))
+      | _ ->
+          close_box $ fmt "@ "
+          $ fmt_expression c ~eol:(fmt "@;<1000 0>") xbody )
 
 let end_gen_implementation ?toplevel ~ppf_dump
     (clambda : clambda_and_constants) =

--- a/test/passing/list.ml
+++ b/test/passing/list.ml
@@ -1,13 +1,12 @@
 let f x = match x with P ({xxxxxx} :: {yyyyyyyy} :: zzzzzzz) -> true
 
 let f x =
-  match x
-  with
+  match x with
   | P
       ({xxxxxxxxxxxxxxxxxxxxxx}
       :: {yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy}
-         :: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz)
-  -> true
+         :: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz) ->
+      true
 
 let f x = match x with P [{xxxxxx}; {yyyyyyyy}] -> true
 

--- a/test/passing/match.ml
+++ b/test/passing/match.ml
@@ -18,7 +18,8 @@ let _ =
   | DDDDDDDDDDDDDDd -> DDDDDDDDDDDDDDDDdD
 
 let _ =
-  match x with _ -> (
+  match x with
+  | _ -> (
     match
       something long enough to_break
         _________________________________________________________________

--- a/test/passing/match2.ml
+++ b/test/passing/match2.ml
@@ -18,7 +18,8 @@ let _ =
   | DDDDDDDDDDDDDDd -> DDDDDDDDDDDDDDDDdD
 
 let _ =
-  match x with _ ->
+  match x with
+  | _ ->
     ( match
         something long enough to_break
           _________________________________________________________________

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -1746,8 +1746,10 @@ let rec filter : type a n. (a -> bool) -> (a, n) seq -> (a, n) filter =
   match s with
   | Snil -> Filter (LeZ NZ, Snil)
   | Scons (a, l) -> (
-    match filter f l with Filter (le, l') ->
-      if f a then Filter (LeS le, Scons (a, l')) else Filter (leS' le, l') )
+    match filter f l with
+    | Filter (le, l') ->
+        if f a then Filter (LeS le, Scons (a, l')) else Filter (leS' le, l')
+    )
 
 (* 4.1 AVL trees *)
 
@@ -2277,7 +2279,8 @@ let rec rule : type a b.
  fun v1 v2 ->
   match (v1, v2) with
   | Lam (x, body), v -> (
-    match subst body (Bind (x, v, Id)) with Ex term -> (
+    match subst body (Bind (x, v, Id)) with
+    | Ex term -> (
       match mode term with Pexp -> Inl term | Pval -> Inr term ) )
   | Const (IntTo b, f), Const (IntR, x) -> Inr (Const (b, f x))
 


### PR DESCRIPTION
The reasoning for the compact single case match only really applies for `try`, not for `match`, so specialize. Also, the current compact formatting can be improved wrt readability.