### PR TITLE
Fix let module sparse

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1809,7 +1809,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             "(" ")"
             ( hvbox 2
                 (fmt_module c keyword name xargs (Some xbody) true xmty []
-                   ~epi:(fmt "in") ~can_sparse)
+                   ~epi:(str "in") ~can_sparse)
             $ fmt "@;<1000 0>"
             $ fmt_expression c (sub_exp ~ctx exp) )
         $ fmt_atrs )

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -761,14 +761,13 @@ module type S = sig
 end
 
 let create (type s) to_string apply x =
-  let module M =
-    struct
-      type t = s
+  let module M = struct
+    type t = s
 
-      let to_string = to_string
-      let apply = apply
-      let x = x
-    end
+    let to_string = to_string
+    let apply = apply
+    let x = x
+  end
   in
   (module M : S with type t = s)
 ;;
@@ -785,12 +784,11 @@ let print x =
 
 let apply x =
   let module M = (val x : S) in
-  let module N =
-    struct
-      include M
+  let module N = struct
+    include M
 
-      let x = apply x
-    end
+    let x = apply x
+  end
   in
   (module N : S)
 ;;
@@ -855,16 +853,15 @@ let int = Int TypEq.refl
 let str = String TypEq.refl
 
 let pair (type s1 s2) t1 t2 =
-  let module P =
-    struct
-      type t = s1 * s2
-      type t1 = s1
-      type t2 = s2
+  let module P = struct
+    type t = s1 * s2
+    type t1 = s1
+    type t2 = s2
 
-      let eq = TypEq.refl
-      let t1 = t1
-      let t2 = t2
-    end
+    let eq = TypEq.refl
+    let t1 = t1
+    let t2 = t2
+  end
   in
   let pair = (module P : PAIR with type t = s1 * s2) in
   Pair pair
@@ -2822,12 +2819,11 @@ type 'a tt = 'a t =
 type _ t = I : int t
 
 let f (type a) (x : a t) =
-  let module M =
-    struct
-      let (I : a t) = x (* fail because of toplevel let *)
+  let module M = struct
+    let (I : a t) = x (* fail because of toplevel let *)
 
-      let x : a t = I
-    end
+    let x : a t = I
+  end
   in
   ()
 ;;
@@ -2837,16 +2833,15 @@ let f (type a) (x : a t) =
 type (_, _) eq = Refl : ('a, 'a) eq
 
 let bad (type a) =
-  let module N =
-    struct
-      module rec M : sig
-        val e : (int, a) eq
-      end = struct
-        let (Refl : (int, a) eq) = M.e (* must fail for soundness *)
+  let module N = struct
+    module rec M : sig
+      val e : (int, a) eq
+    end = struct
+      let (Refl : (int, a) eq) = M.e (* must fail for soundness *)
 
-        let e : (int, a) eq = Refl
-      end
+      let e : (int, a) eq = Refl
     end
+  end
   in
   N.M.e
 ;;
@@ -3577,16 +3572,15 @@ let int = Typ.Int TypEq.refl
 let str = Typ.String TypEq.refl
 
 let pair (type s1 s2) t1 t2 =
-  let module P =
-    struct
-      type t = s1 * s2
-      type t1 = s1
-      type t2 = s2
+  let module P = struct
+    type t = s1 * s2
+    type t1 = s1
+    type t2 = s2
 
-      let eq = TypEq.refl
-      let t1 = t1
-      let t2 = t2
-    end
+    let eq = TypEq.refl
+    let t1 = t1
+    let t2 = t2
+  end
   in
   Typ.Pair (module P)
 ;;
@@ -3651,10 +3645,9 @@ let ssmap =
 let ssmap
     : (module MapT with type key = string and type data = string and type map = SSMap.map)
   =
-  let module S =
-    struct
-      include SSMap
-    end
+  let module S = struct
+    include SSMap
+  end
   in
   (module S)
 ;;
@@ -4715,10 +4708,9 @@ type _ prod = Prod : ('a * 'y) prod
 
 let f : type t. t prod -> _ = function
   | Prod ->
-    let module M =
-      struct
-        type d = d * d
-      end
+    let module M = struct
+      type d = d * d
+    end
     in
     ()
 ;;
@@ -5478,10 +5470,9 @@ end
 C3.chr 66
 
 let f x =
-  let module M =
-    struct
-      module L = List
-    end
+  let module M = struct
+    module L = List
+  end
   in
   M.L.length x
 ;;
@@ -7575,17 +7566,16 @@ let _ = test 21 (Fib2.f 10) 89
 let _ =
   let res =
     try
-      let module A =
-        struct
-          module rec Bad : sig
-            val f : int -> int
-          end = struct
-            let f =
-              let y = Bad.f 5 in
-              fun x -> x + y
-            ;;
-          end
+      let module A = struct
+        module rec Bad : sig
+          val f : int -> int
+        end = struct
+          let f =
+            let y = Bad.f 5 in
+            fun x -> x + y
+          ;;
         end
+      end
       in
       false
     with
@@ -7976,26 +7966,25 @@ let _ = test 70 ((new Class1.c)#m 7) 0
 
 let _ =
   try
-    let module A =
-      struct
-        module rec BadClass1 : sig
-          class c :
-            object
-              method m : int
-            end
-        end = struct
-          class c =
-            object
-              method m = 123
-            end
-        end
-
-        and BadClass2 : sig
-          val x : int
-        end = struct
-          let x = (new BadClass1.c)#m
-        end
+    let module A = struct
+      module rec BadClass1 : sig
+        class c :
+          object
+            method m : int
+          end
+      end = struct
+        class c =
+          object
+            method m = 123
+          end
       end
+
+      and BadClass2 : sig
+        val x : int
+      end = struct
+        let x = (new BadClass1.c)#m
+      end
+    end
     in
     test 71 true false
   with
@@ -8618,10 +8607,9 @@ with type 'a t := unit
 
 (* Fails *)
 let property (type t) () =
-  let module M =
-    struct
-      exception E of t
-    end
+  let module M = struct
+    exception E of t
+  end
   in
   ( (fun x -> M.E x)
   , function
@@ -9646,10 +9634,9 @@ and ['a] d () =
 
 (* PR#7329 Pattern open *)
 let _ =
-  let module M =
-    struct
-      type t = { x : int }
-    end
+  let module M = struct
+    type t = { x : int }
+  end
   in
   let f M.(x) = () in
   let g M.{ x } = () in

--- a/test/passing/let_module_compact.ml
+++ b/test/passing/let_module_compact.ml
@@ -47,3 +47,8 @@ let () =
       end)
   in
   foo
+
+let f () =
+  let module (* comment *)
+      M = struct end in
+  ()

--- a/test/passing/let_module_compact.ml.ref
+++ b/test/passing/let_module_compact.ml.ref
@@ -44,3 +44,8 @@ let () =
       end)
   in
   foo
+
+let f () =
+  let module (* comment *)
+      M = struct end in
+  ()

--- a/test/passing/let_module_sparse.ml.ref
+++ b/test/passing/let_module_sparse.ml.ref
@@ -52,3 +52,8 @@ let () =
       end)
   in
   foo
+
+let f () =
+  let module (* comment *)
+      M = struct end in
+  ()


### PR DESCRIPTION
Follow-up of https://github.com/ocaml-ppx/ocamlformat/pull/768
- factorize the option `let-module` (fix #788), not enough differences to define the values in Params
- sparse mode only applied for module applications (fix #789)