### PR TITLE
Remove dead link to preset profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ See the source code of OCamlFormat itself and [Infer](https://github.com/faceboo
   - [Overview](#overview)
   - [Code style](#code-style)
   - [Options](#options)
-  - [Preset profiles](#preset-profiles)
   - [Diff](#diff)
 - [Installation](#installation)
 - [Editor setup](#editor-setup)


### PR DESCRIPTION
It looks like there was once a "preset profiles" section in the readme to which
the table of contents still linked, but it's gone, so let's remove the link.