### PR TITLE
Improve: option nested-match=align

### DIFF
--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -209,10 +209,11 @@ OPTIONS (CODE FORMATTING STYLE)
            one-liners of similar sorts. The default value is sparse.
 
        --nested-match={wrap|align}
-           Style of let_and. wrap classically wraps a match nested in another
-           match case with parentheses and adds indentation. align does not
-           indent and wrap a match if it is nested in the last case of
-           another match. The default value is wrap.
+           Style of a pattern-matching nested in the last case of another
+           pattern-matching. wrap wraps the nested pattern-matching with
+           parentheses and adds indentation. align vertically aligns the
+           nested pattern-matching under the encompassing pattern-matching.
+           The default value is wrap.
 
        --no-break-infix-before-func
            Break infix operators whose right arguments are anonymous

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -208,6 +208,12 @@ OPTIONS (CODE FORMATTING STYLE)
            open line in the input. compact will not leave open lines between
            one-liners of similar sorts. The default value is sparse.
 
+       --nested-match={wrap|align}
+           Style of let_and. wrap classically wraps a match nested in another
+           match case with parentheses and adds indentation. align does not
+           indent and wrap a match if it is nested in the last case of
+           another match. The default value is wrap.
+
        --no-break-infix-before-func
            Break infix operators whose right arguments are anonymous
            functions specially: do not break after the operator so that the

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -45,6 +45,7 @@ type t =
   ; margin: int
   ; max_iters: int
   ; module_item_spacing: [`Compact | `Preserve | `Sparse]
+  ; nested_match: [`Wrap | `Align]
   ; ocp_indent_compat: bool
   ; parens_ite: bool
   ; parens_tuple: [`Always | `Multi_line_only]
@@ -990,6 +991,23 @@ module Formatting = struct
       (fun conf x -> {conf with module_item_spacing= x})
       (fun conf -> conf.module_item_spacing)
 
+  let nested_match =
+    let doc = "Style of let_and." in
+    let names = ["nested-match"] in
+    let all =
+      [ ( "wrap"
+        , `Wrap
+        , "$(b,wrap) classically wraps a match nested in another match \
+           case with parentheses and adds indentation." )
+      ; ( "align"
+        , `Align
+        , "$(b,align) does not indent and wrap a match if it is nested in \
+           the last case of another match." ) ]
+    in
+    C.choice ~names ~all ~doc ~section
+      (fun conf x -> {conf with nested_match= x})
+      (fun conf -> conf.nested_match)
+
   let ocp_indent_compat =
     let doc =
       "Attempt to generate output which does not change (much) when \
@@ -1415,6 +1433,7 @@ let ocamlformat_profile =
   ; margin= C.default Formatting.margin
   ; max_iters= C.default max_iters
   ; module_item_spacing= C.default Formatting.module_item_spacing
+  ; nested_match= C.default Formatting.nested_match
   ; ocp_indent_compat= C.default Formatting.ocp_indent_compat
   ; parens_ite= C.default Formatting.parens_ite
   ; parens_tuple= C.default Formatting.parens_tuple
@@ -1521,6 +1540,7 @@ let janestreet_profile =
   ; margin= 90
   ; max_iters= ocamlformat_profile.max_iters
   ; module_item_spacing= `Compact
+  ; nested_match= `Wrap
   ; ocp_indent_compat= true
   ; parens_ite= true
   ; parens_tuple= `Multi_line_only

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -992,17 +992,20 @@ module Formatting = struct
       (fun conf -> conf.module_item_spacing)
 
   let nested_match =
-    let doc = "Style of let_and." in
+    let doc =
+      "Style of a pattern-matching nested in the last case of another \
+       pattern-matching."
+    in
     let names = ["nested-match"] in
     let all =
       [ ( "wrap"
         , `Wrap
-        , "$(b,wrap) classically wraps a match nested in another match \
-           case with parentheses and adds indentation." )
+        , "$(b,wrap) wraps the nested pattern-matching with parentheses \
+           and adds indentation." )
       ; ( "align"
         , `Align
-        , "$(b,align) does not indent and wrap a match if it is nested in \
-           the last case of another match." ) ]
+        , "$(b,align) vertically aligns the nested pattern-matching under \
+           the encompassing pattern-matching." ) ]
     in
     C.choice ~names ~all ~doc ~section
       (fun conf x -> {conf with nested_match= x})

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -50,6 +50,7 @@ type t =
         (** Fail if output of formatting does not stabilize within
             [max_iters] iterations. *)
   ; module_item_spacing: [`Compact | `Preserve | `Sparse]
+  ; nested_match: [`Wrap | `Align]
   ; ocp_indent_compat: bool  (** Try to indent like ocp-indent *)
   ; parens_ite: bool
   ; parens_tuple: [`Always | `Multi_line_only]

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2486,7 +2486,7 @@ and fmt_class_type_field c ctx (cf : class_type_field) =
     $ fmt_atrs )
 
 and fmt_cases c ctx cs =
-  list_fl cs (fun ~first ~last:_ {pc_lhs; pc_guard; pc_rhs} ->
+  list_fl cs (fun ~first ~last {pc_lhs; pc_guard; pc_rhs} ->
       let xrhs = sub_exp ~ctx pc_rhs in
       let indent =
         match (ctx, pc_rhs.pexp_desc) with
@@ -2495,8 +2495,14 @@ and fmt_cases c ctx cs =
             2
         | _ -> c.conf.cases_exp_indent
       in
+      let align_nested_match =
+        match (pc_rhs.pexp_desc, c.conf.nested_match) with
+        | (Pexp_match _ | Pexp_try _), `Align -> last
+        | _ -> false
+      in
       let parens_here, parens_for_exp =
-        if c.conf.leading_nested_match_parens then (false, None)
+        if align_nested_match then (false, Some false)
+        else if c.conf.leading_nested_match_parens then (false, None)
         else (parenze_exp xrhs, Some false)
       in
       (* side effects of Cmts.fmt_before before [fmt_lhs] is important *)
@@ -2512,6 +2518,7 @@ and fmt_cases c ctx cs =
           (Cmts.has_before c.cmts pc_rhs.pexp_loc)
           (fmt "@;<1000 0>")
       in
+      let indent = if align_nested_match then 0 else indent in
       Params.get_cases c.conf ~first ~indent ~parens_here
       |> fun (p : Params.cases) ->
       p.leading_space $ leading_cmt

--- a/test/passing/break_cases_align.ml
+++ b/test/passing/break_cases_align.ml
@@ -1,0 +1,1 @@
+break_cases_fit.ml

--- a/test/passing/break_cases_align.ml.opts
+++ b/test/passing/break_cases_align.ml.opts
@@ -1,0 +1,1 @@
+--nested-match=align --break-cases=all

--- a/test/passing/break_cases_align.ml.ref
+++ b/test/passing/break_cases_align.ml.ref
@@ -22,12 +22,12 @@ let f =
     | E -> 4
     | Z
      |P
-     |M -> (
-      match y with
-      | O -> 5
-      | P when h x -> (
-          function
-          | A -> 6 ) )
+     |M ->
+    match y with
+    | O -> 5
+    | P when h x -> (
+        function
+        | A -> 6 )
 
 ;;
 match x with
@@ -59,10 +59,10 @@ let _ =
     match x with
     | None -> false
     | Some looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
-      -> (
-      match y with
-      | Some _ -> true
-      | None -> false )
+      ->
+    match y with
+    | Some _ -> true
+    | None -> false
   in
   ()
 
@@ -166,10 +166,10 @@ let ffffff ~foo =
 let () =
   match v with
   | None -> None
-  | Some x -> (
-    match x with
-    | None -> None
-    | Some x -> (
-      match x with
-      | None -> None
-      | Some x -> x ) )
+  | Some x ->
+  match x with
+  | None -> None
+  | Some x ->
+  match x with
+  | None -> None
+  | Some x -> x

--- a/test/passing/break_cases_fit.ml
+++ b/test/passing/break_cases_fit.ml
@@ -144,3 +144,14 @@ let ffffff ~foo =
  | Aaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbb | Ccccccccccccccccc
  | Ddddddddddddddddd | Eeeeeeeeeeeeeeeee -> foooooooooooooooooooo
  | Fffffffffffffffff -> fooooooooooooooooo
+
+let () =
+  match v with
+  | None -> None
+  | Some x ->
+  match x with
+  | None -> None
+  | Some x ->
+  match x with
+  | None -> None
+  | Some x -> x

--- a/test/passing/break_cases_fit.ml.ref
+++ b/test/passing/break_cases_fit.ml.ref
@@ -123,3 +123,11 @@ let ffffff ~foo =
   | Ddddddddddddddddd | Eeeeeeeeeeeeeeeee ->
       foooooooooooooooooooo
   | Fffffffffffffffff -> fooooooooooooooooo
+
+let () =
+  match v with
+  | None -> None
+  | Some x -> (
+    match x with
+    | None -> None
+    | Some x -> ( match x with None -> None | Some x -> x ) )

--- a/test/passing/break_cases_fit_or_vertical.ml.ref
+++ b/test/passing/break_cases_fit_or_vertical.ml.ref
@@ -134,3 +134,14 @@ let ffffff ~foo =
   | Ddddddddddddddddd
   | Eeeeeeeeeeeeeeeee -> foooooooooooooooooooo
   | Fffffffffffffffff -> fooooooooooooooooo
+
+let () =
+  match v with
+  | None -> None
+  | Some x -> (
+    match x with
+    | None -> None
+    | Some x -> (
+      match x with
+      | None -> None
+      | Some x -> x ) )

--- a/test/passing/break_cases_nested.ml.ref
+++ b/test/passing/break_cases_nested.ml.ref
@@ -141,3 +141,14 @@ let ffffff ~foo =
       foooooooooooooooooooo
   | Fffffffffffffffff ->
       fooooooooooooooooo
+
+let () =
+  match v with
+  | None ->
+      None
+  | Some x -> (
+    match x with
+    | None ->
+        None
+    | Some x -> (
+      match x with None -> None | Some x -> x ) )

--- a/test/passing/break_cases_toplevel.ml.ref
+++ b/test/passing/break_cases_toplevel.ml.ref
@@ -136,3 +136,14 @@ let ffffff ~foo =
   | Ddddddddddddddddd | Eeeeeeeeeeeeeeeee ->
       foooooooooooooooooooo
   | Fffffffffffffffff -> fooooooooooooooooo
+
+let () =
+  match v with
+  | None -> None
+  | Some x -> (
+    match x with
+    | None -> None
+    | Some x -> (
+      match x with
+      | None -> None
+      | Some x -> x ) )

--- a/test/passing/print_config.ml.ref
+++ b/test/passing/print_config.ml.ref
@@ -14,6 +14,7 @@ parens-tuple-patterns=multi-line-only (profile ocamlformat (file passing/.ocamlf
 parens-tuple=always (profile ocamlformat (file passing/.ocamlformat:1))
 parens-ite=false (profile ocamlformat (file passing/.ocamlformat:1))
 ocp-indent-compat=false (profile ocamlformat (file passing/.ocamlformat:1))
+nested-match=wrap (profile ocamlformat (file passing/.ocamlformat:1))
 module-item-spacing=sparse (file passing/dir1/dir2/.ocamlformat:1)
 margin=77 (file passing/.ocamlformat:3)
 let-open=short (command line)

--- a/test/passing/verbose1.ml.ref
+++ b/test/passing/verbose1.ml.ref
@@ -14,6 +14,7 @@ parens-tuple-patterns=multi-line-only (profile ocamlformat (file passing/.ocamlf
 parens-tuple=always (profile ocamlformat (file passing/.ocamlformat:1))
 parens-ite=false (profile ocamlformat (file passing/.ocamlformat:1))
 ocp-indent-compat=false (profile ocamlformat (file passing/.ocamlformat:1))
+nested-match=wrap (profile ocamlformat (file passing/.ocamlformat:1))
 module-item-spacing=sparse (profile ocamlformat (file passing/.ocamlformat:1))
 margin=77 (file passing/.ocamlformat:3)
 let-open=preserve (profile ocamlformat (file passing/.ocamlformat:1))

--- a/test/passing/verbose2.ml.ref
+++ b/test/passing/verbose2.ml.ref
@@ -14,6 +14,7 @@ parens-tuple-patterns=multi-line-only (profile ocamlformat (file passing/.ocamlf
 parens-tuple=always (profile ocamlformat (file passing/.ocamlformat:1))
 parens-ite=false (profile ocamlformat (file passing/.ocamlformat:1))
 ocp-indent-compat=false (profile ocamlformat (file passing/.ocamlformat:1))
+nested-match=wrap (profile ocamlformat (file passing/.ocamlformat:1))
 module-item-spacing=sparse (profile ocamlformat (file passing/.ocamlformat:1))
 margin=77 (file passing/.ocamlformat:3)
 let-open=preserve (profile ocamlformat (file passing/.ocamlformat:1))


### PR DESCRIPTION
Fix #492 
No bug with test_branch (the changes are similar to those of the tests).

The change is made for nested `match` and `try` but maybe we should only make for nested `match`.