### PR TITLE
Fix: sugarized extensions

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -1606,9 +1606,15 @@ end = struct
                     Pstr_eval
                       ( { pexp_desc=
                             ( Pexp_new _ | Pexp_object _ | Pexp_while _
-                            | Pexp_for _ ) }
+                            | Pexp_for _ | Pexp_function _ | Pexp_fun _
+                            | Pexp_try _ | Pexp_match _ | Pexp_let _ ) }
                       , _ ) } ] ) ->
           Some Apply
+      | Pexp_extension
+          ( _
+          , PStr [{pstr_desc= Pstr_eval ({pexp_desc= Pexp_sequence _}, _)}]
+          ) ->
+          Some Semi
       | Pexp_setfield _ -> Some LessMinus
       | Pexp_setinstvar _ -> Some LessMinus
       | Pexp_field _ -> Some Dot

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -14,17 +14,23 @@
 open Migrate_ast
 open Parsetree
 
-let init, register_reset, leading_nested_match_parens, parens_ite =
+let ( init
+    , extension_sugar
+    , register_reset
+    , leading_nested_match_parens
+    , parens_ite ) =
   let l = ref [] in
+  let extension_sugar = ref `Preserve in
   let leading_nested_match_parens = ref false in
   let parens_ite = ref false in
   let register f = l := f :: !l in
-  let init conf =
-    leading_nested_match_parens := conf.Conf.leading_nested_match_parens ;
-    parens_ite := conf.Conf.parens_ite ;
+  let init (conf : Conf.t) =
+    extension_sugar := conf.extension_sugar ;
+    leading_nested_match_parens := conf.leading_nested_match_parens ;
+    parens_ite := conf.parens_ite ;
     List.iter !l ~f:(fun f -> f ())
   in
-  (init, register, leading_nested_match_parens, parens_ite)
+  (init, extension_sugar, register, leading_nested_match_parens, parens_ite)
 
 (** Predicates recognizing special symbol identifiers. *)
 
@@ -1598,22 +1604,30 @@ end = struct
       | Pexp_apply _ -> Some Apply
       | Pexp_assert _ | Pexp_lazy _ | Pexp_for _
        |Pexp_variant (_, Some _)
-       |Pexp_while _ | Pexp_new _ | Pexp_object _
-       |Pexp_extension
-          ( _
+       |Pexp_while _ | Pexp_new _ | Pexp_object _ ->
+          Some Apply
+      | Pexp_extension
+          ( ext
           , PStr
               [ { pstr_desc=
                     Pstr_eval
-                      ( { pexp_desc=
-                            ( Pexp_new _ | Pexp_object _ | Pexp_while _
-                            | Pexp_for _ | Pexp_function _ | Pexp_fun _
-                            | Pexp_try _ | Pexp_match _ | Pexp_let _ ) }
-                      , _ ) } ] ) ->
+                      ( ( { pexp_desc=
+                              ( Pexp_new _ | Pexp_object _ | Pexp_while _
+                              | Pexp_for _ | Pexp_function _ | Pexp_fun _
+                              | Pexp_try _ | Pexp_match _ | Pexp_let _ ) }
+                        as e )
+                      , _ ) } ] )
+        when Poly.(!extension_sugar = `Always)
+             || Source.extension_using_sugar ~name:ext ~payload:e ->
           Some Apply
       | Pexp_extension
-          ( _
-          , PStr [{pstr_desc= Pstr_eval ({pexp_desc= Pexp_sequence _}, _)}]
-          ) ->
+          ( ext
+          , PStr
+              [ { pstr_desc=
+                    Pstr_eval (({pexp_desc= Pexp_sequence _} as e), _) } ]
+          )
+        when Poly.(!extension_sugar = `Always)
+             || Source.extension_using_sugar ~name:ext ~payload:e ->
           Some Semi
       | Pexp_setfield _ -> Some LessMinus
       | Pexp_setinstvar _ -> Some LessMinus

--- a/test/passing/extensions.ml
+++ b/test/passing/extensions.ml
@@ -125,3 +125,33 @@ let%lwt f = function
 
 type%any_extension t =
   < a: 'a >
+
+let value =
+  f
+    [%any_extension
+      function
+      | 0 -> false
+      | _ -> true
+    ]
+
+let value =
+    [%any_extension
+      fun x -> y
+    ]
+      x
+
+let value =
+  f
+    [%any_extension
+      try x with
+      | x -> false
+      | _ -> true
+    ]
+
+let value =
+  f
+    [%any_extension
+      match x with
+      | x -> false
+      | _ -> true
+    ]

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -32,14 +32,14 @@ let invariant t =
   , xxxxxxxxxxxxxx
   , xxxxxxxxxxx
   , xxxxxxxxxxxxxxxxxxxx ) when a < b]
-  ( [%ext
-      let f = () and g () = () in
-      e] )
+  [%ext
+    let f = () and g () = () in
+    e]
   (let%ext f = () and g () = () in
    e)
-  ( [%ext
-      let rec f = () and g () = () in
-      e] )
+  [%ext
+    let rec f = () and g () = () in
+    e]
   (let%ext rec f = () and g () = () in
    e)
 
@@ -73,9 +73,9 @@ let _ = [%stri let [%p xxx] = fun (t : [%t tt]) (ut : [%t tt]) -> [%e xxx]]
 let _ =
   [ x
   ; x
-    ---> ( [%expr
-             [%e x ~loc [%expr x] x] ;
-             iter tail] )
+    ---> [%expr
+           [%e x ~loc [%expr x] x] ;
+           iter tail]
   ; x ]
 
 let _ =
@@ -109,9 +109,9 @@ let _ = f (function%ext x -> x) x
 
 let _ = [%ext function x -> x]
 
-let _ = f ([%ext function x -> x])
+let _ = f [%ext function x -> x]
 
-let _ = f ([%ext function x -> x]) x
+let _ = f [%ext function x -> x] x
 
 let _ = f ([%ext e] [@attr]) x
 
@@ -144,10 +144,10 @@ let%lwt f = function _ -> ()
 
 type%any_extension t = < a: 'a >
 
-let value = f ([%any_extension function 0 -> false | _ -> true])
+let value = f [%any_extension function 0 -> false | _ -> true]
 
-let value = ([%any_extension fun x -> y]) x
+let value = [%any_extension fun x -> y] x
 
-let value = f ([%any_extension try x with x -> false | _ -> true])
+let value = f [%any_extension try x with x -> false | _ -> true]
 
-let value = f ([%any_extension match x with x -> false | _ -> true])
+let value = f [%any_extension match x with x -> false | _ -> true]

--- a/test/passing/extensions_sugar_always.ml
+++ b/test/passing/extensions_sugar_always.ml
@@ -1,0 +1,1 @@
+extensions.ml

--- a/test/passing/extensions_sugar_always.ml.opts
+++ b/test/passing/extensions_sugar_always.ml.opts
@@ -1,0 +1,1 @@
+--max-iters=3 --extension-sugar=always

--- a/test/passing/extensions_sugar_always.ml.ref
+++ b/test/passing/extensions_sugar_always.ml.ref
@@ -32,14 +32,12 @@ let invariant t =
   , xxxxxxxxxxxxxx
   , xxxxxxxxxxx
   , xxxxxxxxxxxxxxxxxxxx ) when a < b]
-  ( [%ext
-      let f = () and g () = () in
-      e] )
   (let%ext f = () and g () = () in
    e)
-  ( [%ext
-      let rec f = () and g () = () in
-      e] )
+  (let%ext f = () and g () = () in
+   e)
+  (let%ext rec f = () and g () = () in
+   e)
   (let%ext rec f = () and g () = () in
    e)
 
@@ -70,13 +68,7 @@ let (_ : [%ext? (x : x)]) = [%ext? (x : x)]
 
 let _ = [%stri let [%p xxx] = fun (t : [%t tt]) (ut : [%t tt]) -> [%e xxx]]
 
-let _ =
-  [ x
-  ; x
-    ---> ( [%expr
-             [%e x ~loc [%expr x] x] ;
-             iter tail] )
-  ; x ]
+let _ = [x; x ---> ([%e x ~loc [%expr x] x] ;%expr iter tail); x]
 
 let _ =
   ( [%expr
@@ -107,18 +99,18 @@ let _ = f (function%ext x -> x)
 
 let _ = f (function%ext x -> x) x
 
-let _ = [%ext function x -> x]
+let _ = function%ext x -> x
 
-let _ = f ([%ext function x -> x])
+let _ = f (function%ext x -> x)
 
-let _ = f ([%ext function x -> x]) x
+let _ = f (function%ext x -> x) x
 
 let _ = f ([%ext e] [@attr]) x
 
 let _ =
   a ;%ext
   b ;
-  [%ext a ; b]
+  a ;%ext b
 
 let _ = try%lwt Lwt.return 2 with _ -> assert false
 
@@ -144,10 +136,10 @@ let%lwt f = function _ -> ()
 
 type%any_extension t = < a: 'a >
 
-let value = f ([%any_extension function 0 -> false | _ -> true])
+let value = f (function%any_extension 0 -> false | _ -> true)
 
 let value = ([%any_extension fun x -> y]) x
 
-let value = f ([%any_extension try x with x -> false | _ -> true])
+let value = f (try%any_extension x with x -> false | _ -> true)
 
-let value = f ([%any_extension match x with x -> false | _ -> true])
+let value = f (match%any_extension x with x -> false | _ -> true)


### PR DESCRIPTION
Fix #796 
The modifications on the sequences and let are due to the `extension-sugar=always` mode that crashed for the test `extensions.ml`.