### PR TITLE
Fix inconsistency of break-separators=after-and-docked for record expressions

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2197,13 +2197,19 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
               Cmts.fmt c f.pexp_loc
               @@ fmt_record_field c ~rhs:(fmt_rhs f) lid1 )
       in
+      let p = Params.get_record_expr c.conf ~wrap_record in
+      let fmt_field ~first ~last x =
+        fmt_if_k (not first) p.sep_before
+        $ fmt_field x
+        $ fmt_if_k (not last) p.sep_after
+      in
       hvbox 0
-        ( wrap_record c.conf
+        ( p.box
             ( opt default (fun d ->
                   hvbox 2
                     (fmt_expression c (sub_exp ~ctx d) $ fmt "@;<1 -2>")
                   $ fmt "with@;<1 2>")
-            $ list flds (semic_sep c) fmt_field )
+            $ list_fl flds fmt_field )
         $ fmt_atrs )
   | Pexp_sequence (e1, e2) when Option.is_some ext ->
       let parens1 =

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2208,7 +2208,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             ( opt default (fun d ->
                   hvbox 2
                     (fmt_expression c (sub_exp ~ctx d) $ fmt "@;<1 -2>")
-                  $ fmt "with@;<1 2>")
+                  $ fmt "with" $ p.break_after_with)
             $ list_fl flds fmt_field )
         $ fmt_atrs )
   | Pexp_sequence (e1, e2) when Option.is_some ext ->
@@ -3047,8 +3047,7 @@ and fmt_type_declaration c ?ext ?(pre = "") ?(brk = noop) ctx ?fmt_name
         $ list_fl ctor_decls
             (fmt_constructor_declaration c ~max_len_name ctx)
     | Ptype_record lbl_decls ->
-        Params.get_record_type c.conf ~wrap_record
-        |> fun (p : Params.record_type) ->
+        let p = Params.get_record_type c.conf ~wrap_record in
         let fmt_decl ~first ~last x =
           fmt_if_k (not first) p.sep_before
           $ fmt_label_declaration c ctx x ~last

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3103,29 +3103,30 @@ and fmt_label_declaration c ctx decl ?(last = false) =
   update_config_maybe_disabled c pld_loc pld_attributes
   @@ fun c ->
   let doc, atrs = doc_atrs pld_attributes in
-  let indent = if Poly.(c.conf.break_separators = `Before) then 2 else 0 in
   let cmt_after_type = Cmts.fmt_after c pld_type.ptyp_loc in
   let field_loose =
     match c.conf.field_space with
     | `Loose -> true
     | `Tight_decl | `Tight -> false
   in
-  Cmts.fmt_before c ~eol:(break_unless_newline 1 indent) pld_loc
-  $ hvbox 4
-      ( hvbox 3
-          ( hvbox 4
-              ( hvbox 2
-                  ( fmt_if Poly.(pld_mutable = Mutable) "mutable "
-                  $ fmt_str_loc c pld_name $ fmt_if field_loose " "
-                  $ fmt ":@ "
-                  $ fmt_core_type c (sub_typ ~ctx pld_type)
-                  $ fmt_if
-                      (Poly.(c.conf.break_separators <> `Before) && not last)
-                      ";" )
-              $ cmt_after_type )
-          $ fmt_attributes c ~pre:(fmt "@;<1 1>") ~key:"@" atrs )
-      $ Cmts.fmt_after c pld_loc
-      $ fmt_docstring_padded c doc )
+  hovbox 0
+    ( Cmts.fmt_before c pld_loc
+    $ hvbox 4
+        ( hvbox 3
+            ( hvbox 4
+                ( hvbox 2
+                    ( fmt_if Poly.(pld_mutable = Mutable) "mutable "
+                    $ fmt_str_loc c pld_name $ fmt_if field_loose " "
+                    $ fmt ":@ "
+                    $ fmt_core_type c (sub_typ ~ctx pld_type)
+                    $ fmt_if
+                        ( Poly.(c.conf.break_separators <> `Before)
+                        && not last )
+                        ";" )
+                $ cmt_after_type )
+            $ fmt_attributes c ~pre:(fmt "@;<1 1>") ~key:"@" atrs )
+        $ Cmts.fmt_after c pld_loc
+        $ fmt_docstring_padded c doc ) )
 
 and fmt_constructor_declaration c ctx ~max_len_name ~first ~last:_ cstr_decl
     =

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -423,10 +423,6 @@ let wrap_array c =
   if c.conf.space_around_arrays then wrap "[| " "@ |]"
   else wrap_fits_breaks c.conf "[|" "|]"
 
-let wrap_record (c : Conf.t) =
-  if c.space_around_records then wrap "{ " "@ }"
-  else wrap_fits_breaks c "{" "}"
-
 let wrap_tuple ~parens ~no_parens_if_break c =
   if parens then wrap_fits_breaks c.conf "(" ")"
   else if no_parens_if_break then Fn.id
@@ -1005,7 +1001,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
       in
       hvbox 0
         (wrap_if parens "(" ")"
-           (wrap_record c.conf
+           (Params.wrap_record c.conf
               ( list flds (semic_sep c) fmt_field
               $ fmt_if_k
                   Poly.(closed_flag = Open)
@@ -2197,7 +2193,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
               Cmts.fmt c f.pexp_loc
               @@ fmt_record_field c ~rhs:(fmt_rhs f) lid1 )
       in
-      let p = Params.get_record_expr c.conf ~wrap_record in
+      let p = Params.get_record_expr c.conf in
       let fmt_field ~first ~last x =
         fmt_if_k (not first) p.sep_before
         $ fmt_field x
@@ -3047,7 +3043,7 @@ and fmt_type_declaration c ?ext ?(pre = "") ?(brk = noop) ctx ?fmt_name
         $ list_fl ctor_decls
             (fmt_constructor_declaration c ~max_len_name ctx)
     | Ptype_record lbl_decls ->
-        let p = Params.get_record_type c.conf ~wrap_record in
+        let p = Params.get_record_type c.conf in
         let fmt_decl ~first ~last x =
           fmt_if_k (not first) p.sep_before
           $ fmt_label_declaration c ctx x ~last
@@ -3183,7 +3179,7 @@ and fmt_constructor_arguments c ctx ~pre = function
         $ fmt_if (last && exposed_right_typ x.pld_type) " "
         $ fmt_if ((not last) && not break_before) "@;<1 2>"
       in
-      pre $ wrap_record c.conf (list_fl lds fmt_ld)
+      pre $ Params.wrap_record c.conf (list_fl lds fmt_ld)
 
 and fmt_constructor_arguments_result c ctx args res =
   let pre = fmt_or (Option.is_none res) " of@ " " :@ " in

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -96,6 +96,26 @@ let get_record_type (c : Conf.t) ~wrap_record =
       ; break_after= break space (-2)
       ; docked_after= fmt "}" }
 
+type record_expr = {box: Fmt.t -> Fmt.t; sep_before: Fmt.t; sep_after: Fmt.t}
+
+let get_record_expr (c : Conf.t) ~wrap_record =
+  match c.break_separators with
+  | `Before ->
+      { box= (fun k -> hvbox 0 (wrap_record c k))
+      ; sep_before= fmt "@,; "
+      ; sep_after= noop }
+  | `After ->
+      { box= (fun k -> hvbox 2 (wrap_record c k))
+      ; sep_before= noop
+      ; sep_after= fmt ";@ " }
+  | `After_and_docked ->
+      let space = if c.space_around_records then 1 else 0 in
+      { box=
+          (fun k ->
+            hvbox 2 (wrap "{" "}" (break space 0 $ k $ break space (-2))))
+      ; sep_before= noop
+      ; sep_after= fmt ";@ " }
+
 type if_then_else =
   { box_branch: Fmt.t -> Fmt.t
   ; cond: Fmt.t

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -110,10 +110,10 @@ let get_record_expr (c : Conf.t) ~wrap_record =
       ; sep_before= fmt "@,; "
       ; sep_after= noop }
   | `After ->
-      { box= (fun k -> hvbox 2 (wrap_record c k))
-      ; break_after_with= break 1 0
+      { box= (fun k -> hvbox 0 (wrap_record c k))
+      ; break_after_with= break 1 2
       ; sep_before= noop
-      ; sep_after= fmt ";@ " }
+      ; sep_after= fmt ";@;<1 2>" }
   | `After_and_docked ->
       let space = if c.space_around_records then 1 else 0 in
       { box=

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -62,6 +62,19 @@ let wrap_record (c : Conf.t) =
   if c.space_around_records then wrap "{ " "@ }"
   else wrap_fits_breaks c "{" "}"
 
+let wrap_list (c : Conf.t) =
+  if c.space_around_lists then wrap_k (str "[ ") (or_newline "]" "]")
+  else wrap_fits_breaks c "[" "]"
+
+let wrap_array (c : Conf.t) =
+  if c.space_around_arrays then wrap "[| " "@ |]"
+  else wrap_fits_breaks c "[|" "|]"
+
+let wrap_tuple (c : Conf.t) ~parens ~no_parens_if_break =
+  if parens then wrap_fits_breaks c "(" ")"
+  else if no_parens_if_break then Fn.id
+  else wrap_k (fits_breaks "" "( ") (fits_breaks "" ~hint:(1, 0) ")")
+
 type record_type =
   { docked_before: Fmt.t
   ; break_before: Fmt.t

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -58,6 +58,10 @@ let get_cases (c : Conf.t) ~first ~indent ~parens_here =
       ; break_after_arrow= fmt_if (not parens_here) "@;<0 3>"
       ; break_after_opening_paren= fmt "@ " }
 
+let wrap_record (c : Conf.t) =
+  if c.space_around_records then wrap "{ " "@ }"
+  else wrap_fits_breaks c "{" "}"
+
 type record_type =
   { docked_before: Fmt.t
   ; break_before: Fmt.t
@@ -67,7 +71,7 @@ type record_type =
   ; break_after: Fmt.t
   ; docked_after: Fmt.t }
 
-let get_record_type (c : Conf.t) ~wrap_record =
+let get_record_type (c : Conf.t) =
   let sparse_type_decl = Poly.(c.type_decl = `Sparse) in
   match c.break_separators with
   | `Before ->
@@ -102,7 +106,7 @@ type record_expr =
   ; sep_before: Fmt.t
   ; sep_after: Fmt.t }
 
-let get_record_expr (c : Conf.t) ~wrap_record =
+let get_record_expr (c : Conf.t) =
   match c.break_separators with
   | `Before ->
       { box= (fun k -> hvbox 0 (wrap_record c k))

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -96,16 +96,22 @@ let get_record_type (c : Conf.t) ~wrap_record =
       ; break_after= break space (-2)
       ; docked_after= fmt "}" }
 
-type record_expr = {box: Fmt.t -> Fmt.t; sep_before: Fmt.t; sep_after: Fmt.t}
+type record_expr =
+  { box: Fmt.t -> Fmt.t
+  ; break_after_with: Fmt.t
+  ; sep_before: Fmt.t
+  ; sep_after: Fmt.t }
 
 let get_record_expr (c : Conf.t) ~wrap_record =
   match c.break_separators with
   | `Before ->
       { box= (fun k -> hvbox 0 (wrap_record c k))
+      ; break_after_with= break 1 2
       ; sep_before= fmt "@,; "
       ; sep_after= noop }
   | `After ->
       { box= (fun k -> hvbox 2 (wrap_record c k))
+      ; break_after_with= break 1 0
       ; sep_before= noop
       ; sep_after= fmt ";@ " }
   | `After_and_docked ->
@@ -113,6 +119,7 @@ let get_record_expr (c : Conf.t) ~wrap_record =
       { box=
           (fun k ->
             hvbox 2 (wrap "{" "}" (break space 0 $ k $ break space (-2))))
+      ; break_after_with= break 1 0
       ; sep_before= noop
       ; sep_after= fmt ";@ " }
 

--- a/src/Params.mli
+++ b/src/Params.mli
@@ -25,6 +25,13 @@ val get_cases :
 
 val wrap_record : Conf.t -> Fmt.t -> Fmt.t
 
+val wrap_list : Conf.t -> Fmt.t -> Fmt.t
+
+val wrap_array : Conf.t -> Fmt.t -> Fmt.t
+
+val wrap_tuple :
+  Conf.t -> parens:bool -> no_parens_if_break:bool -> Fmt.t -> Fmt.t
+
 type record_type =
   { docked_before: Fmt.t
   ; break_before: Fmt.t

--- a/src/Params.mli
+++ b/src/Params.mli
@@ -35,7 +35,11 @@ type record_type =
 val get_record_type :
   Conf.t -> wrap_record:(Conf.t -> Fmt.t -> Fmt.t) -> record_type
 
-type record_expr = {box: Fmt.t -> Fmt.t; sep_before: Fmt.t; sep_after: Fmt.t}
+type record_expr =
+  { box: Fmt.t -> Fmt.t
+  ; break_after_with: Fmt.t
+  ; sep_before: Fmt.t
+  ; sep_after: Fmt.t }
 
 val get_record_expr :
   Conf.t -> wrap_record:(Conf.t -> Fmt.t -> Fmt.t) -> record_expr

--- a/src/Params.mli
+++ b/src/Params.mli
@@ -23,6 +23,8 @@ type cases =
 val get_cases :
   Conf.t -> first:bool -> indent:int -> parens_here:bool -> cases
 
+val wrap_record : Conf.t -> Fmt.t -> Fmt.t
+
 type record_type =
   { docked_before: Fmt.t
   ; break_before: Fmt.t
@@ -32,8 +34,7 @@ type record_type =
   ; break_after: Fmt.t
   ; docked_after: Fmt.t }
 
-val get_record_type :
-  Conf.t -> wrap_record:(Conf.t -> Fmt.t -> Fmt.t) -> record_type
+val get_record_type : Conf.t -> record_type
 
 type record_expr =
   { box: Fmt.t -> Fmt.t
@@ -41,8 +42,7 @@ type record_expr =
   ; sep_before: Fmt.t
   ; sep_after: Fmt.t }
 
-val get_record_expr :
-  Conf.t -> wrap_record:(Conf.t -> Fmt.t -> Fmt.t) -> record_expr
+val get_record_expr : Conf.t -> record_expr
 
 type if_then_else =
   { box_branch: Fmt.t -> Fmt.t

--- a/src/Params.mli
+++ b/src/Params.mli
@@ -35,6 +35,11 @@ type record_type =
 val get_record_type :
   Conf.t -> wrap_record:(Conf.t -> Fmt.t -> Fmt.t) -> record_type
 
+type record_expr = {box: Fmt.t -> Fmt.t; sep_before: Fmt.t; sep_after: Fmt.t}
+
+val get_record_expr :
+  Conf.t -> wrap_record:(Conf.t -> Fmt.t -> Fmt.t) -> record_expr
+
 type if_then_else =
   { box_branch: Fmt.t -> Fmt.t
   ; cond: Fmt.t

--- a/test/passing/break_separators.ml
+++ b/test/passing/break_separators.ml
@@ -298,6 +298,8 @@ let x
       aaaaaaaaaaaaaaaaaa;
       aaaaaaaaaa }
   =
-  { aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
+  {
+    aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
     bbbbbbbbbbbbb= bbb bb bbbbbb;
-    cccccc= cccc ccccccccccccccccccccccc }
+    cccccc= cccc ccccccccccccccccccccccc
+  }

--- a/test/passing/break_separators.ml
+++ b/test/passing/break_separators.ml
@@ -271,3 +271,10 @@ let x
   { aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa
   ; bbbbbbbbbbbbb= bbb bb bbbbbb
   ; cccccc= cccc ccccccccccccccccccccccc }
+
+let foooooooooooooooooooooooooooooooooo =
+  { (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
+    aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa
+  ; (* fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
+    bbbbbbbbbbbbb= bbb bb bbbbbb
+  ; cccccc= cccc ccccccccccccccccccccccc }

--- a/test/passing/break_separators.ml
+++ b/test/passing/break_separators.ml
@@ -67,25 +67,25 @@ type t =
 
 let _ =
   match something with
-  | { very_very_long_field_name_running_out_of_space= 1;
-      another_very_very_long_field_name_running_out_of_space= 2;
-      _ } ->
+  | { very_very_long_field_name_running_out_of_space= 1
+    ; another_very_very_long_field_name_running_out_of_space= 2
+    ; _ } ->
       0
   | _ -> 1
 
 let _ =
   match something with
-  | [ very_very_long_field_name_running_out_of_space;
-      another_very_very_long_field_name_running_out_of_space;
-      _ ] ->
+  | [ very_very_long_field_name_running_out_of_space
+    ; another_very_very_long_field_name_running_out_of_space
+    ; _ ] ->
       0
   | _ -> 1
 
 let _ =
   match something with
-  | [| very_very_long_field_name_running_out_of_space;
-       another_very_very_long_field_name_running_out_of_space;
-       _ |] ->
+  | [| very_very_long_field_name_running_out_of_space
+     ; another_very_very_long_field_name_running_out_of_space
+     ; _ |] ->
       0
   | _ -> 1
 

--- a/test/passing/break_separators.ml
+++ b/test/passing/break_separators.ml
@@ -278,3 +278,14 @@ let foooooooooooooooooooooooooooooooooo =
   ; (* fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
     bbbbbbbbbbbbb= bbb bb bbbbbb
   ; cccccc= cccc ccccccccccccccccccccccc }
+
+let foooooooooooo =
+  { foooooooooooooo with
+    fooooooooooooooooooooooooooooo= fooooooooooooo
+  ; fooooooooooooo= foooooooooooooo }
+
+let foooooooooooo =
+  { foooooooooooooo with
+    (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
+    fooooooooooooooooooooooooooooo= fooooooooooooo
+  ; fooooooooooooo= foooooooooooooo }

--- a/test/passing/break_separators.ml
+++ b/test/passing/break_separators.ml
@@ -1,5 +1,3 @@
-[@@@ocamlformat "break-separators=before"]
-
 type t =
   { (* fooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
     foooooooooooooooooooooooo: foooooooooooooooooooooooooooooooooooooooo
@@ -13,67 +11,59 @@ type x =
       ; (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo*)
         bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
 
-[@@@ocamlformat "break-separators=after"]
-
 type t =
-  { aaaaaaaaaaaaaaaaaaaaaaaaa: aaaa aaaaaaaaaaaaaaaaaaa;
-    bbbbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbb bbbb;
-    cccccccccccccccccccccc: ccccccc ccccccccccc cccccccc }
-
-type t =
-  { (* fooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
-    foooooooooooooooooooooooo: foooooooooooooooooooooooooooooooooooooooo;
-    (* foooooooooooooooooooooooooooooooooooooooooooo *)
-    fooooooooooooooooooooooooooooo: fooooooooooooooooooooooooooo }
+  { aaaaaaaaaaaaaaaaaaaaaaaaa: aaaa aaaaaaaaaaaaaaaaaaa
+  ; bbbbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbb bbbb
+  ; cccccccccccccccccccccc: ccccccc ccccccccccc cccccccc }
 
 type x =
   | B of
-      { aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
-        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
+      { aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa
+      ; bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
 
 type t =
-  { break_cases: [`Fit | `Nested | `All];
-    break_collection_expressions: [`Wrap | `Fit_or_vertical];
-    break_infix: [`Wrap | `Fit_or_vertical];
-    break_separators: bool;
-    break_sequences: bool;
-    break_string_literals: [`Newlines | `Never | `Wrap];
+  { break_cases: [`Fit | `Nested | `All]
+  ; break_collection_expressions: [`Wrap | `Fit_or_vertical]
+  ; break_infix: [`Wrap | `Fit_or_vertical]
+  ; break_separators: bool
+  ; break_sequences: bool
+  ; break_string_literals: [`Newlines | `Never | `Wrap]
         (** How to potentially break string literals into new lines. *)
-    break_struct: bool;
-    cases_exp_indent: int;
-    comment_check: bool;
-    disable: bool;
-    doc_comments: [`Before | `After];
-    escape_chars: [`Decimal | `Hexadecimal | `Preserve];
+  ; break_struct: bool
+  ; cases_exp_indent: int
+  ; comment_check: bool
+  ; disable: bool
+  ; doc_comments: [`Before | `After]
+  ; escape_chars: [`Decimal | `Hexadecimal | `Preserve]
         (** Escape encoding for chars literals. *)
-    escape_strings: [`Decimal | `Hexadecimal | `Preserve];
+  ; escape_strings: [`Decimal | `Hexadecimal | `Preserve]
         (** Escape encoding for string literals. *)
-    extension_sugar: [`Preserve | `Always];
-    field_space: [`Tight | `Loose];
-    if_then_else: [`Compact | `Keyword_first];
-    indicate_multiline_delimiters: bool;
-    indicate_nested_or_patterns: bool;
-    infix_precedence: [`Indent | `Parens];
-    leading_nested_match_parens: bool;
-    let_and: [`Compact | `Sparse];
-    let_binding_spacing: [`Compact | `Sparse | `Double_semicolon];
-    let_open: [`Preserve | `Auto | `Short | `Long];
-    margin: int;  (** Format code to fit within [margin] columns. *)
-    max_iters: int;
+  ; extension_sugar: [`Preserve | `Always]
+  ; field_space: [`Tight | `Loose]
+  ; if_then_else: [`Compact | `Keyword_first]
+  ; indicate_multiline_delimiters: bool
+  ; indicate_nested_or_patterns: bool
+  ; infix_precedence: [`Indent | `Parens]
+  ; leading_nested_match_parens: bool
+  ; let_and: [`Compact | `Sparse]
+  ; let_binding_spacing: [`Compact | `Sparse | `Double_semicolon]
+  ; let_open: [`Preserve | `Auto | `Short | `Long]
+  ; margin: int  (** Format code to fit within [margin] columns. *)
+  ; max_iters: int
         (** Fail if output of formatting does not stabilize within
             [max_iters] iterations. *)
-    module_item_spacing: [`Compact | `Sparse];
-    ocp_indent_compat: bool;  (** Try to indent like ocp-indent *)
-    parens_ite: bool;
-    parens_tuple: [`Always | `Multi_line_only];
-    parens_tuple_patterns: [`Always | `Multi_line_only];
-    parse_docstrings: bool;
-    quiet: bool;
-    sequence_style: [`Separator | `Terminator];
-    single_case: [`Compact | `Sparse];
-    type_decl: [`Compact | `Sparse];
-    wrap_comments: bool;  (** Wrap comments at margin. *)
-    wrap_fun_args: bool }
+  ; module_item_spacing: [`Compact | `Sparse]
+  ; ocp_indent_compat: bool  (** Try to indent like ocp-indent *)
+  ; parens_ite: bool
+  ; parens_tuple: [`Always | `Multi_line_only]
+  ; parens_tuple_patterns: [`Always | `Multi_line_only]
+  ; parse_docstrings: bool
+  ; quiet: bool
+  ; sequence_style: [`Separator | `Terminator]
+  ; single_case: [`Compact | `Sparse]
+  ; type_decl: [`Compact | `Sparse]
+  ; wrap_comments: bool  (** Wrap comments at margin. *)
+  ; wrap_fun_args: bool }
 
 let _ =
   match something with
@@ -109,197 +99,175 @@ type trace_mod_funs =
 [@@@ocamlformat "type-decl=sparse"]
 
 type t =
-  { aaaaaaaaa: aaaa;
-    bbbbbbbbb: bbbb }
+  { aaaaaaaaa: aaaa
+  ; bbbbbbbbb: bbbb }
 
 type trace_mod_funs =
-  { trace_mod: bool option;
-    trace_funs: bool Map.M(String).t }
+  { trace_mod: bool option
+  ; trace_funs: bool Map.M(String).t }
 
 let x {aaaaaaaaaaaaaa; aaaaaaaaaaaaa; aaaaaaaaaa} =
   {aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa; bbbbbbbbbbbbb= bbb bb bbbbbb}
 
 let x
-    { aaaaaaaaaaaaaaaaaaaaaa;
-      aaaaaaaaaaaaaaaaaaa;
-      aaaaaaaaaaaaaa;
-      aaaaaaaaaaaaaaaaaa;
-      aaaaaaaaaa } =
-  { aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
-    bbbbbbbbbbbbb= bbb bb bbbbbb;
-    cccccc= cccc ccccccccccccccccccccccc }
+    { aaaaaaaaaaaaaaaaaaaaaa
+    ; aaaaaaaaaaaaaaaaaaa
+    ; aaaaaaaaaaaaaa
+    ; aaaaaaaaaaaaaaaaaa
+    ; aaaaaaaaaa } =
+  { aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa
+  ; bbbbbbbbbbbbb= bbb bb bbbbbb
+  ; cccccc= cccc ccccccccccccccccccccccc }
 
 (* this is an array *)
 let length =
-  [| 0;
-     269999999999999999999999999999999999999999999999999;
-     26;
-     (* foo *) 27 (* foo *);
-     27;
-     27 |] [@foo]
+  [| 0
+   ; 269999999999999999999999999999999999999999999999999
+   ; 26
+   ; (* foo *) 27 (* foo *)
+   ; 27
+   ; 27 |] [@foo]
 
 (* this is a list *)
 let length =
-  ([ 0;
-    14;
-    (* foo *)
-    14;
-    17 (* foo *);
-    17;
-    2777777777777777777777777777777777;
-    27 ] [@foo])
+  ([ 0
+  ; 14
+  ; (* foo *)
+    14
+  ; 17 (* foo *)
+  ; 17
+  ; 2777777777777777777777777777777777
+  ; 27 ] [@foo])
 
 [@@@ocamlformat "break-collection-expressions=wrap"]
 
 (* this is an array *)
 let length =
-  [| 0; 1; 2; 3; 4; 5; 6; 7; 8; 8; 9; 9; 10; 10; 11; 11; 12; 12; 12; 12; 13;
-     25; 25; 25; 25; 25; 25; 25; 25; 25; 26; 26; 26; 26; 26; 26; 26; 26; 26;
-     26; 26; 26; 26; 26; 26;
-     269999999999999999999999999999999999999999999999999; 26; 26; 26; 26;
-     26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 27; 27; 27; 27; 27; 27;
-     27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27;
-     (* foo *) 27 (* foo *); 27; 27; 27; 27; 27; 27; 27; 27; 27; 28
+  [| 0; 1; 2; 3; 4; 5; 6; 7; 8; 8; 9; 9; 10; 10; 11; 11; 12; 12; 12; 12; 13
+   ; 25; 25; 25; 25; 25; 25; 25; 25; 25; 26; 26; 26; 26; 26; 26; 26; 26; 26
+   ; 26; 26; 26; 26; 26; 26
+   ; 269999999999999999999999999999999999999999999999999; 26; 26; 26; 26; 26
+   ; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 27; 27; 27; 27; 27; 27; 27
+   ; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27
+   ; (* foo *) 27 (* foo *); 27; 27; 27; 27; 27; 27; 27; 27; 27; 28
   |] [@foo]
 
 (* this is a list *)
 let length =
-  ([ 0; 1; 2; 3; 4; 5; 6; 7; 8; 8; 9; 9; 10; 10; 11; 11; 12; 12; 12; 12; 13;
-     13; 13; 13; 14; 14; 14; (* foo *) 14; 15; 15; 15; 15; 16; 16; 16; 16;
-     16; 16; 16; 16; 17; 17; 17; 17 (* foo *); 17; 17; 17; 17; 18; 18; 18;
-     18; 18; 18; 18; 18; 19; 19; 19; 19; 19; 19; 19; 19; 20; 20; 20; 20; 20;
-     20; 20; 20; 20; 20; 20; 26; 26; 26; 26; 26; 27; 27; 27; 27;
-     2777777777777777777777777777777777; 27; 27; 27; 27; 27; 27; 27; 27; 27;
-     27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 28
+  ([ 0; 1; 2; 3; 4; 5; 6; 7; 8; 8; 9; 9; 10; 10; 11; 11; 12; 12; 12; 12; 13
+   ; 13; 13; 13; 14; 14; 14; (* foo *) 14; 15; 15; 15; 15; 16; 16; 16; 16
+   ; 16; 16; 16; 16; 17; 17; 17; 17 (* foo *); 17; 17; 17; 17; 18; 18; 18
+   ; 18; 18; 18; 18; 18; 19; 19; 19; 19; 19; 19; 19; 19; 20; 20; 20; 20; 20
+   ; 20; 20; 20; 20; 20; 20; 26; 26; 26; 26; 26; 27; 27; 27; 27
+   ; 2777777777777777777777777777777777; 27; 27; 27; 27; 27; 27; 27; 27; 27
+   ; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 28
   ] [@foo])
 
 class
-  [ 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
-    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ]
+  [ 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  , 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ]
   x =
-  [ 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
-    'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy ]
+  [ 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  , 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy ]
   k
 
-type ( 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
-       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
+type ( 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+     , 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
      a =
-  ( 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
-    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
+  ( 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  , 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
   e
 
-type ( 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
-       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
+type ( 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+     , 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
      a =
   ('aaaaaaaaa, 'bbbbbbbbbbbb) e
 
-let ( xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
-      yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy,
-      zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz,
-      (aaaaaaaaaaaa, bbbbbbbbbbbb) ) =
-  ( ( xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
-      yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy,
-      zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz ),
-    (aaaaaaaaaaaaaa, bbbbbbbbbbbb) )
+let ( xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    , yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+    , zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+    , (aaaaaaaaaaaa, bbbbbbbbbbbb) ) =
+  ( ( xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    , yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+    , zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz )
+  , (aaaaaaaaaaaaaa, bbbbbbbbbbbb) )
 
 type t = aaaaaaaaaaaa -> bbbbbbbbbbbb -> cccccccccc
 
 type t =
-  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
-  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ->
-  ccccccccccccccccccccccccc
+     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  -> bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  -> ccccccccccccccccccccccccc
 
 type t =
-  (* foooooooooooo *)
-  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
-  (* foooooooooooooooooooooooooooooooo*)
-  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ->
-  (* fooooooooooooooooo *)
-  ccccccccccccccccccccccccc ->
-  (* foooooo *)
-  foo * [`Foo of foo * foo] ->
-  (* foooooooooooooooo *)
-  foo
-  * foo
-  * foo
-  * foo
-  * [ `Foo of
-      (* fooooooooooooooooooo *)
-      foo * foo * foo ->
-      foo ->
-      foo ->
-      (* foooooooooooo *)
-      foo ->
-      foo ->
-      foo * foo ->
-      foo * foo ->
-      foo * foo ] ->
-  (* foooooooooooooooo *)
-  fooooooooooooooooo
+     (* foooooooooooo *)
+     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  -> (* foooooooooooooooooooooooooooooooo*)
+     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  -> (* fooooooooooooooooo *)
+     ccccccccccccccccccccccccc
+  -> (* foooooo *)
+     foo * [`Foo of foo * foo]
+  -> (* foooooooooooooooo *)
+     foo
+     * foo
+     * foo
+     * foo
+     * [ `Foo of
+            (* fooooooooooooooooooo *)
+            foo * foo * foo
+         -> foo
+         -> foo
+         -> (* foooooooooooo *)
+            foo
+         -> foo
+         -> foo * foo
+         -> foo * foo
+         -> foo * foo ]
+  -> (* foooooooooooooooo *)
+     fooooooooooooooooo
 
 type t =
   { (* fooooooooooooooooo *)
-    foo: foo;
-    (* foooooooooooooooooooooo fooooooooooooooooooo fooooooooooooooo
+    foo: foo
+  ; (* foooooooooooooooooooooo fooooooooooooooooooo fooooooooooooooo
        foooooooooooooooooo foooooooooooooooo *)
     foo:
-      (* fooooooooooooooooooo *)
-      foooooooooooo ->
-      (* foooooooooooooo *)
-      foooooooooooooooo ->
-      foooooooooooooo ->
-      foooooooooo ->
-      fooooooooooooooo;
-    foo: foo }
+         (* fooooooooooooooooooo *)
+         foooooooooooo
+      -> (* foooooooooooooo *)
+         foooooooooooooooo
+      -> foooooooooooooo
+      -> foooooooooo
+      -> fooooooooooooooo
+  ; foo: foo }
 
 [@@@ocamlformat "ocp-indent-compat"]
 
 type t =
-  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
-  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ->
-  ccccccccccccccccccccccccc
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  -> bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  -> ccccccccccccccccccccccccc
 
 type t =
-  (string Location.loc * payload) list ->
-  (string Location.loc * bool) list option
-  * (string Location.loc * payload) list ->
-  (string Location.loc * bool) list option
-  * (string Location.loc * payload) list ->
-  (string Location.loc * bool) list option
-  * (string Location.loc * payload) list
-
-[@@@ocamlformat "break-separators=after-and-docked"]
-
-type t = {
-  aaaaaaaaaaaaaaaaaaaaaaaaa: aaaa aaaaaaaaaaaaaaaaaaa;
-  bbbbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbb bbbb;
-  cccccccccccccccccccccc: ccccccc ccccccccccc cccccccc
-}
-
-type t = {
-  (* fooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
-  foooooooooooooooooooooooo: foooooooooooooooooooooooooooooooooooooooo;
-  (* foooooooooooooooooooooooooooooooooooooooooooo *)
-  fooooooooooooooooooooooooooooo: fooooooooooooooooooooooooooo
-}
-
-type x =
-  | B of
-      { aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
-        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
+  (string Location.loc * payload) list
+  -> (string Location.loc * bool) list option
+     * (string Location.loc * payload) list
+  -> (string Location.loc * bool) list option
+     * (string Location.loc * payload) list
+  -> (string Location.loc * bool) list option
+     * (string Location.loc * payload) list
 
 let x {aaaaaaaaaaaaaa; aaaaaaaaaaaaa; aaaaaaaaaa} =
   {aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa; bbbbbbbbbbbbb= bbb bb bbbbbb}
 
 let x
-    { aaaaaaaaaaaaaaaaaaaaaa;
-      aaaaaaaaaaaaaaaaaaa;
-      aaaaaaaaaaaaaa;
-      aaaaaaaaaaaaaaaaaa;
-      aaaaaaaaaa }
+    { aaaaaaaaaaaaaaaaaaaaaa
+    ; aaaaaaaaaaaaaaaaaaa
+    ; aaaaaaaaaaaaaa
+    ; aaaaaaaaaaaaaaaaaa
+    ; aaaaaaaaaa }
   =
-  {
-    aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
-    bbbbbbbbbbbbb= bbb bb bbbbbb;
-    cccccc= cccc ccccccccccccccccccccccc
-  }
+  { aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa
+  ; bbbbbbbbbbbbb= bbb bb bbbbbb
+  ; cccccc= cccc ccccccccccccccccccccccc }

--- a/test/passing/break_separators.ml
+++ b/test/passing/break_separators.ml
@@ -289,3 +289,11 @@ let foooooooooooo =
     (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
     fooooooooooooooooooooooooooooo= fooooooooooooo
   ; fooooooooooooo= foooooooooooooo }
+
+let fooooooooooo = function
+  | Pmty_alias lid ->
+      { empty with
+        bdy= fmt_longident_loc c lid
+      ; epi=
+          Some (fmt_attributes c ~key:"@" pmty_attributes ~pre:(fmt "@ "))
+      }

--- a/test/passing/break_separators.ml.opts
+++ b/test/passing/break_separators.ml.opts
@@ -1,0 +1,1 @@
+--break-separators=before

--- a/test/passing/break_separators_after.ml
+++ b/test/passing/break_separators_after.ml
@@ -1,0 +1,1 @@
+break_separators.ml

--- a/test/passing/break_separators_after.ml.opts
+++ b/test/passing/break_separators_after.ml.opts
@@ -1,0 +1,1 @@
+--break-separators=after

--- a/test/passing/break_separators_after.ml.ref
+++ b/test/passing/break_separators_after.ml.ref
@@ -289,3 +289,11 @@ let foooooooooooo =
     (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
     fooooooooooooooooooooooooooooo= fooooooooooooo;
     fooooooooooooo= foooooooooooooo }
+
+let fooooooooooo = function
+  | Pmty_alias lid ->
+      { empty with
+        bdy= fmt_longident_loc c lid;
+        epi=
+          Some (fmt_attributes c ~key:"@" pmty_attributes ~pre:(fmt "@ "))
+      }

--- a/test/passing/break_separators_after.ml.ref
+++ b/test/passing/break_separators_after.ml.ref
@@ -278,3 +278,14 @@ let foooooooooooooooooooooooooooooooooo =
     (* fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
     bbbbbbbbbbbbb= bbb bb bbbbbb;
     cccccc= cccc ccccccccccccccccccccccc }
+
+let foooooooooooo =
+  { foooooooooooooo with
+    fooooooooooooooooooooooooooooo= fooooooooooooo;
+    fooooooooooooo= foooooooooooooo }
+
+let foooooooooooo =
+  { foooooooooooooo with
+    (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
+    fooooooooooooooooooooooooooooo= fooooooooooooo;
+    fooooooooooooo= foooooooooooooo }

--- a/test/passing/break_separators_after.ml.ref
+++ b/test/passing/break_separators_after.ml.ref
@@ -247,3 +247,10 @@ let x
   { aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
     bbbbbbbbbbbbb= bbb bb bbbbbb;
     cccccc= cccc ccccccccccccccccccccccc }
+
+let foooooooooooooooooooooooooooooooooo =
+  { (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
+    aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
+    (* fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
+    bbbbbbbbbbbbb= bbb bb bbbbbb;
+    cccccc= cccc ccccccccccccccccccccccc }

--- a/test/passing/break_separators_after.ml.ref
+++ b/test/passing/break_separators_after.ml.ref
@@ -1,0 +1,249 @@
+type t =
+  { (* fooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
+    foooooooooooooooooooooooo: foooooooooooooooooooooooooooooooooooooooo;
+    (* foooooooooooooooooooooooooooooooooooooooooooo *)
+    fooooooooooooooooooooooooooooo: fooooooooooooooooooooooooooo }
+
+type x =
+  | B of
+      { (* fooooooooooooooooooooooooooooooooooooooooo *)
+      aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
+        (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo*)
+      bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
+
+type t =
+  { aaaaaaaaaaaaaaaaaaaaaaaaa: aaaa aaaaaaaaaaaaaaaaaaa;
+    bbbbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbb bbbb;
+    cccccccccccccccccccccc: ccccccc ccccccccccc cccccccc }
+
+type x =
+  | B of
+      { aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
+        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
+
+type t =
+  { break_cases: [`Fit | `Nested | `All];
+    break_collection_expressions: [`Wrap | `Fit_or_vertical];
+    break_infix: [`Wrap | `Fit_or_vertical];
+    break_separators: bool;
+    break_sequences: bool;
+    break_string_literals: [`Newlines | `Never | `Wrap];
+        (** How to potentially break string literals into new lines. *)
+    break_struct: bool;
+    cases_exp_indent: int;
+    comment_check: bool;
+    disable: bool;
+    doc_comments: [`Before | `After];
+    escape_chars: [`Decimal | `Hexadecimal | `Preserve];
+        (** Escape encoding for chars literals. *)
+    escape_strings: [`Decimal | `Hexadecimal | `Preserve];
+        (** Escape encoding for string literals. *)
+    extension_sugar: [`Preserve | `Always];
+    field_space: [`Tight | `Loose];
+    if_then_else: [`Compact | `Keyword_first];
+    indicate_multiline_delimiters: bool;
+    indicate_nested_or_patterns: bool;
+    infix_precedence: [`Indent | `Parens];
+    leading_nested_match_parens: bool;
+    let_and: [`Compact | `Sparse];
+    let_binding_spacing: [`Compact | `Sparse | `Double_semicolon];
+    let_open: [`Preserve | `Auto | `Short | `Long];
+    margin: int;  (** Format code to fit within [margin] columns. *)
+    max_iters: int;
+        (** Fail if output of formatting does not stabilize within
+            [max_iters] iterations. *)
+    module_item_spacing: [`Compact | `Sparse];
+    ocp_indent_compat: bool;  (** Try to indent like ocp-indent *)
+    parens_ite: bool;
+    parens_tuple: [`Always | `Multi_line_only];
+    parens_tuple_patterns: [`Always | `Multi_line_only];
+    parse_docstrings: bool;
+    quiet: bool;
+    sequence_style: [`Separator | `Terminator];
+    single_case: [`Compact | `Sparse];
+    type_decl: [`Compact | `Sparse];
+    wrap_comments: bool;  (** Wrap comments at margin. *)
+    wrap_fun_args: bool }
+
+[@@@ocamlformat "type-decl=compact"]
+
+type t = {aaaaaaaaa: aaaa; bbbbbbbbb: bbbb}
+
+type trace_mod_funs =
+  {trace_mod: bool option; trace_funs: bool Map.M(String).t}
+
+[@@@ocamlformat "type-decl=sparse"]
+
+type t =
+  { aaaaaaaaa: aaaa;
+    bbbbbbbbb: bbbb }
+
+type trace_mod_funs =
+  { trace_mod: bool option;
+    trace_funs: bool Map.M(String).t }
+
+let x {aaaaaaaaaaaaaa; aaaaaaaaaaaaa; aaaaaaaaaa} =
+  {aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa; bbbbbbbbbbbbb= bbb bb bbbbbb}
+
+let x
+    { aaaaaaaaaaaaaaaaaaaaaa;
+      aaaaaaaaaaaaaaaaaaa;
+      aaaaaaaaaaaaaa;
+      aaaaaaaaaaaaaaaaaa;
+      aaaaaaaaaa } =
+  { aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
+    bbbbbbbbbbbbb= bbb bb bbbbbb;
+    cccccc= cccc ccccccccccccccccccccccc }
+
+(* this is an array *)
+let length =
+  [| 0;
+     269999999999999999999999999999999999999999999999999;
+     26;
+     (* foo *) 27 (* foo *);
+     27;
+     27 |] [@foo]
+
+(* this is a list *)
+let length =
+  ([ 0;
+    14;
+    (* foo *)
+    14;
+    17 (* foo *);
+    17;
+    2777777777777777777777777777777777;
+    27 ] [@foo])
+
+[@@@ocamlformat "break-collection-expressions=wrap"]
+
+(* this is an array *)
+let length =
+  [| 0; 1; 2; 3; 4; 5; 6; 7; 8; 8; 9; 9; 10; 10; 11; 11; 12; 12; 12; 12; 13;
+     25; 25; 25; 25; 25; 25; 25; 25; 25; 26; 26; 26; 26; 26; 26; 26; 26; 26;
+     26; 26; 26; 26; 26; 26;
+     269999999999999999999999999999999999999999999999999; 26; 26; 26; 26;
+     26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 27; 27; 27; 27; 27; 27;
+     27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27;
+     (* foo *) 27 (* foo *); 27; 27; 27; 27; 27; 27; 27; 27; 27; 28
+  |] [@foo]
+
+(* this is a list *)
+let length =
+  ([ 0; 1; 2; 3; 4; 5; 6; 7; 8; 8; 9; 9; 10; 10; 11; 11; 12; 12; 12; 12; 13;
+     13; 13; 13; 14; 14; 14; (* foo *) 14; 15; 15; 15; 15; 16; 16; 16; 16;
+     16; 16; 16; 16; 17; 17; 17; 17 (* foo *); 17; 17; 17; 17; 18; 18; 18;
+     18; 18; 18; 18; 18; 19; 19; 19; 19; 19; 19; 19; 19; 20; 20; 20; 20; 20;
+     20; 20; 20; 20; 20; 20; 26; 26; 26; 26; 26; 27; 27; 27; 27;
+     2777777777777777777777777777777777; 27; 27; 27; 27; 27; 27; 27; 27; 27;
+     27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 28
+  ] [@foo])
+
+class
+  [ 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ]
+  x =
+  [ 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+    'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy ]
+  k
+
+type ( 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
+     a =
+  ( 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
+  e
+
+type ( 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
+     a =
+  ('aaaaaaaaa, 'bbbbbbbbbbbb) e
+
+let ( xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+      yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy,
+      zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz,
+      (aaaaaaaaaaaa, bbbbbbbbbbbb) ) =
+  ( ( xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+      yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy,
+      zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz ),
+    (aaaaaaaaaaaaaa, bbbbbbbbbbbb) )
+
+type t = aaaaaaaaaaaa -> bbbbbbbbbbbb -> cccccccccc
+
+type t =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ->
+  ccccccccccccccccccccccccc
+
+type t =
+  (* foooooooooooo *)
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+  (* foooooooooooooooooooooooooooooooo*)
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ->
+  (* fooooooooooooooooo *)
+  ccccccccccccccccccccccccc ->
+  (* foooooo *)
+  foo * [`Foo of foo * foo] ->
+  (* foooooooooooooooo *)
+  foo
+  * foo
+  * foo
+  * foo
+  * [ `Foo of
+      (* fooooooooooooooooooo *)
+      foo * foo * foo ->
+      foo ->
+      foo ->
+      (* foooooooooooo *)
+      foo ->
+      foo ->
+      foo * foo ->
+      foo * foo ->
+      foo * foo ] ->
+  (* foooooooooooooooo *)
+  fooooooooooooooooo
+
+type t =
+  { (* fooooooooooooooooo *)
+    foo: foo;
+    (* foooooooooooooooooooooo fooooooooooooooooooo fooooooooooooooo
+       foooooooooooooooooo foooooooooooooooo *)
+    foo:
+      (* fooooooooooooooooooo *)
+      foooooooooooo ->
+      (* foooooooooooooo *)
+      foooooooooooooooo ->
+      foooooooooooooo ->
+      foooooooooo ->
+      fooooooooooooooo;
+    foo: foo }
+
+[@@@ocamlformat "ocp-indent-compat"]
+
+type t =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ->
+  ccccccccccccccccccccccccc
+
+type t =
+  (string Location.loc * payload) list ->
+  (string Location.loc * bool) list option
+  * (string Location.loc * payload) list ->
+  (string Location.loc * bool) list option
+  * (string Location.loc * payload) list ->
+  (string Location.loc * bool) list option
+  * (string Location.loc * payload) list
+
+let x {aaaaaaaaaaaaaa; aaaaaaaaaaaaa; aaaaaaaaaa} =
+  {aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa; bbbbbbbbbbbbb= bbb bb bbbbbb}
+
+let x
+    { aaaaaaaaaaaaaaaaaaaaaa;
+      aaaaaaaaaaaaaaaaaaa;
+      aaaaaaaaaaaaaa;
+      aaaaaaaaaaaaaaaaaa;
+      aaaaaaaaaa }
+  =
+  { aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
+    bbbbbbbbbbbbb= bbb bb bbbbbb;
+    cccccc= cccc ccccccccccccccccccccccc }

--- a/test/passing/break_separators_after.ml.ref
+++ b/test/passing/break_separators_after.ml.ref
@@ -7,9 +7,9 @@ type t =
 type x =
   | B of
       { (* fooooooooooooooooooooooooooooooooooooooooo *)
-      aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
+        aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
         (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo*)
-      bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
+        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
 
 type t =
   { aaaaaaaaaaaaaaaaaaaaaaaaa: aaaa aaaaaaaaaaaaaaaaaaa;

--- a/test/passing/break_separators_after.ml.ref
+++ b/test/passing/break_separators_after.ml.ref
@@ -65,6 +65,30 @@ type t =
     wrap_comments: bool;  (** Wrap comments at margin. *)
     wrap_fun_args: bool }
 
+let _ =
+  match something with
+  | { very_very_long_field_name_running_out_of_space= 1;
+      another_very_very_long_field_name_running_out_of_space= 2;
+      _ } ->
+      0
+  | _ -> 1
+
+let _ =
+  match something with
+  | [ very_very_long_field_name_running_out_of_space;
+      another_very_very_long_field_name_running_out_of_space;
+      _ ] ->
+      0
+  | _ -> 1
+
+let _ =
+  match something with
+  | [| very_very_long_field_name_running_out_of_space;
+       another_very_very_long_field_name_running_out_of_space;
+       _ |] ->
+      0
+  | _ -> 1
+
 [@@@ocamlformat "type-decl=compact"]
 
 type t = {aaaaaaaaa: aaaa; bbbbbbbbb: bbbb}

--- a/test/passing/break_separators_after_docked.ml
+++ b/test/passing/break_separators_after_docked.ml
@@ -1,0 +1,1 @@
+break_separators.ml

--- a/test/passing/break_separators_after_docked.ml.opts
+++ b/test/passing/break_separators_after_docked.ml.opts
@@ -1,0 +1,1 @@
+--break-separators=after-and-docked

--- a/test/passing/break_separators_after_docked.ml.ref
+++ b/test/passing/break_separators_after_docked.ml.ref
@@ -292,3 +292,18 @@ let foooooooooooooooooooooooooooooooooo =
     bbbbbbbbbbbbb= bbb bb bbbbbb;
     cccccc= cccc ccccccccccccccccccccccc
   }
+
+let foooooooooooo =
+  {
+    foooooooooooooo with
+    fooooooooooooooooooooooooooooo= fooooooooooooo;
+    fooooooooooooo= foooooooooooooo
+  }
+
+let foooooooooooo =
+  {
+    foooooooooooooo with
+    (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
+    fooooooooooooooooooooooooooooo= fooooooooooooo;
+    fooooooooooooo= foooooooooooooo
+  }

--- a/test/passing/break_separators_after_docked.ml.ref
+++ b/test/passing/break_separators_after_docked.ml.ref
@@ -307,3 +307,12 @@ let foooooooooooo =
     fooooooooooooooooooooooooooooo= fooooooooooooo;
     fooooooooooooo= foooooooooooooo
   }
+
+let fooooooooooo = function
+  | Pmty_alias lid ->
+      {
+        empty with
+        bdy= fmt_longident_loc c lid;
+        epi=
+          Some (fmt_attributes c ~key:"@" pmty_attributes ~pre:(fmt "@ "))
+      }

--- a/test/passing/break_separators_after_docked.ml.ref
+++ b/test/passing/break_separators_after_docked.ml.ref
@@ -8,9 +8,9 @@ type t = {
 type x =
   | B of
       { (* fooooooooooooooooooooooooooooooooooooooooo *)
-      aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
+        aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
         (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo*)
-      bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
+        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
 
 type t = {
   aaaaaaaaaaaaaaaaaaaaaaaaa: aaaa aaaaaaaaaaaaaaaaaaa;

--- a/test/passing/break_separators_after_docked.ml.ref
+++ b/test/passing/break_separators_after_docked.ml.ref
@@ -68,6 +68,30 @@ type t = {
   wrap_fun_args: bool
 }
 
+let _ =
+  match something with
+  | { very_very_long_field_name_running_out_of_space= 1;
+      another_very_very_long_field_name_running_out_of_space= 2;
+      _ } ->
+      0
+  | _ -> 1
+
+let _ =
+  match something with
+  | [ very_very_long_field_name_running_out_of_space;
+      another_very_very_long_field_name_running_out_of_space;
+      _ ] ->
+      0
+  | _ -> 1
+
+let _ =
+  match something with
+  | [| very_very_long_field_name_running_out_of_space;
+       another_very_very_long_field_name_running_out_of_space;
+       _ |] ->
+      0
+  | _ -> 1
+
 [@@@ocamlformat "type-decl=compact"]
 
 type t = {aaaaaaaaa: aaaa; bbbbbbbbb: bbbb}

--- a/test/passing/break_separators_after_docked.ml.ref
+++ b/test/passing/break_separators_after_docked.ml.ref
@@ -1,0 +1,261 @@
+type t = {
+  (* fooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
+  foooooooooooooooooooooooo: foooooooooooooooooooooooooooooooooooooooo;
+  (* foooooooooooooooooooooooooooooooooooooooooooo *)
+  fooooooooooooooooooooooooooooo: fooooooooooooooooooooooooooo
+}
+
+type x =
+  | B of
+      { (* fooooooooooooooooooooooooooooooooooooooooo *)
+      aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
+        (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo*)
+      bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
+
+type t = {
+  aaaaaaaaaaaaaaaaaaaaaaaaa: aaaa aaaaaaaaaaaaaaaaaaa;
+  bbbbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbb bbbb;
+  cccccccccccccccccccccc: ccccccc ccccccccccc cccccccc
+}
+
+type x =
+  | B of
+      { aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
+        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
+
+type t = {
+  break_cases: [`Fit | `Nested | `All];
+  break_collection_expressions: [`Wrap | `Fit_or_vertical];
+  break_infix: [`Wrap | `Fit_or_vertical];
+  break_separators: bool;
+  break_sequences: bool;
+  break_string_literals: [`Newlines | `Never | `Wrap];
+      (** How to potentially break string literals into new lines. *)
+  break_struct: bool;
+  cases_exp_indent: int;
+  comment_check: bool;
+  disable: bool;
+  doc_comments: [`Before | `After];
+  escape_chars: [`Decimal | `Hexadecimal | `Preserve];
+      (** Escape encoding for chars literals. *)
+  escape_strings: [`Decimal | `Hexadecimal | `Preserve];
+      (** Escape encoding for string literals. *)
+  extension_sugar: [`Preserve | `Always];
+  field_space: [`Tight | `Loose];
+  if_then_else: [`Compact | `Keyword_first];
+  indicate_multiline_delimiters: bool;
+  indicate_nested_or_patterns: bool;
+  infix_precedence: [`Indent | `Parens];
+  leading_nested_match_parens: bool;
+  let_and: [`Compact | `Sparse];
+  let_binding_spacing: [`Compact | `Sparse | `Double_semicolon];
+  let_open: [`Preserve | `Auto | `Short | `Long];
+  margin: int;  (** Format code to fit within [margin] columns. *)
+  max_iters: int;
+      (** Fail if output of formatting does not stabilize within [max_iters]
+          iterations. *)
+  module_item_spacing: [`Compact | `Sparse];
+  ocp_indent_compat: bool;  (** Try to indent like ocp-indent *)
+  parens_ite: bool;
+  parens_tuple: [`Always | `Multi_line_only];
+  parens_tuple_patterns: [`Always | `Multi_line_only];
+  parse_docstrings: bool;
+  quiet: bool;
+  sequence_style: [`Separator | `Terminator];
+  single_case: [`Compact | `Sparse];
+  type_decl: [`Compact | `Sparse];
+  wrap_comments: bool;  (** Wrap comments at margin. *)
+  wrap_fun_args: bool
+}
+
+[@@@ocamlformat "type-decl=compact"]
+
+type t = {aaaaaaaaa: aaaa; bbbbbbbbb: bbbb}
+
+type trace_mod_funs = {
+  trace_mod: bool option;
+  trace_funs: bool Map.M(String).t
+}
+
+[@@@ocamlformat "type-decl=sparse"]
+
+type t = {
+  aaaaaaaaa: aaaa;
+  bbbbbbbbb: bbbb
+}
+
+type trace_mod_funs = {
+  trace_mod: bool option;
+  trace_funs: bool Map.M(String).t
+}
+
+let x {aaaaaaaaaaaaaa; aaaaaaaaaaaaa; aaaaaaaaaa} =
+  {aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa; bbbbbbbbbbbbb= bbb bb bbbbbb}
+
+let x
+    { aaaaaaaaaaaaaaaaaaaaaa;
+      aaaaaaaaaaaaaaaaaaa;
+      aaaaaaaaaaaaaa;
+      aaaaaaaaaaaaaaaaaa;
+      aaaaaaaaaa } =
+  {
+    aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
+    bbbbbbbbbbbbb= bbb bb bbbbbb;
+    cccccc= cccc ccccccccccccccccccccccc
+  }
+
+(* this is an array *)
+let length =
+  [| 0;
+     269999999999999999999999999999999999999999999999999;
+     26;
+     (* foo *) 27 (* foo *);
+     27;
+     27 |] [@foo]
+
+(* this is a list *)
+let length =
+  ([ 0;
+    14;
+    (* foo *)
+    14;
+    17 (* foo *);
+    17;
+    2777777777777777777777777777777777;
+    27 ] [@foo])
+
+[@@@ocamlformat "break-collection-expressions=wrap"]
+
+(* this is an array *)
+let length =
+  [| 0; 1; 2; 3; 4; 5; 6; 7; 8; 8; 9; 9; 10; 10; 11; 11; 12; 12; 12; 12; 13;
+     25; 25; 25; 25; 25; 25; 25; 25; 25; 26; 26; 26; 26; 26; 26; 26; 26; 26;
+     26; 26; 26; 26; 26; 26;
+     269999999999999999999999999999999999999999999999999; 26; 26; 26; 26;
+     26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 27; 27; 27; 27; 27; 27;
+     27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27;
+     (* foo *) 27 (* foo *); 27; 27; 27; 27; 27; 27; 27; 27; 27; 28
+  |] [@foo]
+
+(* this is a list *)
+let length =
+  ([ 0; 1; 2; 3; 4; 5; 6; 7; 8; 8; 9; 9; 10; 10; 11; 11; 12; 12; 12; 12; 13;
+     13; 13; 13; 14; 14; 14; (* foo *) 14; 15; 15; 15; 15; 16; 16; 16; 16;
+     16; 16; 16; 16; 17; 17; 17; 17 (* foo *); 17; 17; 17; 17; 18; 18; 18;
+     18; 18; 18; 18; 18; 19; 19; 19; 19; 19; 19; 19; 19; 20; 20; 20; 20; 20;
+     20; 20; 20; 20; 20; 20; 26; 26; 26; 26; 26; 27; 27; 27; 27;
+     2777777777777777777777777777777777; 27; 27; 27; 27; 27; 27; 27; 27; 27;
+     27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 28
+  ] [@foo])
+
+class
+  [ 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ]
+  x =
+  [ 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+    'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy ]
+  k
+
+type ( 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
+     a =
+  ( 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
+  e
+
+type ( 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
+     a =
+  ('aaaaaaaaa, 'bbbbbbbbbbbb) e
+
+let ( xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+      yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy,
+      zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz,
+      (aaaaaaaaaaaa, bbbbbbbbbbbb) ) =
+  ( ( xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+      yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy,
+      zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz ),
+    (aaaaaaaaaaaaaa, bbbbbbbbbbbb) )
+
+type t = aaaaaaaaaaaa -> bbbbbbbbbbbb -> cccccccccc
+
+type t =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ->
+  ccccccccccccccccccccccccc
+
+type t =
+  (* foooooooooooo *)
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+  (* foooooooooooooooooooooooooooooooo*)
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ->
+  (* fooooooooooooooooo *)
+  ccccccccccccccccccccccccc ->
+  (* foooooo *)
+  foo * [`Foo of foo * foo] ->
+  (* foooooooooooooooo *)
+  foo
+  * foo
+  * foo
+  * foo
+  * [ `Foo of
+      (* fooooooooooooooooooo *)
+      foo * foo * foo ->
+      foo ->
+      foo ->
+      (* foooooooooooo *)
+      foo ->
+      foo ->
+      foo * foo ->
+      foo * foo ->
+      foo * foo ] ->
+  (* foooooooooooooooo *)
+  fooooooooooooooooo
+
+type t = {
+  (* fooooooooooooooooo *)
+  foo: foo;
+  (* foooooooooooooooooooooo fooooooooooooooooooo fooooooooooooooo
+     foooooooooooooooooo foooooooooooooooo *)
+  foo:
+    (* fooooooooooooooooooo *)
+    foooooooooooo ->
+    (* foooooooooooooo *)
+    foooooooooooooooo ->
+    foooooooooooooo ->
+    foooooooooo ->
+    fooooooooooooooo;
+  foo: foo
+}
+
+[@@@ocamlformat "ocp-indent-compat"]
+
+type t =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ->
+  ccccccccccccccccccccccccc
+
+type t =
+  (string Location.loc * payload) list ->
+  (string Location.loc * bool) list option
+  * (string Location.loc * payload) list ->
+  (string Location.loc * bool) list option
+  * (string Location.loc * payload) list ->
+  (string Location.loc * bool) list option
+  * (string Location.loc * payload) list
+
+let x {aaaaaaaaaaaaaa; aaaaaaaaaaaaa; aaaaaaaaaa} =
+  {aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa; bbbbbbbbbbbbb= bbb bb bbbbbb}
+
+let x
+    { aaaaaaaaaaaaaaaaaaaaaa;
+      aaaaaaaaaaaaaaaaaaa;
+      aaaaaaaaaaaaaa;
+      aaaaaaaaaaaaaaaaaa;
+      aaaaaaaaaa }
+  =
+  {
+    aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
+    bbbbbbbbbbbbb= bbb bb bbbbbb;
+    cccccc= cccc ccccccccccccccccccccccc
+  }

--- a/test/passing/break_separators_after_docked.ml.ref
+++ b/test/passing/break_separators_after_docked.ml.ref
@@ -259,3 +259,12 @@ let x
     bbbbbbbbbbbbb= bbb bb bbbbbb;
     cccccc= cccc ccccccccccccccccccccccc
   }
+
+let foooooooooooooooooooooooooooooooooo =
+  {
+    (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
+    aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
+    (* fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
+    bbbbbbbbbbbbb= bbb bb bbbbbb;
+    cccccc= cccc ccccccccccccccccccccccc
+  }


### PR DESCRIPTION
Improving #835, only changed the record expressions for now, if the result is alright we can do the same for lists and arrays.
We now get something like:
```ocaml
let long_variable_name =
  {
    xxx= 1;
    yyy= 2;
    yyy= 2;
    yyy= 2;
    yyy= 2;
    yyy= 2;
    yyy= 2;
    yyy= 2;
    yyy= 2;
    yyy= 2;
    zzz= 3
  }
in
foo
```
we cannot do better and put the opening `{` on the previous line due to the current implementation of expressions.