### PR TITLE
Improve split attribute in let binding for expect test with uncaught exn

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3964,7 +3964,11 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
     match xbody.ast with {pexp_desc= Pexp_fun _} -> 1 | _ -> 2
   in
   let at_attrs, at_at_attrs =
-    match ext with None -> (atrs, []) | Some _ -> ([], atrs)
+    match ext with
+    | None -> (atrs, [])
+    | Some _ ->
+        List.partition_tf atrs ~f:(fun ({txt}, _) ->
+            not (String.equal txt "expect.uncaught_exn") )
   in
   let stmt_loc = Sugar.args_location xargs in
   fmt_docstring c ~epi:(fmt "@\n") doc1

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3967,8 +3967,8 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
     match ext with
     | None -> (atrs, [])
     | Some _ ->
-        List.partition_tf atrs ~f:(fun ({txt}, _) ->
-            not (String.equal txt "expect.uncaught_exn") )
+        List.partition_tf atrs ~f:(fun ({loc}, _) ->
+            Location.compare_start loc pvb_expr.pexp_loc < 1 )
   in
   let stmt_loc = Sugar.args_location xargs in
   fmt_docstring c ~epi:(fmt "@\n") doc1

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3963,6 +3963,9 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
   let indent =
     match xbody.ast with {pexp_desc= Pexp_fun _} -> 1 | _ -> 2
   in
+  let at_attrs, at_at_attrs =
+    match ext with None -> (atrs, []) | Some _ -> ([], atrs)
+  in
   let stmt_loc = Sugar.args_location xargs in
   fmt_docstring c ~epi:(fmt "@\n") doc1
   $ Cmts.fmt_before c pvb_loc
@@ -3971,7 +3974,7 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
       $ ( hovbox 4
             ( fmt_or first "let" "and"
             $ fmt_extension_suffix c ext
-            $ fmt_attributes c ~key:"@" atrs
+            $ fmt_attributes c ~key:"@" at_attrs
             $ fmt_if (first && Poly.(rec_flag = Recursive)) " rec"
             $ fmt " " $ fmt_pattern c xpat
             $ fmt_if_k
@@ -3984,6 +3987,7 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
             else fits_breaks " =" "@;<1000 0>=" )
             (fmt "@;<1 2>=") )
       $ fmt_body c ?ext xbody $ Cmts.fmt_after c pvb_loc
+      $ fmt_attributes c ~pre:(fmt "@;") ~key:"@@" at_at_attrs
       $ (match in_ with Some in_ -> in_ indent | None -> Fn.const ())
       $ Option.call ~f:epi )
   $ fmt_docstring c ~pro:(fmt "@\n") doc2

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3964,11 +3964,8 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
     match xbody.ast with {pexp_desc= Pexp_fun _} -> 1 | _ -> 2
   in
   let at_attrs, at_at_attrs =
-    match ext with
-    | None -> (atrs, [])
-    | Some _ ->
-        List.partition_tf atrs ~f:(fun ({loc}, _) ->
-            Location.compare_start loc pvb_expr.pexp_loc < 1 )
+    List.partition_tf atrs ~f:(fun ({loc}, _) ->
+        Location.compare_start loc pvb_expr.pexp_loc < 1 )
   in
   let stmt_loc = Sugar.args_location xargs in
   fmt_docstring c ~epi:(fmt "@\n") doc1

--- a/test/passing/expect_test.ml
+++ b/test/passing/expect_test.ml
@@ -1,3 +1,16 @@
 let%expect_test _ = e
 
 let%bench "test" = fun () -> ()
+
+let%expect_test _ =
+  assert false ;
+  [%expect.unreachable]
+  [@@expect.uncaught_exn
+    {|
+      (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+         This is strongly discouraged as backtraces are fragile.
+         Please change this test to not include a backtrace. *)
+
+      "Assert_failure test.ml:5:6"
+      Raised at file "test.ml", line 4, characters 6-18
+      Called from file "collector/expect_test_collector.ml", line 225, characters 12-19 |}]

--- a/test/passing/expect_test.ml
+++ b/test/passing/expect_test.ml
@@ -14,3 +14,12 @@ let%expect_test _ =
       "Assert_failure test.ml:5:6"
       Raised at file "test.ml", line 4, characters 6-18
       Called from file "collector/expect_test_collector.ml", line 225, characters 12-19 |}]
+
+let _ =
+  assert false ;
+  [%expect.unreachable]
+  [@@expect.uncaught_exn
+    {|
+      "Assert_failure test.ml:5:6"
+      Raised at file "test.ml", line 4, characters 6-18
+      Called from file "collector/expect_test_collector.ml", line 225, characters 12-19 |}]

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -81,7 +81,7 @@ let%foo _ = ()
 
 (* Expressions *)
 let () =
-  let%foo[@foo] x = 3
+  let%foo x = 3 [@@foo]
   and[@foo] y = 4 in
   [%foo
     (let module M = M in
@@ -184,7 +184,7 @@ module type S = sig
 end
 
 (* Structure items *)
-let%foo[@foo] x = 4
+let%foo x = 4 [@@foo]
 
 and[@foo] y = x
 

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -1,6 +1,6 @@
 [@@@foo]
 
-let[@foo] ((x[@foo]) : (unit[@foo])) = (() [@foo])
+let ((x[@foo]) : (unit[@foo])) = (() [@foo]) [@@foo]
 
 type t = Foo of (t[@foo]) [@foo] [@@foo]
 

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -81,7 +81,7 @@ let%foo _ = ()
 
 (* Expressions *)
 let () =
-  let%foo x = 3 [@@foo]
+  let%foo[@foo] x = 3
   and[@foo] y = 4 in
   [%foo
     (let module M = M in
@@ -184,7 +184,7 @@ module type S = sig
 end
 
 (* Structure items *)
-let%foo x = 4 [@@foo]
+let%foo[@foo] x = 4
 
 and[@foo] y = x
 

--- a/test/passing/let_binding.ml
+++ b/test/passing/let_binding.ml
@@ -127,7 +127,7 @@ let fooo = fooooooooooo [@@foo];;
 let fooo = fooooooooooo [@@foo]
 and fooo = fooooooooooo [@@foo];;
 
-let foooo = fooooooooo [@foo] in
+let foooo = fooooooooo [@@foo] in
 fooooooooooooooooooooo
 
 let [@foo] fooo = fooooooooooo;;

--- a/test/passing/let_binding.ml
+++ b/test/passing/let_binding.ml
@@ -121,3 +121,19 @@ let _ =
   let%ext (_ : int) = x in
   let%ext _ : int = x in
   ()
+
+let fooo = fooooooooooo [@@foo];;
+
+let fooo = fooooooooooo [@@foo]
+and fooo = fooooooooooo [@@foo];;
+
+let foooo = fooooooooo [@foo] in
+fooooooooooooooooooooo
+
+let [@foo] fooo = fooooooooooo;;
+
+let [@foo] fooo = fooooooooooo
+and [@foo] fooo = fooooooooooo;;
+
+let [@foo] foooo = fooooooooo in
+fooooooooooooooooooooo

--- a/test/passing/let_binding.ml.ref
+++ b/test/passing/let_binding.ml.ref
@@ -121,3 +121,23 @@ let _ =
   let%ext (_ : int) = x in
   let%ext (_ : int) = x in
   ()
+
+let fooo = fooooooooooo [@@foo]
+
+let fooo = fooooooooooo [@@foo]
+
+and fooo = fooooooooooo [@@foo]
+
+;;
+let foooo = (fooooooooo [@foo]) in
+fooooooooooooooooooooo
+
+let[@foo] fooo = fooooooooooo
+
+let[@foo] fooo = fooooooooooo
+
+and[@foo] fooo = fooooooooooo
+
+;;
+let[@foo] foooo = fooooooooo in
+fooooooooooooooooooooo

--- a/test/passing/let_binding.ml.ref
+++ b/test/passing/let_binding.ml.ref
@@ -129,7 +129,7 @@ let fooo = fooooooooooo [@@foo]
 and fooo = fooooooooooo [@@foo]
 
 ;;
-let foooo = (fooooooooo [@foo]) in
+let foooo = fooooooooo [@@foo] in
 fooooooooooooooooooooo
 
 let[@foo] fooo = fooooooooooo

--- a/test/passing/module_item_spacing.ml.ref
+++ b/test/passing/module_item_spacing.ml.ref
@@ -97,13 +97,13 @@ and x = x
 let a = a
 and a = a
 
-and[@ocamlformat "module-item-spacing=sparse"] a = a
+and a = a [@@ocamlformat "module-item-spacing=sparse"]
 
 and a = a
 
 and a = a
 
-and[@ocamlformat "module-item-spacing=compact"] a = a
+and a = a [@@ocamlformat "module-item-spacing=compact"]
 
 and a = a
 and a = a

--- a/test/passing/option.ml.ref
+++ b/test/passing/option.ml.ref
@@ -13,41 +13,46 @@ Invalid value for if-then-else: "Invalid value 'bad', expecting 'compact' or 'fi
 File "passing/option.ml", line 39, characters 14-25:
 Warning 47: illegal payload for attribute 'ocamlformat'.
 Invalid value for if-then-else: "Invalid value 'bad', expecting 'compact' or 'fit-or-vertical' or 'keyword-first'"
-let[@ocamlformat "if-then-else=keyword-first"] _ =
+let _ =
   if b
   then e
   else (
     something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
     this is more )
+  [@@ocamlformat "if-then-else=keyword-first"]
 
-let[@ocamlformat.typo "if-then-else=keyword-first"] _ =
+let _ =
   if b then e
   else (
     something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
     this is more )
+  [@@ocamlformat.typo "if-then-else=keyword-first"]
 
-let[@ocamlformat 1, "if-then-else=keyword-first"] _ =
+let _ =
   if b then e
   else (
     something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
     this is more )
+  [@@ocamlformat 1, "if-then-else=keyword-first"]
 
-let[@ocamlformat "if-then-else=bad"] _ =
+let _ =
   if b then e
   else (
     something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
     this is more )
+  [@@ocamlformat "if-then-else=bad"]
 
 module M = struct
   [@@@ocamlformat "if-then-else=keyword-first"]
 
-  let[@ocamlformat "if-then-else=bad"] _ =
+  let _ =
     if b
     then e
     else (
       something loooooooooooooooooooooooooooooooong enough to_trigger a
         break ;
       this is more )
+    [@@ocamlformat "if-then-else=bad"]
 
   let _ =
     if b

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -1,6 +1,6 @@
 (* Expressions *)
 let () =
-  let%foo[@foo] x = 3 and[@foo] y = 4 in
+  let%foo x = 3 [@@foo] and[@foo] y = 4 in
   [%foo
     (let module M = M in
     ()) [@foo]] ;
@@ -82,7 +82,7 @@ module type S = functor [@foo1]
   -> sig end [@foo3]
 
 (* Structure items *)
-let%foo[@foo] x = 4
+let%foo x = 4 [@@foo]
 
 and[@foo] y = x
 

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -1,6 +1,6 @@
 (* Expressions *)
 let () =
-  let%foo x = 3 [@@foo] and[@foo] y = 4 in
+  let%foo[@foo] x = 3 and[@foo] y = 4 in
   [%foo
     (let module M = M in
     ()) [@foo]] ;
@@ -82,7 +82,7 @@ module type S = functor [@foo1]
   -> sig end [@foo3]
 
 (* Structure items *)
-let%foo x = 4 [@@foo]
+let%foo[@foo] x = 4
 
 and[@foo] y = x
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -98,7 +98,7 @@ let%foo _ = ()
 
 (* Expressions *)
 let () =
-  let%foo[@foo] x = 3 and[@foo] y = 4 in
+  let%foo x = 3 [@@foo] and[@foo] y = 4 in
   [%foo
     (let module M = M in
     ()) [@foo]] ;
@@ -203,7 +203,7 @@ module type S = sig
 end
 
 (* Structure items *)
-let%foo[@foo] x = 4
+let%foo x = 4 [@@foo]
 
 and[@foo] y = x
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -1,6 +1,6 @@
 [@@@foo]
 
-let[@foo] ((x[@foo]) : (unit[@foo])) = (() [@foo])
+let ((x[@foo]) : (unit[@foo])) = (() [@foo]) [@@foo]
 
 type t = Foo of (t[@foo]) [@foo] [@@foo]
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -98,7 +98,7 @@ let%foo _ = ()
 
 (* Expressions *)
 let () =
-  let%foo x = 3 [@@foo] and[@foo] y = 4 in
+  let%foo[@foo] x = 3 and[@foo] y = 4 in
   [%foo
     (let module M = M in
     ()) [@foo]] ;
@@ -203,7 +203,7 @@ module type S = sig
 end
 
 (* Structure items *)
-let%foo x = 4 [@@foo]
+let%foo[@foo] x = 4
 
 and[@foo] y = x
 


### PR DESCRIPTION
From https://github.com/janestreet/ocamlformat/commit/c60d7378061fda35c158f399451735465ccef87f

fix #649 