### PR TITLE
Fix value binding ocp indent compat

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -551,7 +551,7 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
   @@ fun c ->
   ( match (ptyp_desc, pro) with
   | Ptyp_arrow _, Some pro when c.conf.ocp_indent_compat ->
-      fmt_or pro_space "@;" "@," $ str pro $ fmt " "
+      fmt_if pro_space "@;" $ str pro $ fmt " "
   | _, Some pro -> fmt_if pro_space " " $ str pro $ fmt "@ "
   | _ -> fmt "" )
   $

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -434,6 +434,11 @@ let field_alias ~field:(li1 : Longident.t) (li2 : Longident.t) =
   | Lident x, Lident y -> String.equal x y
   | _ -> false
 
+let is_arrow_or_poly = function
+  | {ptyp_desc= Ptyp_arrow _} -> true
+  | {ptyp_desc= Ptyp_poly _} -> true
+  | _ -> false
+
 let fmt_let c ctx ~ext ~rec_flag ~bindings ~body ~parens ~attributes
     ~fmt_atrs ~sub ~fmt_expr ~fmt_value_binding =
   wrap_if
@@ -2681,11 +2686,6 @@ and fmt_cases c ctx cs =
               $ fmt_if_k parens_here
                   (fmt_or c.conf.indicate_multiline_delimiters "@ )" "@,)")
               ) ) )
-
-and is_arrow_or_poly = function
-  | {ptyp_desc= Ptyp_arrow _} -> true
-  | {ptyp_desc= Ptyp_poly _} -> true
-  | _ -> false
 
 and fmt_value_description c ctx vd =
   let { pval_name= {txt; loc}

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -550,8 +550,10 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
   update_config_maybe_disabled c ptyp_loc ptyp_attributes
   @@ fun c ->
   ( match (ptyp_desc, pro) with
-  | Ptyp_arrow _, Some pro when c.conf.ocp_indent_compat ->
+  | (Ptyp_arrow _ | Ptyp_poly _), Some pro when c.conf.ocp_indent_compat ->
       fmt_if pro_space "@;" $ str pro $ fmt " "
+  | _, Some pro when c.conf.ocp_indent_compat ->
+      fmt_if pro_space "@ " $ str pro $ fmt " "
   | _, Some pro -> fmt_if pro_space " " $ str pro $ fmt "@ "
   | _ -> fmt "" )
   $

--- a/test/passing/break_separators.ml
+++ b/test/passing/break_separators.ml
@@ -272,7 +272,8 @@ let x
       aaaaaaaaaaaaaaaaaaa;
       aaaaaaaaaaaaaa;
       aaaaaaaaaaaaaaaaaa;
-      aaaaaaaaaa } =
+      aaaaaaaaaa }
+  =
   { aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
     bbbbbbbbbbbbb= bbb bb bbbbbb;
     cccccc= cccc ccccccccccccccccccccccc }

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -1456,9 +1456,9 @@ let ty_abc : (([`A of int | `B of string | `C] as 'a), 'e) ty =
          ; "C", TCnoarg (Ttl (Ttl Thd))
          ]
 
-       method inj
-           : type c.  (int -> string -> noarg -> unit, c) ty_sel * c
-                   -> [`A of int | `B of string | `C] =
+       method inj : type c
+           .  (int -> string -> noarg -> unit, c) ty_sel * c
+           -> [`A of int | `B of string | `C] =
          function
          | Thd, v -> `A v
          | Ttl Thd, v -> `B v
@@ -1665,7 +1665,7 @@ let rec plus_func : type a b m n. (a, b, m) plus -> (a, b, n) plus -> (m, n) equ
 ;;
 
 let rec plus_assoc : type a b c ab bc m n.
-       (a, b, ab) plus
+    (a, b, ab) plus
     -> (ab, c, m) plus
     -> (b, c, bc) plus
     -> (a, bc, n) plus
@@ -2453,7 +2453,8 @@ type (_, _, _) binop =
 let eval (type a b c)
          (bop : (a, b, c) binop)
          (x : a constant)
-         (y : b constant) : c constant =
+         (y : b constant)
+    : c constant =
   match bop, x, y with
   | Eq, Bool x, Bool y -> Bool (if x then y else not y)
   | Leq, Int x, Int y -> Bool (x <= y)
@@ -2693,7 +2694,7 @@ let vexpr (type visit_action) : (_, _, visit_action) context -> _ -> visit_actio
 ;;
 
 let vexpr (type visit_action) : ('a, 'result, visit_action) context -> 'a -> visit_action
-    = function
+  = function
   | Local -> fun _ -> raise Exit
   | Global -> fun _ -> raise Exit
 ;;
@@ -3629,7 +3630,8 @@ let ssmap =
      and type map = SSMap.map)
 ;;
 
-let ssmap :
+let ssmap
+    :
     (module MapT with type key = string
                   and type data = string
                   and type map = SSMap.map) =
@@ -8815,7 +8817,7 @@ type v =
 
 let f : type a b c d e f g.
     a t * b t * c t * d t * e t * f t * g t * v * (a, b, c, d) u * (e, f, g, g) u -> int
-    = function
+  = function
   | A, A, A, A, A, A, A, _, U, U -> 1
   | _, _, _, _, _, _, _, G, _, _ -> 1
 ;;

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -3631,10 +3631,9 @@ let ssmap =
 ;;
 
 let ssmap
-    :
-    (module MapT with type key = string
-                  and type data = string
-                  and type map = SSMap.map) =
+    : (module MapT with type key = string
+                    and type data = string
+                    and type map = SSMap.map) =
   let module S = struct
     include SSMap
   end

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -1456,9 +1456,9 @@ let ty_abc : (([`A of int | `B of string | `C] as 'a), 'e) ty =
          ; "C", TCnoarg (Ttl (Ttl Thd))
          ]
 
-       method inj : type c
-           .  (int -> string -> noarg -> unit, c) ty_sel * c
-           -> [`A of int | `B of string | `C] =
+       method inj
+           : type c.  (int -> string -> noarg -> unit, c) ty_sel * c
+                   -> [`A of int | `B of string | `C] =
          function
          | Thd, v -> `A v
          | Ttl Thd, v -> `B v

--- a/test/passing/ocp_indent_compat.ml
+++ b/test/passing/ocp_indent_compat.ml
@@ -13,17 +13,17 @@ module type M = sig
        * (string Location.loc * payload) list
 
   val transl_modtype_longident
-    (* from Typemod *) :
-    (Location.t -> Env.t -> Longident.t -> Path.t) ref
+    (* from Typemod *)
+    : (Location.t -> Env.t -> Longident.t -> Path.t) ref
 
   val transl_modtype_longident
     (* foooooooooo fooooooooooooo foooooooooooo foooooooooooooo
-       foooooooooooooo foooooooooooo *) :
-    (Location.t -> Env.t -> Longident.t -> Path.t) ref
+       foooooooooooooo foooooooooooo *)
+    : (Location.t -> Env.t -> Longident.t -> Path.t) ref
 
-  val imported_sets_of_closures_table :
-    Simple_value_approx.function_declarations option
-    Set_of_closures_id.Tbl.t
+  val imported_sets_of_closures_table
+    : Simple_value_approx.function_declarations option
+      Set_of_closures_id.Tbl.t
 
   type 'a option_decl =
     names:string list

--- a/test/passing/ocp_indent_compat.ml
+++ b/test/passing/ocp_indent_compat.ml
@@ -26,7 +26,7 @@ module type M = sig
     Set_of_closures_id.Tbl.t
 
   type 'a option_decl =
-       names:string list
+    names:string list
     -> doc:string
     -> section:[`Formatting | `Operational]
     -> ?allow_inline:bool


### PR DESCRIPTION
From https://github.com/janestreet/ocamlformat/commit/b461c6001b0787a5c9aaa4bc712708092d682e81
I had to add some conditions to limit the changes to ocp-indent-compat mode.
But I'm having trouble to see what the original commit is trying to achieve, as the original commit doesn't generate valid OCaml code on js_source.ml
I also didn't report the changes on the `:` position, otherwise we get a regression with test/passing/ocp_indent_compat.ml:
```ocaml
external i : (int -> float[@unboxed]) = "i" "i_nat"
```