### PR TITLE
Improve: break before in for let-module construct, because of ocp-indent

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3387,7 +3387,9 @@ and fmt_module c ?epi keyword name xargs xbody colon xmty attributes =
        $ esp_b $ Option.call ~f:epi_b
        $ fmt_attributes c ~pre:(fmt "@ ") ~key:"@@" atrs
        $ fmt_if_k (Option.is_some epi)
-           (fmt_or (Option.is_some epi_b) " " "@ ")
+           (fmt_or
+              (Option.is_some epi_b && not c.conf.ocp_indent_compat)
+              " " "@ ")
        $ Option.call ~f:epi ))
 
 and fmt_module_declaration c ctx ~rec_flag ~first pmd =

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -733,7 +733,8 @@ let make_set (type s) cmp =
     type t = s
 
     let compare = cmp
-  end) in
+  end)
+  in
   (module S : Set.S with type elt = s)
 ;;
 
@@ -763,7 +764,8 @@ let create (type s) to_string apply x =
     let to_string = to_string
     let apply = apply
     let x = x
-  end in
+  end
+  in
   (module M : S with type t = s)
 ;;
 
@@ -783,7 +785,8 @@ let apply x =
     include M
 
     let x = apply x
-  end in
+  end
+  in
   (module N : S)
 ;;
 
@@ -855,7 +858,8 @@ let pair (type s1 s2) t1 t2 =
     let eq = TypEq.refl
     let t1 = t1
     let t2 = t2
-  end in
+  end
+  in
   let pair = (module P : PAIR with type t = s1 * s2) in
   Pair pair
 ;;
@@ -2800,7 +2804,8 @@ let f (type a) (x : a t) =
     let (I : a t) = x (* fail because of toplevel let *)
 
     let x : a t = I
-  end in
+  end
+  in
   ()
 ;;
 
@@ -2817,7 +2822,8 @@ let bad (type a) =
 
       let e : (int, a) eq = Refl
     end
-  end in
+  end
+  in
   N.M.e
 ;;
 
@@ -3559,7 +3565,8 @@ let pair (type s1 s2) t1 t2 =
     let eq = TypEq.refl
     let t1 = t1
     let t2 = t2
-  end in
+  end
+  in
   Typ.Pair (module P)
 ;;
 
@@ -3628,7 +3635,8 @@ let ssmap :
                   and type map = SSMap.map) =
   let module S = struct
     include SSMap
-  end in
+  end
+  in
   (module S)
 ;;
 
@@ -4679,7 +4687,8 @@ let f : type t. t prod -> _ = function
   | Prod ->
     let module M = struct
       type d = d * d
-    end in
+    end
+    in
     ()
 ;;
 
@@ -5439,7 +5448,8 @@ C3.chr 66
 let f x =
   let module M = struct
     module L = List
-  end in
+  end
+  in
   M.L.length x
 ;;
 
@@ -6741,7 +6751,8 @@ let f flag =
     type t = int
 
     let compare = compare
-  end) in
+  end)
+  in
   let _ =
     match flag with
     | `A -> 0
@@ -7541,7 +7552,8 @@ let _ =
             fun x -> x + y
           ;;
         end
-      end in
+      end
+      in
       false
     with
     | Undefined_recursive_module _ -> true
@@ -7948,7 +7960,8 @@ let _ =
       end = struct
         let x = (new BadClass1.c)#m
       end
-    end in
+    end
+    in
     test 71 true false
   with
   | Undefined_recursive_module _ -> test 71 true true
@@ -8575,7 +8588,8 @@ module type S =
 let property (type t) () =
   let module M = struct
     exception E of t
-  end in
+  end
+  in
   ((fun x -> M.E x)
   , function
     | M.E x -> Some x
@@ -8598,7 +8612,8 @@ let sort_uniq (type s) cmp l =
     type t = s
 
     let compare = cmp
-  end) in
+  end)
+  in
   S.elements (List.fold_right S.add l S.empty)
 ;;
 
@@ -9596,7 +9611,8 @@ and ['a] d () =
 let _ =
   let module M = struct
     type t = { x : int }
-  end in
+  end
+  in
   let f M.(x) = () in
   let g M.{ x } = () in
   let h = function


### PR DESCRIPTION
From https://github.com/janestreet/ocamlformat/commit/dee05d12cfb621709cc65bc060951ec8c1f2976f