### PR TITLE
Improve: break the list of 'with type' module constraints

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -586,8 +586,7 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
         (list t1N (comma_sep c) (sub_typ ~ctx >> fmt_core_type c))
       $ fmt "@ " $ fmt_longident_loc c lid
   | Ptyp_extension ext -> hvbox 2 (fmt_extension c ctx "%" ext)
-  | Ptyp_package pty ->
-      hovbox 0 (fmt "module@ " $ fmt_package_type c ctx pty ptyp_loc)
+  | Ptyp_package pty -> hovbox 0 (fmt_package_type c ctx pty ptyp_loc true)
   | Ptyp_poly ([], _) ->
       impossible "produced by the parser, handled elsewhere"
   | Ptyp_poly (a1N, t) ->
@@ -680,13 +679,21 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
       $ fmt_longident_loc c ~pre:"#" lid )
   $ fmt_docstring c ~pro:(fmt "@ ") doc
 
-and fmt_package_type c ctx (lid, cnstrs) parent_loc =
-  let box =
-    if Location.is_single_line parent_loc c.conf.margin then hvbox else vbox
+and fmt_package_type c ctx (lid, cnstrs) parent_loc module_kw =
+  let box_if =
+    if Location.is_single_line parent_loc c.conf.margin then hvbox_if
+    else vbox_if
   in
-  fmt_longident_loc c lid
-  $ fmt_if (not (List.is_empty cnstrs)) "@;<1 2>"
-  $ box 0
+  ( if module_kw then hvbox 0 (fmt "module@ " $ fmt_longident_loc c lid)
+  else fmt_longident_loc c lid )
+  $ fmt_if_k
+      (not (List.is_empty cnstrs))
+      (fmt_or
+         (Location.is_single_line parent_loc c.conf.margin)
+         "@;<1 2>" "@;<1000 2>")
+  $ box_if
+      (not (List.is_empty cnstrs))
+      0
       (list_fl cnstrs (fun ~first ~last:_ (lid, typ) ->
            fmt_or first "with type " "@;<1 1>and type "
            $ fmt_longident_loc c lid $ fmt " = "
@@ -942,7 +949,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
       let ctx = Typ typ in
       wrap_if parens "(" ")"
         ( fmt "module " $ fmt_str_loc c name $ fmt "@ : "
-        $ fmt_package_type c ctx pty ppat_loc )
+        $ hovbox 0 (fmt_package_type c ctx pty ppat_loc false) )
   | Ppat_constraint (pat, typ) ->
       hvbox 2
         (wrap_if parens "(" ")"
@@ -1592,7 +1599,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       $ wrap_fits_breaks ~space:false c.conf "(" ")"
           ( fmt "module " $ Option.call ~f:pro $ psp $ bdy $ cls $ esp
           $ Option.call ~f:epi $ fmt "@ : "
-          $ fmt_package_type c ctx pty pexp_loc
+          $ hovbox 0 (fmt_package_type c ctx pty pexp_loc false)
           $ fmt_atrs )
   | Pexp_constraint (e, t) ->
       hvbox 2
@@ -3673,7 +3680,7 @@ and fmt_module_expr c ({ast= m} as xmod) =
                   ( fmt "val "
                   $ fmt_expression c (sub_exp ~ctx e1)
                   $ fmt "@;<1 2>: "
-                  $ fmt_package_type c ctx pty pmod_loc ))
+                  $ hovbox 0 (fmt_package_type c ctx pty pmod_loc false) ))
       ; epi=
           Option.some_if has_epi
             ( Cmts.fmt_after c pmod_loc

--- a/test/passing/first_class_module.ml
+++ b/test/passing/first_class_module.ml
@@ -48,19 +48,17 @@ end
 let f (module M : S with type a = int and type b = int) = M.va + M.vb
 
 let f (module M : S with type a = int and type b = int)
-    (module N
-    : SSSS
-        with type a = int
-         and type b = int
-         and type c = int
-         and type d = int
-         and type e = int)
-    (module N
-    : SSSS
-        with type a = int
-         and type b = int
-         and type c = int
-         and type d = int)
+    (module N : SSSS
+      with type a = int
+       and type b = int
+       and type c = int
+       and type d = int
+       and type e = int)
+    (module N : SSSS
+      with type a = int
+       and type b = int
+       and type c = int
+       and type d = int)
     (module O : S with type a = int and type b = int and type c = int) =
   M.va + N.vb
 

--- a/test/passing/first_class_module.ml
+++ b/test/passing/first_class_module.ml
@@ -48,17 +48,19 @@ end
 let f (module M : S with type a = int and type b = int) = M.va + M.vb
 
 let f (module M : S with type a = int and type b = int)
-    (module N : SSSS
-      with type a = int
-       and type b = int
-       and type c = int
-       and type d = int
-       and type e = int)
-    (module N : SSSS
-      with type a = int
-       and type b = int
-       and type c = int
-       and type d = int)
+    (module N
+    : SSSS
+        with type a = int
+         and type b = int
+         and type c = int
+         and type d = int
+         and type e = int)
+    (module N
+    : SSSS
+        with type a = int
+         and type b = int
+         and type c = int
+         and type d = int)
     (module O : S with type a = int and type b = int and type c = int) =
   M.va + N.vb
 

--- a/test/passing/first_class_module.ml
+++ b/test/passing/first_class_module.ml
@@ -55,7 +55,10 @@ let f (module M : S with type a = int and type b = int)
        and type d = int
        and type e = int)
     (module N : SSSS
-      with type a = int and type b = int and type c = int and type d = int)
+      with type a = int
+       and type b = int
+       and type c = int
+       and type d = int)
     (module O : S with type a = int and type b = int and type c = int) =
   M.va + N.vb
 

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -3425,7 +3425,7 @@ let make_set (type s) cmp =
     let compare = cmp
   end)
   : Set.S
-      with type elt = s)
+    with type elt = s)
 ;;
 
 (* No type annotation here *)
@@ -3647,9 +3647,9 @@ end
 let ssmap =
   (module SSMap
   : MapT
-      with type key = string
-       and type data = string
-       and type map = SSMap.map)
+    with type key = string
+     and type data = string
+     and type map = SSMap.map)
 ;;
 
 let ssmap =
@@ -3657,16 +3657,15 @@ let ssmap =
     include SSMap
   end
   : MapT
-      with type key = string
-       and type data = string
-       and type map = SSMap.map)
+    with type key = string
+     and type data = string
+     and type map = SSMap.map)
 ;;
 
 let ssmap :
-    (module MapT
-       with type key = string
-        and type data = string
-        and type map = SSMap.map) =
+    (module MapT with type key = string
+                  and type data = string
+                  and type map = SSMap.map) =
   let module S = struct
     include SSMap
   end in
@@ -5199,22 +5198,12 @@ module B' = B
 
 class b : B.a =
   object
-    method a : 'a. 'a M.s -> 'a =
-      fun (type a)
-          (module X
-          : M.S
-              with type a = a) ->
-        X.v
+    method a : 'a. 'a M.s -> 'a = fun (type a) (module X : M.S with type a = a) -> X.v
   end
 
 class b' : B.a =
   object
-    method a : 'a. 'a M'.s -> 'a =
-      fun (type a)
-          (module X
-          : M'.S
-              with type a = a) ->
-        X.v
+    method a : 'a. 'a M'.s -> 'a = fun (type a) (module X : M'.S with type a = a) -> X.v
   end
 
 module type FOO = sig

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -3425,7 +3425,7 @@ let make_set (type s) cmp =
     let compare = cmp
   end)
   : Set.S
-    with type elt = s)
+      with type elt = s)
 ;;
 
 (* No type annotation here *)
@@ -3647,9 +3647,9 @@ end
 let ssmap =
   (module SSMap
   : MapT
-    with type key = string
-     and type data = string
-     and type map = SSMap.map)
+      with type key = string
+       and type data = string
+       and type map = SSMap.map)
 ;;
 
 let ssmap =
@@ -3657,15 +3657,16 @@ let ssmap =
     include SSMap
   end
   : MapT
-    with type key = string
-     and type data = string
-     and type map = SSMap.map)
+      with type key = string
+       and type data = string
+       and type map = SSMap.map)
 ;;
 
 let ssmap :
-    (module MapT with type key = string
-                  and type data = string
-                  and type map = SSMap.map) =
+    (module MapT
+       with type key = string
+        and type data = string
+        and type map = SSMap.map) =
   let module S = struct
     include SSMap
   end in
@@ -5198,12 +5199,22 @@ module B' = B
 
 class b : B.a =
   object
-    method a : 'a. 'a M.s -> 'a = fun (type a) (module X : M.S with type a = a) -> X.v
+    method a : 'a. 'a M.s -> 'a =
+      fun (type a)
+          (module X
+          : M.S
+              with type a = a) ->
+        X.v
   end
 
 class b' : B.a =
   object
-    method a : 'a. 'a M'.s -> 'a = fun (type a) (module X : M'.S with type a = a) -> X.v
+    method a : 'a. 'a M'.s -> 'a =
+      fun (type a)
+          (module X
+          : M'.S
+              with type a = a) ->
+        X.v
   end
 
 module type FOO = sig

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -3647,7 +3647,9 @@ end
 let ssmap =
   (module SSMap
   : MapT
-    with type key = string and type data = string and type map = SSMap.map)
+    with type key = string
+     and type data = string
+     and type map = SSMap.map)
 ;;
 
 let ssmap =
@@ -3655,12 +3657,15 @@ let ssmap =
     include SSMap
   end
   : MapT
-    with type key = string and type data = string and type map = SSMap.map)
+    with type key = string
+     and type data = string
+     and type map = SSMap.map)
 ;;
 
 let ssmap :
-    (module MapT with type key = string and type data = string and type map = SSMap.map)
-    =
+    (module MapT with type key = string
+                  and type data = string
+                  and type map = SSMap.map) =
   let module S = struct
     include SSMap
   end in

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -3258,7 +3258,7 @@ let make_set (type s) cmp =
     let compare = cmp
   end)
   : Set.S
-    with type elt = s )
+      with type elt = s )
 
 (* No type annotation here *)
 let sort_cmp (type s) cmp =
@@ -3471,9 +3471,9 @@ type ('k, 'd, 'm) map =
 let add (type k d m) (m : (k, d, m) map) x y s =
   let module M = ( val m
                      : MapT
-                     with type key = k
-                      and type data = d
-                      and type map = m )
+                         with type key = k
+                          and type data = d
+                          and type map = m )
   in
   M.of_t (M.add x y (M.to_t s))
 
@@ -3492,18 +3492,18 @@ end
 let ssmap =
   (module SSMap
   : MapT
-    with type key = string
-     and type data = string
-     and type map = SSMap.map )
+      with type key = string
+       and type data = string
+       and type map = SSMap.map )
 
 let ssmap =
   ( module struct
     include SSMap
   end
   : MapT
-    with type key = string
-     and type data = string
-     and type map = SSMap.map )
+      with type key = string
+       and type data = string
+       and type map = SSMap.map )
 
 let ssmap :
     (module MapT
@@ -4926,13 +4926,21 @@ module B' = B
 class b : B.a =
   object
     method a : 'a. 'a M.s -> 'a =
-      fun (type a) (module X : M.S with type a = a) -> X.v
+      fun (type a)
+          (module X
+          : M.S
+              with type a = a) ->
+        X.v
   end
 
 class b' : B.a =
   object
     method a : 'a. 'a M'.s -> 'a =
-      fun (type a) (module X : M'.S with type a = a) -> X.v
+      fun (type a)
+          (module X
+          : M'.S
+              with type a = a) ->
+        X.v
   end
 
 module type FOO = sig

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -3471,7 +3471,9 @@ type ('k, 'd, 'm) map =
 let add (type k d m) (m : (k, d, m) map) x y s =
   let module M = ( val m
                      : MapT
-                     with type key = k and type data = d and type map = m )
+                     with type key = k
+                      and type data = d
+                      and type map = m )
   in
   M.of_t (M.add x y (M.to_t s))
 
@@ -3490,16 +3492,18 @@ end
 let ssmap =
   (module SSMap
   : MapT
-    with type key = string and type data = string and type map = SSMap.map
-  )
+    with type key = string
+     and type data = string
+     and type map = SSMap.map )
 
 let ssmap =
   ( module struct
     include SSMap
   end
   : MapT
-    with type key = string and type data = string and type map = SSMap.map
-  )
+    with type key = string
+     and type data = string
+     and type map = SSMap.map )
 
 let ssmap :
     (module MapT

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -3258,7 +3258,7 @@ let make_set (type s) cmp =
     let compare = cmp
   end)
   : Set.S
-      with type elt = s )
+    with type elt = s )
 
 (* No type annotation here *)
 let sort_cmp (type s) cmp =
@@ -3471,9 +3471,9 @@ type ('k, 'd, 'm) map =
 let add (type k d m) (m : (k, d, m) map) x y s =
   let module M = ( val m
                      : MapT
-                         with type key = k
-                          and type data = d
-                          and type map = m )
+                     with type key = k
+                      and type data = d
+                      and type map = m )
   in
   M.of_t (M.add x y (M.to_t s))
 
@@ -3492,18 +3492,18 @@ end
 let ssmap =
   (module SSMap
   : MapT
-      with type key = string
-       and type data = string
-       and type map = SSMap.map )
+    with type key = string
+     and type data = string
+     and type map = SSMap.map )
 
 let ssmap =
   ( module struct
     include SSMap
   end
   : MapT
-      with type key = string
-       and type data = string
-       and type map = SSMap.map )
+    with type key = string
+     and type data = string
+     and type map = SSMap.map )
 
 let ssmap :
     (module MapT
@@ -4926,21 +4926,13 @@ module B' = B
 class b : B.a =
   object
     method a : 'a. 'a M.s -> 'a =
-      fun (type a)
-          (module X
-          : M.S
-              with type a = a) ->
-        X.v
+      fun (type a) (module X : M.S with type a = a) -> X.v
   end
 
 class b' : B.a =
   object
     method a : 'a. 'a M'.s -> 'a =
-      fun (type a)
-          (module X
-          : M'.S
-              with type a = a) ->
-        X.v
+      fun (type a) (module X : M'.S with type a = a) -> X.v
   end
 
 module type FOO = sig


### PR DESCRIPTION
Should address #621 
I think we always want this new behavior, hence no new option