### PR TITLE
Fix extra break in module pack type

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -529,7 +529,8 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
         (list t1N (comma_sep c) (sub_typ ~ctx >> fmt_core_type c))
       $ fmt "@ " $ fmt_longident_loc c lid
   | Ptyp_extension ext -> hvbox 2 (fmt_extension c ctx "%" ext)
-  | Ptyp_package pty -> hvbox 0 (fmt "module@ " $ fmt_package_type c ctx pty)
+  | Ptyp_package pty ->
+      hovbox 0 (fmt "module@ " $ fmt_package_type c ctx pty)
   | Ptyp_poly ([], _) ->
       impossible "produced by the parser, handled elsewhere"
   | Ptyp_poly (a1N, t) ->

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -3502,8 +3502,7 @@ let ssmap =
   )
 
 let ssmap :
-    (module
-     MapT
+    (module MapT
        with type key = string
         and type data = string
         and type map = SSMap.map) =


### PR DESCRIPTION
Small fix to remove an extra break in:

```
val x :
  (module
   M
     with type looooooooooooooooooooooonnnnnnnnnnnnnnnng_type = t
      and type more_types = u)
``` 