### PR TITLE
Fix indentation of functor argument

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3395,7 +3395,7 @@ and fmt_module c ?epi keyword name xargs xbody colon xmty attributes =
   let box_b k = opn_b $ k $ cls_b in
   let fmt_arg ?prev:_ (name, arg_mtyp) ?next =
     let maybe_box k =
-      match arg_mtyp with Some {pro= None} -> hvbox 2 k | _ -> k
+      match arg_mtyp with Some {pro= None} -> hvbox 0 k | _ -> k
     in
     fmt "@ "
     $ maybe_box

--- a/test/passing/functor.ml
+++ b/test/passing/functor.ml
@@ -67,3 +67,17 @@ module type KV_MAKER = functor (G : Irmin_git.G) (C : Irmin.Contents.S) ->
    and type contents = C.t
    and type branch = string
    and module Git = G
+
+module Make
+    (TT : TableFormat.TABLES)
+    (IT : InspectionTableFormat.TABLES with type 'a lr1state = int)
+    (ET : EngineTypes.TABLE
+          with type terminal = int
+           and type nonterminal = int
+           and type semantic_value = Obj.t)
+    (E : sig
+      type 'a env = (ET.state, ET.semantic_value, ET.token) EngineTypes.env
+    end) =
+struct
+  type t = t
+end


### PR DESCRIPTION
Fix #771 

The test_branch diff looks good:

```ocaml
diff --git a/boot/menhir/menhirLib.ml b/boot/menhir/menhirLib.ml
index 5d929a76c..40b6cccc3 100644
--- a/boot/menhir/menhirLib.ml
+++ b/boot/menhir/menhirLib.ml
@@ -2651,7 +2651,7 @@ module InspectionTableInterpreter = struct
             with type terminal = int
              and type nonterminal = int
              and type semantic_value = Obj.t)
-        (E : sig
+      (E : sig
         type 'a env = (ET.state, ET.semantic_value, ET.token) EngineTypes.env
       end) =
   struct
diff --git a/boot/menhir/menhirLib.mli b/boot/menhir/menhirLib.mli
index 0e8448a5b..12a086f1b 100644
--- a/boot/menhir/menhirLib.mli
+++ b/boot/menhir/menhirLib.mli
@@ -1612,7 +1612,7 @@ module InspectionTableInterpreter : sig
             with type terminal = int
              and type nonterminal = int
              and type semantic_value = Obj.t)
-        (E : sig
+      (E : sig
         type 'a env = (ET.state, ET.semantic_value, ET.token) EngineTypes.env
       end) :
```