### PR TITLE
Break after anonymous function arrow after infix op

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1421,7 +1421,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    $ fmt "@ " $ fmt_if parens_r "( " $ fmt "function"
                    $ fmt_extension_suffix c ext
                    $ fmt_attributes c ~key:"@" pexp_attributes ) )
-           $ fmt "@ " $ fmt_cases c (Exp r) cs $ fmt_if parens_r " )" ))
+           $ fmt "@;<1000 0>" $ fmt_cases c (Exp r) cs
+           $ fmt_if parens_r " )" ))
   | Pexp_apply
       ( {pexp_desc= Pexp_ident {txt= Lident id}; pexp_attributes= []}
       , [(Nolabel, _); (Nolabel, _)] )

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1077,9 +1077,9 @@ and fmt_body c ?ext ({ast= body} as xbody) =
         $ fmt_attributes c ~key:"@" pexp_attributes )
       , update_config_maybe_disabled c pexp_loc pexp_attributes
         @@ fun c ->
-        fmt "@ " $ fmt_cases c ctx cs $ fmt_if parens ")"
-        $ Cmts.fmt_after c pexp_loc )
-  | _ -> (noop, fmt "@ " $ fmt_expression c ~eol:(fmt "@;<1000 0>") xbody)
+        fmt_cases c ctx cs $ fmt_if parens ")" $ Cmts.fmt_after c pexp_loc
+      )
+  | _ -> (noop, fmt_expression c ~eol:(fmt "@;<1000 0>") xbody)
 
 and fmt_index_op c ctx ~parens ?set {txt= s, opn, cls; loc} l is =
   wrap_if parens "(" ")"
@@ -1402,7 +1402,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                            4 (fmt_fun_args c xargs)
                        $ fmt "@ ->" ) )
                $ pre_body )
-           $ body ))
+           $ fmt "@;<1000 0>" $ body ))
   | Pexp_apply
       ( ( {pexp_desc= Pexp_ident {txt= Lident id; loc}; pexp_attributes= []}
         as op )
@@ -1687,7 +1687,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                     0 (fmt_fun_args c xargs)
                 $ fmt "@ " )
             $ fmt "->" $ pre_body )
-        $ body
+        $ fmt "@ " $ body
         $ fmt_or_k c.conf.indicate_multiline_delimiters
             (fits_breaks_if parens ")" "@ )")
             (fits_breaks_if parens ")" "@,)") )
@@ -3821,7 +3821,7 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
               (fits_breaks " =" "@;<1000 0>=")
               (fmt "@;<1 2>=")
           $ pre_body )
-      $ body $ Cmts.fmt_after c pvb_loc
+      $ fmt "@ " $ body $ Cmts.fmt_after c pvb_loc
       $ fmt_attributes c ~pre:(fmt "@;") ~key:"@@" at_at_attrs
       $ (match in_ with Some in_ -> in_ indent | None -> noop)
       $ Option.call ~f:epi )

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1421,8 +1421,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    $ fmt "@ " $ fmt_if parens_r "( " $ fmt "function"
                    $ fmt_extension_suffix c ext
                    $ fmt_attributes c ~key:"@" pexp_attributes ) )
-           $ fmt "@;<1000 0>" $ fmt_cases c (Exp r) cs
-           $ fmt_if parens_r " )" ))
+           $ fmt "@ " $ fmt_cases c (Exp r) cs $ fmt_if parens_r " )" ))
   | Pexp_apply
       ( {pexp_desc= Pexp_ident {txt= Lident id}; pexp_attributes= []}
       , [(Nolabel, _); (Nolabel, _)] )

--- a/test/passing/infix_bind.ml
+++ b/test/passing/infix_bind.ml
@@ -23,7 +23,11 @@ f x
 ;;
 f x >>= fun y ->
 g y >>= fun () ->
-f x >>= fun y -> g y >>= fun () -> f x >>= fun y -> g y >>= fun () -> y ()
+f x >>= fun y ->
+g y >>= fun () ->
+f x >>= fun y ->
+g y >>= fun () ->
+y ()
 
 ;;
 f x >>= function
@@ -31,19 +35,24 @@ f x >>= function
     g y >>= fun () ->
     f x >>= fun y ->
     g y >>= function
-    | x -> ( f x >>= fun y -> g y >>= function _ -> y () ) )
+    | x -> (
+        f x >>= fun y ->
+        g y >>= function _ -> y () ) )
 
 ;;
-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> fun x -> x
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> fun x ->
+x
 
 ;;
 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-|> fun xxxxxx xxxxxxxxxx xxxxxxxx xxxxxxxx -> x
+|> fun xxxxxx xxxxxxxxxx xxxxxxxx xxxxxxxx ->
+x
 
 ;;
 eeeeeeeeeeeee eeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeeee
   eeeeeeeeeeee eeeeeeeeee
-|> fun x -> x
+|> fun x ->
+x
 
 ;;
 eeeeeeeeeeeee eeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeeee
@@ -52,18 +61,22 @@ eeeeeeeeeeeee eeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeeee
 xxxxxxxxxxx xxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxx xxxxxxxxxxx
 
 ;;
-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> fun x -> x
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> fun x ->
+x
 
 ;;
 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-|> fun xxxxxx xxxxxxxxxx xxxxxxxx xxxxxxxx -> x
+|> fun xxxxxx xxxxxxxxxx xxxxxxxx xxxxxxxx ->
+x
 
 ;;
-eeeeeeeeeeeee eeeeeeeeeeeeeeeeee |> fun xxxxxxxxx xxxxxxxxxxxxx -> x
+eeeeeeeeeeeee eeeeeeeeeeeeeeeeee |> fun xxxxxxxxx xxxxxxxxxxxxx ->
+x
 
 ;;
 eeeeeeeeeeeee eeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeee
-|> fun xxxxxxxx xxxxxxxxx xxxxxxxxxxxxx -> x
+|> fun xxxxxxxx xxxxxxxxx xxxxxxxxxxxxx ->
+x
 
 ;;
 eeeeeeeeeeeee eeeeeeeeeeeeeeeeee |> fun xxxxxxxxxxxxx ->
@@ -153,13 +166,17 @@ let end_gen_implementation ?toplevel ~ppf_dump
   ( clambda
   ++ Profile.record "cmm" (Cmmgen.compunit ~ppf_dump)
   ++ Profile.record "compile_phrases" (List.iter (compile_phrase ~ppf_dump))
-  ++ fun () -> () ) ;
+  ++ fun () ->
+    () ) ;
   fooooooooooooooo
 
 let foo =
   (* get the tree origin *)
   get_store_tree s >>= function
-  | None -> f t >|= fun x -> Ok x (* no transaction is needed *)
+  | None ->
+      f t >|= fun x ->
+      Ok x
+      (* no transaction is needed *)
   | Some (origin, old_tree) ->
       let batch = {repo; tree= old_tree; origin} in
       let b = Batch batch in

--- a/test/passing/infix_bind.ml
+++ b/test/passing/infix_bind.ml
@@ -37,8 +37,7 @@ f x >>= function
     g y >>= function
     | x -> (
         f x >>= fun y ->
-        g y >>= function
-        | _ -> y () ) )
+        g y >>= function _ -> y () ) )
 
 ;;
 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> fun x ->
@@ -89,8 +88,7 @@ eeeeeeeeeeeee eeeeeeeeee
 xxxxxxxxxxx xxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxx xxxxxxxxxxx
 
 ;;
-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> function
-| x -> x
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> function x -> x
 
 ;;
 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> function
@@ -110,16 +108,14 @@ eeeeeeeeeeeee eeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeeee
     xxxxxxxxxxx xxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxx xxxxxxxxxxx
 
 ;;
-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> function
-| x -> x
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> function x -> x
 
 ;;
 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> function
 | xxxxxx, xxxxxxxxxx, xxxxxxxx, xxxxxxxx -> x
 
 ;;
-eeeeeeeeeeeee eeeeeeeeeeeeeeeeee |> function
-| xxxxxxxxx, xxxxxxxxxxxxx -> x
+eeeeeeeeeeeee eeeeeeeeeeeeeeeeee |> function xxxxxxxxx, xxxxxxxxxxxxx -> x
 
 ;;
 eeeeeeeeeeeee eeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeee |> function

--- a/test/passing/infix_bind.ml
+++ b/test/passing/infix_bind.ml
@@ -37,7 +37,8 @@ f x >>= function
     g y >>= function
     | x -> (
         f x >>= fun y ->
-        g y >>= function _ -> y () ) )
+        g y >>= function
+        | _ -> y () ) )
 
 ;;
 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> fun x ->
@@ -88,7 +89,8 @@ eeeeeeeeeeeee eeeeeeeeee
 xxxxxxxxxxx xxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxx xxxxxxxxxxx
 
 ;;
-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> function x -> x
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> function
+| x -> x
 
 ;;
 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> function
@@ -108,14 +110,16 @@ eeeeeeeeeeeee eeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeeee
     xxxxxxxxxxx xxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxx xxxxxxxxxxx
 
 ;;
-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> function x -> x
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> function
+| x -> x
 
 ;;
 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> function
 | xxxxxx, xxxxxxxxxx, xxxxxxxx, xxxxxxxx -> x
 
 ;;
-eeeeeeeeeeeee eeeeeeeeeeeeeeeeee |> function xxxxxxxxx, xxxxxxxxxxxxx -> x
+eeeeeeeeeeeee eeeeeeeeeeeeeeeeee |> function
+| xxxxxxxxx, xxxxxxxxxxxxx -> x
 
 ;;
 eeeeeeeeeeeee eeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeee |> function

--- a/test/passing/match2.ml
+++ b/test/passing/match2.ml
@@ -57,11 +57,20 @@ let _ = match x with _ -> b >>= fun () -> c
 
 [@@@ocamlformat "break-infix-before-func=false"]
 
-let foo = match foo with 1 -> bar >>= ( function _ -> () ) | other -> ()
+let foo =
+  match foo with
+  | 1 ->
+      bar >>= ( function
+      | _ -> () )
+  | other -> ()
 
 let foo =
   match foo with
-  | 1 -> bar >>= ( function a -> fooooo | b -> fooooo | _ -> () )
+  | 1 ->
+      bar >>= ( function
+      | a -> fooooo
+      | b -> fooooo
+      | _ -> () )
   | other -> ()
 
 let foo =

--- a/test/passing/match2.ml
+++ b/test/passing/match2.ml
@@ -57,20 +57,11 @@ let _ = match x with _ -> b >>= fun () -> c
 
 [@@@ocamlformat "break-infix-before-func=false"]
 
-let foo =
-  match foo with
-  | 1 ->
-      bar >>= ( function
-      | _ -> () )
-  | other -> ()
+let foo = match foo with 1 -> bar >>= ( function _ -> () ) | other -> ()
 
 let foo =
   match foo with
-  | 1 ->
-      bar >>= ( function
-      | a -> fooooo
-      | b -> fooooo
-      | _ -> () )
+  | 1 -> bar >>= ( function a -> fooooo | b -> fooooo | _ -> () )
   | other -> ()
 
 let foo =


### PR DESCRIPTION
Fix #769 
The first commit c4bfb5b should be alright, but I'm not sure about the second one f1532ca maybe I should revert it.

Maybe it should be the default behavior (maybe only if `break-cases` is not equal to `fit` ?).

@samoht for opinion, as you opened #359