### PR TITLE
Improve: break-cases=fit-or-vertical

### DIFF
--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -40,15 +40,16 @@ OPTIONS (CODE FORMATTING STYLE)
            assignment expression does not fit on a single line. The default
            value is end-line.
 
-       --break-cases={nested|fit|toplevel|all}
+       --break-cases={nested|fit|toplevel|fit-or-vertical|all}
            Break pattern match cases. nested forces a break after nested
            or-patterns to highlight the case body. Note that with nested, the
            indicate-nested-or-patterns option is not needed, and so ignored.
            Specifying fit lets pattern matches break at the margin naturally.
            toplevel forces top-level cases (i.e. not nested or-patterns) to
-           break across lines, otherwise break naturally at the margin. all
-           forces all pattern matches to break across lines. The default
-           value is nested.
+           break across lines, otherwise break naturally at the margin.
+           fit-or-vertical tries to fit all or-patterns on the same line,
+           otherwise breaks. all forces all pattern matches to break across
+           lines. The default value is nested.
 
        --break-collection-expressions={fit-or-vertical|wrap}
            Break collection expressions (lists and arrays) elements by

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -13,7 +13,7 @@
 
 type t =
   { assignment_operator: [`Begin_line | `End_line]
-  ; break_cases: [`Fit | `Nested | `Toplevel | `All]
+  ; break_cases: [`Fit | `Nested | `Toplevel | `Fit_or_vertical | `All]
   ; break_collection_expressions: [`Wrap | `Fit_or_vertical]
   ; break_infix: [`Wrap | `Fit_or_vertical]
   ; break_infix_before_func: bool
@@ -525,6 +525,10 @@ module Formatting = struct
         , "$(b,toplevel) forces top-level cases (i.e. not nested \
            or-patterns) to break across lines, otherwise break naturally \
            at the margin." )
+      ; ( "fit-or-vertical"
+        , `Fit_or_vertical
+        , "$(b,fit-or-vertical) tries to fit all or-patterns on the same \
+           line, otherwise breaks." )
       ; ( "all"
         , `All
         , "$(b,all) forces all pattern matches to break across lines." ) ]
@@ -1465,7 +1469,7 @@ let sparse_profile =
 
 let janestreet_profile =
   { assignment_operator= `Begin_line
-  ; break_cases= `All
+  ; break_cases= `Fit_or_vertical
   ; break_collection_expressions=
       ocamlformat_profile.break_collection_expressions
   ; break_infix= `Fit_or_vertical

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -13,7 +13,7 @@
 
 type t =
   { assignment_operator: [`Begin_line | `End_line]
-  ; break_cases: [`Fit | `Nested | `Toplevel | `All]
+  ; break_cases: [`Fit | `Nested | `Toplevel | `Fit_or_vertical | `All]
   ; break_collection_expressions: [`Wrap | `Fit_or_vertical]
   ; break_infix: [`Wrap | `Fit_or_vertical]
   ; break_infix_before_func: bool

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -957,9 +957,14 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
         ( list_fl (List.group xpats ~break)
             (fun ~first:first_grp ~last:_ xpat_grp ->
               list_fl xpat_grp (fun ~first ~last xpat ->
+                  let open_box =
+                    if Poly.(c.conf.break_cases = `Fit_or_vertical) then
+                      open_hvbox
+                    else open_hovbox
+                  in
                   let pro =
-                    if first_grp && first then pro0 $ open_hovbox (-2)
-                    else if first then proI $ open_hovbox (-2)
+                    if first_grp && first then pro0 $ open_box (-2)
+                    else if first then proI $ open_box (-2)
                     else proI ~space:(space xpat.ast)
                   in
                   (* side effects of Cmts.fmt_before before [fmt_pattern] is

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -41,6 +41,14 @@ let get_cases (c : Conf.t) ~first ~indent ~parens_here =
       ; break_after_arrow= fmt_if (not parens_here) "@;<0 3>"
       ; break_after_opening_paren= fmt_or (indent > 2) "@;<1 4>" "@;<1 2>"
       }
+  | `Fit_or_vertical ->
+      { leading_space= break_unless_newline 1000 0
+      ; bar= fmt "| "
+      ; box_all= hovbox indent
+      ; box_pattern_arrow= hovbox 0
+      ; break_before_arrow= fmt "@;<1 2>"
+      ; break_after_arrow= fmt_if (not parens_here) "@;<0 3>"
+      ; break_after_opening_paren= fmt "@ " }
   | `Toplevel | `All ->
       { leading_space= break_unless_newline 1000 0
       ; bar= fmt "| "

--- a/test/passing/break_cases_all.ml.ref
+++ b/test/passing/break_cases_all.ml.ref
@@ -152,3 +152,13 @@ let rec loop items =
   | _ ->
       let a = 3 in
       a
+
+let ffffff ~foo =
+  match (foo : Fooooooooooooo.t) with
+  | Aaaaaaaaaaaaaaaaa
+  | Bbbbbbbbbbbbbbbbb
+  | Ccccccccccccccccc
+  | Ddddddddddddddddd
+  | Eeeeeeeeeeeeeeeee ->
+      foooooooooooooooooooo
+  | Fffffffffffffffff -> fooooooooooooooooo

--- a/test/passing/break_cases_fit.ml
+++ b/test/passing/break_cases_fit.ml
@@ -138,3 +138,9 @@ let rec loop items =
   | _ ->
       let a = 3 in
       a
+
+let ffffff ~foo =
+ match (foo : Fooooooooooooo.t) with
+ | Aaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbb | Ccccccccccccccccc
+ | Ddddddddddddddddd | Eeeeeeeeeeeeeeeee -> foooooooooooooooooooo
+ | Fffffffffffffffff -> fooooooooooooooooo

--- a/test/passing/break_cases_fit.ml.ref
+++ b/test/passing/break_cases_fit.ml.ref
@@ -116,3 +116,10 @@ let rec loop items =
   | _ ->
       let a = 3 in
       a
+
+let ffffff ~foo =
+  match (foo : Fooooooooooooo.t) with
+  | Aaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbb | Ccccccccccccccccc
+  | Ddddddddddddddddd | Eeeeeeeeeeeeeeeee ->
+      foooooooooooooooooooo
+  | Fffffffffffffffff -> fooooooooooooooooo

--- a/test/passing/break_cases_fit_or_vertical.ml
+++ b/test/passing/break_cases_fit_or_vertical.ml
@@ -1,0 +1,1 @@
+break_cases_fit.ml

--- a/test/passing/break_cases_fit_or_vertical.ml.opts
+++ b/test/passing/break_cases_fit_or_vertical.ml.opts
@@ -1,0 +1,1 @@
+--break-cases=fit-or-vertical

--- a/test/passing/break_cases_fit_or_vertical.ml.ref
+++ b/test/passing/break_cases_fit_or_vertical.ml.ref
@@ -125,3 +125,12 @@ let rec loop items =
   | _ ->
       let a = 3 in
       a
+
+let ffffff ~foo =
+  match (foo : Fooooooooooooo.t) with
+  | Aaaaaaaaaaaaaaaaa
+  | Bbbbbbbbbbbbbbbbb
+  | Ccccccccccccccccc
+  | Ddddddddddddddddd
+  | Eeeeeeeeeeeeeeeee -> foooooooooooooooooooo
+  | Fffffffffffffffff -> fooooooooooooooooo

--- a/test/passing/break_cases_fit_or_vertical.ml.ref
+++ b/test/passing/break_cases_fit_or_vertical.ml.ref
@@ -1,0 +1,127 @@
+let f x = function
+  | C | P (this, test, [is; wide; enough; _to; break], [the; line]) | A | K
+    -> 1
+  | D ->
+      let a = "this" in
+      let b = "breaks" in
+      ()
+
+let f =
+  let g = function
+    | H when x y <> k -> 2
+    | T | P | U -> 3
+  in
+  fun x g t h y u ->
+    match x with
+    | E -> 4
+    | Z | P | M -> (
+      match y with
+      | O -> 5
+      | P when h x -> (
+          function
+          | A -> 6 ) )
+
+;;
+match x with
+| true -> (
+  match y with
+  | true -> "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  | false -> "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" )
+| false -> "cccccccccccccccccccccccccccccc"
+
+;;
+match x with
+| "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", yyyyyyyyyy
+  when fffffffffffffff bbbbbbbbbb yyyyyyyyyy -> ()
+| _ -> ()
+
+let is_sequence exp =
+  match exp.pexp_desc with
+  | Pexp_sequence _
+   |Pexp_extension
+      ( _
+      , PStr [{pstr_desc= Pstr_eval ({pexp_desc= Pexp_sequence _}, []); _}]
+      ) -> true
+  | _ -> false
+
+let _ =
+  let f x y =
+    match x with
+    | None -> false
+    | Some looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+      -> (
+      match y with
+      | Some _ -> true
+      | None -> false )
+  in
+  ()
+
+let () =
+  match fooooo with
+  | x -> x
+
+let () =
+  match foooo with
+  | x | x | x -> x
+  | y | foooooooooo | fooooooooo -> y
+  | foooooo when ff fff fooooooooooooooooooo ->
+      foooooooooooooooooooooo foooooooooooooooooo
+
+let foo =
+  match instr with
+  | Store (Lvar lhs_pvar, lhs_typ, rhs_exp, loc)
+    when Pvar.is_ssa_frontend_tmp lhs_pvar ->
+      (* do not need to add deref here as it is added implicitly in of_pvar
+         by forgetting the & *)
+      analyze_id_assignment (Var.of_pvar lhs_pvar) rhs_exp lhs_typ loc
+  | Call
+      ( (ret_id, _)
+      , Const (Cfun callee_pname)
+      , (target_exp, _) :: (Sizeof {typ= cast_typ}, _) :: _
+      , loc
+      , _ )
+    when Typ.Procname.equal callee_pname BuiltinDecl.__cast ->
+      analyze_id_assignment (Var.of_id ret_id) target_exp cast_typ loc
+
+let mod_int c1 c2 is_safe dbg =
+  match (c1, c2) with
+  | c1, Cconst_int (0, _) ->
+      Csequence (c1, raise_symbol dbg "caml_exn_Division_by_zero")
+  | c1, Cconst_int ((1 | -1), _) -> Csequence (c1, Cconst_int (0, dbg))
+  | x | -1 -> ()
+
+let merge_columns l old_table =
+  let rec aux = function
+    | [] | [None] -> ([], [])
+  in
+  foooooooooooooooooooooooooo fooooooooooooooooooooo
+
+[@@@ocamlformat "indicate-nested-or-patterns=unsafe-no"]
+
+let is_sequence exp =
+  match exp.pexp_desc with
+  | Pexp_sequence _
+  | Pexp_extension
+      ( _
+      , PStr [{pstr_desc= Pstr_eval ({pexp_desc= Pexp_sequence _}, []); _}]
+      ) -> true
+  | _ -> false
+
+let () =
+  match foooo with
+  | x | x | x -> x
+  | y | foooooooooo | fooooooooo -> y
+  | foooooo when ff fff fooooooooooooooooooo ->
+      foooooooooooooooooooooo foooooooooooooooooo
+
+let rec loop items =
+  match [] with
+  | _ :: _ :: items ->
+      (* a comment *)
+      loop items
+  | _ :: items ->
+      (* another comment*)
+      loop items
+  | _ ->
+      let a = 3 in
+      a

--- a/test/passing/break_cases_nested.ml.ref
+++ b/test/passing/break_cases_nested.ml.ref
@@ -130,3 +130,14 @@ let rec loop items =
   | _ ->
       let a = 3 in
       a
+
+let ffffff ~foo =
+  match (foo : Fooooooooooooo.t) with
+  | Aaaaaaaaaaaaaaaaa
+  | Bbbbbbbbbbbbbbbbb
+  | Ccccccccccccccccc
+  | Ddddddddddddddddd
+  | Eeeeeeeeeeeeeeeee ->
+      foooooooooooooooooooo
+  | Fffffffffffffffff ->
+      fooooooooooooooooo

--- a/test/passing/break_cases_toplevel.ml.ref
+++ b/test/passing/break_cases_toplevel.ml.ref
@@ -129,3 +129,10 @@ let rec loop items =
   | _ ->
       let a = 3 in
       a
+
+let ffffff ~foo =
+  match (foo : Fooooooooooooo.t) with
+  | Aaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbb | Ccccccccccccccccc
+  | Ddddddddddddddddd | Eeeeeeeeeeeeeeeee ->
+      foooooooooooooooooooo
+  | Fffffffffffffffff -> fooooooooooooooooo

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -4562,27 +4562,19 @@ let f x =
 let f x =
   ignore
     (match x with
-    | `A
-    | `B ->
-      1);
+    | `A | `B -> 1);
   ignore (x : [ `A ])
 ;;
 
 let f (x : [< `A | `B ]) =
   match x with
-  | `A
-  | `B
-  | `C ->
-    0
+  | `A | `B | `C -> 0
 ;;
 
 (* warn *)
 let f (x : [ `A | `B ]) =
   match x with
-  | `A
-  | `B
-  | `C ->
-    0
+  | `A | `B | `C -> 0
 ;;
 
 (* fail *)
@@ -4699,9 +4691,7 @@ end = struct
     | B
 
   let f = function
-    | A
-    | B ->
-      0
+    | A | B -> 0
   ;;
 end
 
@@ -9564,9 +9554,7 @@ let f = function
 ;;
 
 let f = function
-  | '1' .. '9'
-  | '1' .. '8' ->
-    ()
+  | '1' .. '9' | '1' .. '8' -> ()
   | 'a' .. 'z' -> ()
 ;;
 
@@ -9645,15 +9633,10 @@ let _ =
   let f M.(x) = () in
   let g M.{ x } = () in
   let h = function
-    | M.[]
-    | M.[ a ]
-    | M.(a :: q) ->
-      ()
+    | M.[] | M.[ a ] | M.(a :: q) -> ()
   in
   let i = function
-    | M.[||]
-    | M.[| x |] ->
-      true
+    | M.[||] | M.[| x |] -> true
     | _ -> false
   in
   ()
@@ -9698,9 +9681,7 @@ class type t = object ((_[@foo])) end
 let test f x = f ~x:(x [@foo])
 
 let f = function
-  | (`A | `B)[@bar]
-  | `C ->
-    ()
+  | (`A | `B)[@bar] | `C -> ()
 ;;
 
 let f = function


### PR DESCRIPTION
Request from Jane Street: (replaces the patch https://github.com/janestreet/ocamlformat/commit/9adc31fe7d54c0c0ea4140cd2aa2694d37fc49ff)
- or-patterns fit on the same line if possible, otherwise break all of them (don't wrap)
- if it breaks, don't break after the arrow