### PR TITLE
Fix regression for variants with docstrings

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -636,10 +636,11 @@ and fmt_row_field c ctx = function
       let c = update_config c atrs in
       let doc, atrs = doc_atrs atrs in
       hvbox 0
-        ( fmt_str_loc c ~pre:"`" name
-        $ fmt_if (not (const && List.is_empty typs)) " of@ "
-        $ fmt_if (const && not (List.is_empty typs)) " & "
-        $ list typs "@ & " (sub_typ ~ctx >> fmt_core_type c)
+        ( hvbox 0
+            ( fmt_str_loc c ~pre:"`" name
+            $ fmt_if (not (const && List.is_empty typs)) " of@ "
+            $ fmt_if (const && not (List.is_empty typs)) " & "
+            $ list typs "@ & " (sub_typ ~ctx >> fmt_core_type c) )
         $ fmt_attributes c ~key:"@" atrs
         $ fmt_docstring_padded c doc )
   | Rinherit typ -> fmt_core_type c (sub_typ ~ctx typ)

--- a/test/passing/types.ml
+++ b/test/passing/types.ml
@@ -19,3 +19,34 @@ type t =
       [ `Doc_comment of
         [ `Moved of Location.t * Location.t * string
         | `Unstable of Location.t * string ] ]
+
+val x :
+  [ `X of int
+    (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
+        fooooooooooooooooooo fooooooooooooooo*) ]
+
+val x :
+  [ `X of
+    int
+    * foooooooooooooo
+    * fooooooooooo
+    * fooooooooooo foooooooooo
+    * foooooooooooo
+    (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
+        fooooooooooooooooooo fooooooooooooooo*) ]
+
+val x :
+  [ `X of int (* booooom *)
+    (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
+        fooooooooooooooooooo fooooooooooooooo*) ]
+
+val x :
+  [ `X of
+    int
+    * foooooooooooooo
+    * fooooooooooo
+    * fooooooooooo foooooooooo
+    * foooooooooooo
+    (* boooooom *)
+    (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
+        fooooooooooooooooooo fooooooooooooooo*) ]


### PR DESCRIPTION
Fix #598 
The diff of test_branch looks good:
```ocaml
--- a/infer/src/absint/TransferFunctions.mli
+++ b/infer/src/absint/TransferFunctions.mli
@@ -39,12 +39,10 @@ end
 
 module type DisjunctiveConfig = sig
   val join_policy :
-    [ `JoinAfter of
-      int
+    [ `JoinAfter of int
       (** when the set of disjuncts gets bigger than [n] the underlying domain's join is called to
        collapse them into one state *)
-    | `UnderApproximateAfter of
-      int
+    | `UnderApproximateAfter of int
       (** When the set of disjuncts gets bigger than [n] then just stop adding new states to it,
          drop any further states on the floor. This corresponds to an under-approximation/bounded
          approach. *)
```