### PR TITLE
Fix uneven spaces around module pack

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1617,9 +1617,9 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let {opn; pro; psp; bdy; cls; esp; epi} =
         fmt_module_expr c (sub_mod ~ctx me)
       in
-      opn
-      $ wrap_fits_breaks ~space:false c.conf "(" ")"
-          ( fmt "module " $ Option.call ~f:pro $ psp $ bdy $ cls $ esp
+      hovbox 0 @@
+      wrap_fits_breaks ~space:false c.conf "(" ")"
+        ( opn $ fmt "module " $ Option.call ~f:pro $ psp $ bdy $ cls $ esp
           $ Option.call ~f:epi $ fmt "@ : "
           $ fmt_package_type c ctx pty pexp_loc
           $ fmt_atrs )

--- a/test/passing/first_class_module.ml
+++ b/test/passing/first_class_module.ml
@@ -69,3 +69,26 @@ end
 let _ =
   let module M = (val m : M) in
   ()
+
+let _ =
+  ( module Ephemeron
+             (HHHHHHHHHHHHHHHHHHHHHHHHHH)
+             (HHHHHHHHHHHHHHHHHHHHHHHHHH) : Ephemeron.S )
+
+let _ =
+  ( module Ephemeron (HHHHHHHHHHHHHHHHHHHHHHHHHH) (HHHHHHHHHHHHHHHHHH)
+  : Ephemeron.S )
+
+let _ = (module Ephemeron (HHHHHHHHHHHHHHH) (HHHHHHHHHHHHH) : Ephemeron.S)
+
+let _ = (module Ephemeron (HHH) : Ephemeron.S)
+
+let _ =
+  ( module Ephemeron (struct
+      type t = t
+  end) : Ephemeron.S )
+
+let _ =
+  ( module struct
+    let a = b
+  end )

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -3395,12 +3395,10 @@ let sort (type s) (module Set : Set.S with type elt = s) l =
 (* No real improvement here? *)
 let make_set (type s) cmp =
   (module Set.Make (struct
-    type t = s
+     type t = s
 
-    let compare = cmp
-  end)
-  : Set.S
-    with type elt = s)
+     let compare = cmp
+  end) : Set.S with type elt = s)
 ;;
 
 (* No type annotation here *)
@@ -3469,9 +3467,8 @@ let m =
 (* Error *)
 let m =
   (module struct
-    let x = 3
-  end
-  : S)
+     let x = 3
+  end : S)
 ;;
 
 ;;
@@ -3508,9 +3505,8 @@ end
 ;;
 let rec (module M : S') =
   (module struct
-    let f n = if n <= 0 then 1 else n * M.f (n - 1)
-  end
-  : S')
+     let f n = if n <= 0 then 1 else n * M.f (n - 1)
+  end : S')
 in
 M.f 3
 
@@ -3621,8 +3617,7 @@ module SSMap = struct
 end
 
 let ssmap =
-  (module SSMap
-  : MapT
+  (module SSMap : MapT
     with type key = string
      and type data = string
      and type map = SSMap.map)
@@ -3630,12 +3625,10 @@ let ssmap =
 
 let ssmap =
   (module struct
-    include SSMap
-  end
-  : MapT
-    with type key = string
-     and type data = string
-     and type map = SSMap.map)
+     include SSMap
+  end : MapT with type key = string
+              and type data = string
+              and type map = SSMap.map)
 ;;
 
 let ssmap
@@ -6075,9 +6068,8 @@ end
 
 let v =
   (module struct
-    let x = 3
-  end
-  : S)
+     let x = 3
+  end : S)
 ;;
 
 module F () = (val v)
@@ -6099,11 +6091,10 @@ end
 
 let v =
   (module struct
-    type t = int
+     type t = int
 
-    let x = 3
-  end
-  : S)
+     let x = 3
+  end : S)
 ;;
 
 module F () = (val v)

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -3218,12 +3218,10 @@ let sort (type s) (module Set : Set.S with type elt = s) l =
 (* No real improvement here? *)
 let make_set (type s) cmp =
   ( module Set.Make (struct
-    type t = s
+      type t = s
 
-    let compare = cmp
-  end)
-  : Set.S
-    with type elt = s )
+      let compare = cmp
+  end) : Set.S with type elt = s )
 
 (* No type annotation here *)
 let sort_cmp (type s) cmp =
@@ -3290,9 +3288,8 @@ let m =
 (* Error *)
 let m =
   ( module struct
-    let x = 3
-  end
-  : S )
+      let x = 3
+  end : S )
 
 ;;
 f m 1 m
@@ -3326,9 +3323,8 @@ end
 ;;
 let rec (module M : S') =
   ( module struct
-    let f n = if n <= 0 then 1 else n * M.f (n - 1)
-  end
-  : S' )
+      let f n = if n <= 0 then 1 else n * M.f (n - 1)
+  end : S' )
 in
 M.f 3
 
@@ -3455,17 +3451,15 @@ module SSMap = struct
 end
 
 let ssmap =
-  (module SSMap
-  : MapT
+  ( module SSMap : MapT
     with type key = string
      and type data = string
      and type map = SSMap.map )
 
 let ssmap =
   ( module struct
-    include SSMap
-  end
-  : MapT
+      include SSMap
+  end : MapT
     with type key = string
      and type data = string
      and type map = SSMap.map )
@@ -5798,9 +5792,8 @@ end
 
 let v =
   ( module struct
-    let x = 3
-  end
-  : S )
+      let x = 3
+  end : S )
 
 module F () = (val v)
 
@@ -5821,11 +5814,10 @@ end
 
 let v =
   ( module struct
-    type t = int
+      type t = int
 
-    let x = 3
-  end
-  : S )
+      let x = 3
+  end : S )
 
 module F () = (val v)
 


### PR DESCRIPTION
While investigating #722, I accidentally improved formatting of module packs:

```
let v =
  ( module struct
      let x = 3
  end : S )
```

I tried to do this before (#585), the issue have been lost.

This is still a work in progress, there is a few regressions:

- undo #714 for module packs
- alignment of with constraints with `janestreet` profile