### PR TITLE
Check that all locations have been considered during formatting

### DIFF
--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -605,15 +605,15 @@ let drop_inside t loc =
   clear t.cmts_before ; clear t.cmts_within ; clear t.cmts_after
 
 let has_before t loc =
-  Hashtbl.remove t.remaining loc ;
+  if !remove then Hashtbl.remove t.remaining loc ;
   Hashtbl.mem t.cmts_before loc
 
 let has_within t loc =
-  Hashtbl.remove t.remaining loc ;
+  if !remove then Hashtbl.remove t.remaining loc ;
   Hashtbl.mem t.cmts_within loc
 
 let has_after t loc =
-  Hashtbl.remove t.remaining loc ;
+  if !remove then Hashtbl.remove t.remaining loc ;
   Hashtbl.mem t.cmts_within loc || Hashtbl.mem t.cmts_after loc
 
 (** returns comments that have not been formatted *)

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -20,7 +20,8 @@ type t =
   { cmts_before: (Location.t, (string * Location.t) list) Hashtbl.t
   ; cmts_after: (Location.t, (string * Location.t) list) Hashtbl.t
   ; cmts_within: (Location.t, (string * Location.t) list) Hashtbl.t
-  ; source: Source.t }
+  ; source: Source.t
+  ; remaining: (Location.t, unit) Hashtbl.t }
 
 (** A tree of non-overlapping intervals. Intervals are non-overlapping if
     whenever 2 intervals share more than an end-point, then one contains the
@@ -150,7 +151,7 @@ module Loc_tree = struct
       Ast_mapper.{default_mapper with location}
       (map_ast Ast_mapper.{default_mapper with attribute} ast)
     |> ignore ;
-    of_list !locs
+    (of_list !locs, !locs)
 end
 
 module Cmt = struct
@@ -402,7 +403,8 @@ let init map_ast source asts comments_n_docstrings =
     { cmts_before= Hashtbl.create (module Location)
     ; cmts_after= Hashtbl.create (module Location)
     ; cmts_within= Hashtbl.create (module Location)
-    ; source }
+    ; source
+    ; remaining= Hashtbl.create (module Location) }
   in
   let comments = dedup_cmts map_ast asts comments_n_docstrings in
   if Conf.debug then
@@ -410,7 +412,10 @@ let init map_ast source asts comments_n_docstrings =
         Format.eprintf "%a %s %s@\n%!" Location.fmt loc txt
           (if Source.ends_line source loc then "eol" else "")) ;
   if not (List.is_empty comments) then (
-    let loc_tree = Loc_tree.of_ast map_ast asts in
+    let loc_tree, locs = Loc_tree.of_ast map_ast asts in
+    List.iter locs ~f:(fun loc ->
+        if not (Location.compare loc Location.none = 0) then
+          Hashtbl.set t.remaining ~key:loc ~data:()) ;
     if Conf.debug then
       Format.eprintf "@\n%a@\n@\n%!" (Fn.flip Loc_tree.dump) loc_tree ;
     let locs = Loc_tree.roots loc_tree in
@@ -455,7 +460,10 @@ let relocate t ~src ~before ~after =
     update_multi t.cmts_after src after ~f:(fun src_cmts dst_cmts ->
         List.append dst_cmts src_cmts) ;
     update_multi t.cmts_within src after ~f:(fun src_cmts dst_cmts ->
-        List.append dst_cmts src_cmts) )
+        List.append dst_cmts src_cmts) ;
+    Hashtbl.remove t.remaining src ;
+    Hashtbl.set t.remaining ~key:after ~data:() ;
+    Hashtbl.set t.remaining ~key:before ~data:() )
 
 let split_asterisk_prefixed (txt, {Location.loc_start}) =
   let len = Position.column loc_start + 3 in
@@ -512,7 +520,12 @@ let fmt_cmt (conf : Conf.t) cmt =
 let fmt_cmts t (conf : Conf.t) ?pro ?epi ?(eol = Fmt.fmt "@\n") ?(adj = eol)
     tbl loc =
   let open Fmt in
-  let find = if !remove then Hashtbl.find_and_remove else Hashtbl.find in
+  let find =
+    if !remove then (
+      Hashtbl.remove t.remaining loc ;
+      Hashtbl.find_and_remove )
+    else Hashtbl.find
+  in
   match find tbl loc with
   | None | Some [] -> noop
   | Some cmts ->
@@ -591,11 +604,16 @@ let drop_inside t loc =
   in
   clear t.cmts_before ; clear t.cmts_within ; clear t.cmts_after
 
-let has_before t loc = Hashtbl.mem t.cmts_before loc
+let has_before t loc =
+  Hashtbl.remove t.remaining loc ;
+  Hashtbl.mem t.cmts_before loc
 
-let has_within t loc = Hashtbl.mem t.cmts_within loc
+let has_within t loc =
+  Hashtbl.remove t.remaining loc ;
+  Hashtbl.mem t.cmts_within loc
 
 let has_after t loc =
+  Hashtbl.remove t.remaining loc ;
   Hashtbl.mem t.cmts_within loc || Hashtbl.mem t.cmts_after loc
 
 (** returns comments that have not been formatted *)
@@ -617,6 +635,8 @@ let remaining_comments t =
     [ get t.cmts_before "before"
     ; get t.cmts_within "within"
     ; get t.cmts_after "after" ]
+
+let remaining_locs t = Hashtbl.to_alist t.remaining |> List.map ~f:fst
 
 let diff x y =
   let norm z =

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -413,9 +413,10 @@ let init map_ast source asts comments_n_docstrings =
           (if Source.ends_line source loc then "eol" else "")) ;
   if not (List.is_empty comments) then (
     let loc_tree, locs = Loc_tree.of_ast map_ast asts in
-    List.iter locs ~f:(fun loc ->
-        if Conf.debug && not (Location.compare loc Location.none = 0) then
-          Hashtbl.set t.remaining ~key:loc ~data:()) ;
+    if Conf.debug then
+      List.iter locs ~f:(fun loc ->
+          if not (Location.compare loc Location.none = 0) then
+            Hashtbl.set t.remaining ~key:loc ~data:()) ;
     if Conf.debug then
       Format.eprintf "@\n%a@\n@\n%!" (Fn.flip Loc_tree.dump) loc_tree ;
     let locs = Loc_tree.roots loc_tree in

--- a/src/Cmts.mli
+++ b/src/Cmts.mli
@@ -118,6 +118,8 @@ val has_after : t -> Location.t -> bool
 val remaining_comments : t -> (Location.t * string * string * Sexp.t) list
 (** Returns comments that have not been formatted yet. *)
 
+val remaining_locs : t -> Location.t list
+
 val diff :
      (string * Location.t) list
   -> (string * Location.t) list


### PR DESCRIPTION
(depend on #862) 

In debug mode, check that all locations have been considered during formatting.
One could also activate that feature with a new flag if needed. 

This should help with fixing https://github.com/ocaml-ppx/ocamlformat/issues/744
We should probably aim at fixing all these warnings later.
   
```
Warning: Some locations have not been considered
File "src/Ast.ml", line 210, characters 25-40
File "src/Ast.ml", line 241, characters 20-26
File "src/Ast.ml", line 241, characters 44-55
File "src/Ast.ml", line 241, characters 49-55
File "src/Ast.ml", line 253, characters 20-26
File "src/Ast.ml", line 262, characters 33-39
File "src/Ast.ml", line 272, characters 34-40
File "src/Ast.ml", line 302, characters 21-48
File "src/Ast.ml", line 304, characters 20-49
File "src/Ast.ml", line 307, characters 22-62
File "src/Ast.ml", line 311, characters 23-50
File "src/Ast.ml", line 312, characters 18-45
File "src/Ast.ml", line 388, characters 20-49
File "src/Ast.ml", line 394, characters 23-50
File "src/Ast.ml", line 395, characters 18-45
File "src/Ast.ml", line 398, characters 9-73
File "src/Ast.ml", line 1336, characters 14-27
File "src/Ast.ml", line 1344, characters 14-27
File "src/Ast.ml", line 1509, characters 24-35
File "src/Ast.ml", line 1509, characters 29-35
File "src/Ast.ml", line 1516, characters 24-35
File "src/Ast.ml", line 1516, characters 29-35
File "src/Ast.ml", line 1529, characters 20-27
File "src/Ast.ml", line 1552, characters 51-72
File "src/Ast.ml", line 1555, characters 51-72
File "src/Ast.ml", line 1635, characters 51-71
File "src/Ast.ml", line 1638, characters 51-71
File "src/Ast.ml", line 1995, characters 53-73
File "src/Ast.ml", line 2001, characters 53-73
File "src/Ast.ml", line 2079, characters 51-71
File "src/Ast.ml", line 2083, characters 51-71
File "src/Ast.ml", line 2111, characters 54-71
File "src/Ast.ml", line 2111, characters 59-71
File "src/Ast.ml", line 2146, characters 26-32
File "src/Ast.ml", line 2159, characters 40-74
File "src/Ast.ml", line 2159, characters 56-74
```