### PR TITLE
Fix reason wrt strings and chars

### DIFF
--- a/test-reason/test-gen.ml
+++ b/test-reason/test-gen.ml
@@ -15,3 +15,7 @@ let greeting person =
   | ((Student anyOtherName)[@explicit_arity]) ->
       ("Hey, " [@reason.raw_literal "Hey, "]) ^ anyOtherName
       ^ ("." [@reason.raw_literal "."])
+
+let x = ("\255" [@reason.raw_literal "\\xff"])
+
+let x = '\255'

--- a/test-reason/test.re
+++ b/test-reason/test.re
@@ -11,3 +11,6 @@ let greeting = person =>
   | Student("Richard") => "Still here Ricky?"
   | Student(anyOtherName) => "Hey, " ++ anyOtherName ++ "."
   };
+
+let x = "\xff"
+let x = '\xff'


### PR DESCRIPTION
Fix the fallback code path when sources are not available.
Strings and chars were not properly escaped.