### PR TITLE
Improve: preserve the position of type annotation in bindings

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3684,6 +3684,24 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
             let ctx = Exp body in
             match (body.pexp_desc, pat.ppat_desc) with
             | ( Pexp_constraint
+                  ( ({pexp_desc= Pexp_pack _; pexp_attributes= []} as exp)
+                  , ({ptyp_desc= Ptyp_package _; ptyp_attributes= []} as typ)
+                  )
+              , _ )
+              when Poly.(Source.typed_expression typ exp = `Type_first) ->
+                Cmts.relocate c.cmts ~src:body.pexp_loc ~before:exp.pexp_loc
+                  ~after:exp.pexp_loc ;
+                ( Some
+                    ( fmt_or_k c.conf.ocp_indent_compat
+                        (fits_breaks " " "@;<1000 0>")
+                        (fmt "@;<0 -1>")
+                    $ cbox_if c.conf.ocp_indent_compat 0
+                        (fmt_core_type c ~pro:":"
+                           ~pro_space:(not c.conf.ocp_indent_compat)
+                           ~box:(not c.conf.ocp_indent_compat)
+                           (sub_typ ~ctx typ)) )
+                , sub_exp ~ctx exp )
+            | ( Pexp_constraint
                   ({pexp_desc= Pexp_pack _}, {ptyp_desc= Ptyp_package _})
               , _ )
              |Pexp_constraint _, Ppat_constraint _ ->

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3682,6 +3682,18 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
           in
           let fmt_cstr, xbody =
             let ctx = Exp body in
+            let fmt_cstr_and_xbody typ exp =
+              ( Some
+                  ( fmt_or_k c.conf.ocp_indent_compat
+                      (fits_breaks " " "@;<1000 0>")
+                      (fmt "@;<0 -1>")
+                  $ cbox_if c.conf.ocp_indent_compat 0
+                      (fmt_core_type c ~pro:":"
+                         ~pro_space:(not c.conf.ocp_indent_compat)
+                         ~box:(not c.conf.ocp_indent_compat)
+                         (sub_typ ~ctx typ)) )
+              , sub_exp ~ctx exp )
+            in
             match (body.pexp_desc, pat.ppat_desc) with
             | ( Pexp_constraint
                   ( ({pexp_desc= Pexp_pack _; pexp_attributes= []} as exp)
@@ -3691,16 +3703,7 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
               when Poly.(Source.typed_expression typ exp = `Type_first) ->
                 Cmts.relocate c.cmts ~src:body.pexp_loc ~before:exp.pexp_loc
                   ~after:exp.pexp_loc ;
-                ( Some
-                    ( fmt_or_k c.conf.ocp_indent_compat
-                        (fits_breaks " " "@;<1000 0>")
-                        (fmt "@;<0 -1>")
-                    $ cbox_if c.conf.ocp_indent_compat 0
-                        (fmt_core_type c ~pro:":"
-                           ~pro_space:(not c.conf.ocp_indent_compat)
-                           ~box:(not c.conf.ocp_indent_compat)
-                           (sub_typ ~ctx typ)) )
-                , sub_exp ~ctx exp )
+                fmt_cstr_and_xbody typ exp
             | ( Pexp_constraint
                   ({pexp_desc= Pexp_pack _}, {ptyp_desc= Ptyp_package _})
               , _ )
@@ -3709,16 +3712,7 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
             | Pexp_constraint (exp, typ), _ ->
                 Cmts.relocate c.cmts ~src:body.pexp_loc ~before:exp.pexp_loc
                   ~after:exp.pexp_loc ;
-                ( Some
-                    ( fmt_or_k c.conf.ocp_indent_compat
-                        (fits_breaks " " "@;<1000 0>")
-                        (fmt "@;<0 -1>")
-                    $ cbox_if c.conf.ocp_indent_compat 0
-                        (fmt_core_type c ~pro:":"
-                           ~pro_space:(not c.conf.ocp_indent_compat)
-                           ~box:(not c.conf.ocp_indent_compat)
-                           (sub_typ ~ctx typ)) )
-                , sub_exp ~ctx exp )
+                fmt_cstr_and_xbody typ exp
             | _ -> (None, xbody)
           in
           (xpat, xargs, fmt_cstr, xbody)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3709,7 +3709,8 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
               , _ )
              |Pexp_constraint _, Ppat_constraint _ ->
                 (None, xbody)
-            | Pexp_constraint (exp, typ), _ ->
+            | Pexp_constraint (exp, typ), _
+              when Poly.(Source.typed_expression typ exp = `Type_first) ->
                 Cmts.relocate c.cmts ~src:body.pexp_loc ~before:exp.pexp_loc
                   ~after:exp.pexp_loc ;
                 fmt_cstr_and_xbody typ exp

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -102,7 +102,7 @@ end
 
 let f = (* comment *) function x -> x
 
-let foo x : z = (* comment *) y
+let foo x = (* comment *) (y : z)
 
 let _ =
   (*a*)

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -43,7 +43,7 @@ let invariant t =
   (let%ext rec f = () and g () = () in
    e)
 
-let (_ : [%ext? (x : x)]) = [%ext? (x : x)]
+let _ = ([%ext? (x : x)] : [%ext? (x : x)])
 
 [%%ext
 11111111111111111111]

--- a/test/passing/extensions_sugar_always.ml.ref
+++ b/test/passing/extensions_sugar_always.ml.ref
@@ -41,7 +41,7 @@ let invariant t =
   (let%ext rec f = () and g () = () in
    e)
 
-let (_ : [%ext? (x : x)]) = [%ext? (x : x)]
+let _ = ([%ext? (x : x)] : [%ext? (x : x)])
 
 [%%ext
 11111111111111111111]

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -3405,13 +3405,12 @@ let sort (type s) (module Set : Set.S with type elt = s) l =
 ;;
 
 (* No real improvement here? *)
-let make_set (type s) cmp =
+let make_set (type s) cmp : (module Set.S with type elt = s) =
   (module Set.Make (struct
     type t = s
 
     let compare = cmp
-  end) : Set.S
-    with type elt = s)
+  end))
 ;;
 
 (* No type annotation here *)

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -2827,7 +2827,7 @@ let f (type a) (x : a t) =
   let module M = struct
     let (I : a t) = x (* fail because of toplevel let *)
 
-    let x : a t = I
+    let x = (I : a t)
   end
   in
   ()
@@ -3646,14 +3646,13 @@ let ssmap =
      and type map = SSMap.map)
 ;;
 
-let ssmap
-    : (module MapT with type key = string and type data = string and type map = SSMap.map)
-  =
-  let module S = struct
-    include SSMap
-  end
-  in
-  (module S)
+let ssmap =
+  (let module S = struct
+     include SSMap
+   end
+   in
+   (module S)
+    : (module MapT with type key = string and type data = string and type map = SSMap.map))
 ;;
 
 let ssmap = (module SSMap : MapT with type key = _ and type data = _ and type map = _)
@@ -4676,7 +4675,7 @@ type foo =
 
 type bar = { x : int }
 
-let f (r : bar) : foo = { r with z = 3 }
+let f (r : bar) = ({ r with z = 3 } : foo)
 
 type foo = { x : int }
 
@@ -4733,8 +4732,8 @@ module Hash2 : sig
 end =
   Hash
 
-let f1 (x : (_, _) Hash1.t) : (_, _) Hashtbl.t = x
-let f2 (x : (_, _) Hash2.t) : (_, _) Hashtbl.t = x
+let f1 (x : (_, _) Hash1.t) = (x : (_, _) Hashtbl.t)
+let f2 (x : (_, _) Hash2.t) = (x : (_, _) Hashtbl.t)
 
 (* Another case, not using include *)
 
@@ -4747,7 +4746,7 @@ end
 module Std' = Std2
 module M' : module type of Std'.M = Std2.M
 
-let f3 (x : M'.t) : Std2.M.t = x
+let f3 (x : M'.t) = (x : Std2.M.t)
 
 (* original report required Core_kernel:
 module type S = sig
@@ -4795,7 +4794,7 @@ module DUMMY = struct
   let x = 2
 end
 
-let x : X.F(DUMMY).t = 3
+let x = (3 : X.F(DUMMY).t)
 
 module X2 = struct
   module type SIG = sig
@@ -4815,8 +4814,8 @@ module X2 = struct
   end
 end
 
-let x : X2.F(DUMMY)(DUMMY).t = 3
-let x : X2.F(DUMMY)(DUMMY).t' = 3
+let x = (3 : X2.F(DUMMY)(DUMMY).t)
+let x = (3 : X2.F(DUMMY)(DUMMY).t')
 
 module F (M : sig
   type 'a t
@@ -5697,7 +5696,7 @@ module S = String
 module StringSet = Set.Make (String)
 module SSet = Set.Make (S)
 
-let f (x : StringSet.t) : SSet.t = x
+let f (x : StringSet.t) = (x : SSet.t)
 
 (* Also using include (cf. Leo's mail 2013-11-16) *)
 module F (M : sig end) : sig
@@ -6052,7 +6051,7 @@ end
 
 (* ok to convert between structurally equal signatures, and parameters
    are inferred *)
-let f (x : (module S with type t = 'a and type u = 'b)) : (module S') = x
+let f (x : (module S with type t = 'a and type u = 'b)) = (x : (module S'))
 let g x = (x : (module S with type t = 'a and type u = 'b) :> (module S'))
 
 (* with subtyping it is also ok to forget some types *)
@@ -6064,10 +6063,10 @@ end
 
 let g2 x = (x : (module S2 with type t = 'a and type u = 'b) :> (module S'))
 let h x = (x : (module S2 with type t = 'a) :> (module S with type t = 'a))
-let f2 (x : (module S2 with type t = 'a and type u = 'b)) : (module S') = x
+let f2 (x : (module S2 with type t = 'a and type u = 'b)) = (x : (module S'))
 
 (* fail *)
-let k (x : (module S2 with type t = 'a)) : (module S with type t = 'a) = x
+let k (x : (module S2 with type t = 'a)) = (x : (module S with type t = 'a))
 
 (* fail *)
 
@@ -6666,7 +6665,7 @@ type refer1 = < poly : 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 type refer2 = < poly : 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 
 (* Actually this should succeed ... *)
-let f (x : refer1) : refer2 = x
+let f (x : refer1) = (x : refer2)
 
 module Classdef = struct
   class virtual ['a, 'b, 'c] cl0 =
@@ -6702,7 +6701,7 @@ end
 open Pr3918b
 
 let f x = (x : 'a vlist :> 'b vlist)
-let f (x : 'a vlist) : 'b vlist = x
+let f (x : 'a vlist) = (x : 'b vlist)
 
 module type Poly = sig
   type 'a t = 'a constraint 'a = [> ]
@@ -6917,13 +6916,13 @@ module F0 : sig
 end =
   Foobar
 
-let f (x : F0.t) : Foobar.t = x
+let f (x : F0.t) = (x : Foobar.t)
 
 (* fails *)
 
 module F = Foobar
 
-let f (x : F.t) : Foobar.t = x
+let f (x : F.t) = (x : Foobar.t)
 
 module M = struct
   type t = < m : int >
@@ -6991,7 +6990,7 @@ module Bar : sig
 end = struct
   type t = int
 
-  let f (x : int) : t = x
+  let f (x : int) = (x : t)
 end
 
 (* must fail *)
@@ -7092,7 +7091,7 @@ end
 
 module Test2 : module type of Test with type t = Test.t = Test
 
-let f (x : Test.t) : Test2.t = x
+let f (x : Test.t) = (x : Test2.t)
 let f Test2.A = ()
 let a = Test2.A
 
@@ -7435,7 +7434,7 @@ module PR_4758 = struct
     type t
   end
 
-  let f (x : F(C).t) : F(C').t = x
+  let f (x : F(C).t) = (x : F(C').t)
 end
 
 (* PR 4557 *)
@@ -7622,7 +7621,7 @@ end = struct
     | A
     | B
 
-  let (_ : Strengthen.t) = A
+  let _ = (A : Strengthen.t)
   let f x = if true then A else Strengthen.f B
 end
 
@@ -7643,13 +7642,13 @@ end = struct
     | A
     | B
 
-  let (_ : Strengthen2.t) = A
+  let _ = (A : Strengthen2.t)
   let f x = if true then A else Strengthen2.f B
 
   module M = struct
     type u = C
 
-    let (_ : Strengthen2.M.u) = C
+    let _ = (C : Strengthen2.M.u)
   end
 
   module rec R : sig
@@ -7657,8 +7656,8 @@ end = struct
   end = struct
     type v = D
 
-    let (_ : R.v) = D
-    let (_ : Strengthen2.R.v) = D
+    let _ = (D : R.v)
+    let _ = (D : Strengthen2.R.v)
   end
 end
 
@@ -7675,7 +7674,7 @@ end = struct
     | Leaf of 'a
     | Node of 'a list t * 'a list t
 
-  let x : int t = PolyRec.Leaf 1
+  let x = (PolyRec.Leaf 1 : int t)
 
   let depth = function
     | Leaf x -> 0

--- a/test/passing/let_binding.ml
+++ b/test/passing/let_binding.ml
@@ -137,3 +137,7 @@ and [@foo] fooo = fooooooooooo;;
 
 let [@foo] foooo = fooooooooo in
 fooooooooooooooooooooo
+
+let a : int = 0
+
+let b = (0 : int)

--- a/test/passing/let_binding.ml.ref
+++ b/test/passing/let_binding.ml.ref
@@ -141,3 +141,7 @@ and[@foo] fooo = fooooooooooo
 ;;
 let[@foo] foooo = fooooooooo in
 fooooooooooooooooooooo
+
+let a : int = 0
+
+let b = (0 : int)

--- a/test/passing/module.ml
+++ b/test/passing/module.ml
@@ -51,3 +51,7 @@ end
 include A (struct
   (* a *)
 end)
+
+let x : (module S) = (module struct end)
+
+let x = (module struct end : S)

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -3222,13 +3222,12 @@ let sort (type s) (module Set : Set.S with type elt = s) l =
   Set.elements (List.fold_right Set.add l Set.empty)
 
 (* No real improvement here? *)
-let make_set (type s) cmp =
+let make_set (type s) cmp : (module Set.S with type elt = s) =
   ( module Set.Make (struct
     type t = s
 
     let compare = cmp
-  end) : Set.S
-    with type elt = s )
+  end) )
 
 (* No type annotation here *)
 let sort_cmp (type s) cmp =

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -2697,7 +2697,7 @@ let f (type a) (x : a t) =
   let module M = struct
     let (I : a t) = x (* fail because of toplevel let *)
 
-    let x : a t = I
+    let x = (I : a t)
   end in
   ()
 
@@ -3471,15 +3471,15 @@ let ssmap =
      and type data = string
      and type map = SSMap.map )
 
-let ssmap :
-    (module MapT
-       with type key = string
-        and type data = string
-        and type map = SSMap.map) =
-  let module S = struct
-    include SSMap
-  end in
-  (module S)
+let ssmap =
+  ( let module S = struct
+      include SSMap
+    end in
+    (module S)
+    : (module MapT
+         with type key = string
+          and type data = string
+          and type map = SSMap.map) )
 
 let ssmap =
   (module SSMap : MapT with type key = _ and type data = _ and type map = _)
@@ -4381,7 +4381,7 @@ type foo = {y: int; z: int}
 
 type bar = {x: int}
 
-let f (r : bar) : foo = {r with z= 3}
+let f (r : bar) = ({r with z= 3} : foo)
 
 type foo = {x: int}
 
@@ -4433,9 +4433,9 @@ module Hash2 : sig
 end =
   Hash
 
-let f1 (x : (_, _) Hash1.t) : (_, _) Hashtbl.t = x
+let f1 (x : (_, _) Hash1.t) = (x : (_, _) Hashtbl.t)
 
-let f2 (x : (_, _) Hash2.t) : (_, _) Hashtbl.t = x
+let f2 (x : (_, _) Hash2.t) = (x : (_, _) Hashtbl.t)
 
 (* Another case, not using include *)
 
@@ -4449,7 +4449,7 @@ module Std' = Std2
 
 module M' : module type of Std'.M = Std2.M
 
-let f3 (x : M'.t) : Std2.M.t = x
+let f3 (x : M'.t) = (x : Std2.M.t)
 
 (* original report required Core_kernel: module type S = sig open
    Core_kernel.Std
@@ -4493,7 +4493,7 @@ module DUMMY = struct
   let x = 2
 end
 
-let x : X.F(DUMMY).t = 3
+let x = (3 : X.F(DUMMY).t)
 
 module X2 = struct
   module type SIG = sig
@@ -4513,9 +4513,9 @@ module X2 = struct
   end
 end
 
-let x : X2.F(DUMMY)(DUMMY).t = 3
+let x = (3 : X2.F(DUMMY)(DUMMY).t)
 
-let x : X2.F(DUMMY)(DUMMY).t' = 3
+let x = (3 : X2.F(DUMMY)(DUMMY).t')
 
 module F (M : sig
   type 'a t
@@ -5394,7 +5394,7 @@ module S = String
 module StringSet = Set.Make (String)
 module SSet = Set.Make (S)
 
-let f (x : StringSet.t) : SSet.t = x
+let f (x : StringSet.t) = (x : SSet.t)
 
 (* Also using include (cf. Leo's mail 2013-11-16) *)
 module F (M : sig end) : sig
@@ -5753,7 +5753,7 @@ end
 
 (* ok to convert between structurally equal signatures, and parameters are
    inferred *)
-let f (x : (module S with type t = 'a and type u = 'b)) : (module S') = x
+let f (x : (module S with type t = 'a and type u = 'b)) = (x : (module S'))
 
 let g x = (x : (module S with type t = 'a and type u = 'b) :> (module S'))
 
@@ -5770,10 +5770,10 @@ let g2 x = (x : (module S2 with type t = 'a and type u = 'b) :> (module S'))
 
 let h x = (x : (module S2 with type t = 'a) :> (module S with type t = 'a))
 
-let f2 (x : (module S2 with type t = 'a and type u = 'b)) : (module S') = x
+let f2 (x : (module S2 with type t = 'a and type u = 'b)) = (x : (module S'))
 
 (* fail *)
-let k (x : (module S2 with type t = 'a)) : (module S with type t = 'a) = x
+let k (x : (module S2 with type t = 'a)) = (x : (module S with type t = 'a))
 
 (* fail *)
 
@@ -6361,7 +6361,7 @@ type refer1 = < poly: 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 type refer2 = < poly: 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 
 (* Actually this should succeed ... *)
-let f (x : refer1) : refer2 = x
+let f (x : refer1) = (x : refer2)
 
 module Classdef = struct
   class virtual ['a, 'b, 'c] cl0 =
@@ -6394,7 +6394,7 @@ open Pr3918b
 
 let f x = (x : 'a vlist :> 'b vlist)
 
-let f (x : 'a vlist) : 'b vlist = x
+let f (x : 'a vlist) = (x : 'b vlist)
 
 module type Poly = sig
   type 'a t = 'a constraint 'a = [> ]
@@ -6579,13 +6579,13 @@ module F0 : sig
 end =
   Foobar
 
-let f (x : F0.t) : Foobar.t = x
+let f (x : F0.t) = (x : Foobar.t)
 
 (* fails *)
 
 module F = Foobar
 
-let f (x : F.t) : Foobar.t = x
+let f (x : F.t) = (x : Foobar.t)
 
 module M = struct
   type t = < m: int >
@@ -6654,7 +6654,7 @@ module Bar : sig
 end = struct
   type t = int
 
-  let f (x : int) : t = x
+  let f (x : int) = (x : t)
 end
 
 (* must fail *)
@@ -6757,7 +6757,7 @@ end
 
 module Test2 : module type of Test with type t = Test.t = Test
 
-let f (x : Test.t) : Test2.t = x
+let f (x : Test.t) = (x : Test2.t)
 
 let f Test2.A = ()
 
@@ -7102,7 +7102,7 @@ module PR_4758 = struct
     type t
   end
 
-  let f (x : F(C).t) : F(C').t = x
+  let f (x : F(C).t) = (x : F(C').t)
 end
 
 (* PR 4557 *)
@@ -7280,7 +7280,7 @@ module rec Strengthen : sig
 end = struct
   type t = A | B
 
-  let (_ : Strengthen.t) = A
+  let _ = (A : Strengthen.t)
 
   let f x = if true then A else Strengthen.f B
 end
@@ -7300,14 +7300,14 @@ module rec Strengthen2 : sig
 end = struct
   type t = A | B
 
-  let (_ : Strengthen2.t) = A
+  let _ = (A : Strengthen2.t)
 
   let f x = if true then A else Strengthen2.f B
 
   module M = struct
     type u = C
 
-    let (_ : Strengthen2.M.u) = C
+    let _ = (C : Strengthen2.M.u)
   end
 
   module rec R : sig
@@ -7315,9 +7315,9 @@ end = struct
   end = struct
     type v = D
 
-    let (_ : R.v) = D
+    let _ = (D : R.v)
 
-    let (_ : Strengthen2.R.v) = D
+    let _ = (D : Strengthen2.R.v)
   end
 end
 
@@ -7330,7 +7330,7 @@ module rec PolyRec : sig
 end = struct
   type 'a t = Leaf of 'a | Node of 'a list t * 'a list t
 
-  let x : int t = PolyRec.Leaf 1
+  let x = (PolyRec.Leaf 1 : int t)
 
   let depth = function
     | Leaf x -> 0


### PR DESCRIPTION
Fix #629 
No regression with test_branch, with or without the janestreet profile.