### PR TITLE
Improve: remove break before ending paren for anonymous functions

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -859,13 +859,13 @@ end = struct
           assert (
             List.exists r1N ~f:(function
               | Rtag (_, _, _, t1N) -> List.exists t1N ~f
-              | Rinherit t1 -> typ == t1 ) )
+              | Rinherit t1 -> typ == t1) )
       | Ptyp_package (_, it1N) -> assert (List.exists it1N ~f:snd_f)
       | Ptyp_object (fields, _) ->
           assert (
             List.exists fields ~f:(function
               | Otag (_, _, t1) -> typ == t1
-              | Oinherit t1 -> typ == t1 ) )
+              | Oinherit t1 -> typ == t1) )
       | Ptyp_class (_, l) -> assert (List.exists l ~f) )
     | Cty {pcty_desc} ->
         assert (
@@ -930,7 +930,7 @@ end = struct
               List.exists c1N ~f:(function
                 | Pwith_type (_, d1) | Pwith_typesubst (_, d1) ->
                     check_type d1
-                | _ -> false )
+                | _ -> false)
               || loop m.pmty_desc
           | _ -> false
         in
@@ -1181,7 +1181,7 @@ end = struct
           assert (
             List.exists cases ~f:(function
               | {pc_lhs} when pc_lhs == pat -> true
-              | _ -> false ) )
+              | _ -> false) )
       | Pexp_for (p, _, _, _, _) | Pexp_fun (_, _, p, _) -> assert (p == pat)
       )
     | Cl ctx ->
@@ -1274,7 +1274,7 @@ end = struct
               List.exists cases ~f:(function
                 | {pc_guard= Some g} when g == exp -> true
                 | {pc_rhs} when pc_rhs == exp -> true
-                | _ -> false ) )
+                | _ -> false) )
         | Pexp_fun (_, default, _, body) ->
             assert (
               Option.value_map default ~default:false ~f || body == exp )
@@ -1413,7 +1413,7 @@ end = struct
           List.exists cd1N ~f:(function
             | {pcd_args= Pcstr_tuple t1N} ->
                 List.exists t1N ~f:(phys_equal ty)
-            | _ -> false )
+            | _ -> false)
       | _ -> false
     in
     let is_tuple_lvl1_in_ext_constructor ty = function
@@ -1823,7 +1823,7 @@ end = struct
         List.exists bindings ~f:(function
           | {pvb_pat; pvb_expr= {pexp_desc= Pexp_constraint _}} ->
               pvb_pat == pat
-          | _ -> false )
+          | _ -> false)
     | Pld _, Ppat_constraint _ -> true
     | _ -> false
 

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -57,7 +57,7 @@ end = struct
            if Itv.contains root elt then
              Hashtbl.find_and_call tbl root
                ~if_found:(fun children ->
-                 parent tbl children ~ancestor:root elt )
+                 parent tbl children ~ancestor:root elt)
                ~if_not_found:Option.some
            else None))
       ancestor

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -462,7 +462,7 @@ let split_asterisk_prefixed (txt, {Location.loc_start}) =
       (String.init len ~f:(function
         | 0 -> '\n'
         | n when n < len - 1 -> ' '
-        | _ -> '*' ))
+        | _ -> '*'))
   in
   let rec split_asterisk_prefixed_ pos =
     match String.Search_pattern.index pat ~pos ~in_:txt with

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -1558,7 +1558,7 @@ let (_profile : t option C.t) =
   C.choice ~names ~all ~doc ~section ~has_default:false
     (fun conf p ->
       selected_profile_ref := p ;
-      Option.value p ~default:conf )
+      Option.value p ~default:conf)
     (fun _ -> !selected_profile_ref)
 
 let validate () =

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -1785,7 +1785,7 @@ let read_config_file conf filename_kind =
                       ("unknown option", Sexp.Atom name)
                   | `Bad_value (name, reason) ->
                       ( "bad value for"
-                      , Sexp.List [Sexp.Atom name; Sexp.Atom reason] ) )))
+                      , Sexp.List [Sexp.Atom name; Sexp.Atom reason] ))))
     with Sys_error _ -> conf )
 
 let update_using_env conf =
@@ -1806,7 +1806,7 @@ let update_using_env conf =
             | `Unknown (name, _value) -> ("unknown option", Sexp.Atom name)
             | `Bad_value (name, reason) ->
                 ( "bad value for"
-                , Sexp.List [Sexp.Atom name; Sexp.Atom reason] ) ))
+                , Sexp.List [Sexp.Atom name; Sexp.Atom reason] )))
   with Sys_error _ -> conf
 
 type 'a input = {kind: 'a; name: string; file: string; conf: t}

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -64,7 +64,7 @@ let list_pn x1N (pp : ?prev:_ -> _ -> ?next:_ -> _ -> unit) fs =
 let list_fl xs pp fs =
   list_pn xs
     (fun ?prev x ?next fs ->
-      pp ~first:(Option.is_none prev) ~last:(Option.is_none next) x fs )
+      pp ~first:(Option.is_none prev) ~last:(Option.is_none next) x fs)
     fs
 
 let list xs sep pp fs =

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1619,7 +1619,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    ( opn_paren $ str "module " $ m $ fmt "@ : "
                    $ fmt_longident_loc c id )
                $ fmt_package_type c ctx cnstrs
-               $ fmt_atrs $ cls_paren ) ))
+               $ fmt_atrs $ cls_paren )))
   | Pexp_constraint (e, t) ->
       hvbox 2
         (wrap_fits_breaks ~space:false c.conf "(" ")"
@@ -1712,10 +1712,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                     0 (fmt_fun_args c xargs)
                 $ fmt "@ " )
             $ str "->" $ pre_body )
-        $ fmt "@ " $ body
-        $ fmt_or_k c.conf.indicate_multiline_delimiters
-            (fits_breaks_if parens ")" "@ )")
-            (fits_breaks_if parens ")" "@,)") )
+        $ fmt "@ " $ body $ fmt_if parens ")" )
   | Pexp_function cs ->
       fmt_if parens "("
       $ hvbox 2
@@ -2329,9 +2326,7 @@ and fmt_class_expr c ?eol ?(box = true) ({ast= exp} as xexp) =
             $ str "->" )
         $ fmt "@ "
         $ fmt_class_expr c ~eol:(fmt "@;<1000 0>") xbody
-        $ fmt_or_k c.conf.indicate_multiline_delimiters
-            (fits_breaks_if parens ")" "@ )")
-            (fits_breaks_if parens ")" "@,)") )
+        $ fmt_if parens ")" )
   | Pcl_apply (e0, e1N1) ->
       wrap_if parens "(" ")" (hvbox 2 (fmt_args_grouped e0 e1N1) $ fmt_atrs)
   | Pcl_let (rec_flag, bindings, body) ->
@@ -2835,7 +2830,7 @@ and fmt_exception ~pre c sep ctx te =
         ~f:(fun (s, _) ->
           match s.txt with
           | "deprecated" | "ocaml.deprecated" -> true
-          | _ -> false )
+          | _ -> false)
         te.pext_attributes
     in
     (atat, {te with pext_attributes= at})
@@ -3577,7 +3572,7 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
       fmt_recmodule c ctx bindings
         (fun c ctx ~rec_flag ~first b ->
           (* To ignore the ?epi parameter *)
-          fmt_module_binding c ctx ~rec_flag ~first b )
+          fmt_module_binding c ctx ~rec_flag ~first b)
         (fun x -> Mod x.pmb_expr)
   | Pstr_type (rec_flag, decls) -> fmt_type c ?ext rec_flag decls ctx
   | Pstr_typext te -> fmt_type_extension c ctx te

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1548,7 +1548,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                        $ fmt "@ ->" )
                    $ fmt "@ "
                    $ cbox 0 (fmt_expression c (sub_exp ~ctx pc_rhs))
-                   $ fmt ")" $ Cmts.fmt_after c pexp_loc )
+                   $ str ")" $ Cmts.fmt_after c pexp_loc )
                $ fmt_atrs ))
       | (lbl, ({pexp_desc= Pexp_function cs; pexp_loc} as eN)) :: rev_e1N
         when List.for_all rev_e1N ~f:(fun (_, eI) ->
@@ -1565,7 +1565,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                       $ fmt_label lbl ":" $ str "(function"
                       $ fmt_attributes c ~pre:(str " ") ~key:"@"
                           eN.pexp_attributes ))
-               $ fmt "@ " $ fmt_cases c ctx'' cs $ fmt ")"
+               $ fmt "@ " $ fmt_cases c ctx'' cs $ str ")"
                $ Cmts.fmt_after c pexp_loc $ fmt_atrs ))
       | _ ->
           wrap_if parens "(" ")"

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -806,7 +806,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
           | Parser.CHAR _ | Parser.DOTDOT
            |Parser.(INT _ | STRING _ | FLOAT _) ->
               true
-          | _ -> false )
+          | _ -> false)
       in
       match toks with
       | [ (Parser.(CHAR _ | INT _ | STRING _ | FLOAT _), loc1)
@@ -1548,9 +1548,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                        $ fmt "@ ->" )
                    $ fmt "@ "
                    $ cbox 0 (fmt_expression c (sub_exp ~ctx pc_rhs))
-                   $ fmt_or_k c.conf.indicate_multiline_delimiters
-                       (fits_breaks ")" " )") (str ")")
-                   $ Cmts.fmt_after c pexp_loc )
+                   $ fmt ")" $ Cmts.fmt_after c pexp_loc )
                $ fmt_atrs ))
       | (lbl, ({pexp_desc= Pexp_function cs; pexp_loc} as eN)) :: rev_e1N
         when List.for_all rev_e1N ~f:(fun (_, eI) ->
@@ -1567,9 +1565,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                       $ fmt_label lbl ":" $ str "(function"
                       $ fmt_attributes c ~pre:(str " ") ~key:"@"
                           eN.pexp_attributes ))
-               $ fmt "@ " $ fmt_cases c ctx'' cs
-               $ fmt_or_k c.conf.indicate_multiline_delimiters
-                   (fits_breaks ")" " )") (str ")")
+               $ fmt "@ " $ fmt_cases c ctx'' cs $ fmt ")"
                $ Cmts.fmt_after c pexp_loc $ fmt_atrs ))
       | _ ->
           wrap_if parens "(" ")"
@@ -1721,9 +1717,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
           $ fmt_attributes c ~key:"@" pexp_attributes )
       $ fmt "@ "
       $ hvbox 0 (fmt_cases c ctx cs)
-      $ fmt_or_k c.conf.indicate_multiline_delimiters
-          (fits_breaks_if parens ")" "@ )")
-          (fits_breaks_if parens ")" "@,)")
+      $ fmt_if parens ")"
   | Pexp_ident {txt; loc} ->
       let wrap, wrap_ident =
         if is_symbol exp && not (List.is_empty pexp_attributes) then

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -172,7 +172,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch ~xcond
               $ fmt "@ ")
       ; box_keyword_and_expr=
           (fun k ->
-            hvbox 2 (fmt_or (Option.is_some xcond) "then" "else" $ k) )
+            hvbox 2 (fmt_or (Option.is_some xcond) "then" "else" $ k))
       ; wrap_parens=
           wrap_k
             (fmt_or parens_bch (if imd then " (@ " else " (@,") "@ ")

--- a/src/Reason.ml
+++ b/src/Reason.ml
@@ -97,7 +97,7 @@ module Mappers = struct
       let explicit_arity, attrs =
         List.partition_tf ppat_attributes ~f:(function
           | {txt= "explicit_arity"}, _ -> true
-          | _ -> false )
+          | _ -> false)
       in
       match ppat_desc with
       | Ppat_construct (id, Some {ppat_desc= Ppat_tuple [p0]})
@@ -116,7 +116,7 @@ module Mappers = struct
       let explicit_arity, attrs =
         List.partition_tf pexp_attributes ~f:(function
           | {txt= "explicit_arity"}, _ -> true
-          | _ -> false )
+          | _ -> false)
       in
       match pexp_desc with
       | Pexp_construct (id, Some {pexp_desc= Pexp_tuple [e0]})
@@ -163,7 +163,7 @@ module Mappers = struct
         if ignore_doc_comments then
           List.filter atrs ~f:(function
             | {txt= "ocaml.doc" | "ocaml.text"}, _ -> false
-            | _ -> true )
+            | _ -> true)
         else atrs
       in
       (* remove docstrings that duplicate comments *)
@@ -176,7 +176,7 @@ module Mappers = struct
       Normalize.(mapper c).structure m
         (List.filter pstr ~f:(function
           | {pstr_desc= Pstr_attribute atr} -> not (atr_is_dup atr)
-          | _ -> true ))
+          | _ -> true))
     in
     let signature (m : Ast_mapper.mapper) psig =
       (* remove signature items that are attributes that duplicate comments,
@@ -184,7 +184,7 @@ module Mappers = struct
       Normalize.(mapper c).signature m
         (List.filter psig ~f:(function
           | {psig_desc= Psig_attribute atr} -> not (atr_is_dup atr)
-          | _ -> true ))
+          | _ -> true))
     in
     {(Normalize.mapper c) with attributes; structure; signature}
 end

--- a/src/Source.ml
+++ b/src/Source.ml
@@ -149,7 +149,7 @@ let extend_loc_to_include_attributes t (loc : Location.t)
            |LBRACKETPERCENT | LBRACKETPERCENTPERCENT | LBRACKETAT
            |LBRACKETATAT | LBRACKETATATAT ->
               Int.incr count ; false
-          | _ -> false )
+          | _ -> false)
         loc
     in
     match l with
@@ -184,7 +184,7 @@ let string_literal t mode (l : Location.t) =
         | Parser.STRING (_, None) -> true
         | Parser.LBRACKETAT | Parser.LBRACKETATAT | Parser.LBRACKETATATAT ->
             true
-        | _ -> false )
+        | _ -> false)
       l
   in
   match toks with
@@ -207,7 +207,7 @@ let char_literal t (l : Location.t) =
         | Parser.CHAR _ -> true
         | Parser.LBRACKETAT | Parser.LBRACKETATAT | Parser.LBRACKETATATAT ->
             true
-        | _ -> false )
+        | _ -> false)
       l
   in
   match toks with

--- a/src/Sugar.ml
+++ b/src/Sugar.ml
@@ -74,8 +74,7 @@ let args_location xargs =
   let last_loc =
     List.fold_left
       ~f:(fun p -> function Val (_, {ast= {ppat_loc}}, _) -> ppat_loc
-        | Newtypes ts -> List.fold_left ~f:(fun _ {loc} -> loc) ~init:p ts
-        )
+        | Newtypes ts -> List.fold_left ~f:(fun _ {loc} -> loc) ~init:p ts)
       ~init:first_loc xargs
   in
   Location.

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -268,7 +268,7 @@ let print_error ?(quiet_unstable = false) ?(quiet_comments = false)
                        comment in the source or disable the formatting \
                        using the option --no-parse-docstrings.\n\
                        %!"
-                      Location.print_loc loc (ellipsis_cmt s) )
+                      Location.print_loc loc (ellipsis_cmt s))
           | `Comment_dropped l when not conf.Conf.quiet ->
               List.iter l ~f:(fun (loc, msg) ->
                   Format.fprintf fmt

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -92,12 +92,12 @@ let parse parse_ast (conf : Conf.t) ~source =
         | Warnings.Bad_docstring _ when conf.comment_check ->
             w50 := (loc, warn) :: !w50 ;
             false
-        | _ -> not conf.quiet )
+        | _ -> not conf.quiet)
       ~f:(fun () ->
         let ast = parse_ast lexbuf in
         Warnings.check_fatal () ;
         let comments = Lexer.comments () in
-        {ast; comments; prefix= hash_bang} )
+        {ast; comments; prefix= hash_bang})
   in
   match List.rev !w50 with [] -> t | w50 -> raise (Warning50 w50)
 

--- a/test/passing/infix_arg_grouping.ml
+++ b/test/passing/infix_arg_grouping.ml
@@ -47,7 +47,7 @@ hvbox 0
                       $ fmt_core_type c (sub_typ ~ctx typ) )
                   $ fmt_docstring c ~pro:(fmt "@;<2 0>") doc
                   $ fmt_attributes c (fmt " ") ~key:"@" atrs (fmt "") )
-         | Oinherit typ -> fmt_core_type c (sub_typ ~ctx typ) )
+         | Oinherit typ -> fmt_core_type c (sub_typ ~ctx typ))
      $ fmt_if
          Poly.(closedness = Open)
          (match fields with [] -> "@ .. " | _ -> "@ ; .. ") ))

--- a/test/passing/issue289.ml
+++ b/test/passing/issue289.ml
@@ -7,9 +7,9 @@ let foo =
       ~doc:"Toy ID."
       ~args:[]
       ~typ:(non_null guid)
-      ~resolve:(function _ctx -> x.id )
+      ~resolve:(function _ctx -> x.id)
   ; field "id" ~doc:"Toy ID." ~args:[] ~typppp ~resolve:(function _ctx ->
-        x.id )
+        x.id)
   ; field
       "id"
       ~doc:"Toy ID."
@@ -17,10 +17,10 @@ let foo =
       ~typ:(non_null guid)
       ~resolve:(function
         | A -> x.id
-        | B -> c )
+        | B -> c)
   ; field "id" ~doc:"Toy ID." ~args:[] ~resolve:(function
         | A -> x.id
-        | B -> c )
+        | B -> c)
   ; field
       "id"
       ~doc:"Toy ID."
@@ -28,10 +28,10 @@ let foo =
       ~typppppppppppppppppppp
       ~resolve:(function
         | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
-        | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
+        | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc)
   ; field "id" ~doc:"Toy ID." ~args:[] ~resolve:(function
         | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
-        | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
+        | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc)
   ; field
       "id"
       ~doc:"Toy ID."
@@ -68,23 +68,23 @@ let foo =
 let foo =
   let open Gql in
   [ field "id" ~doc:"Toy ID." ~args:[] ~typ:(non_null guid)
-        ~resolve:(function _ctx -> x.id )
+        ~resolve:(function _ctx -> x.id)
   ; field "id" ~doc:"Toy ID." ~args:[] ~typppp ~resolve:(function _ctx ->
-        x.id )
+        x.id)
   ; field "id" ~doc:"Toy ID." ~args:[] ~typ:(non_null guid)
       ~resolve:(function
       | A -> x.id
-      | B -> c )
+      | B -> c)
   ; field "id" ~doc:"Toy ID." ~args:[] ~resolve:(function
       | A -> x.id
-      | B -> c )
+      | B -> c)
   ; field "id" ~doc:"Toy ID." ~args:[] ~typppppppppppppppppppp
       ~resolve:(function
       | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
-      | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
+      | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc)
   ; field "id" ~doc:"Toy ID." ~args:[] ~resolve:(function
       | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
-      | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
+      | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc)
   ; field "id" ~doc:"Toy ID." ~args:[] ~typ:(non_null guid)
       ~resolve:(fun _ctx x -> x.id)
   ; field "name" ~doc:"Toy name." ~args:[] ~typ:(non_null string)

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -3037,7 +3037,9 @@ let rec weaken_alist : type m n. (m, n) alist -> (m succ, n succ) alist = functi
 let rec sub' : type m. m ealist -> m fin -> m term = function
   | EAlist Anil -> var
   | EAlist (Asnoc (s, t, x)) ->
-    comp_subst (sub' (EAlist (weaken_alist s))) (fun t' -> weaken_term (subst_var x t t'))
+    comp_subst
+      (sub' (EAlist (weaken_alist s)))
+      (fun t' -> weaken_term (subst_var x t t'))
 ;;
 
 let subst' d = pre_subst (sub' d)

--- a/test/passing/object.ml
+++ b/test/passing/object.ml
@@ -156,7 +156,7 @@ class tttttttttttttttttttttttttt x y =
       inherit f a
 
       method x a b = a + b
-    end )
+    end)
     0
 
 class c =

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -1023,7 +1023,7 @@ let id x = x
 let idb1 =
   (fun id ->
     let _ = id true in
-    id )
+    id)
     id
 
 let idb2 : bool -> bool = id
@@ -1119,7 +1119,7 @@ let rec variantize : type t. t ty -> t -> variant =
       VRecord
         (List.map
            (fun (Field {field_type; label; get}) ->
-             (label, variantize field_type (get x)) )
+             (label, variantize field_type (get x)))
            fields)
 
 (* Extraction *)
@@ -1160,7 +1160,7 @@ let rec devariantize : type t. t ty -> variant -> t =
       List.iter2
         (fun (Field {label; field_type; set}) (lab, v) ->
           if label <> lab then raise VariantMismatch ;
-          set builder (devariantize field_type v) )
+          set builder (devariantize field_type v))
         fields fl ;
       of_builder builder
   | _ -> raise VariantMismatch
@@ -1377,8 +1377,7 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
        ; sum_inj=
            (fun (type c) ->
              ( function Thd, Noarg -> `Nil | Ttl Thd, v -> `Cons v
-               : (noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist )
-             )
+               : (noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist ))
            (* One can also write the type annotation directly *) })
 
 let v = variantize Enil (ty_list Int) (`Cons (1, `Cons (2, `Nil)))
@@ -5956,7 +5955,7 @@ class c (v : int) =
       (fun v ->
         object
           method v : string = v
-        end )
+        end)
         "42"
   end
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -1372,7 +1372,7 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
        { sum_proj=
            (function
            | `Nil -> ("Nil", None)
-           | `Cons p -> ("Cons", Some (Tdyn (tcons, p))) )
+           | `Cons p -> ("Cons", Some (Tdyn (tcons, p))))
        ; sum_cases= [("Nil", TCnoarg Thd); ("Cons", TCarg (Ttl Thd, tcons))]
        ; sum_inj=
            (fun (type c) ->
@@ -1406,7 +1406,7 @@ let ty_abc : ([`A of int | `B of string | `C], 'e) ty =
     ( (function
       | `A n -> ("A", Some (Tdyn (Int, n)))
       | `B s -> ("B", Some (Tdyn (String, s)))
-      | `C -> ("C", None) )
+      | `C -> ("C", None))
     , function
       | "A", Some (Tdyn (Int, n)) -> `A n
       | "B", Some (Tdyn (String, s)) -> `B s
@@ -1420,8 +1420,7 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
   Rec
     (Sum
        ( (function
-         | `Nil -> ("Nil", None) | `Cons p -> ("Cons", Some (Tdyn (targ, p)))
-         )
+         | `Nil -> ("Nil", None) | `Cons p -> ("Cons", Some (Tdyn (targ, p))))
        , function
          | "Nil", None -> `Nil
          | "Cons", Some (Tdyn (Pair (_, Var), (p : a * a vlist))) -> `Cons p


### PR DESCRIPTION
Follow up on #801, taking care of the remaining cases for `fun` and `function`.
The remaining cases of `indicate-multiline-delimiters` (assert, match cases, constraints, etc) do not seem to be problematic.