### PR TITLE
Improve: Fmt.noop

### DIFF
--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -512,7 +512,7 @@ let fmt_cmts t (conf : Conf.t) ?pro ?epi ?(eol = Fmt.fmt "@\n") ?(adj = eol)
   let open Fmt in
   let find = if !remove then Hashtbl.find_and_remove else Hashtbl.find in
   match find tbl loc with
-  | None | Some [] -> fmt ""
+  | None | Some [] -> noop
   | Some cmts ->
       let line_dist a b =
         b.Location.loc_start.pos_lnum - a.Location.loc_end.pos_lnum
@@ -537,7 +537,7 @@ let fmt_cmts t (conf : Conf.t) ?pro ?epi ?(eol = Fmt.fmt "@\n") ?(adj = eol)
         match next with
         | Some ((_, next_loc) :: _) ->
             fmt_if (line_dist cur_last_loc next_loc > 1) "\n"
-        | _ -> fmt ""
+        | _ -> noop
       in
       list_pn groups (fun ?prev group ?next ->
           fmt_or_k (Option.is_none prev)
@@ -561,12 +561,12 @@ let fmt_before t conf ?pro ?(epi = Fmt.break_unless_newline 1 0) ?eol ?adj =
 
 let fmt_after t conf ?(pro = Fmt.break_unless_newline 1 0) ?epi =
   let within = fmt_cmts t conf t.cmts_within ~pro ?epi in
-  let after = fmt_cmts t conf t.cmts_after ~pro ?epi ~eol:(Fmt.fmt "") in
+  let after = fmt_cmts t conf t.cmts_after ~pro ?epi ~eol:Fmt.noop in
   fun loc -> within loc $ after loc
 
 let fmt_within t conf ?(pro = Fmt.break_unless_newline 1 0)
     ?(epi = Fmt.break_unless_newline 1 0) =
-  fmt_cmts t conf t.cmts_within ~pro ~epi ~eol:(Fmt.fmt "")
+  fmt_cmts t conf t.cmts_within ~pro ~epi ~eol:Fmt.noop
 
 let fmt t conf ?pro ?epi ?eol ?adj loc =
   (* remove the before comments from the map first *)

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -30,6 +30,9 @@ val set_margin : int -> t
 val break : int -> int -> t
 (** Format a break hint. *)
 
+val noop : t
+(** Format nothing. *)
+
 val fmt : s -> t
 (** Format a format string. *)
 

--- a/src/Fmt_odoc.ml
+++ b/src/Fmt_odoc.ml
@@ -138,7 +138,7 @@ and fmt_text txt =
       | List _ | Enum _ -> fmt_text_elt curr $ fmt_newline
       | Raw x when not (is_space x.[String.length x - 1]) -> (
           fmt_text_elt curr
-          $ match next with List _ | Enum _ -> fmt "@\n" | _ -> fmt "" )
+          $ match next with List _ | Enum _ -> fmt "@\n" | _ -> noop )
       | Code _ -> (
           fmt_text_elt curr
           $

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -28,7 +28,7 @@ let get_cases (c : Conf.t) ~first ~indent ~parens_here =
       ; box_all= hvbox indent
       ; box_pattern_arrow= hovbox 2
       ; break_before_arrow= fmt "@;<1 0>"
-      ; break_after_arrow= fmt ""
+      ; break_after_arrow= noop
       ; break_after_opening_paren= fmt "@ " }
   | `Nested ->
       { leading_space= fmt_if (not first) "@ "
@@ -61,27 +61,27 @@ let get_record_type (c : Conf.t) ~wrap_record =
   let sparse_type_decl = Poly.(c.type_decl = `Sparse) in
   match c.break_separators with
   | `Before ->
-      { docked_before= fmt ""
+      { docked_before= noop
       ; break_before= fmt "@ "
       ; box_record= (fun k -> hvbox 0 (wrap_record c k))
       ; sep_before= fmt_or sparse_type_decl "@;<1000 0>; " "@,; "
-      ; sep_after= fmt ""
-      ; break_after= fmt ""
-      ; docked_after= fmt "" }
+      ; sep_after= noop
+      ; break_after= noop
+      ; docked_after= noop }
   | `After ->
-      { docked_before= fmt ""
+      { docked_before= noop
       ; break_before= fmt "@ "
       ; box_record= (fun k -> hvbox 2 (wrap_record c k))
-      ; sep_before= fmt ""
+      ; sep_before= noop
       ; sep_after= fmt_or sparse_type_decl "@;<1000 0>" "@ "
-      ; break_after= fmt ""
-      ; docked_after= fmt "" }
+      ; break_after= noop
+      ; docked_after= noop }
   | `After_and_docked ->
       let space = if c.space_around_collection_expressions then 1 else 0 in
       { docked_before= fmt " {"
       ; break_before= break space 0
       ; box_record= Fn.id
-      ; sep_before= fmt ""
+      ; sep_before= noop
       ; sep_after= fmt_or sparse_type_decl "@;<1000 0>" "@ "
       ; break_after= break space (-2)
       ; docked_after= fmt "}" }


### PR DESCRIPTION
I think it's cleaner to have a dedicated function `Fmt.noop` instead of `fmt ""`.