### PR TITLE
Improve: less breaks for break-cases=all but correctly breaks or-patterns

### DIFF
--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -1384,7 +1384,7 @@ let sparse_profile =
   ; wrap_fun_args= false }
 
 let janestreet_profile =
-  { break_cases= `Toplevel
+  { break_cases= `All
   ; break_collection_expressions=
       ocamlformat_profile.break_collection_expressions
   ; break_infix= `Fit_or_vertical

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -866,14 +866,21 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
         (wrap_array c
            (list pats "@;<0 1>; " (sub_pat ~ctx >> fmt_pattern c)))
   | Ppat_or _ ->
+      let has_doc = not (List.is_empty xpat.ast.ppat_attributes) in
       let nested =
         match ctx0 with
-        | Pat {ppat_desc= Ppat_or _} -> true
+        | Pat {ppat_desc= Ppat_or _} -> not has_doc
         | Exp {pexp_desc= Pexp_match _ | Pexp_try _ | Pexp_function _} ->
-            true
+            not has_doc
         | _ -> false
       in
       let xpats = Sugar.or_pat c.cmts xpat in
+      let pat_needs_space_before p =
+        match p.ppat_desc with
+        | Ppat_constant (Pconst_integer (i, _) | Pconst_float (i, _)) -> (
+          match i.[0] with '-' | '+' -> true | _ -> false )
+        | _ -> false
+      in
       let pro0 =
         Option.call ~f:pro
         $ fits_breaks
@@ -884,16 +891,21 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
         match ctx0 with
         | Exp {pexp_desc= Pexp_function _ | Pexp_match _ | Pexp_try _}
           when Poly.(c.conf.break_cases <> `Nested) -> (
-          match c.conf.indicate_nested_or_patterns with
-          | `Space -> or_newline "| " " |"
-          | `Unsafe_no -> or_newline "| " "| " )
+            fmt_if Poly.(c.conf.break_cases = `All) "@;<1000 0>"
+            $
+            match c.conf.indicate_nested_or_patterns with
+            | `Space -> or_newline "| " " |"
+            | `Unsafe_no -> or_newline "| " "| " )
         | _ -> break_unless_newline 1 0 $ fmt "| "
       in
-      let pro2 =
+      let pro2 pat_needs_space_before =
         fmt_or_k
           Poly.(c.conf.break_cases = `All)
           ( match c.conf.indicate_nested_or_patterns with
-          | `Space -> break_unless_newline 1000 0 $ fmt " |"
+          | `Space ->
+              break_unless_newline 1000 0
+              $ fmt " |"
+              $ fmt_if pat_needs_space_before " "
           | `Unsafe_no -> break_unless_newline 1000 0 $ fmt "| " )
           proI
       in
@@ -917,7 +929,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
                   let pro =
                     if first_grp && first then pro0 $ open_hovbox (-2)
                     else if first then proI $ open_hovbox (-2)
-                    else pro2
+                    else pro2 (pat_needs_space_before xpat.ast)
                   in
                   (* side effects of Cmts.fmt_before before [fmt_pattern] is
                      important *)

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -39,15 +39,7 @@ let get_cases (c : Conf.t) ~first ~indent ~parens_here =
       ; break_after_arrow= fmt_if (not parens_here) "@;<0 3>"
       ; break_after_opening_paren= fmt_or (indent > 2) "@;<1 4>" "@;<1 2>"
       }
-  | `Toplevel ->
-      { leading_space= break_unless_newline 1000 0
-      ; bar= fmt "| "
-      ; box_all= hvbox indent
-      ; box_pattern_arrow= hovbox 0
-      ; break_before_arrow= fmt "@;<1 2>"
-      ; break_after_arrow= fmt_if (not parens_here) "@;<0 3>"
-      ; break_after_opening_paren= fmt "@ " }
-  | `All ->
+  | `Toplevel | `All ->
       { leading_space= break_unless_newline 1000 0
       ; bar= fmt "| "
       ; box_all= hvbox indent

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -48,11 +48,11 @@ let get_cases (c : Conf.t) ~first ~indent ~parens_here =
       ; break_after_arrow= fmt_if (not parens_here) "@;<0 3>"
       ; break_after_opening_paren= fmt "@ " }
   | `All ->
-      { leading_space= fmt_if (not first) "@ "
-      ; bar= break_unless_newline 1000 0 $ fmt "| "
+      { leading_space= break_unless_newline 1000 0
+      ; bar= fmt "| "
       ; box_all= hvbox indent
       ; box_pattern_arrow= hovbox 0
-      ; break_before_arrow= fmt_or parens_here "@;<1 2>" "@;<1 -2>"
+      ; break_before_arrow= fmt "@;<1 2>"
       ; break_after_arrow= fmt_if (not parens_here) "@;<0 3>"
       ; break_after_opening_paren= fmt "@ " }
 

--- a/test/passing/break_cases_all.ml.ref
+++ b/test/passing/break_cases_all.ml.ref
@@ -11,9 +11,7 @@ let f x = function
 
 let f =
   let g = function
-    | H
-      when x y <> k ->
-        2
+    | H when x y <> k -> 2
     | T
      |P
      |U ->
@@ -21,38 +19,30 @@ let f =
   in
   fun x g t h y u ->
     match x with
-    | E ->
-        4
+    | E -> 4
     | Z
      |P
      |M -> (
       match y with
-      | O ->
-          5
-      | P
-        when h x -> (
+      | O -> 5
+      | P when h x -> (
           function
-          | A ->
-              6 ) )
+          | A -> 6 ) )
 
 ;;
 match x with
 | true -> (
   match y with
-  | true ->
-      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-  | false ->
-      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" )
-| false ->
-    "cccccccccccccccccccccccccccccc"
+  | true -> "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  | false -> "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" )
+| false -> "cccccccccccccccccccccccccccccc"
 
 ;;
 match x with
 | "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", yyyyyyyyyy
   when fffffffffffffff bbbbbbbbbb yyyyyyyyyy ->
     ()
-| _ ->
-    ()
+| _ -> ()
 
 let is_sequence exp =
   match exp.pexp_desc with
@@ -62,28 +52,23 @@ let is_sequence exp =
       , PStr [{pstr_desc= Pstr_eval ({pexp_desc= Pexp_sequence _}, []); _}]
       ) ->
       true
-  | _ ->
-      false
+  | _ -> false
 
 let _ =
   let f x y =
     match x with
-    | None ->
-        false
+    | None -> false
     | Some looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
       -> (
       match y with
-      | Some _ ->
-          true
-      | None ->
-          false )
+      | Some _ -> true
+      | None -> false )
   in
   ()
 
 let () =
   match fooooo with
-  | x ->
-      x
+  | x -> x
 
 let () =
   match foooo with
@@ -95,8 +80,7 @@ let () =
    |foooooooooo
    |fooooooooo ->
       y
-  | foooooo
-    when ff fff fooooooooooooooooooo ->
+  | foooooo when ff fff fooooooooooooooooooo ->
       foooooooooooooooooooooo foooooooooooooooooo
 
 let foo =
@@ -115,6 +99,28 @@ let foo =
     when Typ.Procname.equal callee_pname BuiltinDecl.__cast ->
       analyze_id_assignment (Var.of_id ret_id) target_exp cast_typ loc
 
+let mod_int c1 c2 is_safe dbg =
+  match (c1, c2) with
+  | c1, Cconst_int (0, _) ->
+      Csequence (c1, raise_symbol dbg "caml_exn_Division_by_zero")
+  | ( c1
+    , Cconst_int
+        ( ( 1
+           | -1 )
+        , _ ) ) ->
+      Csequence (c1, Cconst_int (0, dbg))
+  | x
+   | -1 ->
+      ()
+
+let merge_columns l old_table =
+  let rec aux = function
+    | []
+     |[None] ->
+        ([], [])
+  in
+  foooooooooooooooooooooooooo fooooooooooooooooooooo
+
 [@@@ocamlformat "indicate-nested-or-patterns=unsafe-no"]
 
 let is_sequence exp =
@@ -125,8 +131,7 @@ let is_sequence exp =
       , PStr [{pstr_desc= Pstr_eval ({pexp_desc= Pexp_sequence _}, []); _}]
       ) ->
       true
-  | _ ->
-      false
+  | _ -> false
 
 let () =
   match foooo with
@@ -138,8 +143,7 @@ let () =
   | foooooooooo
   | fooooooooo ->
       y
-  | foooooo
-    when ff fff fooooooooooooooooooo ->
+  | foooooo when ff fff fooooooooooooooooooo ->
       foooooooooooooooooooooo foooooooooooooooooo
 
 let rec loop items =

--- a/test/passing/break_cases_fit.ml
+++ b/test/passing/break_cases_fit.ml
@@ -85,6 +85,22 @@ let foo =
     when Typ.Procname.equal callee_pname BuiltinDecl.__cast ->
       analyze_id_assignment (Var.of_id ret_id) target_exp cast_typ loc
 
+let mod_int c1 c2 is_safe dbg =
+  match (c1, c2) with
+    (c1, Cconst_int (0, _)) ->
+      Csequence(c1, raise_symbol dbg "caml_exn_Division_by_zero")
+  | (c1, Cconst_int ((1 | (-1)), _)) ->
+      Csequence(c1, Cconst_int (0, dbg))
+  | x | -1 -> ()
+
+let merge_columns l old_table =
+   let rec aux = function
+    | []
+     |[None] ->
+        [], []
+   in
+   foooooooooooooooooooooooooo fooooooooooooooooooooo
+
 [@@@ocamlformat "indicate-nested-or-patterns=unsafe-no"]
 
 let is_sequence exp =

--- a/test/passing/break_cases_fit.ml.ref
+++ b/test/passing/break_cases_fit.ml.ref
@@ -75,6 +75,17 @@ let foo =
     when Typ.Procname.equal callee_pname BuiltinDecl.__cast ->
       analyze_id_assignment (Var.of_id ret_id) target_exp cast_typ loc
 
+let mod_int c1 c2 is_safe dbg =
+  match (c1, c2) with
+  | c1, Cconst_int (0, _) ->
+      Csequence (c1, raise_symbol dbg "caml_exn_Division_by_zero")
+  | c1, Cconst_int ((1 | -1), _) -> Csequence (c1, Cconst_int (0, dbg))
+  | x | -1 -> ()
+
+let merge_columns l old_table =
+  let rec aux = function [] | [None] -> ([], []) in
+  foooooooooooooooooooooooooo fooooooooooooooooooooo
+
 [@@@ocamlformat "indicate-nested-or-patterns=unsafe-no"]
 
 let is_sequence exp =

--- a/test/passing/break_cases_nested.ml.ref
+++ b/test/passing/break_cases_nested.ml.ref
@@ -84,6 +84,19 @@ let foo =
     when Typ.Procname.equal callee_pname BuiltinDecl.__cast ->
       analyze_id_assignment (Var.of_id ret_id) target_exp cast_typ loc
 
+let mod_int c1 c2 is_safe dbg =
+  match (c1, c2) with
+  | c1, Cconst_int (0, _) ->
+      Csequence (c1, raise_symbol dbg "caml_exn_Division_by_zero")
+  | c1, Cconst_int ((1 | -1), _) ->
+      Csequence (c1, Cconst_int (0, dbg))
+  | x | -1 ->
+      ()
+
+let merge_columns l old_table =
+  let rec aux = function [] | [None] -> ([], []) in
+  foooooooooooooooooooooooooo fooooooooooooooooooooo
+
 [@@@ocamlformat "indicate-nested-or-patterns=unsafe-no"]
 
 let is_sequence exp =

--- a/test/passing/break_cases_toplevel.ml.ref
+++ b/test/passing/break_cases_toplevel.ml.ref
@@ -86,6 +86,19 @@ let foo =
     when Typ.Procname.equal callee_pname BuiltinDecl.__cast ->
       analyze_id_assignment (Var.of_id ret_id) target_exp cast_typ loc
 
+let mod_int c1 c2 is_safe dbg =
+  match (c1, c2) with
+  | c1, Cconst_int (0, _) ->
+      Csequence (c1, raise_symbol dbg "caml_exn_Division_by_zero")
+  | c1, Cconst_int ((1 | -1), _) -> Csequence (c1, Cconst_int (0, dbg))
+  | x | -1 -> ()
+
+let merge_columns l old_table =
+  let rec aux = function
+    | [] | [None] -> ([], [])
+  in
+  foooooooooooooooooooooooooo fooooooooooooooooooooo
+
 [@@@ocamlformat "indicate-nested-or-patterns=unsafe-no"]
 
 let is_sequence exp =

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -4555,19 +4555,27 @@ let f x =
 let f x =
   ignore
     (match x with
-    | `A | `B -> 1);
+    | `A
+    | `B ->
+      1);
   ignore (x : [ `A ])
 ;;
 
 let f (x : [< `A | `B ]) =
   match x with
-  | `A | `B | `C -> 0
+  | `A
+  | `B
+  | `C ->
+    0
 ;;
 
 (* warn *)
 let f (x : [ `A | `B ]) =
   match x with
-  | `A | `B | `C -> 0
+  | `A
+  | `B
+  | `C ->
+    0
 ;;
 
 (* fail *)
@@ -4684,7 +4692,9 @@ end = struct
     | B
 
   let f = function
-    | A | B -> 0
+    | A
+    | B ->
+      0
   ;;
 end
 
@@ -9543,7 +9553,9 @@ let f = function
 ;;
 
 let f = function
-  | '1' .. '9' | '1' .. '8' -> ()
+  | '1' .. '9'
+  | '1' .. '8' ->
+    ()
   | 'a' .. 'z' -> ()
 ;;
 
@@ -9622,10 +9634,15 @@ let _ =
   let f M.(x) = () in
   let g M.{ x } = () in
   let h = function
-    | M.[] | M.[ a ] | M.(a :: q) -> ()
+    | M.[]
+    | M.[ a ]
+    | M.(a :: q) ->
+      ()
   in
   let i = function
-    | M.[||] | M.[| x |] -> true
+    | M.[||]
+    | M.[| x |] ->
+      true
     | _ -> false
   in
   ()
@@ -9670,7 +9687,10 @@ class type t = object ((_[@foo])) end
 let test f x = f ~x:(x [@foo])
 
 let f = function
-  | (`A | `B)[@bar] | `C -> ()
+  | ( `A
+    | `B )[@bar]
+  | `C ->
+    ()
 ;;
 
 let f = function


### PR DESCRIPTION
- From https://github.com/janestreet/ocamlformat/commit/a6af924d9bf4184b7c64d697824f4d51d8bd6a29
- also fixes the incorrect OCaml code generated issue of  test/code/ocaml/asmcomp/cmmgen.ml with `break-cases=all`
- Fix #597 

No issue with test_branch with or without `break-cases=all`.
I will change the value of this option in the janestreet profile if the new output is close enought to what @hhugo had in mind.