### PR TITLE
Improve: remove field spurious parens

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2092,9 +2092,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                       (fmt_expression c) ))
            $ fmt_atrs ))
   | Pexp_setfield (e1, lid, e2) ->
+      let ctx_lhs = Exp (Ast_helper.Exp.field e1 lid) in
       hvbox 0
         (wrap_fits_breaks_if ~space:false c.conf parens "(" ")"
-           ( fmt_expression c (sub_exp ~ctx e1)
+           ( fmt_expression c (sub_exp ~ctx:ctx_lhs e1)
            $ fmt "." $ fmt_longident_loc c lid $ fmt "@ <- "
            $ fmt_expression c (sub_exp ~ctx e2)
            $ fmt_atrs ))

--- a/test/passing/field.ml
+++ b/test/passing/field.ml
@@ -1,13 +1,13 @@
 let foo =
-  (entry.logdata).value_end
+  entry.logdata.value_end
   <- entry.logdata.value_end - !remove_size + testtesttest ;
-  (entry.logdata).value_end
+  entry.logdata.value_end
   <- (entry.logdata.value_end - !remove_size + testtesttest) [@foo] ;
   (* foooooooooo *)
-  (entry.logdata).value_end
+  entry.logdata.value_end
   <- (entry.logdata.value_end - !remove_size + testtesttest) [@foo]
   (* foooooooooooo *) ;
-  (entry.logdata).value_end
+  entry.logdata.value_end
   <- entry.logdata.value_end - !remove_size + testtesttest
   (* fooooooooooooooooooooooooo *) ;
   value_end


### PR DESCRIPTION
Fix #718 

Here is the test_branch diff:
```ocaml
diff --git a/infer/src/IR/Procdesc.ml b/infer/src/IR/Procdesc.ml
index 59cfbc678..57c944ce1 100644
--- a/infer/src/IR/Procdesc.ml
+++ b/infer/src/IR/Procdesc.ml
@@ -447,7 +447,7 @@ let compute_distance_to_exit_node pdesc =
 (** check or indicate if we have performed preanalysis on the CFG *)
 let did_preanalysis pdesc = pdesc.attributes.did_preanalysis
 
-let signal_did_preanalysis pdesc = (pdesc.attributes).did_preanalysis <- true
+let signal_did_preanalysis pdesc = pdesc.attributes.did_preanalysis <- true
 
 let get_attributes pdesc = pdesc.attributes
 
@@ -546,7 +546,7 @@ let set_start_node pdesc node = pdesc.start_node <- node
 
 (** Append the locals to the list of local variables *)
 let append_locals pdesc new_locals =
-  (pdesc.attributes).locals <- pdesc.attributes.locals @ new_locals
+  pdesc.attributes.locals <- pdesc.attributes.locals @ new_locals
 
 
 let set_succs_exn_only (node : Node.t) exn = node.exn <- exn
diff --git a/examples/minesweeper/minesweeper.ml b/examples/minesweeper/minesweeper.ml
index 74a721cb9..07670444c 100644
--- a/examples/minesweeper/minesweeper.ml
+++ b/examples/minesweeper/minesweeper.ml
@@ -66,7 +66,7 @@ let neighbours cf (x, y) =
 let initialize_board cf =
   let cell_init () = {mined = false; seen = false; flag = false; nbm = 0} in
   let copy_cell_init b (i, j) = b.(i).(j) <- cell_init () in
-  let set_mined b n = (b.(n / cf.nbrows).(n mod cf.nbrows)).mined <- true in
+  let set_mined b n = b.(n / cf.nbrows).(n mod cf.nbrows).mined <- true in
   let count_mined_adj b (i, j) =
     let x = ref 0 in
     let inc_if_mined (i, j) = if b.(i).(j).mined then incr x in
@@ -74,7 +74,7 @@ let initialize_board cf =
     !x
   in
   let set_count b (i, j) =
-    if not b.(i).(j).mined then (b.(i).(j)).nbm <- count_mined_adj b (i, j)
+    if not b.(i).(j).mined then b.(i).(j).nbm <- count_mined_adj b (i, j)
   in
   let list_mined = random_list_mines (cf.nbcols * cf.nbrows) cf.nbmines in
   let board = Array.make_matrix cf.nbcols cf.nbrows (cell_init ()) in
@@ -175,15 +175,15 @@ let mark_cell d i j =
   if d.bd.(i).(j).flag
   then (
     d.nb_marked_cells <- d.nb_marked_cells - 1;
-    (d.bd.(i).(j)).flag <- false )
+    d.bd.(i).(j).flag <- false )
   else (
     d.nb_marked_cells <- d.nb_marked_cells + 1;
diff --git a/examples/minesweeper/minesweeper.ml b/examples/minesweeper/mineswee
per.ml
index 74a721cb9..07670444c 100644
--- a/examples/minesweeper/minesweeper.ml
+++ b/examples/minesweeper/minesweeper.ml
@@ -66,7 +66,7 @@ let neighbours cf (x, y) =
 let initialize_board cf =
   let cell_init () = {mined = false; seen = false; flag = false; nbm = 0} in
   let copy_cell_init b (i, j) = b.(i).(j) <- cell_init () in
-  let set_mined b n = (b.(n / cf.nbrows).(n mod cf.nbrows)).mined <- true in
+  let set_mined b n = b.(n / cf.nbrows).(n mod cf.nbrows).mined <- true in
   let count_mined_adj b (i, j) =
     let x = ref 0 in
     let inc_if_mined (i, j) = if b.(i).(j).mined then incr x in
@@ -74,7 +74,7 @@ let initialize_board cf =
     !x
   in
   let set_count b (i, j) =
-    if not b.(i).(j).mined then (b.(i).(j)).nbm <- count_mined_adj b (i, j)
+    if not b.(i).(j).mined then b.(i).(j).nbm <- count_mined_adj b (i, j)
   in
   let list_mined = random_list_mines (cf.nbcols * cf.nbrows) cf.nbmines in
   let board = Array.make_matrix cf.nbcols cf.nbrows (cell_init ()) in
@@ -175,15 +175,15 @@ let mark_cell d i j =
   if d.bd.(i).(j).flag
   then (
     d.nb_marked_cells <- d.nb_marked_cells - 1;
-    (d.bd.(i).(j)).flag <- false )
+    d.bd.(i).(j).flag <- false )
   else (
     d.nb_marked_cells <- d.nb_marked_cells + 1;
-    (d.bd.(i).(j)).flag <- true );
+    d.bd.(i).(j).flag <- true );
   draw_cell d.dom.(j).(i) d.bd.(i).(j)
 
 let reveal d i j =
   let reveal_cell (i, j) =
-    (d.bd.(i).(j)).seen <- true;
+    d.bd.(i).(j).seen <- true;
     draw_cell d.dom.(j).(i) d.bd.(i).(j);
     d.nb_hidden_cells <- d.nb_hidden_cells - 1
   in
@@ -251,7 +251,7 @@ let init_table d board_div =
                   Html.window##alert (js "YOU LOSE") )
                 else reveal d x y
             | Flag ->
-                (d.bd.(x).(y)).flag <- not d.bd.(x).(y).flag;
+                d.bd.(x).(y).flag <- not d.bd.(x).(y).flag;
                 draw_cell img d.bd.(x).(y) );
             Js._false );
       Dom.appendChild buf img
diff --git a/asmcomp/linscan.ml b/asmcomp/linscan.ml
index 7f1b350ee..245808a65 100644
--- a/asmcomp/linscan.ml
+++ b/asmcomp/linscan.ml
@@ -68,8 +68,8 @@ let allocate_stack_slot i =
   let cl = Proc.register_class i.reg in
   let ss = Proc.num_stack_slots.(cl) in
   Proc.num_stack_slots.(cl) <- succ ss ;
-  (i.reg).loc <- Stack (Local ss) ;
-  (i.reg).spill <- true
+  i.reg.loc <- Stack (Local ss) ;
+  i.reg.spill <- true
 

@@ -118,8 +118,8 @@ let allocate_free_register i =
             else if regmask.(r) then (
               (* Assign the free register and insert the
                  current interval into the active list *)
-              (i.reg).loc <- Reg (r0 + r) ;
-              (i.reg).spill <- false ;
+              i.reg.loc <- Reg (r0 + r) ;
+              i.reg.spill <- false ;
               ci.ci_active <- insert_interval_sorted i ci.ci_active )
             else assign (succ r)
           in
@@ -140,7 +140,7 @@ let allocate_blocked_register i =
          not (List.exists chk ci.ci_fixed || List.exists chk ci.ci_inactive) ->
       (match ilast.reg.loc with Reg _ -> () | _ -> assert false) ;
       (* Use register from last interval for current interval *)
-      (i.reg).loc <- ilast.reg.loc ;
+      i.reg.loc <- ilast.reg.loc ;
       (* Remove the last interval from active and insert the current *)
       ci.ci_active <- insert_interval_sorted i il ;
       (* Now get a new stack slot for the spilled register *)
diff --git a/asmcomp/selectgen.ml b/asmcomp/selectgen.ml
index 6ea78409a..831ca5f53 100644
--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -115,11 +115,11 @@ let all_regs_anonymous rv =
 
 let name_regs id rv =
   let id = VP.var id in
diff --git a/asmcomp/selectgen.ml b/asmcomp/selectgen.ml
index 6ea78409a..831ca5f53 100644
--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -115,11 +115,11 @@ let all_regs_anonymous rv =
 
 let name_regs id rv =
   let id = VP.var id in
-  if Array.length rv = 1 then (rv.(0)).raw_name <- Raw_name.create_from_var id
+  if Array.length rv = 1 then rv.(0).raw_name <- Raw_name.create_from_var id
   else
     for i = 0 to Array.length rv - 1 do
-      (rv.(i)).raw_name <- Raw_name.create_from_var id ;
-      (rv.(i)).part <- Some i
+      rv.(i).raw_name <- Raw_name.create_from_var id ;
+      rv.(i).part <- Some i
     done
 

diff --git a/bytecomp/matching.ml b/bytecomp/matching.ml
index e635c3dd4..d29d51b97 100644
--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1068,11 +1068,11 @@ type cell = {pm: pattern_matching; ctx: ctx list; pat: pattern}
 let add make_matching_fun division eq_key key patl_action args =
   try
     let _, cell = List.find (fun (k, _) -> eq_key key k) division in
-    (cell.pm).cases <- patl_action :: cell.pm.cases ;
+    cell.pm.cases <- patl_action :: cell.pm.cases ;
     division
   with Not_found ->
     let cell = make_matching_fun args in
-    (cell.pm).cases <- [patl_action] ;
+    cell.pm.cases <- [patl_action] ;
     (key, cell) :: division
 
 let divide make eq_key get_key get_args ctx pm =
diff --git a/ocamldoc/odoc_dag2html.ml b/ocamldoc/odoc_dag2html.ml
index 985f439b0..6e56f4ba3 100644
--- a/ocamldoc/odoc_dag2html.ml
+++ b/ocamldoc/odoc_dag2html.ml
@@ -555,7 +555,7 @@ let group_elem t =
     for j = 1 to Array.length t.table.(0) - 1 do
       match (t.table.(i + 1).(j - 1).elem, t.table.(i + 1).(j).elem) with
       | Elem x, Elem y when x = y ->
-          (t.table.(i).(j)).span <- t.table.(i).(j - 1).span
+          t.table.(i).(j).span <- t.table.(i).(j - 1).span
       | _ -> ()
     done
   done
@@ -579,7 +579,7 @@ let group_ghost t =
           if t.table.(i + 1).(j - 1).elem = t.table.(i + 1).(j).elem then (
             t.table.(i).(j) <- {elem= Ghost x; span= t.table.(i).(j - 1).span} ;
             if i > 0 then
-              (t.table.(i - 1).(j)).span <- t.table.(i - 1).(j - 1).span )
+              t.table.(i - 1).(j).span <- t.table.(i - 1).(j - 1).span )
       | _ -> ()
     done
   done
@@ -594,7 +594,7 @@ let group_children t =
     let len = Array.length line in
     for j = 1 to len - 1 do
       if line.(j).elem = line.(j - 1).elem && line.(j).elem <> Nothing then
-        (line.(j)).span <- line.(j - 1).span
+        line.(j).span <- line.(j - 1).span
     done
   done
 
@@ -622,7 +622,7 @@ let group_span_by_common_children d t =
           let curr_cs = List.fold_right S.add n.chil S.empty in
           if S.is_empty (S.inter cs curr_cs) then loop (j + 1) curr_cs
           else (
-            (line.(j)).span <- line.(j - 1).span ;
+            line.(j).span <- line.(j - 1).span ;
             loop (j + 1) (S.union cs curr_cs) )
       | _ -> loop (j + 1) S.empty
   in
@@ -867,8 +867,8 @@ let fill_gap t i j1 j2 =
       if j >= Array.length line then ()
       else if line.(j).span = y || t1.(i).(j).elem = t1.(i).(j - 1).elem then (
         let y = line.(j).span in
-        (line.(j)).span <- x ;
-        if i > 0 then (t1.(i - 1).(j)).span <- t1.(i - 1).(j - 1).span ;
+        line.(j).span <- x ;
+        if i > 0 then t1.(i - 1).(j).span <- t1.(i - 1).(j - 1).span ;
         loop y (j + 1) )
     in
     loop y j2 ;
@@ -905,7 +905,7 @@ let group_span_last_row t =
     else (
       ( match row.(i).elem with
       | (Elem _ | Ghost _) as x ->
-          if x = row.(i - 1).elem then (row.(i)).span <- row.(i - 1).span
+          if x = row.(i - 1).elem then row.(i).span <- row.(i - 1).span
       | _ -> () ) ;
       loop (i + 1) )
   in
@@ -987,14 +987,14 @@ let fall t =
             if i1 < i then (
       | (Elem _ | Ghost _) as x ->
-          if x = row.(i - 1).elem then (row.(i)).span <- row.(i - 1).span
+          if x = row.(i - 1).elem then row.(i).span <- row.(i - 1).span
       | _ -> () ) ;
       loop (i + 1) )
   in
@@ -987,14 +987,14 @@ let fall t =
             if i1 < i then (
               for k = i downto i1 + 1 do
                 for j = j to j2 do
-                  (t.table.(k).(j)).elem <- t.table.(k - 1).(j).elem ;
+                  t.table.(k).(j).elem <- t.table.(k - 1).(j).elem ;
                   if k < i then
-                    (t.table.(k).(j)).span <- t.table.(k - 1).(j).span
+                    t.table.(k).(j).span <- t.table.(k - 1).(j).span
                 done
               done ;
               for l = j to j2 do
                 if i1 = 0 || t.table.(i1 - 1).(l).elem = Nothing then
-                  (t.table.(i1).(l)).elem <- Nothing
+                  t.table.(i1).(l).elem <- Nothing
                 else
                   t.table.(i1).(l)
                   <- ( if
@@ -1030,7 +1030,7 @@ let fall2_cool_right t i1 i2 _i3 j1 j2 =
@@ -1030,7 +1030,7 @@ let fall2_cool_right t i1 i2 _i3 j1 j2 =
   let rec loop j =
     if j = Array.length t.table.(i2 - 1) then ()
     else if t.table.(i2 - 1).(j).span = old_span then (
-      (t.table.(i2 - 1).(j)).span <- span ;
+      t.table.(i2 - 1).(j).span <- span ;
       loop (j + 1) )
   in
   loop j1
@@ -1055,7 +1055,7 @@ let fall2_cool_left t i1 i2 _i3 j1 j2 =
   let rec loop j =
     if j < 0 then ()
     else if t.table.(i2 - 1).(j).span = old_span then (
-      (t.table.(i2 - 1).(j)).span <- span ;
+      t.table.(i2 - 1).(j).span <- span ;
       loop (j - 1) )
   in
   loop j2
@@ -1410,7 +1410,7 @@ let invert_table t =
            {elem= d.elem; span= d.span} ) ;
     if i < len - 1 then
       for j = 0 to Array.length t'.table.(i) - 1 do
-        (t'.table.(i).(j)).span <- t.table.(len - 2 - i).(j).span
+        t'.table.(i).(j).span <- t.table.(len - 2 - i).(j).span
       done
   done ;
   t'
diff --git a/ocamldoc/odoc_merge.ml b/ocamldoc/odoc_merge.ml
index aa222f26f..d2f14fa1b 100644
--- a/ocamldoc/odoc_merge.ml
+++ b/ocamldoc/odoc_merge.ml
@@ -311,14 +311,14 @@ let merge_classes merge_options mli ml =
               match ele with
               | Class_attribute a2 ->
                   if a2.att_value.val_name = a.att_value.val_name then (
-                    (a.att_value).val_info
+                    a.att_value.val_info
                     <- merge_info_opt merge_options a.att_value.val_info
                          a2.att_value.val_info ;
-                    (a.att_value).val_loc
+                    a.att_value.val_loc
                     <- { a.att_value.val_loc with
                          loc_impl= a2.att_value.val_loc.loc_impl } ;
                     if !Odoc_global.keep_code then
-                      (a.att_value).val_code <- a2.att_value.val_code ;
+                      a.att_value.val_code <- a2.att_value.val_code ;
                     true )
                   else false
               | _ -> false )
@@ -338,21 +338,21 @@ let merge_classes merge_options mli ml =
               match ele with
               | Class_method m2 ->
                   if m2.met_value.val_name = m.met_value.val_name then (
-                    (m.met_value).val_info
+                    m.met_value.val_info
                     <- merge_info_opt merge_options m.met_value.val_info
                          m2.met_value.val_info ;
-                    (m.met_value).val_loc
+                    m.met_value.val_loc
                     <- { m.met_value.val_loc with
                          loc_impl= m2.met_value.val_loc.loc_impl } ;
                     (* merge the parameter names *)
-                    (m.met_value).val_parameters
+                    m.met_value.val_parameters
                     <- merge_parameters m.met_value.val_parameters
                          m2.met_value.val_parameters ;
                     (* we must reassociate comments in @param to the corresponding
                         parameters because the associated comment of a parameter may have been changed by the merge.*)
                     Odoc_value.update_value_parameters_text m.met_value ;
                     if !Odoc_global.keep_code then
-                      (m.met_value).val_code <- m2.met_value.val_code ;
+                      m.met_value.val_code <- m2.met_value.val_code ;
                     true )
                   else false
               | _ -> false )
@@ -378,14 +378,14 @@ let merge_class_types merge_options mli ml =
               match ele with
               | Class_attribute a2 ->
                   if a2.att_value.val_name = a.att_value.val_name then (
-                    (a.att_value).val_info
+                    a.att_value.val_info
                     <- merge_info_opt merge_options a.att_value.val_info
                          a2.att_value.val_info ;
-                    (a.att_value).val_loc
+                    a.att_value.val_loc
                     <- { a.att_value.val_loc with
                          loc_impl= a2.att_value.val_loc.loc_impl } ;
                     if !Odoc_global.keep_code then
-                      (a.att_value).val_code <- a2.att_value.val_code ;
+                      a.att_value.val_code <- a2.att_value.val_code ;
                     true )
                   else false
               | _ -> false )
@@ -405,20 +405,20 @@ let merge_class_types merge_options mli ml =
               match ele with
               | Class_method m2 ->
                   if m2.met_value.val_name = m.met_value.val_name then (
-                    (m.met_value).val_info
+                    m.met_value.val_info
                     <- merge_info_opt merge_options m.met_value.val_info
                          m2.met_value.val_info ;
-                    (m.met_value).val_loc
+                    m.met_value.val_loc
                     <- { m.met_value.val_loc with
                          loc_impl= m2.met_value.val_loc.loc_impl } ;
-                    (m.met_value).val_parameters
+                    m.met_value.val_parameters
                     <- merge_parameters m.met_value.val_parameters
                          m2.met_value.val_parameters ;
                     (* we must reassociate comments in @param to the corresponding
                         parameters because the associated comment of a parameter may have been changed by the merge.*)
                     Odoc_value.update_value_parameters_text m.met_value ;
                     if !Odoc_global.keep_code then
-                      (m.met_value).val_code <- m2.met_value.val_code ;
+                      m.met_value.val_code <- m2.met_value.val_code ;
                     true )
                   else false
               | _ -> false )
diff --git a/ocamldoc/odoc_sig.ml b/ocamldoc/odoc_sig.ml
index 4505b05d8..3bdb55460 100644
--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -556,7 +556,7 @@ module Analyser (My_ir : Info_retriever) = struct
         My_ir.just_after_special !file_name
           (get_string_of_file pos_end pos_limit2)
       in
-      (met.met_value).val_info
+      met.met_value.val_info
       <- merge_infos met.met_value.val_info info_after_opt ;
       (* update the parameter description *)
       Odoc_value.update_value_parameters_text met.met_value ;
@@ -612,7 +612,7 @@ module Analyser (My_ir : Info_retriever) = struct
                 My_ir.just_after_special !file_name
                   (get_string_of_file pos_end pos_limit2)
               in
-              (att.att_value).val_info
+              att.att_value.val_info
               <- merge_infos att.att_value.val_info info_after_opt ;
               let inher_l, eles = f (pos_end + maybe_more) q in
               (inher_l, eles_comments @ (Class_attribute att :: eles))
```