### PR TITLE
Patch to allow checking of ocamlformat disable directive for disabled files

### DIFF
--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -417,14 +417,15 @@ let format xunit (conf : Conf.t) ?output_file ~input_name ~source ~parsed ()
             print_check ~i:(i + 1) ~conf t_new ~source:fmted
   in
   let result =
-    if conf.disable then Ok source
-    else
-      match (parsed : ('a with_comments, exn) Result.t) with
-      | Error exn -> Error (Invalid_source {exn})
-      | Ok t -> (
-        try print_check ~i:1 ~conf t ~source with
-        | Sys_error msg -> Error (User_error msg)
-        | exn -> Error (Ocamlformat_bug {exn}) )
+    match (parsed : ('a with_comments, exn) Result.t) with
+    | Error exn -> 
+        if conf.disable
+        then Ok source 
+        else Error (Invalid_source {exn})
+    | Ok t -> (
+      try print_check ~i:1 ~conf t ~source with
+      | Sys_error msg -> Error (User_error msg)
+      | exn -> Error (Ocamlformat_bug {exn}) )
   in
   ( match result with
   | Ok _ -> ()

--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -418,10 +418,8 @@ let format xunit (conf : Conf.t) ?output_file ~input_name ~source ~parsed ()
   in
   let result =
     match (parsed : ('a with_comments, exn) Result.t) with
-    | Error exn -> 
-        if conf.disable
-        then Ok source 
-        else Error (Invalid_source {exn})
+    | Error exn ->
+        if conf.disable then Ok source else Error (Invalid_source {exn})
     | Ok t -> (
       try print_check ~i:1 ~conf t ~source with
       | Sys_error msg -> Error (User_error msg)


### PR DESCRIPTION
We currently have the situation where we would like ocamlformat to be disabled by default, with the option of whitelisting it for certain files for integration with an existing project. Our setup is to create a `.ocamlformat` file with `disable=true` in it, and then individual files can specify `[@@@ocamlformat "enable"]`. 

Currently these files are completely ignored (or processed and then semingly the unchanged version returned. This patch attempts to fix this, with the new behaviour being that if the file is disabled, it will try to run the file and if an error occurs it will return the unchanged version. If it runs successfully, it will respect the value of `disable`. I'm not sure if this is the best way of doing it, but happy to fix the PR if there are better ways.