### PR TITLE
fix a bug in test/test.sh

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -167,11 +167,11 @@ for f in ${FAILING[@]}; do
             |wc -l)
         progress=$((refcount - curcount))
         printf "\e[33m[FAILED]\e[m \e[%dm\e[30m[CHANGE: %+d]\e[m %s\n" \
-            $name \
             $(if [ $progress -gt 0 ]; then echo 42; \
               elif [ $progress -eq 0 ]; then echo 43; \
               else echo 41; fi) \
-            $progress
+            $progress \
+            $name
         if [ -n "$ACCEPT" ]; then
 	    cp $TMP/$base failing-output/$base
         elif [ -n "$UPDATE" ]; then


### PR DESCRIPTION
The order of printf argument on the changed line was wrong, printing
the following error message with my use-case (addition of
a not-yet-working testfile for an in-progress feature):

```
./test.sh: line 169: printf: multiline_data_delimiters_style: invalid number
[FAILED] [CHANGE: +42] 41
```