### PR TITLE
Fix nested parens with no break infix before func

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1442,6 +1442,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       , [(Nolabel, l); (Nolabel, ({pexp_desc= Pexp_function cs} as r))] )
     when is_infix_id id && not c.conf.break_infix_before_func ->
       Cmts.relocate c.cmts ~src:pexp_loc ~before:loc ~after:loc ;
+      let xpc_rhs = sub_exp ~ctx r in
+      let parens_fct = parenze_exp xpc_rhs in
       wrap_if parens "(" ")"
         (hvbox 0
            ( hvbox 0
@@ -1449,10 +1451,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                $ fmt "@;"
                $ hovbox 2
                    ( fmt_expression c (sub_exp ~ctx op)
-                   $ fmt "@ " $ fmt "function"
+                   $ fmt "@ " $ fmt_if parens_fct "(" $ fmt "function"
                    $ fmt_extension_suffix c ext
                    $ fmt_attributes c ~key:"@" pexp_attributes ) )
-           $ fmt "@ " $ fmt_cases c (Exp r) cs ))
+           $ fmt "@ " $ fmt_cases c (Exp r) cs $ fmt_if parens_fct ")" ))
   | Pexp_apply
       ( {pexp_desc= Pexp_ident {txt= Lident id}; pexp_attributes= []}
       , [(Nolabel, _); (Nolabel, _)] )

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1442,8 +1442,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       , [(Nolabel, l); (Nolabel, ({pexp_desc= Pexp_function cs} as r))] )
     when is_infix_id id && not c.conf.break_infix_before_func ->
       Cmts.relocate c.cmts ~src:pexp_loc ~before:loc ~after:loc ;
-      let xpc_rhs = sub_exp ~ctx r in
-      let parens_fct = parenze_exp xpc_rhs in
+      let xr = sub_exp ~ctx r in
+      let parens_r = parenze_exp xr in
       wrap_if parens "(" ")"
         (hvbox 0
            ( hvbox 0
@@ -1451,10 +1451,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                $ fmt "@;"
                $ hovbox 2
                    ( fmt_expression c (sub_exp ~ctx op)
-                   $ fmt "@ " $ fmt_if parens_fct "(" $ fmt "function"
+                   $ fmt "@ " $ fmt_if parens_r "( " $ fmt "function"
                    $ fmt_extension_suffix c ext
                    $ fmt_attributes c ~key:"@" pexp_attributes ) )
-           $ fmt "@ " $ fmt_cases c (Exp r) cs $ fmt_if parens_fct ")" ))
+           $ fmt "@ " $ fmt_cases c (Exp r) cs $ fmt_if parens_r " )" ))
   | Pexp_apply
       ( {pexp_desc= Pexp_ident {txt= Lident id}; pexp_attributes= []}
       , [(Nolabel, _); (Nolabel, _)] )

--- a/test/passing/match2.ml
+++ b/test/passing/match2.ml
@@ -57,19 +57,19 @@ let _ = match x with _ -> b >>= fun () -> c
 
 [@@@ocamlformat "break-infix-before-func=false"]
 
-let foo = match foo with 1 -> bar >>= (function _ -> ()) | other -> ()
+let foo = match foo with 1 -> bar >>= ( function _ -> () ) | other -> ()
 
 let foo =
   match foo with
-  | 1 -> bar >>= (function a -> fooooo | b -> fooooo | _ -> ())
+  | 1 -> bar >>= ( function a -> fooooo | b -> fooooo | _ -> () )
   | other -> ()
 
 let foo =
   match foo with
   | 1 ->
-      bar >>= (function
+      bar >>= ( function
       | a -> fooooo
       | b -> fooooo
       | c -> foooooooo foooooooooo fooooooooooooooooooo ()
-      | _ -> ())
+      | _ -> () )
   | other -> ()

--- a/test/passing/match2.ml
+++ b/test/passing/match2.ml
@@ -54,3 +54,22 @@ let x =
   ()
 
 let _ = match x with _ -> b >>= fun () -> c
+
+[@@@ocamlformat "break-infix-before-func=false"]
+
+let foo = match foo with 1 -> bar >>= (function _ -> ()) | other -> ()
+
+let foo =
+  match foo with
+  | 1 -> bar >>= (function a -> fooooo | b -> fooooo | _ -> ())
+  | other -> ()
+
+let foo =
+  match foo with
+  | 1 ->
+      bar >>= (function
+      | a -> fooooo
+      | b -> fooooo
+      | c -> foooooooo foooooooooo fooooooooooooooooooo ()
+      | _ -> ())
+  | other -> ()


### PR DESCRIPTION
Fix #754, I don't know if we should bother trying to handle `indicate-multiline-delimiters` since the beginning and the end of the function are not in the same box and we don't want to rely on `Location.is_single_line`?

No diff with test_branch with `break-infix-before-func=false`.