### PR TITLE
No break module pack

### DIFF
--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -3199,9 +3199,7 @@ let make_set (type s) cmp =
     type t = s
 
     let compare = cmp
-  end)
-  : Set.S
-    with type elt = s)
+  end) : Set.S with type elt = s)
 ;;
 
 (* No type annotation here *)
@@ -3271,8 +3269,7 @@ let m =
 let m =
   (module struct
     let x = 3
-  end
-  : S)
+  end : S)
 ;;
 
 ;;
@@ -3310,8 +3307,7 @@ end
 let rec (module M : S') =
   (module struct
     let f n = if n <= 0 then 1 else n * M.f (n - 1)
-  end
-  : S')
+  end : S')
 in
 M.f 3
 
@@ -3421,17 +3417,14 @@ module SSMap = struct
 end
 
 let ssmap =
-  (module SSMap
-  : MapT
+  (module SSMap : MapT
     with type key = string and type data = string and type map = SSMap.map)
 ;;
 
 let ssmap =
   (module struct
     include SSMap
-  end
-  : MapT
-    with type key = string and type data = string and type map = SSMap.map)
+  end : MapT with type key = string and type data = string and type map = SSMap.map)
 ;;
 
 let ssmap :
@@ -5837,8 +5830,7 @@ end
 let v =
   (module struct
     let x = 3
-  end
-  : S)
+  end : S)
 ;;
 
 module F () = (val v)
@@ -5863,8 +5855,7 @@ let v =
     type t = int
 
     let x = 3
-  end
-  : S)
+  end : S)
 ;;
 
 module F () = (val v)

--- a/test/passing/module.ml
+++ b/test/passing/module.ml
@@ -40,8 +40,7 @@ module type X = sig
   val n : (module S with type t = t)
 
   val o :
-    (module
-     S
+    (module S
        with type long_long_type = t
         and type long_long_long_type = u
         and type very_long_long_type = t)
@@ -49,15 +48,13 @@ end
 
 module X = (val X.n : S with type t = t)
 
-module Y = ( val X.o
-               : S
-               with type long_long_type = t
-                and type long_long_long_type = u
-                and type very_long_long_type = t )
+module Y = ( val X.o : S
+  with type long_long_type = t
+   and type long_long_long_type = u
+   and type very_long_long_type = t )
 
 let _ =
-  (module M
-  : S
+  ( module M : S
     with type long_long_type = t
      and type long_long_long_type = u
      and type very_long_long_type = t )
@@ -65,15 +62,12 @@ let _ =
 let _ =
   ( module struct
     type t
-  end
-  : S
-    with type t = t )
+  end : S with type t = t )
 
 let _ =
   ( module struct
     type t
-  end
-  : S )
+  end : S )
 
 let _ =
   ( module struct
@@ -93,17 +87,12 @@ let _ =
   ( module struct
     (* a *)
     type t
-  end
-  (* b *)
-  : S
-  (* c *)
-    with type t = t (* d *) )
+  end (* b *) : S (* c *) with type t = t (* d *) )
 
 let _ =
   ( module struct
     type t
-  end
-  : S
+  end : S
     with type long_long_type = t
      and type long_long_long_type = u
      and type very_long_long_type = t )

--- a/test/passing/module.ml
+++ b/test/passing/module.ml
@@ -28,3 +28,82 @@ module C = struct
 
   and B : sig end = B
 end
+
+module M :
+  S
+  with type long_long_type = t
+   and type long_long_long_type = u
+   and type very_long_long_type = t =
+  M
+
+module type X = sig
+  val n : (module S with type t = t)
+
+  val o :
+    (module
+     S
+       with type long_long_type = t
+        and type long_long_long_type = u
+        and type very_long_long_type = t)
+end
+
+module X = (val X.n : S with type t = t)
+
+module Y = ( val X.o
+               : S
+               with type long_long_type = t
+                and type long_long_long_type = u
+                and type very_long_long_type = t )
+
+let _ =
+  (module M
+  : S
+    with type long_long_type = t
+     and type long_long_long_type = u
+     and type very_long_long_type = t )
+
+let _ =
+  ( module struct
+    type t
+  end
+  : S
+    with type t = t )
+
+let _ =
+  ( module struct
+    type t
+  end
+  : S )
+
+let _ =
+  ( module struct
+    type t
+  end
+  : Loooooooooooooooonnnnnnnnnnnnnnnng.Looooooooooooooonnnnnnnnnnnnnng.Mod
+  )
+
+let _ =
+  ( module struct
+    type t
+  end
+  : Loooooooooooooooonnnnnnnnnnnnnnnng.Looooooooooooooonnnnnnnnnnnnnng.Mod
+    with type looooooooonnnnnnng_type = t and type not_long_type = t' )
+
+let _ =
+  ( module struct
+    (* a *)
+    type t
+  end
+  (* b *)
+  : S
+  (* c *)
+    with type t = t (* d *) )
+
+let _ =
+  ( module struct
+    type t
+  end
+  : S
+    with type long_long_type = t
+     and type long_long_long_type = u
+     and type very_long_long_type = t )

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -3256,9 +3256,7 @@ let make_set (type s) cmp =
     type t = s
 
     let compare = cmp
-  end)
-  : Set.S
-    with type elt = s )
+  end) : Set.S with type elt = s )
 
 (* No type annotation here *)
 let sort_cmp (type s) cmp =
@@ -3326,8 +3324,7 @@ let m =
 let m =
   ( module struct
     let x = 3
-  end
-  : S )
+  end : S )
 
 ;;
 f m 1 m
@@ -3362,8 +3359,7 @@ end
 let rec (module M : S') =
   ( module struct
     let f n = if n <= 0 then 1 else n * M.f (n - 1)
-  end
-  : S' )
+  end : S' )
 in
 M.f 3
 
@@ -3469,9 +3465,8 @@ type ('k, 'd, 'm) map =
   (module MapT with type key = 'k and type data = 'd and type map = 'm)
 
 let add (type k d m) (m : (k, d, m) map) x y s =
-  let module M = ( val m
-                     : MapT
-                     with type key = k and type data = d and type map = m )
+  let module M = ( val m : MapT
+    with type key = k and type data = d and type map = m )
   in
   M.of_t (M.add x y (M.to_t s))
 
@@ -3488,22 +3483,19 @@ module SSMap = struct
 end
 
 let ssmap =
-  (module SSMap
-  : MapT
+  ( module SSMap : MapT
     with type key = string and type data = string and type map = SSMap.map
   )
 
 let ssmap =
   ( module struct
     include SSMap
-  end
-  : MapT
+  end : MapT
     with type key = string and type data = string and type map = SSMap.map
   )
 
 let ssmap :
-    (module
-     MapT
+    (module MapT
        with type key = string
         and type data = string
         and type map = SSMap.map) =
@@ -5841,8 +5833,7 @@ end
 let v =
   ( module struct
     let x = 3
-  end
-  : S )
+  end : S )
 
 module F () = (val v)
 
@@ -5866,8 +5857,7 @@ let v =
     type t = int
 
     let x = 3
-  end
-  : S )
+  end : S )
 
 module F () = (val v)
 


### PR DESCRIPTION
(one of https://github.com/ocaml-ppx/ocamlformat/issues/569)

An extra break is added when the expression does not fit on one line:

```
let _ =
  (module M
  : S
    with type long_long_type = t
     and type long_long_long_type = u
     and type very_long_long_type = t )

let _ =
  ( module struct
    type t
  end
  : S )
```

A little indentation is added because I moved the parenthesis outside of the box.