### PR TITLE
Improve: support --name with --inplace

### DIFF
--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -293,8 +293,7 @@ OPTIONS
            Name of input file for use in error reporting. Defaults to the
            input file name. Some options can be specified in configuration
            files named '.ocamlformat' in the same or a parent directory of
-           NAME, see documentation of other options for details. Mutually
-           exclusive with --inplace.
+           NAME, see documentation of other options for details.
 
        --no-comment-check
            UNSAFE: Control whether to check comments and documentation

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -1194,8 +1194,7 @@ let name =
     "Name of input file for use in error reporting. Defaults to the input \
      file name. Some options can be specified in configuration files named \
      '.ocamlformat' in the same or a parent directory of $(docv), see \
-     documentation of other options for details. Mutually exclusive with \
-     --inplace."
+     documentation of other options for details."
   in
   let default = None in
   mk ~default

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -1828,11 +1828,11 @@ let build_config ~file =
 ;;
 if !print_config then
   let file =
-    match !inputs with
-    | [] ->
+    match (!name, !inputs) with
+    | Some file, _ | None, file :: _ -> file
+    | None, [] ->
         let root = Option.value root ~default:(Fpath.cwd ()) in
         Fpath.(root / dot_ocamlformat |> to_string)
-    | file :: _ -> file
   in
   C.print_config (build_config ~file)
 
@@ -1841,13 +1841,15 @@ let action =
     Inplace
       (List.map !inputs ~f:(fun file ->
            let name = Option.value !name ~default:file in
-           {kind= kind_of file; name; file; conf= build_config ~file} ))
+           {kind= kind_of file; name; file; conf= build_config ~file:name}
+       ))
   else if !check then
     Check
       (List.map !inputs ~f:(fun file ->
-           let conf = build_config ~file in
+           let name = Option.value !name ~default:file in
+           let conf = build_config ~file:name in
            let conf = {conf with max_iters= 1} in
-           {kind= kind_of file; name= file; file; conf} ))
+           {kind= kind_of file; name; file; conf} ))
   else
     match !inputs with
     | [input_file] ->

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -1489,8 +1489,6 @@ let validate () =
     `Error (false, "Cannot specify stdin together with other inputs")
   else if has_stdin && Option.is_none !name then
     `Error (false, "Must specify name when reading from stdin")
-  else if !inplace && Option.is_some !name then
-    `Error (false, "Cannot specify --name with --inplace")
   else if !inplace && Option.is_some !output then
     `Error (false, "Cannot specify --output with --inplace")
   else if !check && !inplace then
@@ -1842,8 +1840,8 @@ let action =
   if !inplace then
     Inplace
       (List.map !inputs ~f:(fun file ->
-           {kind= kind_of file; name= file; file; conf= build_config ~file}
-       ))
+           let name = Option.value !name ~default:file in
+           {kind= kind_of file; name; file; conf= build_config ~file} ))
   else if !check then
     Check
       (List.map !inputs ~f:(fun file ->


### PR DESCRIPTION
In the case where a temporary file derived from some other file is to
be formatted in-place, it is necessary to specify the original file's
name to look up the config, etc.