### PR TITLE
Improve: break with type constraints

### DIFF
--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -3649,9 +3649,7 @@ let ssmap =
 ;;
 
 let ssmap
-    : (module MapT with type key = string
-                    and type data = string
-                    and type map = SSMap.map)
+    : (module MapT with type key = string and type data = string and type map = SSMap.map)
   =
   let module S =
     struct

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -3431,8 +3431,7 @@ type ('k, 'd, 'm) map =
   (module MapT with type key = 'k and type data = 'd and type map = 'm)
 
 let add (type k d m) (m : (k, d, m) map) x y s =
-  let module M = ( val m
-                     : MapT
+  let module M = ( val m : MapT
                      with type key = k
                       and type data = d
                       and type map = m )
@@ -3452,7 +3451,7 @@ module SSMap = struct
 end
 
 let ssmap =
-  ( module SSMap : MapT
+  (module SSMap : MapT
     with type key = string
      and type data = string
      and type map = SSMap.map )


### PR DESCRIPTION
Fix #790

The new output is:

```ocaml
let x (module M : S with type a = a and type b = b) = ()

module type X = sig
  val x : (module S with type a = a and type b = b) -> unit
end
```