### PR TITLE
Fix call to gen_version script in dune file

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -12,7 +12,7 @@ Jbuild_plugin.V1.send
 (rule
  (targets Version.ml)
  (deps (universe))
- (action (run sh %%{dep:../tools/gen_version.sh} Version.ml))
+ (action (run bash %%{dep:../tools/gen_version.sh} Version.ml))
  (mode fallback))
 
 (ocamllex Literal_lexer)


### PR DESCRIPTION
`sh` is the legacy shell on most platforms and this script use bash features