### PR TITLE
Fix exception when calling String.sub

### DIFF
--- a/src/Source.ml
+++ b/src/Source.ml
@@ -29,7 +29,7 @@ let position_before t (pos : Lexing.position) =
   Option.map pos_cnum_opt ~f:(fun x -> {pos with pos_cnum= x + 1})
 
 let string_between t (l1 : Location.t) (l2 : Location.t) =
-  let pos = l1.loc_end.pos_cnum in
+  let pos = max 0 l1.loc_end.pos_cnum in
   let len = Position.distance l1.loc_end l2.loc_start in
   if
     len < 0

--- a/src/Source.ml
+++ b/src/Source.ml
@@ -29,10 +29,10 @@ let position_before t (pos : Lexing.position) =
   Option.map pos_cnum_opt ~f:(fun x -> {pos with pos_cnum= x + 1})
 
 let string_between t (l1 : Location.t) (l2 : Location.t) =
-  let pos = max 0 l1.loc_end.pos_cnum in
+  let pos = l1.loc_end.pos_cnum in
   let len = Position.distance l1.loc_end l2.loc_start in
   if
-    len < 0
+    len < 0 || pos < 0
     (* can happen e.g. if comment is within a parenthesized expression *)
   then None
   else if


### PR DESCRIPTION
Fix the following failure:
```
$ echo '(* *)'  | ocamlformat --name f - --debug
([1,0+0]..[1,0+5])   eol


ocamlformat.exe: Cannot process "f".
  Please report this bug at https://github.com/ocaml-ppx/ocamlformat/issues.
  BUG: unhandled exception. Use [--debug] for details.
(Invalid_argument "Negative position: -1")
```

No diff with test_branch.