### PR TITLE
Break closing bracket in polymorphic variants

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -867,6 +867,12 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
           | None -> false
           | Some x -> exposed_right_typ x )
       in
+      let closing_break =
+        match c.conf.type_decl with
+        | `Sparse when c.conf.space_around_collection_expressions ->
+            "@;<1000 0>]"
+        | _ -> "@ ]"
+      in
       hvbox 0
         ( fits_breaks "[" "["
         $ ( match (flag, lbls, rfs) with
@@ -878,7 +884,7 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
               fmt "< " $ row_fields rfs $ fmt " > "
               $ list ls "@ " (fmt "`" >$ str)
           | Open, Some _, _ -> impossible "not produced by parser" )
-        $ fits_breaks (if protect_token then " ]" else "]") "@ ]" )
+        $ fits_breaks (if protect_token then " ]" else "]") closing_break )
   | Ptyp_object ([], o_c) ->
       fmt "<@ "
       $ fmt_if Poly.(o_c = Open) "..@ "

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -867,11 +867,10 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
           | None -> false
           | Some x -> exposed_right_typ x )
       in
-      let closing_break =
+      let close_break =
         match c.conf.type_decl with
-        | `Sparse when c.conf.space_around_collection_expressions ->
-            "@;<1000 0>]"
-        | _ -> "@ ]"
+        | `Sparse when c.conf.space_around_collection_expressions -> true
+        | _ -> false
       in
       hvbox 0
         ( fits_breaks "[" "["
@@ -884,7 +883,9 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
               fmt "< " $ row_fields rfs $ fmt " > "
               $ list ls "@ " (fmt "`" >$ str)
           | Open, Some _, _ -> impossible "not produced by parser" )
-        $ fits_breaks (if protect_token then " ]" else "]") closing_break )
+        $ fits_breaks
+            (if protect_token then " ]" else "]")
+            (if close_break then "@;<1000 0>]" else "@ ]") )
   | Ptyp_object ([], o_c) ->
       fmt "<@ "
       $ fmt_if Poly.(o_c = Open) "..@ "

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -867,7 +867,7 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
           | None -> false
           | Some x -> exposed_right_typ x )
       in
-      let close_break =
+      let force_break =
         match c.conf.type_decl with
         | `Sparse when c.conf.space_around_collection_expressions -> true
         | _ -> false
@@ -885,7 +885,7 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
           | Open, Some _, _ -> impossible "not produced by parser" )
         $ fits_breaks
             (if protect_token then " ]" else "]")
-            (if close_break then "@;<1000 0>]" else "@ ]") )
+            (if force_break then "@;<1000 0>]" else "@ ]") )
   | Ptyp_object ([], o_c) ->
       fmt "<@ "
       $ fmt_if Poly.(o_c = Open) "..@ "

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -30,7 +30,8 @@ type obj =
 
 type var =
   [ `Foo  (** foo *)
-  | `Bar of int * string  (** bar *) ]
+  | `Bar of int * string  (** bar *)
+  ]
 
 [%%foo
 let x = 1 in
@@ -1299,7 +1300,8 @@ let a = devariantize Enil ty_abc v
 (* And an example with recursion... *)
 type 'a vlist =
   [ `Nil
-  | `Cons of 'a * 'a vlist ]
+  | `Cons of 'a * 'a vlist
+  ]
 
 let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
  fun t ->
@@ -1415,7 +1417,8 @@ let ty_abc : (([`A of int | `B of string | `C] as 'a), 'e) ty =
 
 type 'a vlist =
   [ `Nil
-  | `Cons of 'a * 'a vlist ]
+  | `Cons of 'a * 'a vlist
+  ]
 
 let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
  fun t ->
@@ -2210,7 +2213,8 @@ let f : type env a. (env, a) typ -> (env, a) typ -> int =
 (* let x = f Tint (Tvar Zero) ;; *)
 type inkind =
   [ `Link
-  | `Nonlink ]
+  | `Nonlink
+  ]
 
 type _ inline_t =
   | Text : string -> [< inkind > `Nonlink] inline_t
@@ -2335,7 +2339,8 @@ let _ = eval Eq (Int 2) (Int 3)
 type tag =
   [ `TagA
   | `TagB
-  | `TagC ]
+  | `TagC
+  ]
 
 type 'a poly =
   | AandBTags : [< `TagA of int | `TagB] poly
@@ -2397,7 +2402,8 @@ module M : sig
 end = struct
   type s =
     [ `A
-    | `B ]
+    | `B
+    ]
 
   let eq = Eq
 end
@@ -2475,7 +2481,8 @@ type _ nat =
 
 type 'a pre_nat =
   [ `Zero
-  | `Succ of 'a ]
+  | `Succ of 'a
+  ]
 
 type aux = Aux : [`Succ of [< [< [< [`Zero] pre_nat] pre_nat] pre_nat]] nat -> aux
 
@@ -3474,7 +3481,8 @@ let free_var : var -> _ = function `Var s -> Names.singleton s
 type 'a lambda =
   [ `Var of string
   | `Abs of string * 'a
-  | `App of 'a * 'a ]
+  | `App of 'a * 'a
+  ]
 
 let free_lambda ~free_rec : _ lambda -> _ = function
   | #var as x -> free_var x
@@ -3536,7 +3544,8 @@ type 'a expr =
   | `Num of int
   | `Add of 'a * 'a
   | `Neg of 'a
-  | `Mult of 'a * 'a ]
+  | `Mult of 'a * 'a
+  ]
 
 let free_expr ~free_rec : _ expr -> _ = function
   | #var as x -> free_var x
@@ -3591,7 +3600,8 @@ type lexpr =
   | `Num of int
   | `Add of lexpr * lexpr
   | `Neg of lexpr
-  | `Mult of lexpr * lexpr ]
+  | `Mult of lexpr * lexpr
+  ]
 
 let rec free : lexpr -> _ = function
   | #lambda as x -> free_lambda ~free_rec:free x
@@ -3702,7 +3712,8 @@ class ['a] var_ops =
 type 'a lambda =
   [ `Var of string
   | `Abs of string * 'a
-  | `App of 'a * 'a ]
+  | `App of 'a * 'a
+  ]
 
 let next_id =
   let current = ref 3 in
@@ -3770,7 +3781,8 @@ type 'a expr =
   | `Num of int
   | `Add of 'a * 'a
   | `Neg of 'a
-  | `Mult of 'a * 'a ]
+  | `Mult of 'a * 'a
+  ]
 
 class ['a] expr_ops (ops : ('a, 'a) #ops Lazy.t) =
   let var : 'a var_ops = new var_ops
@@ -3824,7 +3836,8 @@ let expr = lazy_fix (new expr_ops)
 
 type 'a lexpr =
   [ 'a lambda
-  | 'a expr ]
+  | 'a expr
+  ]
 
 class ['a] lexpr_ops (ops : ('a, 'a) #ops Lazy.t) =
   let lambda = new lambda_ops ops in
@@ -3937,7 +3950,8 @@ let var =
 type 'a lambda =
   [ `Var of string
   | `Abs of string * 'a
-  | `App of 'a * 'a ]
+  | `App of 'a * 'a
+  ]
 
 let next_id =
   let current = ref 3 in
@@ -4003,7 +4017,8 @@ type 'a expr =
   | `Num of int
   | `Add of 'a * 'a
   | `Neg of 'a
-  | `Mult of 'a * 'a ]
+  | `Mult of 'a * 'a
+  ]
 
 let expr_ops (ops : ('a, 'a) #ops Lazy.t) =
   let free = lazy !!ops#free
@@ -4055,7 +4070,8 @@ let expr = lazy_fix expr_ops
 
 type 'a lexpr =
   [ 'a lambda
-  | 'a expr ]
+  | 'a expr
+  ]
 
 let lexpr_ops (ops : ('a, 'a) #ops Lazy.t) =
   let lambda = lambda_ops ops in
@@ -4289,7 +4305,8 @@ let f (g : 'a * 'b -> 'a t -> 'a) s = g s s
 
 type ab =
   [ `A
-  | `B ]
+  | `B
+  ]
 
 let f (x : [`A]) = match x with #ab -> 1
 
@@ -4345,7 +4362,8 @@ let _ = fun (x : a t) -> h x
 
 type t =
   [ 'A_name
-  | `Hi ]
+  | `Hi
+  ]
 
 let f (x : 'id_arg) = x
 let f (x : 'Id_arg) = x
@@ -5894,7 +5912,8 @@ type t = F(Does_not_exist).t
 
 type expr =
   [ `Abs of string * expr
-  | `App of expr * expr ]
+  | `App of expr * expr
+  ]
 
 class type exp =
   object
@@ -6511,12 +6530,14 @@ type 'a termpc =
   [ `And of 'a * 'a
   | `Or of 'a * 'a
   | `Not of 'a
-  | `Atom of string ]
+  | `Atom of string
+  ]
 
 type 'a termk =
   [ `Dia of 'a
   | `Box of 'a
-  | 'a termpc ]
+  | 'a termpc
+  ]
 
 module type T = sig
   type term
@@ -7949,7 +7970,8 @@ end
 
 type t =
   [ `A
-  | `B ]
+  | `B
+  ]
 
 type 'a u = t
 

--- a/test/passing/space_around_collection_expressions.ml
+++ b/test/passing/space_around_collection_expressions.ml
@@ -1,0 +1,20 @@
+[@@@ocamlformat "type-decl=sparse"]
+
+type t =
+  { x: int
+  ; y: int }
+
+type t =
+  [ `X
+  | `Y ]
+
+[@@@ocamlformat "space-around-collection-expressions"]
+
+type t =
+  { x: int
+  ; y: int
+  }
+
+type t =
+  [ `X
+  | `Y ]

--- a/test/passing/space_around_collection_expressions.ml
+++ b/test/passing/space_around_collection_expressions.ml
@@ -17,4 +17,5 @@ type t =
 
 type t =
   [ `X
-  | `Y ]
+  | `Y
+  ]


### PR DESCRIPTION
(One of https://github.com/ocaml-ppx/ocamlformat/issues/569)

With `space-around-collection-expressions` and `type-decl=sparse`, brackets on records and variants are not consistent:

```
type t =
  { x: int
  ; y: int
  }

type t =
  [ `A
  | `B ]
```