### PR TITLE
Implement box debugging

### DIFF
--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -166,7 +166,8 @@ let with_box_debug k fs =
 
 let box_depth = ref 0
 
-let box_depth_colors = [|32; 33; 34; 31; 35; 36|]
+(* Numeric part of the ANSI escape sequence for colors *)
+let box_depth_colors = [|32; 33; 94; 31; 35; 36|]
 
 let box_depth_color () =
   box_depth_colors.(!box_depth % Array.length box_depth_colors)
@@ -184,6 +185,7 @@ let debug_box_open box_kind n fs =
 let debug_box_close fs =
   if !box_debug_enabled then
     if !box_depth = 0 then
+      (* mismatched close, red background *)
       pp_color_k 41 (fun fs -> Format.fprintf fs "@<0>]") fs
     else (
       Int.decr box_depth ;

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -146,6 +146,10 @@ val wrap_fits_breaks_if :
 
 (** Boxes ---------------------------------------------------------------*)
 
+val with_box_debug : t -> t
+(** Represent boxes inside a format thunk with colored brackets. For debug
+    purposes *)
+
 val open_vbox : int -> t
 (** Open an vbox with specified indentation. *)
 

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2877,9 +2877,10 @@ and fmt_cases c ctx cs =
         let fmt_arrow_close_box =
           fmt_or_k
             (break_cases_level c > 0)
-            (fmt_or_k parens_here (fmt "@;<1 2>->@]")
-               (fmt "@;<1 -2>->@]@;<0 3>"))
-            ( fmt "@;<1 -2>->@]"
+            (fmt_or_k parens_here
+               (fmt "@;<1 2>->" $ close_box)
+               (fmt "@;<1 -2>->" $ close_box $ fmt "@;<0 3>"))
+            ( fmt "@;<1 -2>->" $ close_box
             $ fmt_or_k parens_here (fmt " (") (fmt "@;<0 -1>") )
         in
         let pro =
@@ -3542,25 +3543,24 @@ and fmt_module c ?epi keyword name xargs xbody colon xmty attributes =
     $ hvbox 4
         ( keyword $ fmt " " $ fmt_str_loc c name
         $ list_pn arg_blks (fun ?prev:_ (name, arg_mtyp) ?next ->
-              ( match arg_mtyp with
-              | Some {pro= None} -> fmt "@ @[<hv 2>("
-              | _ -> fmt "@ (" )
-              $ fmt_str_loc c name
-              $ opt arg_mtyp (fun {pro; psp; bdy; cls; esp; epi} ->
-                    fmt " : " $ Option.call ~f:pro
-                    $ fmt_if_k (Option.is_some pro) close_box
-                    $ psp $ bdy
-                    $ fmt_if_k (Option.is_some pro) cls
-                    $ esp
-                    $ ( match next with
-                      | Some (_, Some {opn; pro= Some _}) ->
-                          opn $ open_hvbox 0
-                      | _ -> fmt "" )
-                    $ Option.call ~f:epi )
-              $
-              match arg_mtyp with
-              | Some {pro= None} -> fmt ")@]"
-              | _ -> fmt ")" ) )
+              let maybe_box k =
+                match arg_mtyp with Some {pro= None} -> hvbox 2 k | _ -> k
+              in
+              fmt "@ "
+              $ maybe_box
+                  (wrap "(" ")"
+                     ( fmt_str_loc c name
+                     $ opt arg_mtyp (fun {pro; psp; bdy; cls; esp; epi} ->
+                           fmt " : " $ Option.call ~f:pro
+                           $ fmt_if_k (Option.is_some pro) close_box
+                           $ psp $ bdy
+                           $ fmt_if_k (Option.is_some pro) cls
+                           $ esp
+                           $ ( match next with
+                             | Some (_, Some {opn; pro= Some _}) ->
+                                 opn $ open_hvbox 0
+                             | _ -> fmt "" )
+                           $ Option.call ~f:epi ) )) ) )
     $ Option.call ~f:pro_t
     $ fmt_if_k (Option.is_some pro_t) close_box
     $ psp_t $ bdy_t $ cls_t $ esp_t $ Option.call ~f:epi_t

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -178,8 +178,9 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
         in
         let tmp = print_to_file (Format.sprintf "%s.%i%s" base i ext) in
         ignore
-          (print_to_file ~box_debug:true
-             (Format.sprintf "%s.%i.boxes%s" base i ext)) ;
+          ( print_to_file ~box_debug:true
+              (Format.sprintf "%s.%i.boxes%s" base i ext)
+            : _ * _ ) ;
         tmp
     in
     let conf = if Conf.debug then conf else {conf with Conf.quiet= true} in

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -149,25 +149,39 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
   (* iterate until formatting stabilizes *)
   let rec print_check ~i ~(conf : Conf.t) ~ast ~comments ~prefix ~source_txt
       ~source_file : result =
-    let tmp, oc =
-      if not Conf.debug then Filename.open_temp_file ~temp_dir:dir base ext
-      else
-        let name = Format.sprintf "%s.%i%s" base i ext in
-        let tmp = Filename.concat dir name in
-        Format.eprintf "%s@\n%!" tmp ;
-        let oc = Out_channel.create ~fail_if_exists:(not Conf.debug) tmp in
-        (tmp, oc)
-    in
     dump xunit dir base ".old" ".ast" ast ;
-    let source = Source.create source_txt in
-    let cmts_t = xunit.init_cmts source conf ast comments in
-    let fs = Format.formatter_of_out_channel oc in
-    Fmt.set_margin conf.margin fs ;
-    (* note that [fprintf fs "%s" ""] is not a not-opt. *)
-    if not (String.is_empty prefix) then Format.fprintf fs "%s" prefix ;
-    xunit.fmt source cmts_t conf ast fs ;
-    Format.pp_print_newline fs () ;
-    Out_channel.close oc ;
+    let remaining_comments, tmp =
+      let print_and_get_remaining_comments ?(box_debug = false) oc =
+        let source = Source.create source_txt in
+        let cmts_t = xunit.init_cmts source conf ast comments in
+        let fs = Format.formatter_of_out_channel oc in
+        Fmt.set_margin conf.margin fs ;
+        (* note that [fprintf fs "%s" ""] is not a not-opt. *)
+        if not (String.is_empty prefix) then Format.fprintf fs "%s" prefix ;
+        let do_fmt = xunit.fmt source cmts_t conf ast in
+        if box_debug then Fmt.with_box_debug do_fmt fs else do_fmt fs ;
+        Format.pp_print_newline fs () ;
+        Out_channel.close oc ;
+        lazy (Cmts.remaining_comments cmts_t)
+      in
+      if not Conf.debug then
+        let tmp, oc = Filename.open_temp_file ~temp_dir:dir base ext in
+        let cmts = print_and_get_remaining_comments oc in
+        (cmts, tmp)
+      else
+        let print_to_file ?box_debug base_name =
+          let tmp = Filename.concat dir base_name in
+          Format.eprintf "%s@\n%!" tmp ;
+          let oc = Out_channel.create ~fail_if_exists:false tmp in
+          let cmts = print_and_get_remaining_comments ?box_debug oc in
+          (cmts, tmp)
+        in
+        let tmp = print_to_file (Format.sprintf "%s.%i%s" base i ext) in
+        ignore
+          (print_to_file ~box_debug:true
+             (Format.sprintf "%s.%i.boxes%s" base i ext)) ;
+        tmp
+    in
     let conf = if Conf.debug then conf else {conf with Conf.quiet= true} in
     let fmted = In_channel.with_file tmp ~f:In_channel.input_all in
     if String.equal source_txt fmted then (
@@ -204,7 +218,7 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
             else internal_error `Ast [("output file", String.sexp_of_t tmp)] ) ;
           (* Comments not preserved ? *)
           if conf.comment_check then (
-            ( match Cmts.remaining_comments cmts_t with
+            ( match Lazy.force remaining_comments with
             | [] -> ()
             | l ->
                 let l = List.map l ~f:(fun (l, n, _t, _s) -> (l, n)) in

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -177,10 +177,9 @@ let parse_print (XUnit xunit) (conf : Conf.t) ~input_name ~input_file ic
           (cmts, tmp)
         in
         let tmp = print_to_file (Format.sprintf "%s.%i%s" base i ext) in
-        ignore
-          ( print_to_file ~box_debug:true
-              (Format.sprintf "%s.%i.boxes%s" base i ext)
-            : _ * _ ) ;
+        print_to_file ~box_debug:true
+          (Format.sprintf "%s.%i.boxes%s" base i ext)
+        |> (ignore : _ * _ -> _) ;
         tmp
     in
     let conf = if Conf.debug then conf else {conf with Conf.quiet= true} in


### PR DESCRIPTION
Print colored brackets around boxes to a temporary *.boxes.ml* file

I needed this to understand the behavior of `fmt_module`, which I still don't understand.

When printed to a terminal, the debug file looks like this: https://imgur.com/hPrcAkn