### PR TITLE
Fix missing space before attribute on includes

### DIFF
--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -26,7 +26,7 @@ type t =
     whenever 2 intervals share more than an end-point, then one contains the
     other. *)
 module Non_overlapping_interval_tree (Itv : sig
-  include Hashtbl.Key[@@ocaml.warning "-3"]
+  include Hashtbl.Key [@@ocaml.warning "-3"]
 
   val contains : t -> t -> bool
 

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3145,7 +3145,7 @@ and fmt_signature_item c {ast= si} =
         (fmt_docstring_around ~loc:pincl_loc c doc
            ( box (hvbox 2 (keyword $ Option.call ~f:pro $ psp $ bdy))
            $ esp $ Option.call ~f:epi
-           $ fmt_attributes c ~key:"@@" atrs ))
+           $ fmt_attributes c ~pre:(fmt "@ ") ~key:"@@" atrs ))
   | Psig_modtype mtd -> fmt_module_type_declaration c ctx mtd
   | Psig_module md ->
       hvbox 0 (fmt_module_declaration c ctx ~rec_flag:false ~first:true md)

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -14,7 +14,7 @@ end [@foo]
 [@@foo]
 
 module type S = sig
-  include ((module type of M [@foo]) [@foo] with type t := M.t) [@foo][@@foo]
+  include ((module type of M [@foo]) [@foo] with type t := M.t) [@foo] [@@foo]
 
   [@@@foo]
 end [@foo]
@@ -241,7 +241,7 @@ module type S = sig
 
   [%%foo: module M = M [@@foo]]
   [%%foo: module type S = S [@@foo]]
-  [%%foo: include M[@@foo]]
+  [%%foo: include M [@@foo]]
   [%%foo: open M [@@foo]]
   [%%foo: class x : t [@@foo]]
   [%%foo: class type x = x [@@foo]]

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -144,7 +144,7 @@ module type S = sig
 
   [%%foo: module type S = S [@@foo]]
 
-  [%%foo: include M[@@foo]]
+  [%%foo: include M [@@foo]]
 
   [%%foo: open M [@@foo]]
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -15,7 +15,8 @@ end [@foo]
 
 module type S = sig
   include ((module type of M [@foo]) [@foo] with type t := M.t)
-  [@foo][@@foo]
+  [@foo]
+  [@@foo]
 
   [@@@foo]
 end [@foo]
@@ -265,7 +266,7 @@ module type S = sig
 
   [%%foo: module type S = S [@@foo]]
 
-  [%%foo: include M[@@foo]]
+  [%%foo: include M [@@foo]]
 
   [%%foo: open M [@@foo]]
 


### PR DESCRIPTION
A break was missing just before the attribute

```diff
 module M = struct
-  include N[@@attribute]
+  include N [@@attribute]
 end
```