### PR TITLE
Improve: break-cases-all shouldn't break nested patterns

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -903,7 +903,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
         | _ -> false
       in
       let xpats = Sugar.or_pat c.cmts xpat in
-      let pat_needs_space_before p =
+      let space p =
         match p.ppat_desc with
         | Ppat_constant (Pconst_integer (i, _) | Pconst_float (i, _)) -> (
           match i.[0] with '-' | '+' -> true | _ -> false )
@@ -915,27 +915,17 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
             (if parens then "(" else "")
             (if nested then "" else "( ")
       in
-      let proI =
+      let proI ?(space = false) =
         match ctx0 with
         | Exp {pexp_desc= Pexp_function _ | Pexp_match _ | Pexp_try _}
           when Poly.(c.conf.break_cases <> `Nested) -> (
             fmt_if Poly.(c.conf.break_cases = `All) "@;<1000 0>"
             $
             match c.conf.indicate_nested_or_patterns with
+            | `Space when space -> or_newline "| " " | "
             | `Space -> or_newline "| " " |"
             | `Unsafe_no -> or_newline "| " "| " )
         | _ -> break_unless_newline 1 0 $ str "| "
-      in
-      let pro2 pat_needs_space_before =
-        fmt_or_k
-          Poly.(c.conf.break_cases = `All)
-          ( match c.conf.indicate_nested_or_patterns with
-          | `Space ->
-              break_unless_newline 1000 0
-              $ str " |"
-              $ fmt_if pat_needs_space_before " "
-          | `Unsafe_no -> break_unless_newline 1000 0 $ str "| " )
-          proI
       in
       let is_simple {ppat_desc} =
         match ppat_desc with
@@ -957,7 +947,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
                   let pro =
                     if first_grp && first then pro0 $ open_hovbox (-2)
                     else if first then proI $ open_hovbox (-2)
-                    else pro2 (pat_needs_space_before xpat.ast)
+                    else proI ~space:(space xpat.ast)
                   in
                   (* side effects of Cmts.fmt_before before [fmt_pattern] is
                      important *)

--- a/test/passing/break_cases_all.ml.ref
+++ b/test/passing/break_cases_all.ml.ref
@@ -103,12 +103,7 @@ let mod_int c1 c2 is_safe dbg =
   match (c1, c2) with
   | c1, Cconst_int (0, _) ->
       Csequence (c1, raise_symbol dbg "caml_exn_Division_by_zero")
-  | ( c1
-    , Cconst_int
-        ( ( 1
-           | -1 )
-        , _ ) ) ->
-      Csequence (c1, Cconst_int (0, dbg))
+  | c1, Cconst_int ((1 | -1), _) -> Csequence (c1, Cconst_int (0, dbg))
   | x
    | -1 ->
       ()

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -9707,8 +9707,7 @@ class type t = object ((_[@foo])) end
 let test f x = f ~x:(x [@foo])
 
 let f = function
-  | ( `A
-    | `B )[@bar]
+  | (`A | `B)[@bar]
   | `C ->
     ()
 ;;


### PR DESCRIPTION
No issue, but requested by Jane Street
Breaking each nested or-pattern was too much.