### PR TITLE
Unecessary breaks in module pack

### DIFF
--- a/test/passing/first_class_module.ml
+++ b/test/passing/first_class_module.ml
@@ -73,8 +73,7 @@ let _ =
 let _ =
   ( module Ephemeron
              (HHHHHHHHHHHHHHHHHHHHHHHHHH)
-             (HHHHHHHHHHHHHHHHHHHHHHHHHH)
-  : Ephemeron.S )
+             (HHHHHHHHHHHHHHHHHHHHHHHHHH) : Ephemeron.S )
 
 let _ =
   ( module Ephemeron (HHHHHHHHHHHHHHHHHHHHHHHHHH) (HHHHHHHHHHHHHHHHHH)
@@ -87,8 +86,7 @@ let _ = (module Ephemeron (HHH) : Ephemeron.S)
 let _ =
   ( module Ephemeron (struct
     type t = t
-  end)
-  : Ephemeron.S )
+  end) : Ephemeron.S )
 
 let _ =
   ( module struct

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -3197,8 +3197,7 @@ end
 
 module Z : sig
   type t [@@immediate]
-end = (
-  Y : X with type t = int)
+end = (Y : X with type t = int)
 
 [%%expect
 {|
@@ -3397,8 +3396,7 @@ let make_set (type s) cmp =
     type t = s
 
     let compare = cmp
-  end)
-  : Set.S
+  end) : Set.S
     with type elt = s)
 ;;
 
@@ -3469,8 +3467,7 @@ let m =
 let m =
   (module struct
     let x = 3
-  end
-  : S)
+  end : S)
 ;;
 
 ;;
@@ -3508,8 +3505,7 @@ end
 let rec (module M : S') =
   (module struct
     let f n = if n <= 0 then 1 else n * M.f (n - 1)
-  end
-  : S')
+  end : S')
 in
 M.f 3
 
@@ -3620,8 +3616,7 @@ module SSMap = struct
 end
 
 let ssmap =
-  (module SSMap
-  : MapT
+  (module SSMap : MapT
     with type key = string
      and type data = string
      and type map = SSMap.map)
@@ -3630,8 +3625,7 @@ let ssmap =
 let ssmap =
   (module struct
     include SSMap
-  end
-  : MapT
+  end : MapT
     with type key = string
      and type data = string
      and type map = SSMap.map)
@@ -6075,8 +6069,7 @@ end
 let v =
   (module struct
     let x = 3
-  end
-  : S)
+  end : S)
 ;;
 
 module F () = (val v)
@@ -6101,8 +6094,7 @@ let v =
     type t = int
 
     let x = 3
-  end
-  : S)
+  end : S)
 ;;
 
 module F () = (val v)

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -3025,8 +3025,7 @@ end
 
 module Z : sig
   type t [@@immediate]
-end = (
-  Y : X with type t = int )
+end = (Y : X with type t = int )
 
 [%%expect
 {|
@@ -3220,8 +3219,7 @@ let make_set (type s) cmp =
     type t = s
 
     let compare = cmp
-  end)
-  : Set.S
+  end) : Set.S
     with type elt = s )
 
 (* No type annotation here *)
@@ -3290,8 +3288,7 @@ let m =
 let m =
   ( module struct
     let x = 3
-  end
-  : S )
+  end : S )
 
 ;;
 f m 1 m
@@ -3326,8 +3323,7 @@ end
 let rec (module M : S') =
   ( module struct
     let f n = if n <= 0 then 1 else n * M.f (n - 1)
-  end
-  : S' )
+  end : S' )
 in
 M.f 3
 
@@ -3454,8 +3450,7 @@ module SSMap = struct
 end
 
 let ssmap =
-  ( module SSMap
-  : MapT
+  ( module SSMap : MapT
     with type key = string
      and type data = string
      and type map = SSMap.map )
@@ -3463,8 +3458,7 @@ let ssmap =
 let ssmap =
   ( module struct
     include SSMap
-  end
-  : MapT
+  end : MapT
     with type key = string
      and type data = string
      and type map = SSMap.map )
@@ -5798,8 +5792,7 @@ end
 let v =
   ( module struct
     let x = 3
-  end
-  : S )
+  end : S )
 
 module F () = (val v)
 
@@ -5823,8 +5816,7 @@ let v =
     type t = int
 
     let x = 3
-  end
-  : S )
+  end : S )
 
 module F () = (val v)
 


### PR DESCRIPTION
This was one of the Jane street issues, which was lost.
(Previous attempt: #585)

(Rebased on #735)

Remove unecessary breaks:


```diff
 let m =
   (module struct
     let x = 3
-  end
-  : S)
+  end : S)

 let m =
-  ( module SSMap
-  : MapT
+  ( module SSMap : MapT
     with type key = string
      and type data = string
      and type map = SSMap.map )

 let m =
   ( module struct
     let x = 3
-  end
-  : MapT
+  end : MapT
     with type key = string
      and type data = string
      and type map = SSMap.map )
```
