### PR TITLE
Fix formatting of arguments when break-fun-decl=fit-or-vertical

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2444,7 +2444,7 @@ and fmt_class_expr c ?eol ?(box = true) ({ast= exp; _} as xexp) =
         (if Option.is_none eol then 2 else 1)
         (wrap_if parens "(" ")"
            ( hovbox 2
-               ( box_fun_decl_args c 4
+               ( box_fun_decl_args c 0
                    ( str "fun "
                    $ fmt_attributes c ~key:"@" pcl_attributes ~suf:(str " ")
                    $ wrap_fun_decl_args c (fmt_fun_args c xargs)
@@ -2583,20 +2583,26 @@ and fmt_class_field c ctx (cf : class_field) =
         let l, eq, expr = fmt_kind kind in
         hvbox 2
           ( hovbox 2
-              ( box_fun_decl_args c 4
-                  ( str "method" $ virtual_or_override kind
-                  $ fmt_if Poly.(priv = Private) "@ private"
-                  $ fmt "@ " $ fmt_str_loc c name $ list l "" Fn.id )
+              ( hovbox 4
+                  (box_fun_decl_args c 4
+                     ( hovbox 4
+                         ( str "method" $ virtual_or_override kind
+                         $ fmt_if Poly.(priv = Private) "@ private"
+                         $ fmt "@ " $ fmt_str_loc c name )
+                     $ list l "" Fn.id ))
               $ eq )
           $ expr )
     | Pcf_val (name, mut, kind) ->
         let l, eq, expr = fmt_kind kind in
         hvbox 2
           ( hovbox 2
-              ( box_fun_decl_args c 4
-                  ( str "val" $ virtual_or_override kind
-                  $ fmt_if Poly.(mut = Mutable) "@ mutable"
-                  $ fmt "@ " $ fmt_str_loc c name $ list l "" Fn.id )
+              ( hovbox 4
+                  (box_fun_decl_args c 4
+                     ( hovbox 4
+                         ( str "val" $ virtual_or_override kind
+                         $ fmt_if Poly.(mut = Mutable) "@ mutable"
+                         $ fmt "@ " $ fmt_str_loc c name )
+                     $ list l "" Fn.id ))
               $ eq )
           $ expr )
     | Pcf_constraint (t1, t2) ->
@@ -3262,14 +3268,16 @@ and fmt_class_exprs c ctx (cls : class_expr class_infos list) =
       in
       let class_exprs =
         hovbox 2
-          ( box_fun_decl_args c 2
-              ( str (if first then "class" else "and")
-              $ fmt_if Poly.(cl.pci_virt = Virtual) "@ virtual"
-              $ fmt "@ "
-              $ fmt_class_params c ctx cl.pci_params
-              $ fmt_str_loc c cl.pci_name
-              $ fmt_if (not (List.is_empty xargs)) "@ "
-              $ wrap_fun_decl_args c (fmt_fun_args c xargs)
+          ( hovbox 2
+              ( box_fun_decl_args c 2
+                  ( hovbox 2
+                      ( str (if first then "class" else "and")
+                      $ fmt_if Poly.(cl.pci_virt = Virtual) "@ virtual"
+                      $ fmt "@ "
+                      $ fmt_class_params c ctx cl.pci_params
+                      $ fmt_str_loc c cl.pci_name )
+                  $ fmt_if (not (List.is_empty xargs)) "@ "
+                  $ wrap_fun_decl_args c (fmt_fun_args c xargs) )
               $ opt ty (fun t ->
                     fmt " :@ " $ fmt_class_type c (sub_cty ~ctx t))
               $ fmt "@ =" )
@@ -3924,16 +3932,19 @@ and fmt_value_binding c ~rec_flag ~first ?ext ?in_ ?epi ctx binding =
   $ Cmts.fmt_before c pvb_loc
   $ hvbox indent
       ( hovbox 2
-          ( box_fun_decl_args c 4
-              ( fmt_or first "let" "and"
-              $ fmt_extension_suffix c ext
-              $ fmt_attributes c ~key:"@" at_attrs
-              $ fmt_if (first && Poly.(rec_flag = Recursive)) " rec"
-              $ fmt_or pat_has_cmt "@ " " "
-              $ fmt_pattern c xpat
-              $ fmt_if_k
-                  (not (List.is_empty xargs))
-                  (fmt "@ " $ wrap_fun_decl_args c (fmt_fun_args c xargs))
+          ( hovbox 4
+              ( box_fun_decl_args c 4
+                  ( hovbox 4
+                      ( fmt_or first "let" "and"
+                      $ fmt_extension_suffix c ext
+                      $ fmt_attributes c ~key:"@" at_attrs
+                      $ fmt_if (first && Poly.(rec_flag = Recursive)) " rec"
+                      $ fmt_or pat_has_cmt "@ " " "
+                      $ fmt_pattern c xpat )
+                  $ fmt_if_k
+                      (not (List.is_empty xargs))
+                      ( fmt "@ "
+                      $ wrap_fun_decl_args c (fmt_fun_args c xargs) ) )
               $ Option.call ~f:fmt_cstr )
           $ fmt_or_k c.conf.ocp_indent_compat
               (fits_breaks " =" "@;<1000 0>=")

--- a/src/Sugar.ml
+++ b/src/Sugar.ml
@@ -62,28 +62,6 @@ type arg_kind =
   | Val of arg_label * pattern xt * expression xt option
   | Newtypes of string loc list
 
-let args_location xargs =
-  let rec first_loc xargs =
-    match xargs with
-    | Val (_, {ast= {ppat_loc; _}; _}, _) :: _ -> ppat_loc
-    | Newtypes ({loc; _} :: _) :: _ -> loc
-    | Newtypes [] :: tl -> first_loc tl
-    | [] -> Location.none
-  in
-  let first_loc = first_loc xargs in
-  let last_loc =
-    List.fold_left
-      ~f:(fun p -> function
-        | Val (_, {ast= {ppat_loc; _}; _}, _) -> ppat_loc
-        | Newtypes ts ->
-            List.fold_left ~f:(fun _ {loc; _} -> loc) ~init:p ts)
-      ~init:first_loc xargs
-  in
-  Location.
-    { loc_start= first_loc.loc_start
-    ; loc_end= last_loc.loc_end
-    ; loc_ghost= true }
-
 let fun_ cmts ?(will_keep_first_ast_node = true) xexp =
   let rec fun_ ?(will_keep_first_ast_node = false) ({ast= exp; _} as xexp) =
     let ctx = Exp exp in

--- a/src/Sugar.mli
+++ b/src/Sugar.mli
@@ -39,10 +39,6 @@ type arg_kind =
   | Val of arg_label * pattern Ast.xt * expression Ast.xt option
   | Newtypes of string loc list
 
-val args_location : arg_kind list -> Location.t
-(** [args_location xargs] returns the location containing the arguments
-    [xargs] *)
-
 val fun_ :
      Cmts.t
   -> ?will_keep_first_ast_node:bool

--- a/test/passing/break_fun_decl-fit_or_vertical.ml.ref
+++ b/test/passing/break_fun_decl-fit_or_vertical.ml.ref
@@ -1,7 +1,6 @@
 class t =
   object
-    method
-        meth
+    method meth
         aaaaaaaaaaa
         bbbbbbbbbbbbbb
         ccccccccccccccccccc
@@ -43,34 +42,28 @@ let ffffffffffffffffffff
 
 class ffffffffffffffffffff aaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbb = g
 
-class
-  ffffffffffffffffffff
+class ffffffffffffffffffff
   aaaaaaaaaaaaaaaaaaaaaa
   bbbbbbbbbbbbbbbbbbbbbb
-  cccccccccccccccccccccc
-  = g
+  cccccccccccccccccccccc = g
 
-class
-  ffffffffffffffffffff
+class ffffffffffffffffffff
   aaaaaaaaaaaaaaaaaaaaaa
   bbbbbbbbbbbbbbbbbbbbbb
   cccccccccccccccccccccc
-  dddddddddddddddddddddd
-  = g
+  dddddddddddddddddddddd = g
 
 let ffffffffffffffffffff : aaaaaaaaaaaaaaaaaaaaaa -> bbbbbbbbbbbbbbbbbbbbbb
     =
   g
 
-let ffffffffffffffffffff
-    :
+let ffffffffffffffffffff :
        aaaaaaaaaaaaaaaaaaaaaa
     -> bbbbbbbbbbbbbbbbbbbbbb
     -> cccccccccccccccccccccc =
   g
 
-let ffffffffffffffffffff
-    :
+let ffffffffffffffffffff :
        aaaaaaaaaaaaaaaaaaaaaa
     -> bbbbbbbbbbbbbbbbbbbbbb
     -> cccccccccccccccccccccc

--- a/test/passing/break_fun_decl-fit_or_vertical.ml.ref
+++ b/test/passing/break_fun_decl-fit_or_vertical.ml.ref
@@ -1,11 +1,12 @@
 class t =
   object
-    method meth
-          aaaaaaaaaaa
-          bbbbbbbbbbbbbb
-          ccccccccccccccccccc
-          ddddddddddddddddddddd
-          eeeeeeeeeeeeeee =
+    method
+        meth
+        aaaaaaaaaaa
+        bbbbbbbbbbbbbb
+        ccccccccccccccccccc
+        ddddddddddddddddddddd
+        eeeeeeeeeeeeeee =
       body
   end
 
@@ -42,28 +43,34 @@ let ffffffffffffffffffff
 
 class ffffffffffffffffffff aaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbb = g
 
-class ffffffffffffffffffff
-  aaaaaaaaaaaaaaaaaaaaaa
-  bbbbbbbbbbbbbbbbbbbbbb
-  cccccccccccccccccccccc = g
-
-class ffffffffffffffffffff
+class
+  ffffffffffffffffffff
   aaaaaaaaaaaaaaaaaaaaaa
   bbbbbbbbbbbbbbbbbbbbbb
   cccccccccccccccccccccc
-  dddddddddddddddddddddd = g
+  = g
+
+class
+  ffffffffffffffffffff
+  aaaaaaaaaaaaaaaaaaaaaa
+  bbbbbbbbbbbbbbbbbbbbbb
+  cccccccccccccccccccccc
+  dddddddddddddddddddddd
+  = g
 
 let ffffffffffffffffffff : aaaaaaaaaaaaaaaaaaaaaa -> bbbbbbbbbbbbbbbbbbbbbb
     =
   g
 
-let ffffffffffffffffffff :
+let ffffffffffffffffffff
+    :
        aaaaaaaaaaaaaaaaaaaaaa
     -> bbbbbbbbbbbbbbbbbbbbbb
     -> cccccccccccccccccccccc =
   g
 
-let ffffffffffffffffffff :
+let ffffffffffffffffffff
+    :
        aaaaaaaaaaaaaaaaaaaaaa
     -> bbbbbbbbbbbbbbbbbbbbbb
     -> cccccccccccccccccccccc

--- a/test/passing/break_fun_decl-fit_or_vertical.ml.ref
+++ b/test/passing/break_fun_decl-fit_or_vertical.ml.ref
@@ -76,3 +76,11 @@ let ffffffffffffffffffff
     -> cccccccccccccccccccccc
     -> dddddddddddddddddddddd =
   g
+
+let fffffffffffffffffffffffffffffffffff x yyyyyyyyyyyyyyyyyyyyyyyyyyy = ()
+
+let fffffffffffffffffffffffffffffffffff
+    x
+    yyyyyyyyyyyyyyyyyyyyyyyyyyy
+    yyyyyyyyyyyyyyyyyyyyyyyyyyy =
+  ()

--- a/test/passing/break_fun_decl-smart.ml.ref
+++ b/test/passing/break_fun_decl-smart.ml.ref
@@ -1,11 +1,11 @@
 class t =
   object
     method meth
-          aaaaaaaaaaa
-          bbbbbbbbbbbbbb
-          ccccccccccccccccccc
-          ddddddddddddddddddddd
-          eeeeeeeeeeeeeee =
+        aaaaaaaaaaa
+        bbbbbbbbbbbbbb
+        ccccccccccccccccccc
+        ddddddddddddddddddddd
+        eeeeeeeeeeeeeee =
       body
   end
 

--- a/test/passing/break_fun_decl-smart.ml.ref
+++ b/test/passing/break_fun_decl-smart.ml.ref
@@ -65,3 +65,9 @@ let ffffffffffffffffffff :
     -> cccccccccccccccccccccc
     -> dddddddddddddddddddddd =
   g
+
+let fffffffffffffffffffffffffffffffffff x yyyyyyyyyyyyyyyyyyyyyyyyyyy = ()
+
+let fffffffffffffffffffffffffffffffffff
+    x yyyyyyyyyyyyyyyyyyyyyyyyyyy yyyyyyyyyyyyyyyyyyyyyyyyyyy =
+  ()

--- a/test/passing/break_fun_decl-wrap.ml.ref
+++ b/test/passing/break_fun_decl-wrap.ml.ref
@@ -47,3 +47,9 @@ let ffffffffffffffffffff :
     -> cccccccccccccccccccccc
     -> dddddddddddddddddddddd =
   g
+
+let fffffffffffffffffffffffffffffffffff x yyyyyyyyyyyyyyyyyyyyyyyyyyy = ()
+
+let fffffffffffffffffffffffffffffffffff x yyyyyyyyyyyyyyyyyyyyyyyyyyy
+    yyyyyyyyyyyyyyyyyyyyyyyyyyy =
+  ()

--- a/test/passing/break_fun_decl.ml
+++ b/test/passing/break_fun_decl.ml
@@ -47,3 +47,9 @@ let ffffffffffffffffffff :
     -> cccccccccccccccccccccc
     -> dddddddddddddddddddddd =
   g
+
+let fffffffffffffffffffffffffffffffffff x yyyyyyyyyyyyyyyyyyyyyyyyyyy = ()
+
+let fffffffffffffffffffffffffffffffffff x yyyyyyyyyyyyyyyyyyyyyyyyyyy
+    yyyyyyyyyyyyyyyyyyyyyyyyyyy =
+  ()

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -1463,8 +1463,7 @@ let ty_abc : (([ `A of int | `B of string | `C ] as 'a), 'e) ty =
          ; "C", TCnoarg (Ttl (Ttl Thd))
          ]
 
-       method
-           inj
+       method inj
            : type c.  (int -> string -> noarg -> unit, c) ty_sel * c
                    -> [ `A of int | `B of string | `C ] =
          function
@@ -2471,11 +2470,7 @@ type (_, _, _) binop =
   | Leq : ('a, 'a, bool) binop
   | Add : (int, int, int) binop
 
-let eval
-    (type a b c)
-    (bop : (a, b, c) binop)
-    (x : a constant)
-    (y : b constant)
+let eval (type a b c) (bop : (a, b, c) binop) (x : a constant) (y : b constant)
     : c constant
   =
   match bop, x, y with
@@ -2723,8 +2718,7 @@ let vexpr (type visit_action) : ('a, 'result, visit_action) context -> 'a -> vis
   | Global -> fun _ -> raise Exit
 ;;
 
-let vexpr
-    (type result visit_action)
+let vexpr (type result visit_action)
     : (unit, result, visit_action) context -> unit -> visit_action
   = function
   | Local -> fun _ -> raise Exit

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -1463,7 +1463,8 @@ let ty_abc : (([ `A of int | `B of string | `C ] as 'a), 'e) ty =
          ; "C", TCnoarg (Ttl (Ttl Thd))
          ]
 
-       method inj
+       method
+           inj
            : type c.  (int -> string -> noarg -> unit, c) ty_sel * c
                    -> [ `A of int | `B of string | `C ] =
          function
@@ -2470,10 +2471,11 @@ type (_, _, _) binop =
   | Leq : ('a, 'a, bool) binop
   | Add : (int, int, int) binop
 
-let eval (type a b c)
-         (bop : (a, b, c) binop)
-         (x : a constant)
-         (y : b constant)
+let eval
+    (type a b c)
+    (bop : (a, b, c) binop)
+    (x : a constant)
+    (y : b constant)
     : c constant
   =
   match bop, x, y with
@@ -2721,7 +2723,8 @@ let vexpr (type visit_action) : ('a, 'result, visit_action) context -> 'a -> vis
   | Global -> fun _ -> raise Exit
 ;;
 
-let vexpr (type result visit_action)
+let vexpr
+    (type result visit_action)
     : (unit, result, visit_action) context -> unit -> visit_action
   = function
   | Local -> fun _ -> raise Exit


### PR DESCRIPTION
Fix #877, maybe it could be improved to not have `:` alone on a line, but as a whole the formatting is more consistent.
And not using `Location.is_single_line` is a plus.

@Julow since you introduced this option, feel free to directly commit to this PR.