### PR TITLE
Improve: less sensitivity to concrete syntax

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -197,14 +197,22 @@ let doc_atrs atrs =
   let docs = match docs with [] -> None | l -> Some (List.rev l) in
   (docs, List.rev rev_atrs)
 
-let longident_is_simple (c : Conf.t) x =
+(** [fit_margin c x] returns [true] if and only if [x] does not exceed 1/3
+    of the margin. *)
+let fit_margin (c : Conf.t) x = x * 3 < c.margin
+
+(** [longident_fit_margin c x] returns [true] if and only if [x] does not
+    exceed 2/3 of the margin. *)
+let longident_fit_margin (c : Conf.t) x = x * 3 < c.margin * 2
+
+let longident_is_simple c x =
   let rec length (x : Longident.t) =
     match x with
     | Lident x -> String.length x
     | Ldot (x, y) -> length x + 1 + String.length y
     | Lapply (x, y) -> length x + length y
   in
-  length x * 3 < c.margin * 2
+  longident_fit_margin c (length x)
 
 let module_type_is_simple x =
   match x.pmty_desc with Pmty_signature _ -> false | _ -> true
@@ -1370,20 +1378,20 @@ end = struct
         ({txt= Lident "::"}, Some {pexp_desc= Pexp_tuple [e1; e2]}) ->
         is_simple c width (sub_exp ~ctx e1)
         && is_simple c width (sub_exp ~ctx e2)
-        && width xexp * 3 < c.margin
+        && fit_margin c (width xexp)
     | Pexp_construct (_, Some e0) | Pexp_variant (_, Some e0) ->
         is_trivial c e0
     | Pexp_array e1N | Pexp_tuple e1N ->
-        List.for_all e1N ~f:(is_trivial c) && width xexp * 3 < c.margin
+        List.for_all e1N ~f:(is_trivial c) && fit_margin c (width xexp)
     | Pexp_record (e1N, e0) ->
         Option.for_all e0 ~f:(is_trivial c)
         && List.for_all e1N ~f:(snd >> is_trivial c)
-        && width xexp * 3 < c.margin
+        && fit_margin c (width xexp)
     | Pexp_apply ({pexp_desc= Pexp_ident {txt= Lident ":="}}, _) -> false
     | Pexp_apply (e0, e1N) ->
         is_trivial c e0
         && List.for_all e1N ~f:(snd >> is_trivial c)
-        && width xexp * 3 < c.margin
+        && fit_margin c (width xexp)
     | Pexp_extension (_, PStr [{pstr_desc= Pstr_eval (e0, []); _}]) ->
         is_simple c width (sub_exp ~ctx e0)
     | Pexp_extension (_, (PStr [] | PTyp _)) -> true

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -210,7 +210,7 @@ let longident_is_simple c x =
     match x with
     | Lident x -> String.length x
     | Ldot (x, y) -> length x + 1 + String.length y
-    | Lapply (x, y) -> length x + length y
+    | Lapply (x, y) -> length x + length y + 3
   in
   longident_fit_margin c (length x)
 

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -206,18 +206,11 @@ let longident_is_simple (c : Conf.t) x =
   in
   length x * 3 < c.margin * 2
 
-let module_type_is_simple (c : Conf.t) x =
-  match x.pmty_desc with
-  | Pmty_ident i | Pmty_alias i | Pmty_typeof {pmod_desc= Pmod_ident i} ->
-      longident_is_simple c i.txt
-  | _ -> false
+let module_type_is_simple x =
+  match x.pmty_desc with Pmty_signature _ -> false | _ -> true
 
-let rec module_expr_is_simple (c : Conf.t) x =
-  match x.pmod_desc with
-  | Pmod_ident i -> longident_is_simple c i.txt
-  | Pmod_constraint (e, t) ->
-      module_expr_is_simple c e && module_type_is_simple c t
-  | _ -> false
+let module_expr_is_simple x =
+  match x.pmod_desc with Pmod_structure _ -> false | _ -> true
 
 module type Module_item = sig
   type t

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -204,7 +204,7 @@ let longident_is_simple (c : Conf.t) x =
     | Ldot (x, y) -> length x + 1 + String.length y
     | Lapply (x, y) -> length x + length y
   in
-  length x * 3 < c.margin
+  length x * 3 < c.margin * 2
 
 let module_type_is_simple (c : Conf.t) x =
   match x.pmty_desc with

--- a/src/Ast.mli
+++ b/src/Ast.mli
@@ -57,9 +57,9 @@ val doc_atrs :
 
 val longident_is_simple : Conf.t -> Longident.t -> bool
 
-val module_expr_is_simple : Conf.t -> module_expr -> bool
+val module_expr_is_simple : module_expr -> bool
 
-val module_type_is_simple : Conf.t -> module_type -> bool
+val module_type_is_simple : module_type -> bool
 
 (** Ast terms of various forms. *)
 type t =

--- a/src/Ast.mli
+++ b/src/Ast.mli
@@ -55,6 +55,12 @@ val doc_atrs :
   -> (string Location.loc * bool) list option
      * (string Location.loc * payload) list
 
+val longident_is_simple : Conf.t -> Longident.t -> bool
+
+val module_expr_is_simple : Conf.t -> module_expr -> bool
+
+val module_type_is_simple : Conf.t -> module_type -> bool
+
 (** Ast terms of various forms. *)
 type t =
   | Pld of payload

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3278,11 +3278,11 @@ and fmt_module c ?epi keyword name xargs xbody colon xmty attributes =
                  $ Option.call ~f:epi ) ))
   in
   let single_line =
-    String.length name.txt * 3 < c.conf.margin
-    && Option.value_map xbody ~default:true ~f:(fun x ->
-           module_expr_is_simple c.conf x.ast )
-    && Option.value_map xmty ~default:true ~f:(fun x ->
-           module_type_is_simple c.conf x.ast )
+    match (xbody, xmty) with
+    | Some {ast= {pmod_desc= Pmod_structure _}}, _
+     |_, Some {ast= {pmty_desc= Pmty_signature _}} ->
+        false
+    | _ -> true
   in
   (fmt_docstring_around ~single_line c doc)
     (hvbox 0

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3152,7 +3152,11 @@ and fmt_signature_item c {ast= si} =
             , blk )
         | _ -> (fmt "include@ ", fmt_module_type c (sub_mty ~ctx pincl_mod))
       in
-      let single_line = module_type_is_simple c.conf pincl_mod in
+      let single_line =
+        match pincl_mod.pmty_desc with
+        | Pmty_signature _ -> false
+        | _ -> true
+      in
       let box = wrap_k opn cls in
       hvbox 0
         (fmt_docstring_around ~single_line c doc
@@ -3650,7 +3654,11 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
       let doc, atrs = doc_atrs pincl_attributes in
       let blk = fmt_module_expr c (sub_mod ~ctx pincl_mod) in
       let box = wrap_k blk.opn blk.cls in
-      let single_line = module_expr_is_simple c.conf pincl_mod in
+      let single_line =
+        match pincl_mod.pmod_desc with
+        | Pmod_structure _ -> false
+        | _ -> true
+      in
       fmt_docstring_around ~single_line c doc
         ( box
             ( hvbox 2 (fmt "include " $ Option.call ~f:blk.pro)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3346,8 +3346,7 @@ and fmt_open_description c
   update_config_maybe_disabled c popen_loc popen_attributes
   @@ fun c ->
   let doc, atrs = doc_atrs popen_attributes in
-  let single_line = longident_is_simple c.conf popen_lid.txt in
-  fmt_docstring_around ~single_line c doc
+  fmt_docstring_around ~single_line:true c doc
     ( fmt "open"
     $ fmt_if Poly.(popen_override = Override) "!"
     $ fmt " "

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3152,11 +3152,7 @@ and fmt_signature_item c {ast= si} =
             , blk )
         | _ -> (fmt "include@ ", fmt_module_type c (sub_mty ~ctx pincl_mod))
       in
-      let single_line =
-        match pincl_mod.pmty_desc with
-        | Pmty_signature _ -> false
-        | _ -> true
-      in
+      let single_line = module_type_is_simple pincl_mod in
       let box = wrap_k opn cls in
       hvbox 0
         (fmt_docstring_around ~single_line c doc
@@ -3278,11 +3274,8 @@ and fmt_module c ?epi keyword name xargs xbody colon xmty attributes =
                  $ Option.call ~f:epi ) ))
   in
   let single_line =
-    match (xbody, xmty) with
-    | Some {ast= {pmod_desc= Pmod_structure _}}, _
-     |_, Some {ast= {pmty_desc= Pmty_signature _}} ->
-        false
-    | _ -> true
+    Option.for_all xbody ~f:(fun x -> module_expr_is_simple x.ast)
+    && Option.for_all xmty ~f:(fun x -> module_type_is_simple x.ast)
   in
   (fmt_docstring_around ~single_line c doc)
     (hvbox 0
@@ -3654,11 +3647,7 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
       let doc, atrs = doc_atrs pincl_attributes in
       let blk = fmt_module_expr c (sub_mod ~ctx pincl_mod) in
       let box = wrap_k blk.opn blk.cls in
-      let single_line =
-        match pincl_mod.pmod_desc with
-        | Pmod_structure _ -> false
-        | _ -> true
-      in
+      let single_line = module_expr_is_simple pincl_mod in
       fmt_docstring_around ~single_line c doc
         ( box
             ( hvbox 2 (fmt "include " $ Option.call ~f:blk.pro)

--- a/test/passing/tag_only.ml
+++ b/test/passing/tag_only.ml
@@ -129,8 +129,8 @@ end =
 open Module.With_veryyyyyy_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame
 (** @deprecated  *)
 
-(** @deprecated  *)
 include Module.With_very_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame
+(** @deprecated  *)
 
 (** @deprecated  *)
 module A = Module.With_very_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame

--- a/test/passing/tag_only.ml
+++ b/test/passing/tag_only.ml
@@ -126,8 +126,8 @@ module A : sig
 end =
   B
 
-(** @deprecated  *)
 open Module.With_veryyyyyy_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame
+(** @deprecated  *)
 
 (** @deprecated  *)
 include Module.With_very_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame

--- a/test/passing/tag_only.ml
+++ b/test/passing/tag_only.ml
@@ -132,5 +132,5 @@ open Module.With_veryyyyyy_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame
 include Module.With_very_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame
 (** @deprecated  *)
 
-(** @deprecated  *)
 module A = Module.With_very_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame
+(** @deprecated  *)

--- a/test/passing/tag_only.ml
+++ b/test/passing/tag_only.ml
@@ -126,11 +126,11 @@ module A : sig
 end =
   B
 
+(** @deprecated  *)
 open Module.With_veryyyyyy_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame
-(** @deprecated  *)
 
+(** @deprecated  *)
 include Module.With_very_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame
-(** @deprecated  *)
 
-module A = Module.With_very_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame
 (** @deprecated  *)
+module A = Module.With_very_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame


### PR DESCRIPTION
Starts to address #747 (4 calls to `Location.is_single_line` removed, a lot more to go, but the diff is already big enough).