### PR TITLE
Fix: don't break line before wrapping comment

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2804,7 +2804,8 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
               $ fmt_constructor_arguments_result c ctx pcd_args pcd_res )
           $ fmt_attributes c ~pre:(fmt "@;") ~key:"@" atrs
           $ fmt_docstring_padded c doc )
-      $ Cmts.fmt_after c pcd_loc )
+      $ Cmts.fmt_after c ~pro:(fmt_or c.conf.wrap_comments "@ " " ") pcd_loc
+      )
 
 and fmt_constructor_arguments c ctx pre args =
   match args with

--- a/test/passing/wrap_comments.ml.ref
+++ b/test/passing/wrap_comments.ml.ref
@@ -9,6 +9,5 @@ type t =
 [@@@ocamlformat "wrap-comments=false"]
 
 type t =
-  | Aaaaaaaaaa
-  (* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. *)
+  | Aaaaaaaaaa (* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. *)
   | Bbbbbbbbbb


### PR DESCRIPTION
Follow up on #613