### PR TITLE
Break comment record

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3069,25 +3069,22 @@ and fmt_label_declaration c ctx lbl_decl ?(last = false) =
   @@ fun c ->
   let doc, atrs = doc_atrs pld_attributes in
   let indent = if Poly.(c.conf.break_separators = `Before) then 2 else 0 in
-  let fmt_cmts =
-    Cmts.fmt c.cmts ~eol:(break_unless_newline 1 indent) pld_loc
-  in
-  fmt_cmts
-  @@ hvbox 4
-       ( hvbox 3
-           ( hvbox 2
-               ( fmt_if Poly.(pld_mutable = Mutable) "mutable "
-               $ fmt_str_loc c pld_name
-               $ fmt_if Poly.(c.conf.field_space = `Loose) " "
-               $ fmt ":@ "
-               $ fmt_core_type c (sub_typ ~ctx pld_type)
-               $ Cmts.fmt_after c.cmts pld_loc
-               $ fmt_if_k
-                   (not Poly.(c.conf.break_separators = `Before))
-                   (fmt_or last "" ";") )
-           $ fmt_attributes c ~pre:(fmt "@;<1 1>") ~box:false ~key:"@" atrs
-           )
-       $ fmt_docstring c ~pro:(fmt "@;<2 0>") doc )
+  Cmts.fmt_before c.cmts ~eol:(break_unless_newline 1 indent) pld_loc
+  $ hvbox 4
+      ( hvbox 3
+          ( hvbox 2
+              ( fmt_if Poly.(pld_mutable = Mutable) "mutable "
+              $ fmt_str_loc c pld_name
+              $ fmt_if Poly.(c.conf.field_space = `Loose) " "
+              $ fmt ":@ "
+              $ fmt_core_type c (sub_typ ~ctx pld_type)
+              $ fmt_if_k
+                  (not Poly.(c.conf.break_separators = `Before))
+                  (fmt_or last "" ";") )
+          $ fmt_attributes c ~pre:(fmt "@;<1 1>") ~box:false ~key:"@" atrs
+          )
+      $ Cmts.fmt_after c.cmts pld_loc
+      $ fmt_docstring c ~pro:(fmt "@;<2 0>") doc )
 
 and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
   let {pcd_name= {txt; loc}; pcd_args; pcd_res; pcd_attributes; pcd_loc} =

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3081,6 +3081,7 @@ and fmt_label_declaration c ctx lbl_decl ?(last = false) =
                $ fmt_if Poly.(c.conf.field_space = `Loose) " "
                $ fmt ":@ "
                $ fmt_core_type c (sub_typ ~ctx pld_type)
+               $ Cmts.fmt_after c.cmts pld_loc
                $ fmt_if_k
                    (not Poly.(c.conf.break_separators = `Before))
                    (fmt_or last "" ";") )

--- a/test/passing/comments_in_record.ml
+++ b/test/passing/comments_in_record.ml
@@ -12,6 +12,17 @@ type t =
   ; c: string
   ; d: [`something_looooooooooooooooooooooooooooooooong] }
 
+type t = { a : int (* Comment *); b : int (* Comment *) }
+
+type t = { a : int (* Comment *); b : int (* Comment *) }
+[@@ocamlformat "type-decl=sparse"]
+
+(* TODO: delete this (module X) when the type t above is correctly formatted
+    (issue #578) *)
+module X = struct
+  type t = { a : int (* Comment *); b : int (* Comment *) }
+end [@@ocamlformat "type-decl=sparse"]
+
 let { (* cmts *)
       pat
     ; loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong

--- a/test/passing/comments_in_record.ml.ref
+++ b/test/passing/comments_in_record.ml.ref
@@ -10,6 +10,21 @@ type t =
   ; c: string
   ; d: [`something_looooooooooooooooooooooooooooooooong] }
 
+type t = {a: int (* Comment *); b: int (* Comment *)}
+
+type t = {a: int (* Comment *); b: int (* Comment *)}
+[@@ocamlformat "type-decl=sparse"]
+
+(* TODO: delete this (module X) when the type t above is correctly formatted
+   (issue #578) *)
+module X = struct
+  type t =
+    { a: int (* Comment *)
+    ; b: int
+    (* Comment *) }
+end
+[@@ocamlformat "type-decl=sparse"]
+
 let { (* cmts *)
         pat
     ; loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong

--- a/test/passing/comments_in_record.ml.ref
+++ b/test/passing/comments_in_record.ml.ref
@@ -20,8 +20,7 @@ type t = {a: int (* Comment *); b: int (* Comment *)}
 module X = struct
   type t =
     { a: int (* Comment *)
-    ; b: int
-    (* Comment *) }
+    ; b: int (* Comment *) }
 end
 [@@ocamlformat "type-decl=sparse"]
 


### PR DESCRIPTION
In:
```ocaml
type t =
  { x : int (* comment *)
  ; y : int
  (* comment for y *)
  }
```
The first comment is attached to the type and the second to the label declaration.

This PR move it directly after the type.

(One of https://github.com/ocaml-ppx/ocamlformat/issues/569)