### PR TITLE
Fix dropped attributes in with_constraints

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2960,7 +2960,7 @@ and fmt_module_type c ({ast= mty} as xmty) =
               open_hvbox 0 $ pro $ fmt_if parens "(")
       ; psp
       ; bdy=
-          fmt_if_k (Option.is_none pro) (open_hvbox 0 $ fmt_if parens "(")
+          fmt_if_k (Option.is_none pro) (open_hvbox 2 $ fmt_if parens "(")
           $ hvbox 0 bdy
           $ fmt_if_k (Option.is_some epi) esp
           $ Option.call ~f:epi $ list_fl wcs fmt_cstrs $ fmt_if parens ")"

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2948,8 +2948,10 @@ and fmt_module_type c ({ast= mty} as xmty) =
       let fmt_cstr ~first ~last:_ wc =
         fmt_or first "@ with" "@;<1 1>and" $ fmt_with_constraint c ctx wc
       in
-      let fmt_cstrs ~first:_ ~last:_ (wcs_and, loc) =
-        Cmts.fmt c loc @@ list_fl wcs_and fmt_cstr
+      let fmt_cstrs ~first:_ ~last:_ (wcs_and, loc, attr) =
+        Cmts.fmt c loc
+          ( list_fl wcs_and fmt_cstr
+          $ fmt_attributes c ~pre:(str " ") ~key:"@" attr )
       in
       let {pro; psp; bdy; esp; epi} = fmt_module_type c mt in
       { empty with
@@ -2964,10 +2966,7 @@ and fmt_module_type c ({ast= mty} as xmty) =
           $ Option.call ~f:epi $ list_fl wcs fmt_cstrs $ fmt_if parens ")"
           $ close_box
       ; esp= fmt_if_k (Option.is_none epi) esp
-      ; epi=
-          Some
-            ( fmt_attributes c ~key:"@" pmty_attributes ~pre:(fmt "@ ")
-            $ Cmts.fmt_after c pmty_loc ) }
+      ; epi= Some (Cmts.fmt_after c pmty_loc) }
   | Pmty_typeof me -> (
       let blk = fmt_module_expr c (sub_mod ~ctx me) in
       let epi =

--- a/src/Sugar.ml
+++ b/src/Sugar.ml
@@ -325,12 +325,8 @@ let mod_with pmty =
     let ctx = Mty me in
     match me with
     | {pmty_desc= Pmty_with (mt, wcs); pmty_attributes; pmty_loc} ->
-        let args, rest =
-          match pmty_attributes with
-          | [] -> mod_with_ (sub_mty ~ctx mt)
-          | _ -> ([], sub_mty ~ctx mt)
-        in
-        ((wcs, pmty_loc) :: args, rest)
+        let args, rest = mod_with_ (sub_mty ~ctx mt) in
+        ((wcs, pmty_loc, pmty_attributes) :: args, rest)
     | _ -> ([], xme)
   in
   let l_rev, m = mod_with_ pmty in

--- a/src/Sugar.mli
+++ b/src/Sugar.mli
@@ -129,7 +129,8 @@ val functor_ :
 
 val mod_with :
      module_type Ast.xt
-  -> (with_constraint list * Warnings.loc) list * module_type Ast.xt
+  -> (with_constraint list * Warnings.loc * attributes) list
+     * module_type Ast.xt
 (** [mod_with m] returns the list of [with type] constraints of module type
     [m]. *)
 

--- a/src/import/Import.ml
+++ b/src/import/Import.ml
@@ -18,11 +18,11 @@ include (
 
       include
         module type of Base
-        (* [Filename], [Format], [Scanf] are all deprecated in [Base], erase
-           them and use the ones from the stdlib. *)
-        with module Filename := Base.Filename
-         and module Format := Base.Format
-         and module Scanf := Base.Scanf
+          (* [Filename], [Format], [Scanf] are all deprecated in [Base],
+             erase them and use the ones from the stdlib. *)
+          with module Filename := Base.Filename
+           and module Format := Base.Format
+           and module Scanf := Base.Scanf
     end )
 
 include Option.Monad_infix

--- a/src/import/Import.mli
+++ b/src/import/Import.mli
@@ -18,11 +18,11 @@ include module type of (
 
       include
         module type of Base
-        (* [Filename], [Format], [Scanf] are all deprecated in [Base], erase
-           them and use the ones from the stdlib. *)
-        with module Filename := Base.Filename
-         and module Format := Base.Format
-         and module Scanf := Base.Scanf
+          (* [Filename], [Format], [Scanf] are all deprecated in [Base],
+             erase them and use the ones from the stdlib. *)
+          with module Filename := Base.Filename
+           and module Format := Base.Format
+           and module Scanf := Base.Scanf
     end )
 
 include module type of Option.Monad_infix

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -51,10 +51,10 @@ module type M = sig
 
   module T :
     (S
-    with type t = t
-     and type u := u
-     and module R = R
-     and module S := S [@test])
+      with type t = t
+       and type u := u
+       and module R = R
+       and module S := S [@test])
 
   module T : module type of X [@test5]
 

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -43,15 +43,18 @@ let[@inline always] f x =
 module type M = S [@test1]
 
 module type M = sig
-  module T (T : sig end) : (S with type t = r) [@test2]
+  module T (T : sig end) : (S with type t = r [@test2])
 
   module T (S : S [@test]) : S
 
-  module T : (S with type t = (r[@test3])) [@test4]
+  module T : (S with type t = (r[@test3]) [@test4])
 
   module T :
-    (S with type t = t and type u := u and module R = R and module S := S)
-  [@test]
+    (S
+    with type t = t
+     and type u := u
+     and module R = R
+     and module S := S [@test])
 
   module T : module type of X [@test5]
 

--- a/test/passing/functor.ml
+++ b/test/passing/functor.ml
@@ -62,19 +62,19 @@ end
 
 module type KV_MAKER = functor (G : Irmin_git.G) (C : Irmin.Contents.S) ->
   S
-  with type key = string list
-   and type step = string
-   and type contents = C.t
-   and type branch = string
-   and module Git = G
+    with type key = string list
+     and type step = string
+     and type contents = C.t
+     and type branch = string
+     and module Git = G
 
 module Make
     (TT : TableFormat.TABLES)
     (IT : InspectionTableFormat.TABLES with type 'a lr1state = int)
     (ET : EngineTypes.TABLE
-          with type terminal = int
-           and type nonterminal = int
-           and type semantic_value = Obj.t)
+            with type terminal = int
+             and type nonterminal = int
+             and type semantic_value = Obj.t)
     (E : sig
       type 'a env = (ET.state, ET.semantic_value, ET.token) EngineTypes.env
     end) =

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -14,7 +14,7 @@ end [@foo]
 [@@foo]
 
 module type S = sig
-  include ((module type of M [@foo]) [@foo] with type t := M.t) [@foo] [@@foo]
+  include ((module type of M [@foo]) [@foo] with type t := M.t [@foo]) [@@foo]
 
   [@@@foo]
 end [@foo]

--- a/test/passing/module_attributes.ml
+++ b/test/passing/module_attributes.ml
@@ -16,3 +16,19 @@ include (val M) [@warning "item"] [@@warning "structure"]
 
 include ( val Aaaaaaaaaaaaaaaa.Bbbbbbbbbbbbbbbb.Cccccccccccccccc
               .Dddddddddddddddd ) [@warning "item"] [@@warning "structure"]
+
+include (
+  List :
+    module type of Foo with module A := A [@warning "-3"] with module B := B )
+
+include (
+  List :
+    (module type of Foo
+    with module A := A [@warning "-3"] [@warning "-3"]
+    with module B := B [@warning "-3"]) )
+
+include (
+  List :
+    (module type of Pervasives
+    with module A := A [@warning "-3"] [@warning "-3"]
+    with module B := B [@warning "-3"] [@warning "-3"]) ) [@warning "-3"]

--- a/test/passing/module_attributes.ml
+++ b/test/passing/module_attributes.ml
@@ -24,11 +24,11 @@ include (
 include (
   List :
     (module type of Foo
-    with module A := A [@warning "-3"] [@warning "-3"]
-    with module B := B [@warning "-3"]) )
+      with module A := A [@warning "-3"] [@warning "-3"]
+      with module B := B [@warning "-3"]) )
 
 include (
   List :
     (module type of Pervasives
-    with module A := A [@warning "-3"] [@warning "-3"]
-    with module B := B [@warning "-3"] [@warning "-3"]) ) [@warning "-3"]
+      with module A := A [@warning "-3"] [@warning "-3"]
+      with module B := B [@warning "-3"] [@warning "-3"]) ) [@warning "-3"]

--- a/test/passing/module_type.ml
+++ b/test/passing/module_type.ml
@@ -25,26 +25,26 @@ end
 
 module type M =
   module type of M
-  with module A := A
-  (*test*)
-   and module A = A
-  (*test*)
-   and module A = A
-  with module A = A
-  (*test*)
-  with module A = A
+    with module A := A
+    (*test*)
+     and module A = A
+    (*test*)
+     and module A = A
+    with module A = A
+    (*test*)
+    with module A = A
 
 module U :
   S
-  with type ttttttttt = int
-   and type uuuuuuuu = int
-   and type vvvvvvvvvvv = int = struct end
+    with type ttttttttt = int
+     and type uuuuuuuu = int
+     and type vvvvvvvvvvv = int = struct end
 
 module U :
   S
-  with type ttttttttt = int
-   and type uuuuuuu = int
-  with type vvvvvvvvv = int = struct end
+    with type ttttttttt = int
+     and type uuuuuuu = int
+    with type vvvvvvvvv = int = struct end
 
 module U = (val S : S with type t = int and type u = int)
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -15,8 +15,7 @@ end [@foo]
 
 module type S = sig
   include
-    ((module type of M [@foo]) [@foo] with type t := M.t)
-  [@foo]
+    ((module type of M [@foo]) [@foo] with type t := M.t [@foo])
   [@@foo]
 
   [@@@foo]


### PR DESCRIPTION
Fix #842, with test_branch: minor changes (less pretty but better attachment) similar to the changes in source.ml/js_source.ml:

```ocaml
diff --git a/sledge/src/import/import.ml b/sledge/src/import/import.ml
index 84013e28c..aa6cd884c 100644
--- a/sledge/src/import/import.ml
+++ b/sledge/src/import/import.ml
@@ -24,8 +24,8 @@ include (
          and module Format := Base.Format
          and module Marshal := Base.Marshal
          and module Scanf := Base.Scanf
-         and type ('ok, 'err) result := ('ok, 'err) Base.result)
-      [@warning "-3"]
+         and type ('ok, 'err) result := ('ok, 'err) Base.result [@warning
+                                                                  "-3"])
     end )
 
 (* undeprecate *)
diff --git a/sledge/src/import/import.mli b/sledge/src/import/import.mli
index 9d3b583a3..7d541460b 100644
--- a/sledge/src/import/import.mli
+++ b/sledge/src/import/import.mli
@@ -24,8 +24,8 @@ include module type of (
          and module Format := Base.Format
          and module Marshal := Base.Marshal
          and module Scanf := Base.Scanf
-         and type ('ok, 'err) result := ('ok, 'err) Base.result)
-      [@warning "-3"]
+         and type ('ok, 'err) result := ('ok, 'err) Base.result [@warning
+                                                                  "-3"])
     end )
```