### PR TITLE
Fix extra parens around ext match

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -1968,7 +1968,8 @@ end = struct
        |Pexp_letexception (_, e)
        |Pexp_letmodule (_, _, e) ->
           continue e
-      | Pexp_extension (_, PStr [{pstr_desc= Pstr_eval (e, _)}]) -> (
+      | Pexp_extension (ext, PStr [{pstr_desc= Pstr_eval (e, _)}])
+        when Source.extension_using_sugar ~name:ext ~payload:e -> (
         match e.pexp_desc with
         | Pexp_function cases | Pexp_match (_, cases) | Pexp_try (_, cases)
           ->

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -161,3 +161,8 @@ let _ = fun [@inlined always] x y -> z
 let () = assert ((assert false [@imp Show]) 1.0 = "1.")
 
 let () = f (assert false)
+
+let _ = match x with A -> [%expr match y with e -> e]
+
+let _ =
+  match x with A -> [%expr match y with e -> ( match e with x -> x )]

--- a/test/passing/js_source.ml
+++ b/test/passing/js_source.ml
@@ -7387,3 +7387,7 @@ let ssmap
   =
   ()
 ;;
+
+let _ = match x with | A -> [%expr match y with | e -> e]
+
+let _ = match x with | A -> [%expr match y with | e -> match e with x -> x]

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -9775,3 +9775,21 @@ let ssmap
   =
   ()
 ;;
+
+let _ =
+  match x with
+  | A ->
+    [%expr
+      match y with
+      | e -> e]
+;;
+
+let _ =
+  match x with
+  | A ->
+    [%expr
+      match y with
+      | e ->
+        (match e with
+        | x -> x)]
+;;


### PR DESCRIPTION
Fix #727, no regression with test_branch (with or without the `janestreet` profile).