### PR TITLE
Improve: don't fit tag-only comments after val declarations

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -274,6 +274,11 @@ and class_type_is_simple x =
       false
   | Pcty_arrow (_, _, t) -> class_type_is_simple t
 
+let type_decl_is_simple x =
+  match x.ptype_kind with
+  | Ptype_abstract | Ptype_open -> true
+  | Ptype_variant _ | Ptype_record _ -> false
+
 module type Module_item = sig
   type t
 

--- a/src/Ast.mli
+++ b/src/Ast.mli
@@ -65,6 +65,8 @@ val class_decl_is_simple : class_expr -> bool
 
 val class_type_is_simple : class_type -> bool
 
+val type_decl_is_simple : type_declaration -> bool
+
 (** Ast terms of various forms. *)
 type t =
   | Pld of payload

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2717,7 +2717,8 @@ and fmt_type_declaration c ?ext ?(pre = "") ?(brk = noop) ctx ?fmt_name
     match ptype_kind with Ptype_variant _ -> true | _ -> false
   in
   let doc_before, doc_after, atrs =
-    fmt_docstring_around_item ~force_before c ptype_attributes
+    let fit = Ast.type_decl_is_simple decl in
+    fmt_docstring_around_item ~force_before ~fit c ptype_attributes
   in
   Cmts.fmt c loc @@ Cmts.fmt c ptype_loc
   @@ hvbox 0

--- a/test/passing/js_source.ml
+++ b/test/passing/js_source.ml
@@ -7396,3 +7396,16 @@ let _ =
   List.map rows ~f:(fun row ->
       Or_error.try_with (fun () -> fffffffffffffffffffffffff row))
 ;;
+
+module type T = sig
+
+  val find : t -> key -> value option (** @raise if not found. *)
+
+  val f
+   :  a_few : params
+   -> with_long_names : to_break
+   -> the_line : before_the_comment
+   -> unit
+   (** @param blablabla *)
+
+end

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -9807,8 +9807,9 @@ let _ =
 ;;
 
 module type T = sig
-  val find : t -> key -> value option (** @raise if not found. *)
+  (** @raise if not found. *)
+  val find : t -> key -> value option
 
-  val f : a_few:params -> with_long_names:to_break -> the_line:before_the_comment -> unit
   (** @param blablabla *)
+  val f : a_few:params -> with_long_names:to_break -> the_line:before_the_comment -> unit
 end

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -9805,3 +9805,10 @@ let _ =
   List.map rows ~f:(fun row ->
       Or_error.try_with (fun () -> fffffffffffffffffffffffff row))
 ;;
+
+module type T = sig
+  val find : t -> key -> value option (** @raise if not found. *)
+
+  val f : a_few:params -> with_long_names:to_break -> the_line:before_the_comment -> unit
+  (** @param blablabla *)
+end

--- a/test/passing/tag_only.ml
+++ b/test/passing/tag_only.ml
@@ -169,7 +169,8 @@ module A = Module.With_very_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame
 (** @deprecated  *)
 type t = T
 
-type t = t  (** @deprecated  *)
+type t = t
+(** @deprecated  *)
 
 (** @deprecated  *)
 let a = b

--- a/test/passing/tag_only.ml
+++ b/test/passing/tag_only.ml
@@ -169,8 +169,7 @@ module A = Module.With_very_loooooooooooooooooooooooong_naaaaaaaaaaaaaaaaame
 (** @deprecated  *)
 type t = T
 
-type t = t
-(** @deprecated  *)
+type t = t  (** @deprecated  *)
 
 (** @deprecated  *)
 let a = b

--- a/test/passing/tag_only.mli
+++ b/test/passing/tag_only.mli
@@ -87,14 +87,11 @@ type t = T
 type t = {a: int}
 (** @deprecated  *)
 
-type t = ..
-(** @deprecated  *)
+type t = ..  (** @deprecated  *)
 
-type t
-(** @deprecated  *)
+type t  (** @deprecated  *)
 
-type t = t
-(** @deprecated  *)
+type t = t  (** @deprecated  *)
 
 val a : b
 (** @deprecated  *)

--- a/test/passing/tag_only.mli
+++ b/test/passing/tag_only.mli
@@ -35,6 +35,15 @@ end
 (** @deprecated  *)
 type t = T
 
+type t = {a: int}
+(** @deprecated  *)
+
+type t = ..
+(** @deprecated  *)
+
+type t
+(** @deprecated  *)
+
 type t = t
 (** @deprecated  *)
 
@@ -74,6 +83,15 @@ end
 
 (** @deprecated  *)
 type t = T
+
+type t = {a: int}
+(** @deprecated  *)
+
+type t = ..
+(** @deprecated  *)
+
+type t
+(** @deprecated  *)
 
 type t = t
 (** @deprecated  *)

--- a/test/passing/tag_only.mli
+++ b/test/passing/tag_only.mli
@@ -75,6 +75,8 @@ end
 (** @deprecated  *)
 type t = T
 
-type t = t  (** @deprecated  *)
+type t = t
+(** @deprecated  *)
 
-val a : b  (** @deprecated  *)
+val a : b
+(** @deprecated  *)


### PR DESCRIPTION
https://github.com/ocaml-ppx/ocamlformat/pull/746 was merged too fast. It causes unexpected formatting:

```ocaml
val f : a_few : params -> with_long_names : to_break -> the_line : before_the_comment -> unit
(** @param blablabla *)
```

```ocaml
val find : t -> key -> value (** @raise if not found. *)
```

This PR disable fitting tag-only comments on `val` declarations.
