### PR TITLE
Fix weird space before type with ocp-indent-compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
   - opam install --with-test ocamlformat
 script:
   - make test
-  - opam install ocamlformat
+  - opam install --with-test ocamlformat

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 install:
   - opam update --upgrade
   - opam pin add --no-action ocamlformat .
-  - opam install --deps-only ocamlformat
+  - opam install --with-test --deps-only ocamlformat
 script:
   - make test
   - opam install ocamlformat

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 install:
   - opam update --upgrade
   - opam pin add --no-action ocamlformat .
-  - opam install --with-test --deps-only ocamlformat
+  - opam install --with-test ocamlformat
 script:
   - make test
-  - opam install --with-test ocamlformat
+  - opam install ocamlformat

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
   - opam install --with-test --deps-only ocamlformat
 script:
   - make test
-  - opam install ocamlformat
+  - opam install --with-test ocamlformat

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -29,7 +29,7 @@ depends: [
   "dune" {build & >= "1.1.1"}
   "fpath"
   "ocaml-migrate-parsetree" {>= "1.0.10"}
-  "ocp-indent" {with-test}
+  "ocp-indent" {with-test & = "1.7.0"}
   "octavius" {>= "1.2.0"}
   "stdio"
   "uutf"

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -29,6 +29,7 @@ depends: [
   "dune" {build & >= "1.1.1"}
   "fpath"
   "ocaml-migrate-parsetree" {>= "1.0.10"}
+  "ocp-indent" {with-test}
   "octavius" {>= "1.2.0"}
   "stdio"
   "uutf"

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -592,7 +592,8 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
                 (String.make (Int.max 1 (indent - String.length pro)) ' ')
           | _ ->
               fmt_or_k
-                Poly.(c.conf.break_separators = `Before)
+                ( Poly.(c.conf.break_separators = `Before)
+                && not c.conf.ocp_indent_compat )
                 (fmt_or_k c.conf.ocp_indent_compat (fits_breaks "" "")
                    (fits_breaks "" "   "))
                 (fmt "") )

--- a/test/passing/ocp_indent.ml
+++ b/test/passing/ocp_indent.ml
@@ -1,0 +1,9 @@
+let rec plus_assoc : type a b c ab bc m n.
+    (a, b, ab) plus
+    -> (ab, c, m) plus
+    -> (b, c, bc) plus
+    -> (a, bc, n) plus
+    -> (b, c, bc) plus
+    -> (a, bc, n) plus
+=
+fooo

--- a/test/passing/ocp_indent.ml.opts
+++ b/test/passing/ocp_indent.ml.opts
@@ -1,0 +1,1 @@
+--profile janestreet

--- a/test/passing/ocp_indent.ml.ref.ocpi
+++ b/test/passing/ocp_indent.ml.ref.ocpi
@@ -1,0 +1,9 @@
+let rec plus_assoc : type a b c ab bc m n.
+  (a, b, ab) plus
+  -> (ab, c, m) plus
+  -> (b, c, bc) plus
+  -> (a, bc, n) plus
+  -> (b, c, bc) plus
+  -> (a, bc, n) plus =
+  fooo
+;;

--- a/test/test.sh
+++ b/test/test.sh
@@ -93,13 +93,19 @@ ocamlformat() {
     [ $# -eq 1 ]
     opts=$(cat $1.opts 2>/dev/null || true)
     tmpfile=$TMP/$(basename $1)
-    OCAMLFORMAT=max-iters=2 bash -c "(\"$OCAMLFORMAT\" $opts \"$1\" || true) 2>&1" | sed "s#${CWD}#{CWD}#" > $tmpfile
+    if [ -e "$1.ref.ocpi" ]; then
+        OCAMLFORMAT=max-iters=2 bash -c "(\"$OCAMLFORMAT\" $opts \"$1\" | ocp-indent || true) 2>&1" | sed "s#${CWD}#{CWD}#" > $tmpfile
+    else
+        OCAMLFORMAT=max-iters=2 bash -c "(\"$OCAMLFORMAT\" $opts \"$1\" || true) 2>&1" | sed "s#${CWD}#{CWD}#" > $tmpfile
+    fi
 }
 
 reffile() {
     [ $# -eq 1 ]
     if [ -e "$1.ref" ]
     then echo "$1.ref"
+    elif [ -e "$1.ref.ocpi" ]
+    then echo "$1.ref.ocpi"
     else echo "$1"
     fi
 }

--- a/tools/update_tests.sh
+++ b/tools/update_tests.sh
@@ -33,12 +33,17 @@ function update () {
             if [ -f $TEST_DIR/$FILE.ref ]; then
                 $EXE `cat $TEST_DIR/$FILE.opts` $TEST_DIR/$FILE \
                     &> $TEST_DIR/$FILE.ref
+            elif [ -f $TEST_DIR/$FILE.ref.ocpi ]; then
+                $EXE `cat $TEST_DIR/$FILE.opts` $TEST_DIR/$FILE \
+                    | ocp-indent &> $TEST_DIR/$FILE.ref.ocpi
             else
                 $EXE `cat $TEST_DIR/$FILE.opts` $TEST_DIR/$FILE -i
             fi
         else
             if [ -f $TEST_DIR/$FILE.ref ]; then
                 $EXE $TEST_DIR/$FILE &> $TEST_DIR/$FILE.ref
+            elif [ -f $TEST_DIR/$FILE.ref.ocpi ]; then
+                $EXE $TEST_DIR/$FILE | ocp-indent &> $TEST_DIR/$FILE.ref.ocpi
             else
                 $EXE $TEST_DIR/$FILE -i
             fi


### PR DESCRIPTION
From https://github.com/janestreet/ocamlformat/commit/d6241cfd3fa32c486689e1d1666e277ef674c03d