### PR TITLE
Fix break before ending paren

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -94,7 +94,7 @@ let all_args_unlabeled args =
   List.fold_right args ~init:(Some []) ~f:(fun arg acc ->
       match (acc, arg) with
       | Some args, (Asttypes.Nolabel, e) -> Some (e :: args)
-      | _ -> None )
+      | _ -> None)
 
 let index_op_get_sugar ({txt= ident; loc} : Longident.t Location.loc) args =
   match all_args_unlabeled args with
@@ -198,7 +198,7 @@ let doc_atrs atrs =
           | _ ->
               ( ({txt= doc; loc}, String.equal "ocaml.text" txt) :: docs
               , rev_atrs ) )
-        | _ -> (docs, atr :: rev_atrs) )
+        | _ -> (docs, atr :: rev_atrs))
   in
   let docs = match docs with [] -> None | l -> Some (List.rev l) in
   (docs, List.rev rev_atrs)
@@ -797,11 +797,11 @@ end = struct
     let check_type {ptype_params; ptype_cstrs; ptype_kind; ptype_manifest} =
       List.exists ptype_params ~f:fst_f
       || List.exists ptype_cstrs ~f:(fun (t1, t2, _) ->
-             typ == t1 || typ == t2 )
+             typ == t1 || typ == t2)
       || ( match ptype_kind with
          | Ptype_variant cd1N ->
              List.exists cd1N ~f:(fun {pcd_args; pcd_res} ->
-                 check_cstr pcd_args || Option.exists pcd_res ~f )
+                 check_cstr pcd_args || Option.exists pcd_res ~f)
          | Ptype_record ld1N ->
              List.exists ld1N ~f:(fun {pld_type} -> typ == pld_type)
          | _ -> false )
@@ -834,8 +834,7 @@ end = struct
               || loop e
           | Pcf_method (_, _, Cfk_concrete _) -> false
           | Pcf_constraint (t1, t2) -> t1 == typ || t2 == typ
-          | Pcf_initializer _ | Pcf_attribute _ | Pcf_extension _ -> false
-      )
+          | Pcf_initializer _ | Pcf_attribute _ | Pcf_extension _ -> false)
     in
     let check_class_type l =
       List.exists l ~f:(fun {pci_expr= {pcty_desc}; pci_params} ->
@@ -844,7 +843,7 @@ end = struct
           match pcty_desc with
           | Pcty_constr (_, l) -> List.exists l ~f:(fun x -> x == typ)
           | Pcty_arrow (_, t, _) -> t == typ
-          | _ -> false )
+          | _ -> false)
     in
     match ctx with
     | Pld (PTyp t1) -> assert (typ == t1)
@@ -884,7 +883,7 @@ end = struct
                      | Pctf_method (_, _, _, t) -> t == typ
                      | Pctf_inherit _ -> false
                      | Pctf_attribute _ -> false
-                     | Pctf_extension _ -> false ) )
+                     | Pctf_extension _ -> false) )
     | Pat ctx -> (
       match ctx.ppat_desc with
       | Ppat_constraint (_, t1) -> assert (typ == t1)
@@ -910,7 +909,7 @@ end = struct
                 | {pexp_desc= Pexp_constraint (_, t); pexp_attributes= []}
                   ->
                     t == typ
-                | _ -> false ) )
+                | _ -> false) )
       | _ -> assert false )
     | Cl {pcl_desc} ->
         assert (
@@ -976,7 +975,7 @@ end = struct
                 ||
                 match pcl_desc with
                 | Pcl_constr (_, l) -> List.exists l ~f:(fun x -> x == typ)
-                | _ -> false ) )
+                | _ -> false) )
       | Pstr_class_type l -> assert (check_class_type l)
       | Pstr_extension ((_, PTyp t), _) -> assert (t == typ)
       | Pstr_extension (_, _) -> assert false
@@ -996,7 +995,7 @@ end = struct
             | Pcty_arrow (_, _, x) -> loop x
             | _ -> false
           in
-          loop pci_expr )
+          loop pci_expr)
     in
     match (ctx : t) with
     | Exp _ -> assert false
@@ -1013,7 +1012,7 @@ end = struct
                   | Pcl_constraint (_, x) -> x == cty
                   | _ -> false
                 in
-                loop pci_expr ) )
+                loop pci_expr) )
       | _ -> assert false )
     | Sig ctx -> (
       match ctx.psig_desc with
@@ -1032,7 +1031,7 @@ end = struct
                 | Pctf_method _ -> false
                 | Pctf_constraint _ -> false
                 | Pctf_attribute _ -> false
-                | Pctf_extension _ -> false ) )
+                | Pctf_extension _ -> false) )
       | Pcty_open (_, _, t) -> assert (t == cty)
       | Pcty_constr _ -> assert false
       | Pcty_extension _ -> assert false )
@@ -1061,7 +1060,7 @@ end = struct
       List.exists pcstr_fields ~f:(fun f ->
           match f.pcf_desc with
           | Pcf_inherit (_, x, _) -> x == cl
-          | _ -> false )
+          | _ -> false)
     in
     match (ctx : t) with
     | Exp e -> (
@@ -1083,7 +1082,7 @@ end = struct
                   | Pcl_constraint (x, _) -> loop x
                   | _ -> false
                 in
-                loop pci_expr ) )
+                loop pci_expr) )
       | _ -> assert false )
     | Sig _ -> assert false
     | Cty _ -> assert false
@@ -1118,7 +1117,7 @@ end = struct
           | Pcf_extension (_, _) -> false
           | Pcf_inherit _ -> false
           | Pcf_constraint _ -> false
-          | Pcf_attribute _ -> false )
+          | Pcf_attribute _ -> false)
     in
     let check_extensions = function
       | PPat (p, _) -> p == pat
@@ -1130,7 +1129,7 @@ end = struct
           ||
           match pvb_pat.ppat_desc with
           | Ppat_constraint (p, _) -> p == pat
-          | _ -> false )
+          | _ -> false)
     in
     match ctx with
     | Pld (PPat (p1, _)) -> assert (p1 == pat)
@@ -1246,7 +1245,7 @@ end = struct
           | Pcf_extension (_, ext) -> check_extensions ext
           | Pcf_inherit _ -> false
           | Pcf_constraint _ -> false
-          | Pcf_attribute _ -> false )
+          | Pcf_attribute _ -> false)
     in
     match ctx with
     | Pld (PPat (_, Some e1)) -> assert (e1 == exp)
@@ -1309,7 +1308,7 @@ end = struct
                      | { pexp_desc= Pexp_constraint (e, _)
                        ; pexp_attributes= [] } ->
                          e == exp
-                     | _ -> e == e ) )
+                     | _ -> e == e) )
         | Pexp_assert e
          |Pexp_constraint (e, _)
          |Pexp_coerce (e, _, _)
@@ -1683,8 +1682,8 @@ end = struct
                    List.exists l ~f:(fun c ->
                        match c.pcd_args with
                        | Pcstr_tuple l -> List.exists l ~f:(phys_equal typ)
-                       | _ -> false )
-               | _ -> false ) ->
+                       | _ -> false)
+               | _ -> false) ->
         true
     | { ast= {ptyp_desc= Ptyp_alias _}
       ; ctx=
@@ -2017,12 +2016,12 @@ end = struct
         | Pexp_function cases | Pexp_match (_, cases) | Pexp_try (_, cases)
           ->
             List.iter cases ~f:(fun case ->
-                mark_parenzed_inner_nested_match case.pc_rhs ) ;
+                mark_parenzed_inner_nested_match case.pc_rhs) ;
             true
         | _ -> continue e )
       | Pexp_function cases | Pexp_match (_, cases) | Pexp_try (_, cases) ->
           List.iter cases ~f:(fun case ->
-              mark_parenzed_inner_nested_match case.pc_rhs ) ;
+              mark_parenzed_inner_nested_match case.pc_rhs) ;
           true
       | Pexp_apply ({pexp_desc= Pexp_ident ident}, (Nolabel, _) :: args)
         when Option.is_some (index_op_set_sugar ident args) ->
@@ -2130,7 +2129,7 @@ end = struct
        |Pexp_try (_, cases) ->
           if !leading_nested_match_parens then
             List.iter cases ~f:(fun {pc_rhs; _} ->
-                mark_parenzed_inner_nested_match pc_rhs ) ;
+                mark_parenzed_inner_nested_match pc_rhs) ;
           List.exists cases ~f:(fun {pc_rhs} -> pc_rhs == exp)
           && exposed_right_exp Match exp
       | Pexp_ifthenelse (cnd, _, _) when cnd == exp -> false
@@ -2159,7 +2158,7 @@ end = struct
                  | {pexp_desc= Pexp_constraint (e, _); pexp_attributes= []}
                    ->
                      e == exp
-                 | _ -> e0 == exp ) ->
+                 | _ -> e0 == exp) ->
           exposed_right_exp Non_apply exp
           (* Non_apply is perhaps pessimistic *)
       | Pexp_record (_, Some ({pexp_desc= Pexp_apply (ident, [_])} as e0))

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -59,7 +59,7 @@ end = struct
                ~if_found:(fun children ->
                  parent tbl children ~ancestor:root elt )
                ~if_not_found:Option.some
-           else None ))
+           else None))
       ancestor
 
   (* Add elements in decreasing width order to construct tree from roots to
@@ -76,7 +76,7 @@ end = struct
     List.iter elts_decreasing_width ~f:(fun elt ->
         match parent tree.tbl tree.roots elt with
         | Some parent -> Hashtbl.add_multi tree.tbl ~key:parent ~data:elt
-        | None -> tree.roots <- elt :: tree.roots ) ;
+        | None -> tree.roots <- elt :: tree.roots) ;
     { tree with
       tbl= Hashtbl.map tree.tbl ~f:(List.sort ~compare:Poly.compare) }
 
@@ -92,7 +92,7 @@ end = struct
                ( str (Sexp.to_string_hum (Itv.sexp_of_t root))
                $ wrap_if
                    (not (List.is_empty children))
-                   "@,{" " }" (dump_ tree children) ) ))
+                   "@,{" " }" (dump_ tree children) )))
     in
     if Conf.debug then set_margin 100000000 $ dump_ tree tree.roots
     else Fn.const ()
@@ -215,7 +215,7 @@ end = struct
     List.fold cmts ~init:empty ~f:(fun (smap, emap) cmt ->
         let _, loc = cmt in
         ( Map.add_multi smap ~key:loc ~data:cmt
-        , Map.add_multi emap ~key:loc ~data:cmt ) )
+        , Map.add_multi emap ~key:loc ~data:cmt ))
 
   let to_list (smap, _) = List.concat (Map.data smap)
 
@@ -251,7 +251,7 @@ let is_adjacent t (l1 : Location.t) (l2 : Location.t) =
       | "|" ->
           Source.begins_line t.source l1
           && Position.column l1.loc_start <= Position.column l2.loc_start
-      | _ -> false )
+      | _ -> false)
 
 (** Whether the symbol preceding location [loc] is an infix symbol or a
     semicolon. If it is the case, comments attached to the following item
@@ -275,7 +275,7 @@ let partition_after_prev_or_before_next t ~prev cmts ~next =
   | (_, loc) :: _ as cmtl when is_adjacent t prev loc -> (
     match
       List.group cmtl ~break:(fun (_, l1) (_, l2) ->
-          not (is_adjacent t l1 l2) )
+          not (is_adjacent t l1 l2))
     with
     | [cmtl] when is_adjacent t (snd (List.last_exn cmtl)) next ->
         let open Location in
@@ -291,7 +291,7 @@ let partition_after_prev_or_before_next t ~prev cmts ~next =
               List.partition_tf cmtl ~f:(fun (_, l1) ->
                   same_line_as_next l1
                   || (same_line_as_prev l1 && infix_symbol_before t prev)
-                  || not (same_line_as_prev l1) )
+                  || not (same_line_as_prev l1))
             in
             (prev, next)
           else ([], cmtl)
@@ -325,7 +325,7 @@ let add_cmts t ?prev ?next tbl loc cmts =
             else if phys_equal tbl t.cmts_after then "after"
             else "within" )
             Location.fmt loc Location.fmt cmt_loc (String.escaped btw_prev)
-            cmt_txt (String.escaped btw_next) ) ;
+            cmt_txt (String.escaped btw_next)) ;
     Hashtbl.add_exn tbl ~key:loc ~data:cmtl )
 
 (** Traverse the location tree from locs, find the deepest location that
@@ -361,7 +361,7 @@ let rec place t loc_tree ?prev_loc locs cmts =
     | None ->
         if Conf.debug then
           List.iter (CmtSet.to_list cmts) ~f:(fun (txt, _) ->
-              Format.eprintf "lost: %s@\n%!" txt ) )
+              Format.eprintf "lost: %s@\n%!" txt) )
 
 (** Remove comments that duplicate docstrings (or other comments). *)
 let dedup_cmts map_ast ast comments =
@@ -397,7 +397,7 @@ let init map_ast loc_of_ast source asts comments_n_docstrings =
   if Conf.debug then
     List.iter comments ~f:(fun (txt, loc) ->
         Format.eprintf "%a %s %s@\n%!" Location.fmt loc txt
-          (if Source.ends_line source loc then "eol" else "") ) ;
+          (if Source.ends_line source loc then "eol" else "")) ;
   if not (List.is_empty comments) then (
     let loc_tree = Loc_tree.of_ast map_ast asts in
     if Conf.debug then
@@ -422,7 +422,7 @@ let init_use_file =
          match (toplevel_phrase : toplevel_phrase) with
          | Ptop_def items ->
              List.map items ~f:(fun {Parsetree.pstr_loc} -> pstr_loc)
-         | Ptop_dir _ -> [] ))
+         | Ptop_dir _ -> []))
 
 let remove = ref true
 
@@ -443,17 +443,17 @@ let relocate t ~src ~before ~after =
       Option.iter (Hashtbl.find_and_remove tbl src) ~f:(fun src_data ->
           Hashtbl.update tbl dst ~f:(fun dst_data ->
               Option.fold dst_data ~init:src_data
-                ~f:(fun src_data dst_data -> f src_data dst_data) ) )
+                ~f:(fun src_data dst_data -> f src_data dst_data)))
     in
     if Conf.debug then
       Format.eprintf "relocate %a to %a and %a@\n%!" Location.fmt src
         Location.fmt before Location.fmt after ;
     update_multi t.cmts_before src before ~f:(fun src_cmts dst_cmts ->
-        List.append src_cmts dst_cmts ) ;
+        List.append src_cmts dst_cmts) ;
     update_multi t.cmts_after src after ~f:(fun src_cmts dst_cmts ->
-        List.append dst_cmts src_cmts ) ;
+        List.append dst_cmts src_cmts) ;
     update_multi t.cmts_within src after ~f:(fun src_cmts dst_cmts ->
-        List.append dst_cmts src_cmts ) )
+        List.append dst_cmts src_cmts) )
 
 let split_asterisk_prefixed (txt, {Location.loc_start}) =
   let len = Position.column loc_start + 3 in
@@ -491,7 +491,7 @@ let fmt_cmt (conf : Conf.t) cmt =
             match (line, next) with
             | "", None -> fmt ")"
             | _, None -> str line $ fmt "*)"
-            | _, Some _ -> str line $ fmt "@,*" ) )
+            | _, Some _ -> str line $ fmt "@,*") )
   in
   if not conf.wrap_comments then
     match split_asterisk_prefixed cmt with
@@ -524,7 +524,7 @@ let fmt_cmts t (conf : Conf.t) ?pro ?epi ?(eol = Fmt.fmt "@\n") ?(adj = eol)
               && Location.is_single_line b conf.margin
               && line_dist a b = 1
               && Location.compare_start_col a b = 0
-              && Location.compare_end_col a b = 0 ) )
+              && Location.compare_end_col a b = 0 ))
       in
       let last_loc = snd (List.last_exn cmts) in
       let eol_cmt = Source.ends_line t.source last_loc in
@@ -548,13 +548,13 @@ let fmt_cmts t (conf : Conf.t) ?pro ?epi ?(eol = Fmt.fmt "@\n") ?(adj = eol)
             | [cmt] -> fmt_cmt conf cmt $ maybe_newline ~next cmt
             | group ->
                 list group "@;<1000 0>" (fun cmt ->
-                    wrap "(*" "*)" (str (fst cmt)) )
+                    wrap "(*" "*)" (str (fst cmt)))
                 $ maybe_newline ~next (List.last_exn group) )
           $ fmt_if_k (Option.is_none next)
               ( close_box
               $ fmt_or_k eol_cmt
                   (fmt_or_k adj_cmt adj eol)
-                  (Option.call ~f:epi) ) )
+                  (Option.call ~f:epi) ))
 
 let fmt_before t conf ?pro ?(epi = Fmt.break_unless_newline 1 0) ?eol ?adj =
   fmt_cmts t conf t.cmts_before ?pro ~epi ?eol ?adj
@@ -585,7 +585,7 @@ let drop_inside t loc =
   let clear tbl =
     Hashtbl.map_inplace tbl ~f:(fun l ->
         List.filter l ~f:(fun (_, cmt_loc) ->
-            not (Location.contains loc cmt_loc) ) )
+            not (Location.contains loc cmt_loc)))
   in
   clear t.cmts_before ; clear t.cmts_within ; clear t.cmts_after
 
@@ -609,7 +609,7 @@ let remaining_comments t =
                  List
                    [ List [Atom "ast_loc"; Location.sexp_of_t ast_loc]
                    ; List [Atom "cmt_loc"; Location.sexp_of_t cmt_loc]
-                   ; List [Atom "cmt_txt"; Atom cmt_txt] ] ) ) )
+                   ; List [Atom "cmt_txt"; Atom cmt_txt] ] )))
   in
   List.concat
     [ get t.cmts_before "before"

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -260,7 +260,7 @@ end = struct
     let opt_names = List.map all ~f:(fun (x, y, _) -> (x, y)) in
     let to_string v' =
       List.find_map_exn all ~f:(fun (str, v, _) ->
-          if Poly.equal v v' then Some str else None )
+          if Poly.equal v v' then Some str else None)
     in
     let docs = section_name section in
     let term =
@@ -272,7 +272,7 @@ end = struct
     let parse s =
       match
         List.find_map all ~f:(fun (n, v, _) ->
-            Option.some_if (String.equal n s) v )
+            Option.some_if (String.equal n s) v)
       with
       | Some v -> Ok v
       | None ->
@@ -304,7 +304,7 @@ end = struct
     let names_for_cmdline =
       if invert_flag then
         List.filter_map names ~f:(fun n ->
-            if String.length n = 1 then None else Some ("no-" ^ n) )
+            if String.length n = 1 then None else Some ("no-" ^ n))
       else names
     in
     let doc = generated_flag_doc ~allow_inline ~doc ~section in
@@ -402,7 +402,7 @@ end = struct
                 update_from config name from ;
                 Some (Ok config)
             | Error error -> Some (Error (`Bad_value (name, error)))
-        else None )
+        else None)
     |> Option.value ~default:(Error (`Unknown (name, value)))
 
   let default {default} = default
@@ -1171,7 +1171,7 @@ let enable_outside_detected_project =
   let witness =
     String.concat ~sep:" or "
       (List.map project_root_witness ~f:(fun name ->
-           Format.sprintf "$(b,%s)" name ))
+           Format.sprintf "$(b,%s)" name))
   in
   let doc =
     Format.sprintf
@@ -1297,7 +1297,7 @@ let ocp_indent_config =
     let supported =
       let l =
         List.filter_map ocp_indent_options ~f:(fun (_, o) ->
-            Option.map o ~f:(fun (_, doc, _) -> doc) )
+            Option.map o ~f:(fun (_, doc, _) -> doc))
       in
       if List.is_empty l then ""
       else
@@ -1709,7 +1709,7 @@ let parse_line config ~from s =
         Result.( >>= )
           (update ~config ~from ~name:"profile" ~value:"janestreet")
           (fun config ->
-            update_many ~config ~from ocp_indent_janestreet_profile )
+            update_many ~config ~from ocp_indent_janestreet_profile)
     | name -> update ~config ~from ~name ~value:"true" )
   | _ -> Error (`Malformed s)
 
@@ -1718,7 +1718,7 @@ let is_project_root dir =
   | Some root -> Fpath.equal dir root
   | None ->
       List.exists project_root_witness ~f:(fun name ->
-          Fpath.(exists (dir / name)) )
+          Fpath.(exists (dir / name)))
 
 let dot_ocp_indent = ".ocp-indent"
 
@@ -1765,7 +1765,7 @@ let read_config_file conf filename_kind =
                   parse_line conf ~from:(`File (filename, num)) line
                 with
                 | Ok conf -> (conf, errors, Int.succ num)
-                | Error e -> (conf, e :: errors, Int.succ num) )
+                | Error e -> (conf, e :: errors, Int.succ num))
           in
           match List.rev errors with
           | [] -> c
@@ -1785,7 +1785,7 @@ let read_config_file conf filename_kind =
                       ("unknown option", Sexp.Atom name)
                   | `Bad_value (name, reason) ->
                       ( "bad value for"
-                      , Sexp.List [Sexp.Atom name; Sexp.Atom reason] ) )) )
+                      , Sexp.List [Sexp.Atom name; Sexp.Atom reason] ) )))
     with Sys_error _ -> conf )
 
 let update_using_env conf =
@@ -1864,12 +1864,12 @@ let is_ignored ~quiet ~ignores ~filename =
                     if not quiet then
                       Format.eprintf "File %a, line %d:\nWarning: %s\n"
                         (Fpath.pp ~pretty:true) ignore_file lno msg ;
-                    None ) )
+                    None))
       with Sys_error err ->
         if not quiet then
           Format.eprintf "Warning: ignoring %a, %s\n"
             (Fpath.pp ~pretty:true) ignore_file err ;
-        None )
+        None)
 
 let build_config ~file =
   let file_abs = Fpath.(v file |> to_absolute |> normalize) in
@@ -1935,15 +1935,14 @@ let action =
     Inplace
       (List.map !inputs ~f:(fun file ->
            let name = Option.value !name ~default:file in
-           {kind= kind_of file; name; file; conf= build_config ~file:name}
-       ))
+           {kind= kind_of file; name; file; conf= build_config ~file:name}))
   else if !check then
     Check
       (List.map !inputs ~f:(fun file ->
            let name = Option.value !name ~default:file in
            let conf = build_config ~file:name in
            let conf = {conf with max_iters= 1} in
-           {kind= kind_of file; name; file; conf} ))
+           {kind= kind_of file; name; file; conf}))
   else
     match !inputs with
     | [input_file] ->

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -247,5 +247,5 @@ let fill_text text =
               | Some str when String.for_all str ~f:Char.is_whitespace ->
                   close_box $ fmt "\n@," $ open_hovbox 0
               | Some _ when not (String.is_empty curr) -> fmt "@ "
-              | _ -> noop )))
+              | _ -> noop)))
   $ fmt_if (Char.is_whitespace text.[String.length text - 1]) " "

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -162,7 +162,7 @@ let maybe_disabled_k c (loc : Location.t) l f k =
           if i = 0 then s
           else
             drop_while s ~f:(fun i c ->
-                Char.is_whitespace c && i < indent_of_first_line ) )
+                Char.is_whitespace c && i < indent_of_first_line))
     in
     k (list l "@\n" str)
 
@@ -197,7 +197,7 @@ let fmt_groups c ctx grps fmt_grp =
       fmt_if (break_struct && not first) "\n@\n"
       $ fmt_if ((not break_struct) && not first) "@;<1000 0>"
       $ fmt_grp ~first ~last grp
-      $ fits_breaks_if ((not break_struct) && not last) "" "\n" )
+      $ fits_breaks_if ((not break_struct) && not last) "" "\n")
 
 let fmt_recmodule c ctx items f ast =
   let update_config c i = update_config c (Ast.attributes (ast i)) in
@@ -207,8 +207,7 @@ let fmt_recmodule c ctx items f ast =
     list_fl itms (fun ~first ~last:_ (itm, c) ->
         fmt_if_k (not first) (fmt_or break_struct "@\n" "@ ")
         $ maybe_disabled c (Ast.location (ast itm)) []
-          @@ fun c -> f c ctx ~rec_flag:true ~first:(first && first_grp) itm
-    )
+          @@ fun c -> f c ctx ~rec_flag:true ~first:(first && first_grp) itm)
   in
   hvbox 0 (fmt_groups c ctx grps fmt_grp)
 
@@ -409,7 +408,7 @@ let fmt_docstring c ?(standalone = false) ?pro ?epi doc =
         | _ -> false
       in
       fmt_parsed_docstring c ~need_break ~loc ?next ?pro ?epi txt
-        (parse_docstring txt) )
+        (parse_docstring txt))
 
 (** Handle the doc-comments-tag-only option: Fits tag-only comments on the
     same line *)
@@ -422,7 +421,7 @@ let fmt_docstring_around ~single_line c doc k =
         ( contains_text parsed
         , fun ?epi ?pro () ->
             fmt_parsed_docstring c ~need_break:false ~loc ?epi ?pro txt
-              parsed ) )
+              parsed ))
   in
   let fmted ?epi ?pro () = list doc "" (fun (_, k) -> k ?epi ?pro ()) in
   if
@@ -959,7 +958,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
                     else noop
                   in
                   leading_cmt $ fmt_pattern c ~pro xpat
-                  $ fmt_if_k last close_box ) )
+                  $ fmt_if_k last close_box))
         $ fits_breaks
             (if parens then ")" else "")
             (if nested then "" else "@;<1 2>)") )
@@ -1108,7 +1107,7 @@ and fmt_index_op c ctx ~parens ?set {txt= s, opn, cls; loc} l is =
        $ list is (comma_sep c) (fun i -> fmt_expression c (sub_exp ~ctx i))
        $ str (Printf.sprintf "%c" cls)
        $ opt set (fun e ->
-             fmt_assign_arrow c $ fmt_expression c (sub_exp ~ctx e) ) ))
+             fmt_assign_arrow c $ fmt_expression c (sub_exp ~ctx e)) ))
 
 and fmt_label_arg ?(box = true) ?epi ?parens ?eol c
     (lbl, ({ast= arg} as xarg)) =
@@ -1249,7 +1248,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    if c.conf.indicate_multiline_delimiters then "@ )"
                    else "@,)"
                  else "" ))
-              (break_unless_newline 1 0) )
+              (break_unless_newline 1 0))
     in
     let op_args_grouped =
       match c.conf.break_infix with
@@ -1452,7 +1451,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                  let fmt_after_cmts = Cmts.fmt_after c pexp_loc in
                  let fmt_op = fmt_expression c op in
                  (has_cmts, fmt_before_cmts, fmt_after_cmts, (fmt_op, args))
-             | None -> (false, noop, noop, (noop, args)) ))
+             | None -> (false, noop, noop, (noop, args))))
   | Pexp_apply
       ( {pexp_desc= Pexp_ident {txt= Lident id; loc}; pexp_loc}
       , (Nolabel, s) :: (Nolabel, i) :: _ )
@@ -1478,7 +1477,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       match List.rev e1N1 with
       | (lbl, ({pexp_desc= Pexp_fun _; pexp_loc} as eN1)) :: rev_e1N
         when List.for_all rev_e1N ~f:(fun (_, eI) ->
-                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI) ) ->
+                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI)) ->
           let e1N = List.rev rev_e1N in
           (* side effects of Cmts.fmt c.cmts before Sugar.fun_ is important *)
           let fmt_cmts = Cmts.fmt c pexp_loc in
@@ -1488,36 +1487,32 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             | Pexp_fun _ | Pexp_function _ -> Some false
             | _ -> None
           in
-          let fit = Location.is_single_line pexp_loc c.conf.margin in
           hvbox 0
             (wrap_if parens "(" ")"
-               ( hovbox 0
-                   ( hovbox 2
-                       ( wrap
-                           ( fmt_args_grouped e0 e1N $ fmt "@ "
-                           $ fmt_label lbl ":"
-                           $ fmt_cmts
-                             @@ hvbox 0
-                                  ( str "(fun "
-                                  $ fmt_attributes c ~key:"@"
-                                      eN1.pexp_attributes ~suf:(str " ")
-                                  $ fmt_fun_args c xargs $ fmt "@ ->" ) )
-                       $ fmt
-                           ( match xbody.ast.pexp_desc with
-                           | Pexp_function _ -> "@ "
-                           | _ -> "@;<1 2>" )
-                       $ fmt_expression c ?box xbody )
-                   $ fmt_or_k c.conf.indicate_multiline_delimiters
-                       (fmt_or_k fit (str ")")
-                          (fits_breaks ~force_fit_if:fit ")" "@ )"))
-                       (fits_breaks ~force_fit_if:fit ")" "@,)") )
+               ( hovbox 2
+                   ( wrap
+                       ( fmt_args_grouped e0 e1N $ fmt "@ "
+                       $ fmt_label lbl ":"
+                       $ fmt_cmts
+                         @@ hvbox 0
+                              ( str "(fun "
+                              $ fmt_attributes c ~key:"@"
+                                  eN1.pexp_attributes ~suf:(str " ")
+                              $ hvbox 0 (fmt_fun_args c xargs $ fmt "@ ->")
+                              ) )
+                   $ fmt
+                       ( match xbody.ast.pexp_desc with
+                       | Pexp_function _ -> "@ "
+                       | _ -> "@;<1 2>" )
+                   $ cbox 0 (fmt_expression c ?box xbody)
+                   $ str ")" )
                $ fmt_atrs ))
       | ( lbl
         , ( { pexp_desc= Pexp_function [{pc_lhs; pc_guard= None; pc_rhs}]
             ; pexp_loc } as eN ) )
         :: rev_e1N
         when List.for_all rev_e1N ~f:(fun (_, eI) ->
-                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI) ) ->
+                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI)) ->
           let e1N = List.rev rev_e1N in
           let ctx = Exp eN in
           (* side effects of Cmts.fmt_before before [fmt_pattern] is
@@ -1545,7 +1540,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                $ fmt_atrs ))
       | (lbl, ({pexp_desc= Pexp_function cs; pexp_loc} as eN)) :: rev_e1N
         when List.for_all rev_e1N ~f:(fun (_, eI) ->
-                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI) ) ->
+                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI)) ->
           let e1N = List.rev rev_e1N in
           let ctx'' = Exp eN in
           hvbox
@@ -1645,7 +1640,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                  ( fmt_expressions c width snd loc_xes (semic_sep c)
                      (fun (locs, xexp) ->
                        Cmts.fmt_list c ~eol:(fmt "@;<1 2>") locs
-                       @@ fmt_expression c xexp )
+                       @@ fmt_expression c xexp)
                  $ Cmts.fmt_before c ~pro:(fmt "@;<1 2>") ~epi:noop nil_loc
                  $ Cmts.fmt_after c ~pro:(fmt "@ ") ~epi:noop nil_loc )
              $ fmt_atrs ))
@@ -1661,7 +1656,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                ( has_cmts
                , fmt_before_cmts
                , fmt_after_cmts
-               , (fmt_op, [(Nolabel, arg)]) ) )) )
+               , (fmt_op, [(Nolabel, arg)]) ))) )
   | Pexp_construct (({txt= Lident "::"} as lid), Some arg) ->
       wrap_if parens "(" ")"
         ( hvbox 2
@@ -1753,7 +1748,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                          ( fmt_expression c ~box:false ~parens:false
                              ?pro:p.expr_pro ?eol:p.expr_eol xbch
                          $ p.break_end_branch )) )
-                $ fmt_if_k (not last) p.space_between_branches )))
+                $ fmt_if_k (not last) p.space_between_branches)))
   | Pexp_let (rec_flag, bindings, body) ->
       let fmt_expr ?box ?pro ?epi ?eol ?parens ?indent_wrap ?ext =
         fmt_expression ?box ?pro ?epi ?eol ?parens ?indent_wrap ?ext
@@ -1908,7 +1903,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                                (sub_pat ~ctx pc_lhs)
                            $ opt pc_guard (fun g ->
                                  fmt "@ when "
-                                 $ fmt_expression c (sub_exp ~ctx g) )
+                                 $ fmt_expression c (sub_exp ~ctx g))
                            $ fmt "@ ->" $ fmt_if parens_here " (" ) )
                    $ fmt "@;<1 2>"
                    $ cbox 0
@@ -1966,7 +1961,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             ( opt default (fun d ->
                   hvbox 2
                     (fmt_expression c (sub_exp ~ctx d) $ fmt "@;<1 -2>")
-                  $ fmt "with@;<1 2>" )
+                  $ fmt "with@;<1 2>")
             $ list flds (semic_sep c) fmt_field )
         $ fmt_atrs )
   | Pexp_sequence (e1, e2) when Option.is_some ext ->
@@ -2162,7 +2157,7 @@ and fmt_class_structure c ~ctx ?ext self_ fields =
           | Pcf_attribute atr -> update_config c [atr]
           | _ -> c
         in
-        (c, (i, c)) )
+        (c, (i, c)))
   in
   let cmts_after_self =
     fmt_if_k (List.is_empty fields) (Cmts.fmt_after c self_.ppat_loc)
@@ -2180,8 +2175,8 @@ and fmt_class_structure c ~ctx ?ext self_ fields =
         ( str "object"
         $ fmt_extension_suffix c ext
         $ opt self_ (fun self_ ->
-              fmt "@;" $ wrap "(" ")" (fmt_pattern c (sub_pat ~ctx self_))
-          ) )
+              fmt "@;" $ wrap "(" ")" (fmt_pattern c (sub_pat ~ctx self_)))
+        )
     $ cmts_after_self
     $ ( match fields with
       | ({pcf_desc= Pcf_attribute a}, _) :: _
@@ -2206,7 +2201,7 @@ and fmt_class_signature c ~ctx ~parens ?ext self_ fields =
           | Pctf_attribute atr -> update_config c [atr]
           | _ -> c
         in
-        (c, (i, c)) )
+        (c, (i, c)))
   in
   let cmts_after_self =
     fmt_if_k (List.is_empty fields) (Cmts.fmt_after c self_.ptyp_loc)
@@ -2228,8 +2223,8 @@ and fmt_class_signature c ~ctx ~parens ?ext self_ fields =
                $ fmt_extension_suffix c ext
                $ opt self_ (fun self_ ->
                      fmt "@;"
-                     $ wrap "(" ")" (fmt_core_type c (sub_typ ~ctx self_))
-                 ) )
+                     $ wrap "(" ")" (fmt_core_type c (sub_typ ~ctx self_)))
+               )
            $ cmts_after_self
            $ ( match fields with
              | ({pctf_desc= Pctf_attribute a}, _) :: _
@@ -2568,7 +2563,7 @@ and fmt_cases c ctx cs =
                   ( fmt_pattern c ~pro:p.bar ~parens:paren_lhs xlhs
                   $ opt pc_guard (fun g ->
                         fmt "@;<1 2>when "
-                        $ fmt_expression c (sub_exp ~ctx g) ) )
+                        $ fmt_expression c (sub_exp ~ctx g)) )
               $ p.break_before_arrow $ str "->" $ p.break_after_arrow
               $ fmt_if parens_here " (" )
           $ p.break_after_opening_paren
@@ -2576,7 +2571,7 @@ and fmt_cases c ctx cs =
               ( fmt_expression ?eol c ?parens:parens_for_exp xrhs
               $ fmt_if_k parens_here
                   (fmt_or c.conf.indicate_multiline_delimiters "@ )" "@,)")
-              ) ) )
+              ) ))
 
 and fmt_value_description c ctx vd =
   let { pval_name= {txt; loc}
@@ -2605,7 +2600,7 @@ and fmt_value_description c ctx vd =
           $ fmt_core_type c ~pro:":" ~box ~pro_space:true
               (sub_typ ~ctx pval_type)
           $ list_fl pval_prim (fun ~first ~last:_ s ->
-                fmt_if first "@ =" $ wrap " \"" "\"" (str s) ) )
+                fmt_if first "@ =" $ wrap " \"" "\"" (str s)) )
       $ fmt_attributes c ~pre:(fmt "@;<1 2>") ~key:"@@" atrs
       $ fmt_if_k
           ((not doc_before) && not both_docs)
@@ -2619,7 +2614,7 @@ and fmt_tydcl_params c ctx params =
         (List.length params > 1)
         "(" ")"
         (list params (comma_sep c) (fun (ty, vc) ->
-             fmt_variance vc $ fmt_core_type c (sub_typ ~ctx ty) ))
+             fmt_variance vc $ fmt_core_type c (sub_typ ~ctx ty)))
     $ fmt "@ " )
 
 and fmt_class_params c ctx ~epi params =
@@ -2632,7 +2627,7 @@ and fmt_class_params c ctx ~epi params =
                 $ fmt_if_k (not first) (fmt (comma_sep c))
                 $ fmt_variance vc
                 $ fmt_core_type c (sub_typ ~ctx ty)
-                $ fmt_if (last && exposed_right_typ ty) " " ))
+                $ fmt_if (last && exposed_right_typ ty) " "))
        $ epi ))
 
 and fmt_type_declaration c ?ext ?(pre = "") ?(brk = noop) ctx ?fmt_name
@@ -2658,7 +2653,7 @@ and fmt_type_declaration c ?ext ?(pre = "") ?(brk = noop) ctx ?fmt_name
     opt manifest (fun typ ->
         str " " $ str eq $ fmt_private_flag priv
         $ break_before_manifest_kind
-        $ fmt_core_type c ~in_type_declaration:true (sub_typ ~ctx typ) )
+        $ fmt_core_type c ~in_type_declaration:true (sub_typ ~ctx typ))
   in
   let box_manifest k =
     hvbox 2
@@ -2949,7 +2944,7 @@ and fmt_module_type c ({ast= mty} as xmty) =
       { empty with
         pro=
           Option.map pro ~f:(fun pro ->
-              open_hvbox 0 $ pro $ fmt_if parens "(" )
+              open_hvbox 0 $ pro $ fmt_if parens "(")
       ; psp
       ; bdy=
           fmt_if_k (Option.is_none pro) (open_hvbox 0 $ fmt_if parens "(")
@@ -3063,7 +3058,7 @@ and fmt_signature_item c ?ext {ast= si} =
   | Psig_open od -> fmt_open_description c od
   | Psig_recmodule mds ->
       fmt_recmodule c ctx mds fmt_module_declaration (fun x ->
-          Mty x.pmd_type )
+          Mty x.pmd_type)
   | Psig_type (rec_flag, decls) -> fmt_type c ?ext rec_flag decls ctx
   | Psig_typext te -> fmt_type_extension c ctx te
   | Psig_value vd -> fmt_value_description c ctx vd
@@ -3087,7 +3082,7 @@ and fmt_class_types c ctx ~pre ~sep (cls : class_type class_infos list) =
               $ fmt_str_loc c cl.pci_name $ fmt "@ " $ str sep )
           $ fmt "@;"
           $ fmt_class_type c (sub_cty ~ctx cl.pci_expr)
-          $ fmt_attributes c ~pre:(fmt "@;") ~key:"@@" atrs ) )
+          $ fmt_attributes c ~pre:(fmt "@;") ~key:"@@" atrs ))
 
 and fmt_class_exprs c ctx (cls : class_expr class_infos list) =
   list_fl cls (fun ~first ~last:_ cl ->
@@ -3119,10 +3114,10 @@ and fmt_class_exprs c ctx (cls : class_expr class_infos list) =
               $ fmt_if (not (List.is_empty xargs)) "@ "
               $ wrap_fun_decl_args ~stmt_loc c (fmt_fun_args c xargs)
               $ opt ty (fun t ->
-                    fmt " :@ " $ fmt_class_type c (sub_cty ~ctx t) )
+                    fmt " :@ " $ fmt_class_type c (sub_cty ~ctx t))
               $ fmt "@ =" )
           $ fmt "@;" $ fmt_class_expr c e )
-      $ fmt_attributes c ~pre:(fmt "@;") ~key:"@@" atrs )
+      $ fmt_attributes c ~pre:(fmt "@;") ~key:"@@" atrs)
 
 and fmt_module c ?epi ?(can_sparse = false) keyword name xargs xbody colon
     xmty attributes =
@@ -3137,7 +3132,7 @@ and fmt_module c ?epi ?(can_sparse = false) keyword name xargs xbody colon
             Some
               ( fmt_or colon " :" " ="
               $ opt blk.pro (fun pro -> str " " $ pro) )
-        ; psp= fmt_if (Option.is_none blk.pro) "@;<1 2>" $ blk.psp } )
+        ; psp= fmt_if (Option.is_none blk.pro) "@;<1 2>" $ blk.psp })
   in
   let blk_b =
     Option.value_map xbody ~default:empty ~f:(fmt_module_expr c)
@@ -3161,7 +3156,7 @@ and fmt_module c ?epi ?(can_sparse = false) keyword name xargs xbody colon
                  $ ( match next with
                    | Some (_, Some {opn; pro= Some _}) -> opn $ open_hvbox 0
                    | _ -> noop )
-                 $ Option.call ~f:epi ) ))
+                 $ Option.call ~f:epi) ))
   in
   let single_line =
     Option.for_all xbody ~f:(fun x -> module_expr_is_simple x.ast)
@@ -3203,7 +3198,7 @@ and fmt_module c ?epi ?(can_sparse = false) keyword name xargs xbody colon
                   (Option.is_some blk_b.epi && not c.conf.ocp_indent_compat)
                   " " "@ ")
                (fmt "@;<1 -2>")
-             $ epi ) ))
+             $ epi) ))
 
 and fmt_module_declaration c ctx ~rec_flag ~first pmd =
   let {pmd_name; pmd_type; pmd_attributes; pmd_loc} = pmd in
@@ -3510,7 +3505,7 @@ and fmt_structure c ctx itms =
         let last = last && last_grp in
         fmt_if_k (not first) (fmt_or break_struct "@\n" "@ ")
         $ maybe_disabled c itm.pstr_loc []
-          @@ fun c -> fmt_structure_item c ~last (sub_str ~ctx itm) )
+          @@ fun c -> fmt_structure_item c ~last (sub_str ~ctx itm))
   in
   hvbox 0 (fmt_groups c ctx grps fmt_grp)
 
@@ -3614,11 +3609,11 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
             fmt_if (not first) "@\n"
             $ fmt_value_binding c ~rec_flag ~first:(first && first_grp)
                 ?ext:(if first && first_grp then ext else None)
-                ctx binding ?epi )
+                ctx binding ?epi)
       in
       hvbox 0
         (list_fl grps (fun ~first ~last grp ->
-             fmt_grp ~first ~last grp $ fmt_if (not last) "\n@\n" ))
+             fmt_grp ~first ~last grp $ fmt_if (not last) "\n@\n"))
   | Pstr_modtype mtd -> fmt_module_type_declaration c ctx mtd
   | Pstr_extension (ext, atrs) ->
       let doc, atrs = doc_atrs atrs in

--- a/src/Migrate_ast.ml
+++ b/src/Migrate_ast.ml
@@ -32,7 +32,7 @@ module Parse = struct
       ~f:(fun (p : Parsetree.toplevel_phrase) ->
         match p with
         | Ptop_def [] -> false
-        | Ptop_def (_ :: _) | Ptop_dir _ -> true )
+        | Ptop_def (_ :: _) | Ptop_dir _ -> true)
 end
 
 let to_current =
@@ -60,7 +60,7 @@ module Printast = struct
 
   let use_file f (x : Parsetree.toplevel_phrase list) =
     List.iter x ~f:(fun (p : Parsetree.toplevel_phrase) ->
-        top_phrase f (to_current.copy_toplevel_phrase p) )
+        top_phrase f (to_current.copy_toplevel_phrase p))
 end
 
 module Pprintast = struct
@@ -84,7 +84,7 @@ let map_use_file mapper use_file =
       match (toplevel_phrase : toplevel_phrase) with
       | Ptop_def structure ->
           Ptop_def (mapper.Ast_mapper.structure mapper structure)
-      | Ptop_dir _ as d -> d )
+      | Ptop_dir _ as d -> d)
 
 module Position = struct
   open Lexing

--- a/src/Normalize.ml
+++ b/src/Normalize.ml
@@ -245,7 +245,7 @@ let make_mapper c ~ignore_doc_comment =
         List.filter si ~f:(fun si ->
             match si.pstr_desc with
             | Pstr_attribute a -> not (doc_attribute a)
-            | _ -> true )
+            | _ -> true)
       else si
     in
     Ast_mapper.default_mapper.structure m si
@@ -256,7 +256,7 @@ let make_mapper c ~ignore_doc_comment =
         List.filter si ~f:(fun si ->
             match si.psig_desc with
             | Psig_attribute a -> not (doc_attribute a)
-            | _ -> true )
+            | _ -> true)
       else si
     in
     Ast_mapper.default_mapper.signature m si
@@ -268,7 +268,7 @@ let make_mapper c ~ignore_doc_comment =
           List.filter si.pcsig_fields ~f:(fun si ->
               match si.pctf_desc with
               | Pctf_attribute a -> not (doc_attribute a)
-              | _ -> true )
+              | _ -> true)
         in
         {si with pcsig_fields}
       else si
@@ -282,7 +282,7 @@ let make_mapper c ~ignore_doc_comment =
           List.filter si.pcstr_fields ~f:(fun si ->
               match si.pcf_desc with
               | Pcf_attribute a -> not (doc_attribute a)
-              | _ -> true )
+              | _ -> true)
         in
         {si with pcstr_fields}
       else si
@@ -419,7 +419,7 @@ let moved_docstrings c get_docstrings s1 s2 =
         List.partition_map l1 ~f:(fun x ->
             match List.find l2 ~f:(equal x) with
             | Some (l, s) -> `Fst (Moved (fst x, l, s))
-            | None -> `Snd x )
+            | None -> `Snd x)
       in
       let l2 = List.filter l2 ~f:(fun x -> not (List.mem ~equal l1 x)) in
       let l1 = List.map ~f:unstable l1 in

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -169,7 +169,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch ~xcond
                     (str "if" $ fmt_extension_suffix)
                     (str "else if")
                 $ fmt_attributes $ str " " $ fmt_cond xcnd )
-              $ fmt "@ " )
+              $ fmt "@ ")
       ; box_keyword_and_expr=
           (fun k ->
             hvbox 2 (fmt_or (Option.is_some xcond) "then" "else" $ k) )

--- a/src/Reason.ml
+++ b/src/Reason.ml
@@ -78,7 +78,7 @@ module Binary_reason = struct
     in
     let comments =
       List.map comments ~f:(fun (c : Reason_comment.t) ->
-          (c.text, c.location) )
+          (c.text, c.location))
     in
     (origin_filename, comments, find_magic magic ast)
 end
@@ -137,7 +137,7 @@ module Mappers = struct
             | {txt= "implicit_arity"; _}, PStr [] -> false
             | {txt= "reason.raw_literal"; _}, _ -> false
             | {txt= "reason.preserve_braces"; _}, _ -> false
-            | _ -> true )
+            | _ -> true)
       in
       Ast_mapper.default_mapper.attributes mapper l
     in

--- a/src/Source.ml
+++ b/src/Source.ml
@@ -97,7 +97,7 @@ let find_after t f (loc : Location.t) =
         Bytes.From_string.blit ~src:t ~src_pos:!pos ~dst:bytes ~dst_pos:0
           ~len:to_write ;
         pos := !pos + to_write ;
-        to_write )
+        to_write)
   in
   let rec loop () =
     match Lexer.token lexbuf with
@@ -115,8 +115,8 @@ let extend_loc_to_include_attributes t (loc : Location.t)
   let last_loc =
     List.fold l ~init:loc
       ~f:(fun (acc : Location.t)
-         (({loc; _}, payload) : Parsetree.attribute)
-         ->
+              (({loc; _}, payload) : Parsetree.attribute)
+              ->
         if loc.loc_ghost then acc
         else
           let loc =
@@ -129,7 +129,7 @@ let extend_loc_to_include_attributes t (loc : Location.t)
             | PPat (p, None) -> p.ppat_loc
             | PPat (_, Some e) -> e.pexp_loc
           in
-          if Location.compare_end loc acc <= 0 then acc else loc )
+          if Location.compare_end loc acc <= 0 then acc else loc)
   in
   if phys_equal last_loc loc then loc
   else

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -131,7 +131,7 @@ let dump_ast ~input_name ?output_file ~suffix fmt =
     let ext = ".ast" in
     let file =
       with_file input_name output_file suffix ext (fun oc ->
-          fmt (Format.formatter_of_out_channel oc) )
+          fmt (Format.formatter_of_out_channel oc))
     in
     Some file
   else None
@@ -141,7 +141,7 @@ let dump_formatted ~input_name ?output_file ~suffix fmted =
   if Conf.debug then
     let file =
       with_file input_name output_file suffix ext (fun oc ->
-          Out_channel.output_string oc fmted )
+          Out_channel.output_string oc fmted)
     in
     Some file
   else None
@@ -275,14 +275,13 @@ let print_error ?(quiet_unstable = false) ?(quiet_comments = false)
                     "%!@{<loc>%a@}:@,@{<error>Error@}: Comment (* %s *) \
                      dropped.\n\
                      %!"
-                    Location.print_loc loc (ellipsis_cmt msg) )
+                    Location.print_loc loc (ellipsis_cmt msg))
           | `Cannot_parse ((Syntaxerr.Error _ | Lexer.Error _) as exn) ->
               if Conf.debug then Location.report_exception fmt exn
           | _ -> () ) ;
           if Conf.debug then
             List.iter l ~f:(fun (msg, sexp) ->
-                Format.fprintf fmt "  %s: %s\n%!" msg (Sexp.to_string sexp)
-            )
+                Format.fprintf fmt "  %s: %s\n%!" msg (Sexp.to_string sexp))
       | exn ->
           Format.fprintf fmt
             "  BUG: unhandled exception. Use [--debug] for details.\n%!" ;
@@ -293,7 +292,7 @@ let format xunit (conf : Conf.t) ?output_file ~input_name ~source ~parsed ()
     =
   let dump_ast ~suffix ast =
     dump_ast ~input_name ?output_file ~suffix (fun fmt ->
-        xunit.printast fmt ast )
+        xunit.printast fmt ast)
   in
   let dump_formatted = dump_formatted ~input_name ?output_file in
   Location.input_name := input_name ;
@@ -328,7 +327,7 @@ let format xunit (conf : Conf.t) ?output_file ~input_name ~source ~parsed ()
           let args =
             [("output file", dump_formatted ~suffix:".invalid-ast" fmted)]
             |> List.filter_map ~f:(fun (s, f_opt) ->
-                   Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)) )
+                   Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)))
           in
           internal_error (`Cannot_parse exn) args
       | t_new ->
@@ -352,8 +351,8 @@ let format xunit (conf : Conf.t) ?output_file ~input_name ~source ~parsed ()
                 ; ("old ast", old_ast)
                 ; ("new ast", new_ast) ]
                 |> List.filter_map ~f:(fun (s, f_opt) ->
-                       Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f))
-                   )
+                       Option.map f_opt ~f:(fun f ->
+                           (s, String.sexp_of_t f)))
               in
               internal_error (`Doc_comment docstrings) args
             else
@@ -363,8 +362,8 @@ let format xunit (conf : Conf.t) ?output_file ~input_name ~source ~parsed ()
                 ; ("old ast", old_ast)
                 ; ("new ast", new_ast) ]
                 |> List.filter_map ~f:(fun (s, f_opt) ->
-                       Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f))
-                   )
+                       Option.map f_opt ~f:(fun f ->
+                           (s, String.sexp_of_t f)))
               in
               internal_error `Ast_changed args ) ;
           (* Comments not preserved ? *)
@@ -384,7 +383,7 @@ let format xunit (conf : Conf.t) ?output_file ~input_name ~source ~parsed ()
             in
             let t_newdocstrings, t_newcomments =
               List.partition_tf t_new.comments ~f:(fun (s, _) ->
-                  is_docstring s )
+                  is_docstring s)
             in
             let f = ellipsis_cmt in
             let f x = Either.First.map ~f x |> Either.Second.map ~f in
@@ -406,7 +405,7 @@ let format xunit (conf : Conf.t) ?output_file ~input_name ~source ~parsed ()
                 ; ("old ast", Option.map old_ast ~f:String.sexp_of_t)
                 ; ("new ast", Option.map new_ast ~f:String.sexp_of_t) ]
                 |> List.filter_map ~f:(fun (s, f_opt) ->
-                       Option.map f_opt ~f:(fun f -> (s, f)) )
+                       Option.map f_opt ~f:(fun f -> (s, f)))
               in
               internal_error `Comment args ) ;
           (* Too many iteration ? *)

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -84,7 +84,7 @@ match Conf.action with
           | Ok formatted ->
               if String.equal formatted source then ()
               else Out_channel.write_all input_file ~data:formatted ;
-              None )
+              None)
     in
     if List.is_empty errors then Caml.exit 0 else Caml.exit 1
 | In_out

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -13,7 +13,7 @@ val f : compare:[%compare: 'a] -> sexp_of:[%sexp_of: 'a] -> t
 
 let invariant t =
   Invariant.invariant [%here] t [%sexp_of: t] (fun () ->
-      assert (check_t_invariant t) )
+      assert (check_t_invariant t))
 
 ;;
 [%e?

--- a/test/passing/extensions_sugar_always.ml.ref
+++ b/test/passing/extensions_sugar_always.ml.ref
@@ -13,7 +13,7 @@ val f : compare:[%compare: 'a] -> sexp_of:[%sexp_of: 'a] -> t
 
 let invariant t =
   Invariant.invariant [%here] t [%sexp_of: t] (fun () ->
-      assert (check_t_invariant t) )
+      assert (check_t_invariant t))
 
 ;;
 [%e?

--- a/test/passing/fun_decl.ml
+++ b/test/passing/fun_decl.ml
@@ -53,4 +53,4 @@ let f ssssssssss =
     function
     | '0' -> g accuuuuuuuuuum
     | '1' -> h accuuuuuuuuuum
-    | _ -> i accuuuuuuuuuum )
+    | _ -> i accuuuuuuuuuum)

--- a/test/passing/infix_arg_grouping.ml
+++ b/test/passing/infix_arg_grouping.ml
@@ -28,7 +28,7 @@ hvbox 1
               fmt "\\n"
               $ fmt_if_k
                   (not (String.is_empty next))
-                  (str spc $ pre_break 0 "\\" 0) ) )
+                  (str spc $ pre_break 0 "\\" 0)))
   $ str "\"" $ Option.call ~f:epi )
 
 ;;
@@ -59,7 +59,7 @@ hvbox 0
       ( str txt
       $ opt mt (fun _ ->
             fmt "@ : " $ Option.call ~f:pro_t $ psp_t $ fmt "@;<1 2>"
-            $ bdy_t $ esp_t $ Option.call ~f:epi_t ) )
+            $ bdy_t $ esp_t $ Option.call ~f:epi_t) )
   $ fmt " ->@ " $ Option.call ~f:pro_e $ psp_e $ bdy_e $ esp_e
   $ Option.call ~f:epi_e )
 

--- a/test/passing/issue289.ml
+++ b/test/passing/issue289.ml
@@ -93,7 +93,7 @@ let foo =
       ~resolve:(fun _ctx x -> x.description |> Util.option_of_string)
   ; field "type" ~doc:"Toy type. Possible values are: car, animal, train."
       ~args:[] ~typ:(non_null toy_type_enum) ~resolve:(fun _ctx x ->
-        x.toy_type )
+        x.toy_type)
   ; field "createdAt" ~doc:"Date created." ~args:[]
       ~typ:(non_null Scalar.date_time) ~resolve:(fun _ctx x -> x.created_at)
   ]

--- a/test/passing/ite.ml
+++ b/test/passing/ite.ml
@@ -78,19 +78,19 @@ let foo =
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo ) )
+        fooooooooooooo) )
   else if cond2 then (
     arm2 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo ) )
+        fooooooooooooo) )
   else (
     arm3 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo ) )
+        fooooooooooooo) )
 
 let foo =
   if some condition then

--- a/test/passing/ite_fit_or_vertical.ml.ref
+++ b/test/passing/ite_fit_or_vertical.ml.ref
@@ -96,19 +96,19 @@ let foo =
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo ) )
+        fooooooooooooo) )
   else if cond2 then (
     arm2 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo ) )
+        fooooooooooooo) )
   else (
     arm3 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo ) )
+        fooooooooooooo) )
 
 let foo =
   if some condition then

--- a/test/passing/ite_kr.ml.ref
+++ b/test/passing/ite_kr.ml.ref
@@ -117,19 +117,19 @@ let foo =
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo )
+        fooooooooooooo)
   ) else if cond2 then (
     arm2 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo )
+        fooooooooooooo)
   ) else (
     arm3 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo )
+        fooooooooooooo)
   )
 
 let foo =

--- a/test/passing/ite_kw_first.ml.ref
+++ b/test/passing/ite_kw_first.ml.ref
@@ -89,20 +89,20 @@ let foo =
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo ) )
+        fooooooooooooo) )
   else if cond2
   then (
     arm2 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo ) )
+        fooooooooooooo) )
   else (
     arm3 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo ) )
+        fooooooooooooo) )
 
 let foo =
   if some condition

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -2826,7 +2826,7 @@ let rec check : type n. n succ fin -> n succ term -> n term option =
   | Leaf -> Some Leaf
   | Fork (t1, t2) ->
       bind (check x t1) (fun t1 ->
-          bind (check x t2) (fun t2 -> Some (Fork (t1, t2))) )
+          bind (check x t2) (fun t2 -> Some (Fork (t1, t2))))
 
 let subst_var x t' y = match thick x y with None -> t' | Some y' -> Var y'
 
@@ -3543,7 +3543,7 @@ let subst_lambda ~subst_rec ~free ~subst : _ lambda -> _ = function
       let used = free t in
       let used_expr =
         Subst.fold subst ~init:[] ~f:(fun ~key ~data acc ->
-            if Names.mem s used then data :: acc else acc )
+            if Names.mem s used then data :: acc else acc)
       in
       if List.exists used_expr ~f:(fun t -> Names.mem s (free t)) then
         let name = s ^ string_of_int (next_id ()) in
@@ -3757,7 +3757,7 @@ class ['a] lambda_ops (ops : ('a, 'a) #ops Lazy.t) =
           let used = !!free t in
           let used_expr =
             Subst.fold sub ~init:[] ~f:(fun ~key ~data acc ->
-                if Names.mem s used then data :: acc else acc )
+                if Names.mem s used then data :: acc else acc)
           in
           if List.exists used_expr ~f:(fun t -> Names.mem s (!!free t)) then
             let name = s ^ string_of_int (next_id ()) in
@@ -3970,7 +3970,7 @@ let lambda_ops (ops : ('a, 'a) #ops Lazy.t) =
           let used = !!free t in
           let used_expr =
             Subst.fold sub ~init:[] ~f:(fun ~key ~data acc ->
-                if Names.mem s used then data :: acc else acc )
+                if Names.mem s used then data :: acc else acc)
           in
           if List.exists used_expr ~f:(fun t -> Names.mem s (!!free t)) then
             let name = s ^ string_of_int (next_id ()) in


### PR DESCRIPTION
Fix #799 
Removed the call to `Location.is_single_line` (#747), as a consequence we don't comply with `indicate-multiline-delimiters` anymore (only for these cases), but:
- it is not possible to do that without relying on the concrete syntax (`fmt_or_k c.conf.indicate_multiline_delimiters
                       (fits_breaks ")" " )") (fmt ")")` does not work for this case)
- there was no space after the opening parenthesis anyway (and it is intended)

I also made the box structure closer to the one of the `function` case.