### PR TITLE
Fix missing break for local open record patterns

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -915,7 +915,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
         if can_skip_parens then (".", "") else (".(", ")")
       in
       cbox 0
-        ( fmt_longident_loc c lid $ str opn
+        ( fmt_longident_loc c lid $ str opn $ fmt "@;<0 2>"
         $ fmt_pattern c (sub_pat ~ctx pat)
         $ str cls )
 

--- a/test/passing/record.ml
+++ b/test/passing/record.ml
@@ -31,3 +31,18 @@ let _ = {(x#x) with e1; e2}
 let f ~l:{f; g} = e
 
 let f ?l:({f; g}) = e
+
+let Mmmmmm.
+      { xxxx
+      ; xxxxxxxxx
+      ; xxxxxxxxxxxxxxxxxx
+      ; xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx } =
+  ()
+
+let Mmmmmm.
+      { xxxx
+      ; xxxxxxxxx
+      ; xxxxxxxxxxxxxxxxxx
+      ; xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx (* foooooooooooo *) }
+    (* fooooooooo *) =
+  ()


### PR DESCRIPTION
Fix #599 

Only diff with test_branch:

```ocaml
--- a/infer/src/bufferoverrun/bufferOverrunChecker.ml
+++ b/infer/src/bufferoverrun/bufferOverrunChecker.ml
@@ -419,9 +419,10 @@ let report_errors : Tenv.t -> Summary.t -> checks -> unit =
 
 let checks_summary : BufferOverrunAnalysis.local_decls -> checks -> checks_summary =
  fun locals
-     Checks.{ cond_set
-            ; unused_branches= _ (* intra-procedural *)
-            ; unreachable_statements= _ (* intra-procedural *) } ->
+     Checks.
+       { cond_set
+       ; unused_branches= _ (* intra-procedural *)
+       ; unreachable_statements= _ (* intra-procedural *) } ->
   PO.ConditionSet.for_summary ~forget_locs:locals cond_set

```