### PR TITLE
Fix missing break before comment

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2785,14 +2785,15 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
   $ Cmts.fmt_before c.cmts pcd_loc
   $ Cmts.fmt_before c.cmts loc
   $ fmt_or_k first (if_newline "| ") (fmt "| ")
-  $ hovbox 2
-      ( hvbox 2
-          ( Cmts.fmt c.cmts loc
-              (wrap_if (is_symbol_id txt) "( " " )" (str txt))
-          $ fmt_constructor_arguments_result c ctx pcd_args pcd_res )
-      $ fmt_attributes c ~pre:(fmt "@;") ~key:"@" atrs
-      $ fmt_docstring_padded c doc )
-  $ Cmts.fmt_after c.cmts ~pro:(fmt " ") ~epi:(fmt "@ ") pcd_loc
+  $ hvbox 0
+      ( hovbox 2
+          ( hvbox 2
+              ( Cmts.fmt c.cmts loc
+                  (wrap_if (is_symbol_id txt) "( " " )" (str txt))
+              $ fmt_constructor_arguments_result c ctx pcd_args pcd_res )
+          $ fmt_attributes c ~pre:(fmt "@;") ~key:"@" atrs
+          $ fmt_docstring_padded c doc )
+      $ Cmts.fmt_after c.cmts pcd_loc )
 
 and fmt_constructor_arguments c ctx pre args =
   match args with

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -137,3 +137,8 @@ let () =
   ()
 
 (* break when unicode sequence length measured in bytes but ¬ in code points *)
+
+type t =
+  | Aaaaaaaaaa (* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. *)
+  | Bbbbbbbbbb (* foo *)
+  | Bbbbbbbbbb (* foo *)

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -173,3 +173,12 @@ let () =
   ()
 
 (* break when unicode sequence length measured in bytes but ¬ in code points *)
+
+type t =
+  | Aaaaaaaaaa
+  (* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+     tempor incididunt ut labore et dolore magna aliqua. *)
+  | Bbbbbbbbbb (* foo *)
+  | Bbbbbbbbbb
+
+(* foo *)


### PR DESCRIPTION
Fix #609 

The diff of this form:

```ocaml
--- a/stdlib/camlinternalFormatBasics.ml
+++ b/stdlib/camlinternalFormatBasics.ml
@@ -256,11 +256,14 @@ Format_subst_ty constructor).
 type block_type =
   | Pp_hbox (* Horizontal block no line breaking *)
   | Pp_vbox (* Vertical block each break leads to a new line *)
-  | Pp_hvbox (* Horizontal-vertical block: same as vbox, except if this block
+  | Pp_hvbox
+  (* Horizontal-vertical block: same as vbox, except if this block
                  is small enough to fit on a single line *)
-  | Pp_hovbox (* Horizontal or Vertical block: breaks lead to new line
+  | Pp_hovbox
+  (* Horizontal or Vertical block: breaks lead to new line
                  only when necessary to print the content of the block *)
-  | Pp_box (* Horizontal or Indent block: breaks lead to new line
+  | Pp_box
```
is in fact closer to the original source (due to the non-wrapping mode).