### PR TITLE
don't include ocamlformat_diff in ocamlformat

### DIFF
--- a/tools/ocamlformat-diff/dune
+++ b/tools/ocamlformat-diff/dune
@@ -1,5 +1,5 @@
 (executable
   (name        ocamlformat_diff)
   (public_name ocamlformat-diff)
-  (package     ocamlformat)
+  (package     ocamlformat_diff)
   (libraries   bos cmdliner))


### PR DESCRIPTION
Right now, the oamlformat_diff tool is part of the ocamlformat package. It looks like a mistake. And it means than an a fresh opam switch, `opam pin add ocamlformat --dev` will fail.