### PR TITLE
Fix: performance issue with long list literals

### DIFF
--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -69,8 +69,7 @@ end = struct
 
   let of_list elts =
     let elts_decreasing_width =
-      List.sort ~compare:Itv.compare_width_decreasing elts
-      |> List.remove_consecutive_duplicates ~equal:Poly.equal
+      List.dedup_and_sort ~compare:Itv.compare_width_decreasing elts
     in
     let tree = create () in
     let rec find_in_previous elt = function

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -51,16 +51,16 @@ end = struct
 
   (* Descend tree from roots, find deepest node that contains elt. *)
 
-  let rec parent tbl roots ?ancestor elt =
-    Option.first_some
+  let rec parents tbl roots ~ancestors elt =
+    Option.value ~default:ancestors
       (List.find_map roots ~f:(fun root ->
            if Itv.contains root elt then
              Hashtbl.find_and_call tbl root
                ~if_found:(fun children ->
-                 parent tbl children ~ancestor:root elt)
-               ~if_not_found:Option.some
+                 parents tbl children ~ancestors:(root :: ancestors) elt)
+               ~if_not_found:(fun x -> x :: ancestors)
+             |> Option.some
            else None))
-      ancestor
 
   (* Add elements in decreasing width order to construct tree from roots to
      leaves. That is, when adding an interval to a partially constructed
@@ -73,10 +73,19 @@ end = struct
         (List.dedup_and_sort ~compare:Poly.compare elts)
     in
     let tree = create () in
-    List.iter elts_decreasing_width ~f:(fun elt ->
-        match parent tree.tbl tree.roots elt with
-        | Some parent -> Hashtbl.add_multi tree.tbl ~key:parent ~data:elt
-        | None -> tree.roots <- elt :: tree.roots) ;
+    let rec find_in_previous elt = function
+      | [] -> parents tree.tbl tree.roots elt ~ancestors:[]
+      | p :: ancestors when Itv.contains p elt ->
+          parents tree.tbl [p] elt ~ancestors
+      | _ :: px -> find_in_previous elt px
+    in
+    List.fold elts_decreasing_width ~init:[] ~f:(fun prev_ancestor elt ->
+        let ancestors = find_in_previous elt prev_ancestor in
+        ( match ancestors with
+        | parent :: _ -> Hashtbl.add_multi tree.tbl ~key:parent ~data:elt
+        | [] -> tree.roots <- elt :: tree.roots ) ;
+        ancestors)
+    |> (ignore : Itv.t list -> unit) ;
     { tree with
       tbl= Hashtbl.map tree.tbl ~f:(List.sort ~compare:Poly.compare) }
 

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -69,8 +69,8 @@ end = struct
 
   let of_list elts =
     let elts_decreasing_width =
-      List.sort ~compare:Itv.compare_width_decreasing
-        (List.dedup_and_sort ~compare:Poly.compare elts)
+      List.sort ~compare:Itv.compare_width_decreasing elts
+      |> List.remove_consecutive_duplicates ~equal:Poly.equal
     in
     let tree = create () in
     let rec find_in_previous elt = function

--- a/src/Migrate_ast.ml
+++ b/src/Migrate_ast.ml
@@ -134,9 +134,9 @@ module Location = struct
   let width x = Position.distance x.loc_start x.loc_end
 
   let compare_width_decreasing l1 l2 =
-    match Int.compare (width l2) (width l1) with
+    match Position.compare l1.loc_start l2.loc_start with
     | 0 -> (
-      match Int.compare l1.loc_start.pos_cnum l2.loc_start.pos_cnum with
+      match Position.compare l2.loc_end l1.loc_end with
       | 0 -> Poly.compare l1 l2
       | n -> n )
     | n -> n

--- a/src/Migrate_ast.ml
+++ b/src/Migrate_ast.ml
@@ -133,7 +133,13 @@ module Location = struct
 
   let width x = Position.distance x.loc_start x.loc_end
 
-  let compare_width_decreasing l1 l2 = Int.compare (width l2) (width l1)
+  let compare_width_decreasing l1 l2 =
+    match Int.compare (width l2) (width l1) with
+    | 0 -> (
+      match Int.compare l1.loc_start.pos_cnum l2.loc_start.pos_cnum with
+      | 0 -> Poly.compare l1 l2
+      | n -> n )
+    | n -> n
 
   let is_single_line x margin =
     width x <= margin && x.loc_start.pos_lnum = x.loc_end.pos_lnum


### PR DESCRIPTION
Fix #409
Building the tree of locations is quadratic when the depth of the ast is very large.

Some relatively simple heuristic reduces the issue a lot.
I'm not 100% confident the heuristic is always correct. I'd like reviewers to think about it.

```
$ wget https://raw.githubusercontent.com/janestreet/core/master/test/bin/ofday_unit_tests_v1.ml
$ time _build/release/src/ocamlformat.exe ofday_unit_tests_v1.ml > /dev/null

real	0m3.470s
user	0m3.434s
sys	0m0.036s
```
Before this change, it was.
```
real	6m37.299s
user	6m36.966s
sys	0m0.120s
```


The heuristic implemented here assumes that two consecutive location (in term of insertion order) will be close to each other in the tree of locations. Instead of looking for where to put the location starting at the roots, one can try to start from ancestors found at the previous iteration.