### PR TITLE
Restore compat with base.v0.11

### DIFF
--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -23,7 +23,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.05"}
-  "base" {>= "v0.12"}
+  "base" {>= "v0.11.0"}
   "base-unix"
   "cmdliner"
   "dune" {build & >= "1.1.1"}

--- a/ocamlformat_reason.opam
+++ b/ocamlformat_reason.opam
@@ -22,7 +22,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.05"}
-  "base" {>= "v0.12"}
+  "base" {>= "v0.11.0"}
   "base-unix"
   "cmdliner"
   "dune" {build & >= "1.1.1"}

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -207,7 +207,7 @@ end = struct
   let empty : t = (empty_start, empty_end)
 
   let invariant (smap, emap) =
-    assert (List.equal Poly.equal (Map.to_alist smap) (Map.to_alist emap))
+    assert (Poly.equal (Map.to_alist smap) (Map.to_alist emap))
 
   let is_empty (smap, _) = Map.is_empty smap
 

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -1390,16 +1390,20 @@ let (_profile : t option C.t) =
     (fun _ -> !selected_profile_ref)
 
 let validate () =
+  let inputs_len = List.length !inputs in
+  let has_stdin = List.exists ~f:(String.equal "-") !inputs in
   if !print_config then `Ok ()
-  else if List.is_empty !inputs then
+  else if inputs_len = 0 then
     `Error (false, "Must specify at least one input file, or `-` for stdin")
-  else if List.equal String.equal !inputs ["-"] && Option.is_none !name then
+  else if has_stdin && inputs_len > 1 then
+    `Error (false, "Cannot specify stdin together with other inputs")
+  else if has_stdin && Option.is_none !name then
     `Error (false, "Must specify name when reading from stdin")
   else if !inplace && Option.is_some !name then
     `Error (false, "Cannot specify --name with --inplace")
   else if !inplace && Option.is_some !output then
     `Error (false, "Cannot specify --output with --inplace")
-  else if (not !inplace) && List.length !inputs > 1 then
+  else if (not !inplace) && inputs_len > 1 then
     `Error (false, "Must specify exactly one input file without --inplace")
   else `Ok ()
 

--- a/src/Normalize.ml
+++ b/src/Normalize.ml
@@ -402,8 +402,8 @@ let moved_docstrings c get_docstrings s1 s2 =
   let d2 = get_docstrings c s2 in
   let equal (_, x) (_, y) = String.equal (docstring c x) (docstring c y) in
   let unstable (x, y) = Unstable (x, y) in
-  match List.zip d1 d2 with
-  | Unequal_lengths ->
+  match List.zip_exn d1 d2 with
+  | exception _ ->
       (* We only return the ones that are not in both lists. *)
       (* [l1] contains the ones that disappeared. *)
       let l1 = List.filter d1 ~f:(fun x -> not (List.mem ~equal d2 x)) in
@@ -412,7 +412,7 @@ let moved_docstrings c get_docstrings s1 s2 =
       let l2 = List.filter d2 ~f:(fun x -> not (List.mem ~equal d1 x)) in
       let l2 = List.map ~f:unstable l2 in
       List.rev_append l1 l2
-  | Ok l ->
+  | l ->
       let l = List.filter l ~f:(fun (x, y) -> not (equal x y)) in
       let l1, l2 = List.unzip l in
       let both, l1 =


### PR DESCRIPTION
This would be useful before v0.9.
Quoting @avsm: 

> The issue is that we need to move all the platform tools at the same time, or else the opam universe splits (i.e. ocamlformat will not be coinstallable with anything else that requires Base v0.11).