### PR TITLE
Fix missing space before closing paren around function

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1714,13 +1714,16 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             (fits_breaks_if parens ")" "@ )")
             (fits_breaks_if parens ")" "@,)") )
   | Pexp_function cs ->
-      wrap_if parens "(" ")"
-        ( hvbox 2
+      fmt_if parens "("
+      $ ( hvbox 2
             ( fmt "function"
             $ fmt_extension_suffix c ext
             $ fmt_attributes c ~key:"@" pexp_attributes )
         $ fmt "@ "
         $ hvbox 0 (fmt_cases c ctx cs) )
+      $ fmt_or_k c.conf.indicate_multiline_delimiters
+          (fits_breaks_if parens ")" "@ )")
+          (fits_breaks_if parens ")" "@,)")
   | Pexp_ident {txt; loc} ->
       let wrap, wrap_ident =
         if is_symbol exp && not (List.is_empty pexp_attributes) then

--- a/src/Source.ml
+++ b/src/Source.ml
@@ -149,7 +149,7 @@ let extend_loc_to_include_attributes t (loc : Location.t)
            |LBRACKETPERCENT | LBRACKETPERCENTPERCENT | LBRACKETAT
            |LBRACKETATAT | LBRACKETATATAT ->
               Int.incr count ; false
-          | _ -> false)
+          | _ -> false )
         loc
     in
     match l with
@@ -184,7 +184,7 @@ let string_literal t mode (l : Location.t) =
         | Parser.STRING (_, None) -> true
         | Parser.LBRACKETAT | Parser.LBRACKETATAT | Parser.LBRACKETATATAT ->
             true
-        | _ -> false)
+        | _ -> false )
       l
   in
   match toks with
@@ -207,7 +207,7 @@ let char_literal t (l : Location.t) =
         | Parser.CHAR _ -> true
         | Parser.LBRACKETAT | Parser.LBRACKETATAT | Parser.LBRACKETATATAT ->
             true
-        | _ -> false)
+        | _ -> false )
       l
   in
   match toks with

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -1368,7 +1368,7 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
        { sum_proj=
            (function
            | `Nil -> ("Nil", None)
-           | `Cons p -> ("Cons", Some (Tdyn (tcons, p))))
+           | `Cons p -> ("Cons", Some (Tdyn (tcons, p))) )
        ; sum_cases= [("Nil", TCnoarg Thd); ("Cons", TCarg (Ttl Thd, tcons))]
        ; sum_inj=
            (fun (type c) ->
@@ -1403,7 +1403,7 @@ let ty_abc : ([`A of int | `B of string | `C], 'e) ty =
     ( (function
       | `A n -> ("A", Some (Tdyn (Int, n)))
       | `B s -> ("B", Some (Tdyn (String, s)))
-      | `C -> ("C", None))
+      | `C -> ("C", None) )
     , function
       | "A", Some (Tdyn (Int, n)) -> `A n
       | "B", Some (Tdyn (String, s)) -> `B s
@@ -1417,7 +1417,8 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
   Rec
     (Sum
        ( (function
-         | `Nil -> ("Nil", None) | `Cons p -> ("Cons", Some (Tdyn (targ, p))))
+         | `Nil -> ("Nil", None) | `Cons p -> ("Cons", Some (Tdyn (targ, p)))
+         )
        , function
          | "Nil", None -> `Nil
          | "Cons", Some (Tdyn (Pair (_, Var), (p : a * a vlist))) -> `Cons p


### PR DESCRIPTION
Makes `function` consistent with `fun`.

fix #653