### PR TITLE
Add field-space=tight-decl

### DIFF
--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -137,11 +137,12 @@ OPTIONS (CODE FORMATTING STYLE)
        --extension-sugar={preserve|always}
            Extension formatting. The default value is preserve.
 
-       --field-space={tight|loose}
+       --field-space={tight|loose|tight-decl}
            Whether or not to use a space between a field name and the rhs.
            This option affects records and objects. tight does not use a
            space between a field name and the punctuation symbol (`:` or
-           `=`). loose does. The default value is tight.
+           `=`). loose does. tight-decl is tight for declarations and loose
+           for instantiations. The default value is tight.
 
        --if-then-else={compact|fit-or-vertical|keyword-first|k-r}
            If-then-else formatting. compact tries to format an if-then-else

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -32,7 +32,7 @@ type t =
   ; escape_chars: [`Decimal | `Hexadecimal | `Preserve]
   ; escape_strings: [`Decimal | `Hexadecimal | `Preserve]
   ; extension_sugar: [`Preserve | `Always]
-  ; field_space: [`Tight | `Loose]
+  ; field_space: [`Tight | `Loose | `Tight_decl]
   ; if_then_else: [`Compact | `Fit_or_vertical | `Keyword_first | `K_R]
   ; indicate_multiline_delimiters: bool
   ; indicate_nested_or_patterns: [`Space | `Unsafe_no]
@@ -800,7 +800,11 @@ module Formatting = struct
         , `Tight
         , "$(b,tight) does not use a space between a field name and the \
            punctuation symbol (`:` or `=`)." )
-      ; ("loose", `Loose, "$(b,loose) does.") ]
+      ; ("loose", `Loose, "$(b,loose) does.")
+      ; ( "tight-decl"
+        , `Tight_decl
+        , "$(b,tight-decl) is $(b,tight) for declarations and $(b,loose) \
+           for instantiations." ) ]
     in
     C.choice ~names ~all ~doc ~section
       (fun conf x -> {conf with field_space= x})

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -35,7 +35,7 @@ type t =
   ; escape_strings: [`Decimal | `Hexadecimal | `Preserve]
         (** Escape encoding for string literals. *)
   ; extension_sugar: [`Preserve | `Always]
-  ; field_space: [`Tight | `Loose]
+  ; field_space: [`Tight | `Loose | `Tight_decl]
   ; if_then_else: [`Compact | `Fit_or_vertical | `Keyword_first | `K_R]
   ; indicate_multiline_delimiters: bool
   ; indicate_nested_or_patterns: [`Space | `Unsafe_no]

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -528,7 +528,9 @@ and fmt_record_field c ?typ ?rhs ?(type_first = false) lid1 =
     fmt "=@;<1 2>" $ fmt_if parens "(" $ cbox 0 r
   in
   let field_space =
-    match c.conf.field_space with `Loose -> str " " | `Tight -> noop
+    match c.conf.field_space with
+    | `Loose | `Tight_decl -> str " "
+    | `Tight -> noop
   in
   let fmt_type_rhs =
     match (typ, rhs) with
@@ -690,11 +692,15 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
             (* label loc * attributes * core_type -> object_field *)
             let doc, atrs = doc_atrs attrs in
             let fmt_cmts = Cmts.fmt c lab_loc.loc in
+            let field_loose =
+              match c.conf.field_space with
+              | `Loose | `Tight_decl -> true
+              | `Tight -> false
+            in
             fmt_cmts
             @@ hvbox 4
                  ( hvbox 2
-                     ( fmt_str_loc c lab_loc
-                     $ fmt_if Poly.(c.conf.field_space = `Loose) " "
+                     ( fmt_str_loc c lab_loc $ fmt_if field_loose " "
                      $ fmt ":@ "
                      $ fmt_core_type c (sub_typ ~ctx typ) )
                  $ fmt_docstring_padded c doc
@@ -2689,14 +2695,18 @@ and fmt_label_declaration c ctx decl ?(last = false) =
   let doc, atrs = doc_atrs pld_attributes in
   let indent = if Poly.(c.conf.break_separators = `Before) then 2 else 0 in
   let cmt_after_type = Cmts.fmt_after c pld_type.ptyp_loc in
+  let field_loose =
+    match c.conf.field_space with
+    | `Loose -> true
+    | `Tight_decl | `Tight -> false
+  in
   Cmts.fmt_before c ~eol:(break_unless_newline 1 indent) pld_loc
   $ hvbox 4
       ( hvbox 3
           ( hvbox 4
               ( hvbox 2
                   ( fmt_if Poly.(pld_mutable = Mutable) "mutable "
-                  $ fmt_str_loc c pld_name
-                  $ fmt_if Poly.(c.conf.field_space = `Loose) " "
+                  $ fmt_str_loc c pld_name $ fmt_if field_loose " "
                   $ fmt ":@ "
                   $ fmt_core_type c (sub_typ ~ctx pld_type)
                   $ fmt_if

--- a/test/passing/record_loose.ml.ref
+++ b/test/passing/record_loose.ml.ref
@@ -1,3 +1,7 @@
+type t = {x : int; y : int}
+
+let _ = {x = 1; y = 2}
+
 let _ = {!e with a; b = c}
 
 let _ = {!(f e) with a; b = c}

--- a/test/passing/record_tight_decl.ml
+++ b/test/passing/record_tight_decl.ml
@@ -1,0 +1,1 @@
+record.ml

--- a/test/passing/record_tight_decl.ml.opts
+++ b/test/passing/record_tight_decl.ml.opts
@@ -1,0 +1,1 @@
+--field-space=tight-decl

--- a/test/passing/record_tight_decl.ml.ref
+++ b/test/passing/record_tight_decl.ml.ref
@@ -1,22 +1,22 @@
 type t = {x: int; y: int}
 
-let _ = {x= 1; y= 2}
+let _ = {x = 1; y = 2}
 
-let _ = {!e with a; b= c}
+let _ = {!e with a; b = c}
 
-let _ = {!(f e) with a; b= c}
+let _ = {!(f e) with a; b = c}
 
 let _ =
   { !looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
     with
     a
-  ; b= c }
+  ; b = c }
 
 let _ =
   { !looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
     with
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  ; b= c }
+  ; b = c }
 
 let _ = {(a : t) with a; b; c}
 
@@ -53,41 +53,41 @@ let Mmmmmm.
     (* fooooooooo *) =
   ()
 
-let _ = {a; b: c = (match b with `A -> A | `B -> B | `C -> C); c}
+let _ = {a; b : c = (match b with `A -> A | `B -> B | `C -> C); c}
 
-let a () = A {A.a: t}
+let a () = A {A.a : t}
 
-let x = {(*test*) aaa: aa; bbb: bb}
+let x = {(*test*) aaa : aa; bbb : bb}
 
-let x = {aaa: aa (* A *); bbb: bb}
+let x = {aaa : aa (* A *); bbb : bb}
 
-let x = {aaa: aa; (* A *) bbb: bb}
+let x = {aaa : aa; (* A *) bbb : bb}
 
-let x = {(*test*) aaa: aa = aa; bbb: bb}
+let x = {(*test*) aaa : aa = aa; bbb : bb}
 
-let x = {aaa: aa (* A *) = aa; bbb: bb}
+let x = {aaa : aa (* A *) = aa; bbb : bb}
 
-let x = {aaa: aa = (* A *) aa; bbb: bb}
+let x = {aaa : aa = (* A *) aa; bbb : bb}
 
-let x = {aaa: aa; (* A *) bbb: bb}
+let x = {aaa : aa; (* A *) bbb : bb}
 
-let {(*a*) a: a} = e
+let {(*a*) a : a} = e
 
-let {a (*a*): a} = e
+let {a (*a*) : a} = e
 
-let {a: (*a*) a} = e
+let {a : (*a*) a} = e
 
-let {a: a (*a*)} = e
+let {a : a (*a*)} = e
 
 let _ =
   (* comment here *)
   { (* comment here *)
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaa= aaaaaaaaaaaaaaaaaaaaaaaa
-  ; bbbbbbbbbbbb: bbbbbbbbbbb = bbbbbbbbbbbbbbbbb }
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaa = aaaaaaaaaaaaaaaaaaaaaaaa
+  ; bbbbbbbbbbbb : bbbbbbbbbbb = bbbbbbbbbbbbbbbbb }
 
 let { (* comment here *)
-      aaaaaaaaaaaaaaaaaaaaaaaaaaaaa= aaaaaaaaaaaaaaaaaaaaaaaa
-    ; bbbbbbbbbbbb: bbbbbbbbbbb = bbbbbbbbbbbbbbbbb } =
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaa = aaaaaaaaaaaaaaaaaaaaaaaa
+    ; bbbbbbbbbbbb : bbbbbbbbbbb = bbbbbbbbbbbbbbbbb } =
   e
 
 type t =
@@ -95,14 +95,14 @@ type t =
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaaaaaaaaaa
   ; bbbbbbbbbbbb: bbbbbbbbbbb }
 
-let _ = x {a= (a' : string); b= (b' : string)}
+let _ = x {a = (a' : string); b = (b' : string)}
 
-let _ = x {a: string = a'; b: string = b'}
+let _ = x {a : string = a'; b : string = b'}
 
-let _ = x {a= (a' : string); b: string = b'}
+let _ = x {a = (a' : string); b : string = b'}
 
-let _ = x {a: string = a'; b= (b' : string)}
+let _ = x {a : string = a'; b = (b' : string)}
 
-let x = function {a= (_ : string); _} -> ()
+let x = function {a = (_ : string); _} -> ()
 
-let x = function {a: string = _; _} -> ()
+let x = function {a : string = _; _} -> ()


### PR DESCRIPTION
Fix #825

Is like `field-space=tight` for declarations and `field-space=loose` in expressions:

```ocaml
type t = {x: int; y: int}
let _ = {x = 1; y = 2}
```
