### PR TITLE
Fix: Require Octavius version 1.2.0

### DIFF
--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -30,7 +30,7 @@ depends: [
   "dune" {build & >= "1.1.1"}
   "fpath"
   "ocaml-migrate-parsetree" {>= "1.0.10"}
-  "octavius"
+  "octavius" {>= "1.2.0"}
   "stdio"
   "uutf"
 ]


### PR DESCRIPTION
The test `doc_comments.mli` fail with Octavius 1.1.0 with:

```
ocamlformat: Cannot process "test/passing/doc_comments.mli".
  Please report this bug at https://github.com/ocaml-ppx/ocamlformat/issues.
  BUG: formatting did not stabilize after 10 iterations.
```

which pass when Octavius 1.2.0 is installed.