### PR TITLE
Improve: normalize setfield and setinstvar

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2233,7 +2233,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
   | Pexp_setinstvar (name, expr) ->
       hvbox 0
         (wrap_fits_breaks_if ~space:false c.conf parens "(" ")"
-           ( fmt_str_loc c name $ fmt " <-@;<1 2>"
+           ( fmt_str_loc c name $ fmt "@ <- "
            $ hvbox 2 (fmt_expression c (sub_exp ~ctx expr)) ))
   | Pexp_poly _ ->
       impossible "only used for methods, handled during method formatting"

--- a/test/passing/field.ml
+++ b/test/passing/field.ml
@@ -1,0 +1,26 @@
+let foo =
+  (entry.logdata).value_end
+  <- entry.logdata.value_end - !remove_size + testtesttest ;
+  (entry.logdata).value_end
+  <- (entry.logdata.value_end - !remove_size + testtesttest) [@foo] ;
+  (* foooooooooo *)
+  (entry.logdata).value_end
+  <- (entry.logdata.value_end - !remove_size + testtesttest) [@foo]
+  (* foooooooooooo *) ;
+  (entry.logdata).value_end
+  <- entry.logdata.value_end - !remove_size + testtesttest
+  (* fooooooooooooooooooooooooo *) ;
+  value_end
+  <- entry.logdata.value_end - !remove_size + testtesttesttesttesttesttest ;
+  value_end
+  <- ( entry.logdata.value_end - !remove_size + testtesttesttesttesttesttest
+     ) [@foo] ;
+  value_end
+  <- ( entry.logdata.value_end - !remove_size + testtesttesttesttesttesttest
+     ) [@foo]
+  (* fooooooooooooo *) ;
+  (* foooooooooooooooooooo *)
+  value_end
+  <- entry.logdata.value_end - !remove_size + testtesttesttesttesttesttest
+  (* foooooooo *) ;
+  foo

--- a/test/passing/object.ml
+++ b/test/passing/object.ml
@@ -50,9 +50,9 @@ let _ =
          ; b = something very
                  loooooooooooooooooooooooooooooooooooooooooooooooong >}
       in
-      x <-
-        something very
-          looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+      x
+      <- something very
+           looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
   end
 
 let _ = f a#b (a#c x y)


### PR DESCRIPTION
Fix what is reported in https://github.com/ocaml-ppx/ocamlformat/pull/719#pullrequestreview-219345387 :

```
  entry.logdata.value_end
  <- entry.logdata.value_end - !remove_size + testtesttest ;
  value_end <-
    entry.logdata.value_end - !remove_size + testtesttesttesttesttesttest ;
```

The `<-` does not format the same depending on the lhs