### PR TITLE
Fix indent of after comments in record types

### DIFF
--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -20,7 +20,7 @@ type t =
   ; break_separators: [`Before | `After | `After_and_docked]
   ; break_sequences: bool
   ; break_string_literals: [`Newlines | `Never | `Wrap]
-        (** How to potentially break string literals into new lines. *)
+    (** How to potentially break string literals into new lines. *)
   ; break_struct: bool
   ; cases_exp_indent: int
   ; comment_check: bool
@@ -29,9 +29,9 @@ type t =
   ; doc_comments_padding: int
   ; doc_comments_tag_only: [`Fit | `Default]
   ; escape_chars: [`Decimal | `Hexadecimal | `Preserve]
-        (** Escape encoding for chars literals. *)
+    (** Escape encoding for chars literals. *)
   ; escape_strings: [`Decimal | `Hexadecimal | `Preserve]
-        (** Escape encoding for string literals. *)
+    (** Escape encoding for string literals. *)
   ; extension_sugar: [`Preserve | `Always]
   ; field_space: [`Tight | `Loose]
   ; if_then_else: [`Compact | `Fit_or_vertical | `Keyword_first]
@@ -44,8 +44,8 @@ type t =
   ; let_open: [`Preserve | `Auto | `Short | `Long]
   ; margin: int  (** Format code to fit within [margin] columns. *)
   ; max_iters: int
-        (** Fail if output of formatting does not stabilize within
-            [max_iters] iterations. *)
+    (** Fail if output of formatting does not stabilize within [max_iters]
+        iterations. *)
   ; module_item_spacing: [`Compact | `Sparse]
   ; ocp_indent_compat: bool  (** Try to indent like ocp-indent *)
   ; parens_ite: bool

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2865,7 +2865,7 @@ and fmt_label_declaration c ctx lbl_decl ?(last = false) =
   let indent = if Poly.(c.conf.break_separators = `Before) then 2 else 0 in
   let cmt_after_type = Cmts.fmt_after c pld_type.ptyp_loc in
   Cmts.fmt_before c ~eol:(break_unless_newline 1 indent) pld_loc
-  $ hvbox 4
+  $ hvbox 0
       ( hvbox 3
           ( hvbox 4
               ( hvbox 2

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -12,7 +12,7 @@ type t =
   { a: int
   ; b: int [@default 1] [@drop_if]
   ; c: int [@default 1] [@drop_if]
-        (** docstring that is long enough to break *) }
+    (** docstring that is long enough to break *) }
 
 type t =
   { a: int
@@ -23,7 +23,7 @@ type t =
   ; c: someloooooooooooooooooooooooooooooong typ
         [@default looooooooooooooooooooooooooooooooooooooooong]
         [@drop_if somethingelse]
-        (** docstring that is long enough to break *) }
+    (** docstring that is long enough to break *) }
 
 val foo : int
   [@@deprecated "it is good the salad"] [@@warning "-32"] [@@warning "-99"]
@@ -83,8 +83,8 @@ let _ = ((A [@test]), (() [@test]), ([] [@test]), [||] [@test])
 type blocklist =
   { f1: int [@version 1, 1, 0]  (** short comment *)
   ; f2: (int64 * int64) list
-        (** loooooooooooooooooooooooooooooong
-            commmmmmmmmmmmmmmmmmmmmmmmmmmmmmmment *) }
+    (** loooooooooooooooooooooooooooooong
+        commmmmmmmmmmmmmmmmmmmmmmmmmmmmmmment *) }
 
 type blocklist =
   | F1 of int [@version 1, 1, 0]  (** short comment *)

--- a/test/passing/break_separators.ml
+++ b/test/passing/break_separators.ml
@@ -38,16 +38,16 @@ type t =
     break_separators: bool;
     break_sequences: bool;
     break_string_literals: [`Newlines | `Never | `Wrap];
-        (** How to potentially break string literals into new lines. *)
+    (** How to potentially break string literals into new lines. *)
     break_struct: bool;
     cases_exp_indent: int;
     comment_check: bool;
     disable: bool;
     doc_comments: [`Before | `After];
     escape_chars: [`Decimal | `Hexadecimal | `Preserve];
-        (** Escape encoding for chars literals. *)
+    (** Escape encoding for chars literals. *)
     escape_strings: [`Decimal | `Hexadecimal | `Preserve];
-        (** Escape encoding for string literals. *)
+    (** Escape encoding for string literals. *)
     extension_sugar: [`Preserve | `Always];
     field_space: [`Tight | `Loose];
     if_then_else: [`Compact | `Keyword_first];
@@ -60,8 +60,8 @@ type t =
     let_open: [`Preserve | `Auto | `Short | `Long];
     margin: int;  (** Format code to fit within [margin] columns. *)
     max_iters: int;
-        (** Fail if output of formatting does not stabilize within
-            [max_iters] iterations. *)
+    (** Fail if output of formatting does not stabilize within [max_iters]
+        iterations. *)
     module_item_spacing: [`Compact | `Sparse];
     ocp_indent_compat: bool;  (** Try to indent like ocp-indent *)
     parens_ite: bool;

--- a/test/passing/comments_in_record.ml.ref
+++ b/test/passing/comments_in_record.ml.ref
@@ -39,8 +39,8 @@ type t =
         (* aaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbb
            cccccccccccccccccccccccccccc ddddddddddddddddd eeeee *)
   ; b: float
-        (* aaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbb
-           cccccccccccccccccccccccccccc ddddddddddddddddd eeeee *) }
+    (* aaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbb
+       cccccccccccccccccccccccccccc ddddddddddddddddd eeeee *) }
 
 type t =
   | Tuple of {elts: t vector; packed: bool}


### PR DESCRIPTION
Fix issue reported in https://github.com/ocaml-ppx/ocamlformat/pull/663#issuecomment-472601110
It looks better to me, I don't know why we had a 4-spaces indentation before.