### PR TITLE
Improve: factorize with integrate_module

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -61,7 +61,7 @@ let empty =
   ; esp= Fn.const ()
   ; epi= None }
 
-let integrate_module {opn; pro; psp; bdy; cls; esp; epi} ~f =
+let compose_module {opn; pro; psp; bdy; cls; esp; epi} ~f =
   opn $ f (Option.call ~f:pro $ psp $ bdy $ cls $ esp $ Option.call ~f:epi)
 
 (* Debug: catch and report failures at nearest enclosing Ast.t *)
@@ -1617,7 +1617,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
   | Pexp_constraint
       ( {pexp_desc= Pexp_pack me; pexp_attributes= []}
       , {ptyp_desc= Ptyp_package pty; ptyp_attributes= []} ) ->
-      integrate_module
+      compose_module
         (fmt_module_expr c (sub_mod ~ctx me))
         ~f:(fun m ->
           wrap_fits_breaks ~space:false c.conf "(" ")"
@@ -2004,7 +2004,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    ( if c.conf.indicate_multiline_delimiters then " )"
                    else ")" ) )) )
   | Pexp_pack me ->
-      integrate_module
+      compose_module
         (fmt_module_expr c (sub_mod ~ctx me))
         ~f:(fun m ->
           wrap_fits_breaks ~space:false c.conf "(" ")"
@@ -3111,7 +3111,7 @@ and fmt_module_type c ({ast= mty} as xmty) =
         wrap "(" ")"
           (hovbox 0
              ( fmt_str_loc c name
-             $ opt mt1 (integrate_module ~f:(fun m -> fmt " :@ " $ m)) ))
+             $ opt mt1 (compose_module ~f:(fun m -> fmt " :@ " $ m)) ))
       in
       let blk = fmt_module_type c mt2 in
       { blk with
@@ -3129,7 +3129,7 @@ and fmt_module_type c ({ast= mty} as xmty) =
         bdy=
           hvbox 0
             (wrap_if parens "(" ")"
-               ( integrate_module (fmt_module_type c mt) ~f:(hvbox 0)
+               ( compose_module (fmt_module_type c mt) ~f:(hvbox 0)
                $ list_fl wcs (fun ~first:_ ~last:_ (wcs_and, loc) ->
                      Cmts.fmt c loc
                      @@ list_fl wcs_and (fun ~first ~last:_ wc ->

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -61,6 +61,9 @@ let empty =
   ; esp= Fn.const ()
   ; epi= None }
 
+let integrate_module {opn; pro; psp; bdy; cls; esp; epi} ~f =
+  opn $ f (Option.call ~f:pro $ psp $ bdy $ cls $ esp $ Option.call ~f:epi)
+
 (* Debug: catch and report failures at nearest enclosing Ast.t *)
 
 let protect =
@@ -1614,15 +1617,13 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
   | Pexp_constraint
       ( {pexp_desc= Pexp_pack me; pexp_attributes= []}
       , {ptyp_desc= Ptyp_package pty; ptyp_attributes= []} ) ->
-      let {opn; pro; psp; bdy; cls; esp; epi} =
-        fmt_module_expr c (sub_mod ~ctx me)
-      in
-      opn
-      $ wrap_fits_breaks ~space:false c.conf "(" ")"
-          ( fmt "module " $ Option.call ~f:pro $ psp $ bdy $ cls $ esp
-          $ Option.call ~f:epi $ fmt "@ : "
-          $ fmt_package_type c ctx pty pexp_loc
-          $ fmt_atrs )
+      integrate_module
+        (fmt_module_expr c (sub_mod ~ctx me))
+        ~f:(fun m ->
+          wrap_fits_breaks ~space:false c.conf "(" ")"
+            ( fmt "module " $ m $ fmt "@ : "
+            $ fmt_package_type c ctx pty pexp_loc
+            $ fmt_atrs ) )
   | Pexp_constraint (e, t) ->
       hvbox 2
         (wrap_fits_breaks ~space:false c.conf "(" ")"
@@ -2003,13 +2004,11 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    ( if c.conf.indicate_multiline_delimiters then " )"
                    else ")" ) )) )
   | Pexp_pack me ->
-      let {opn; pro; psp; bdy; cls; esp; epi} =
-        fmt_module_expr c (sub_mod ~ctx me)
-      in
-      opn
-      $ wrap_fits_breaks ~space:false c.conf "(" ")"
-          ( fmt "module " $ Option.call ~f:pro $ psp $ bdy $ cls $ esp
-          $ Option.call ~f:epi $ fmt_atrs )
+      integrate_module
+        (fmt_module_expr c (sub_mod ~ctx me))
+        ~f:(fun m ->
+          wrap_fits_breaks ~space:false c.conf "(" ")"
+            (fmt "module " $ m $ fmt_atrs) )
   | Pexp_record (flds, default) ->
       let fmt_field (lid1, f) =
         hvbox 0
@@ -3112,12 +3111,7 @@ and fmt_module_type c ({ast= mty} as xmty) =
         wrap "(" ")"
           (hovbox 0
              ( fmt_str_loc c name
-             $ opt mt1 (fun mt1 ->
-                   let {opn; pro; psp; bdy; cls; esp; epi} = mt1 in
-                   let box k = opn $ k $ cls in
-                   box
-                     ( fmt " :" $ Option.call ~f:pro $ psp $ fmt "@;<1 2>"
-                     $ bdy $ esp $ Option.call ~f:epi ) ) ))
+             $ opt mt1 (integrate_module ~f:(fun m -> fmt " :@ " $ m)) ))
       in
       let blk = fmt_module_type c mt2 in
       { blk with
@@ -3131,15 +3125,11 @@ and fmt_module_type c ({ast= mty} as xmty) =
       ; epi= Some (Option.call ~f:blk.epi $ Cmts.fmt_after c pmty_loc) }
   | Pmty_with _ ->
       let wcs, mt = Sugar.mod_with (sub_mty ~ctx mty) in
-      let {opn; pro; psp; bdy; cls; esp; epi} = fmt_module_type c mt in
-      let box k = opn $ k $ cls in
       { empty with
         bdy=
           hvbox 0
             (wrap_if parens "(" ")"
-               ( box
-                   ( Option.call ~f:pro $ psp $ bdy $ esp
-                   $ Option.call ~f:epi )
+               ( integrate_module (fmt_module_type c mt) ~f:(hvbox 0)
                $ list_fl wcs (fun ~first:_ ~last:_ (wcs_and, loc) ->
                      Cmts.fmt c loc
                      @@ list_fl wcs_and (fun ~first ~last:_ wc ->

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -172,11 +172,11 @@ module type S = functor [@foo] (M : S) -> functor (_ : (module type of M) [@foo]
 [@foo]
 
 module type S = functor (_ : S) (_ : S) -> S
-module type S = functor (_ :functor (_ : S) ->  S) -> S
+module type S = functor (_ : functor (_ : S) -> S) -> S
 module type S = functor (M : S) (_ : S) -> S
-module type S = functor (_ :functor (M : S) ->  S) -> S
-module type S = functor (_ :functor [@foo] (_ : S) ->  S) -> S
-module type S = functor (_ :functor [@foo] (M : S) ->  S) -> S
+module type S = functor (_ : functor (M : S) -> S) -> S
+module type S = functor (_ : functor [@foo] (_ : S) -> S) -> S
+module type S = functor (_ : functor [@foo] (M : S) -> S) -> S
 
 module type S = sig
   module rec A : (S with type t = t)
@@ -5550,7 +5550,7 @@ module F (X : sig end) = struct
   module N' = N
 end
 
-module G : functor (X :sig  end) -> sig
+module G : functor (X : sig end) -> sig
   module N' : sig
     val x : int
   end
@@ -6131,7 +6131,7 @@ module F2 : functor () -> sig end = F1
 
 (* fail *)
 module F3 () = struct end
-module F4 : functor (X :sig  end) -> sig end = F3
+module F4 : functor (X : sig end) -> sig end = F3
 
 (* fail *)
 
@@ -6140,7 +6140,7 @@ module X (X : sig end) (Y : sig end) (Z : sig end) = struct end
 module Y (X : sig end) (Y : sig end) (Z : sig end) = struct end
 module Z = functor (_ :sig  end) (_ :sig  end) (_ :sig  end) -> struct end
 
-module GZ : functor (X :sig  end) () (Z :sig  end) -> sig end =
+module GZ : functor (X : sig end) () (Z : sig end) -> sig end =
 functor (X :sig  end) () (Z :sig  end) -> struct end
 
 module F (X : sig end) = struct

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -187,15 +187,15 @@ module type S = functor [@foo]
 
 module type S = functor (_ : S) (_ : S) -> S
 
-module type S = functor (_ :functor (_ : S) ->  S) -> S
+module type S = functor (_ : functor (_ : S) -> S) -> S
 
 module type S = functor (M : S) (_ : S) -> S
 
-module type S = functor (_ :functor (M : S) ->  S) -> S
+module type S = functor (_ : functor (M : S) -> S) -> S
 
-module type S = functor (_ :functor [@foo] (_ : S) ->  S) -> S
+module type S = functor (_ : functor [@foo] (_ : S) -> S) -> S
 
-module type S = functor (_ :functor [@foo] (M : S) ->  S) -> S
+module type S = functor (_ : functor [@foo] (M : S) -> S) -> S
 
 module type S = sig
   module rec A : (S with type t = t)
@@ -5263,7 +5263,7 @@ module F (X : sig end) = struct
   module N' = N
 end
 
-module G : functor (X :sig  end) -> sig
+module G : functor (X : sig end) -> sig
   module N' : sig
     val x : int
   end
@@ -5855,7 +5855,7 @@ module F2 : functor () -> sig end = F1
 (* fail *)
 module F3 () = struct end
 
-module F4 : functor (X :sig  end) -> sig end = F3
+module F4 : functor (X : sig end) -> sig end = F3
 
 (* fail *)
 
@@ -5866,7 +5866,7 @@ module Y (X : sig end) (Y : sig end) (Z : sig end) = struct end
 
 module Z = functor (_ :sig  end) (_ :sig  end) (_ :sig  end) -> struct end
 
-module GZ : functor (X :sig  end) () (Z :sig  end) -> sig end =
+module GZ : functor (X : sig end) () (Z : sig end) -> sig end =
 functor (X :sig  end) () (Z :sig  end) -> struct end
 
 module F (X : sig end) = struct


### PR DESCRIPTION
Part of the redesign of fmt_module_* functions (more PRs to come).
Maybe the new function `integrate_module` could have a better name?

Diff of test_branch:

```ocaml
diff --git a/testsuite/tests/typing-modules/aliases.ml b/testsuite/tests/typing-modules/aliases.ml
index 8acf72863..7faa80739 100644
--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -217,7 +217,7 @@ module F (X : sig end) = struct
   module N' = N
 end
 
-module G : functor (X :sig  end) -> sig
+module G : functor (X : sig end) -> sig
   module N' : sig
     val x : int
   end
diff --git a/testsuite/tests/typing-modules/generative.ml b/testsuite/tests/typing-modules/generative.ml
index b38454a1f..1ce7daa5a 100644
--- a/testsuite/tests/typing-modules/generative.ml
+++ b/testsuite/tests/typing-modules/generative.ml
@@ -122,7 +122,7 @@ Error: Signature mismatch:
 
 module F3 () = struct end
 
-module F4 : functor (X :sig  end) -> sig end = F3
+module F4 : functor (X : sig end) -> sig end = F3
 
 (* fail *)
 [%%expect
@@ -145,7 +145,7 @@ module Y (X : sig end) (Y : sig end) (Z : sig end) = struct end
 
 module Z = functor (_ :sig  end) (_ :sig  end) (_ :sig  end) -> struct end
 
-module GZ : functor (X :sig  end) () (Z :sig  end) -> sig end =
+module GZ : functor (X : sig end) () (Z : sig end) -> sig end =
 functor (X :sig  end) () (Z :sig  end) -> struct end
```