### PR TITLE
Fix weird break parens

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1522,8 +1522,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                           (Location.is_single_line pexp_loc c.conf.margin)
                           (fmt ")") (fits_breaks ")" "@ )"))
                        (fmt_or_k
-                          (Location.is_single_line xbody.ast.pexp_loc
-                             c.conf.margin)
+                          (Location.is_single_line pexp_loc c.conf.margin)
                           (fmt ")") (fits_breaks ")" "@,)")) )
                $ fmt_atrs ))
       | ( lbl

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1521,7 +1521,9 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                        (fmt_or_k
                           (Location.is_single_line pexp_loc c.conf.margin)
                           (fmt ")") (fits_breaks ")" "@ )"))
-                       (fits_breaks ")" "@,)") )
+                       (fmt_or_k
+                          (Location.is_single_line pexp_loc c.conf.margin)
+                          (fmt ")") (fits_breaks ")" "@,)")) )
                $ fmt_atrs ))
       | ( lbl
         , ( { pexp_desc= Pexp_function [{pc_lhs; pc_guard= None; pc_rhs}]

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1522,7 +1522,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                           (Location.is_single_line pexp_loc c.conf.margin)
                           (fmt ")") (fits_breaks ")" "@ )"))
                        (fmt_or_k
-                          (Location.is_single_line pexp_loc c.conf.margin)
+                          (Location.is_single_line xbody.ast.pexp_loc
+                             c.conf.margin)
                           (fmt ")") (fits_breaks ")" "@,)")) )
                $ fmt_atrs ))
       | ( lbl

--- a/test/passing/js_source.ml
+++ b/test/passing/js_source.ml
@@ -7372,3 +7372,8 @@ end
 if fffffffffffffff aaaaa bb
 then (if b then aaaaaaaaaaaaaaaa ffff)
 else aaaaaaaaaaaa qqqqqqqqqqq
+
+let _ =
+  List.map rows ~f:(fun row ->
+      Or_error.try_with (fun () -> fffffffffffffffffffffffff row))
+;;

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -9752,3 +9752,8 @@ end
 if fffffffffffffff aaaaa bb
 then (if b then aaaaaaaaaaaaaaaa ffff)
 else aaaaaaaaaaaa qqqqqqqqqqq
+
+let _ =
+  List.map rows ~f:(fun row ->
+      Or_error.try_with (fun () -> fffffffffffffffffffffffff row))
+;;


### PR DESCRIPTION
Fix #706 
So far minor regressions with test_branch (only if the janestreet profile is applied)
```ocaml
diff --git a/src/Translation_unit.ml b/src/Translation_unit.ml
index a4cdd71..15fc9f1 100644
--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -415,8 +415,8 @@ let format xunit (conf : Conf.t) ?output_file ~input_name ~source ~parsed () =
               ; "old ast", Option.map old_ast ~f:String.sexp_of_t
               ; "new ast", Option.map new_ast ~f:String.sexp_of_t
               ]
-              |> List.filter_map ~f:(fun (s, f_opt) -> Option.map f_opt ~f:(fun f -> s, f)
-                 )
+              |> List.filter_map ~f:(fun (s, f_opt) ->
+                     Option.map f_opt ~f:(fun f -> s, f))
             in
             internal_error `Comment args));
         (* Too many iteration ? *)
diff --git a/ppx/ppx_js/lib_internal/ppx_js_internal.ml b/ppx/ppx_js/lib_internal/ppx_js_internal.ml
index bb25112f0..7a3897068 100644
--- a/ppx/ppx_js/lib_internal/ppx_js_internal.ml
+++ b/ppx/ppx_js/lib_internal/ppx_js_internal.ml
@@ -211,7 +211,8 @@ let invoker ?(extra_types = []) uplift downlift body arguments =
      {[ fun (type res t0 t1 ..) arg1 arg2 -> e ]}
   *)
   let local_types =
-    make_str res :: List.map (extra_types @ arguments) ~f:(fun x -> make_str (Arg.name x))
+    make_str res
+    :: List.map (extra_types @ arguments) ~f:(fun x -> make_str (Arg.name x))
   in
   let result = List.fold_right local_types ~init:invoker ~f:Exp.newtype in
   default_loc := default_loc';
diff --git a/debugger/command_line.ml b/debugger/command_line.ml
index 88c735fd1..752e69c8c 100644
--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -107,7 +107,9 @@ let matching_elements list name instr =
     !list
 ;;
 
-let all_matching_instructions = matching_elements instruction_list (fun i -> i.instr_name)
+let all_matching_instructions =
+  matching_elements instruction_list (fun i -> i.instr_name)
+;;
 
 (* itz 04-21-96 don't do priority completion in emacs mode *)
 (* XL 25-02-97 why? I find it very confusing. *)
diff --git a/stdlib/camlinternalOO.ml b/stdlib/camlinternalOO.ml
index 305f658d1..6f6ef9a12 100644
--- a/stdlib/camlinternalOO.ml
+++ b/stdlib/camlinternalOO.ml
@@ -564,7 +564,10 @@ let app_env_const f e n x =
 ;;
 
 let meth_app_const n x = ret (fun obj -> (sendself obj n : _ -> _) x)
-let meth_app_var n m = ret (fun obj -> (sendself obj n : _ -> _) (Array.unsafe_get obj m))
+
+let meth_app_var n m =
+  ret (fun obj -> (sendself obj n : _ -> _) (Array.unsafe_get obj m))
+;;
 
 let meth_app_env n e m =
   ret (fun obj ->
diff --git a/testsuite/tests/typing-poly/poly.ml b/testsuite/tests/typing-poly/poly.ml
index efc72ce64..65ab5729b 100644
--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -947,7 +947,10 @@ class ['a] olist l =
 
 let sum (l : 'a #olist) = l#fold ~f:(fun x acc -> x + acc) ~init:0
 let count (l : 'a #olist) = l#fold ~f:(fun _ acc -> acc + 1) ~init:0
-let append (l : 'a #olist) (l' : 'b #olist) = l#fold ~init:l' ~f:(fun x acc -> acc#cons x)
+
+let append (l : 'a #olist) (l' : 'b #olist) =
+  l#fold ~init:l' ~f:(fun x acc -> acc#cons x)
+;;
```