### PR TITLE
Improve: Implement break-fun-sig without Location.is_single_line

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2638,17 +2638,21 @@ and fmt_class_type_field c ctx (cf : class_type_field) =
             hovbox 2 (fmt "inherit@ " $ fmt_class_type c (sub_cty ~ctx ct))
         | Pctf_method (name, priv, virt, ty) ->
             box_fun_sig_args c 2
-              ( str "method"
-              $ fmt_if Poly.(virt = Virtual) "@ virtual"
-              $ fmt_if Poly.(priv = Private) "@ private"
-              $ fmt "@ " $ fmt_str_loc c name $ fmt " :@ "
+              ( hovbox 4
+                  ( str "method"
+                  $ fmt_if Poly.(virt = Virtual) "@ virtual"
+                  $ fmt_if Poly.(priv = Private) "@ private"
+                  $ fmt "@ " $ fmt_str_loc c name )
+              $ fmt " :@ "
               $ fmt_core_type c (sub_typ ~ctx ty) )
         | Pctf_val (name, mut, virt, ty) ->
             box_fun_sig_args c 2
-              ( str "val"
-              $ fmt_if Poly.(virt = Virtual) "@ virtual"
-              $ fmt_if Poly.(mut = Mutable) "@ mutable"
-              $ fmt "@ " $ fmt_str_loc c name $ fmt " :@ "
+              ( hovbox 4
+                  ( str "val"
+                  $ fmt_if Poly.(virt = Virtual) "@ virtual"
+                  $ fmt_if Poly.(mut = Mutable) "@ mutable"
+                  $ fmt "@ " $ fmt_str_loc c name )
+              $ fmt " :@ "
               $ fmt_core_type c (sub_typ ~ctx ty) )
         | Pctf_constraint (t1, t2) ->
             fmt "constraint@ "

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -148,11 +148,6 @@ let box_fun_decl_args c =
   | `Wrap | `Smart -> hovbox
 
 (** Handle the `break-fun-sig` option *)
-let wrap_fun_sig_args c indent k =
-  match c.conf.break_fun_sig with
-  | `Wrap | `Fit_or_vertical -> k
-  | `Smart -> hvbox indent k
-
 let box_fun_sig_args c =
   match c.conf.break_fun_sig with
   | _ when c.conf.ocp_indent_compat -> hvbox
@@ -635,24 +630,20 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
       let indent =
         if Poly.(c.conf.break_separators = `Before) then 2 else 0
       in
-      let box_if cnd i = if cnd then wrap_fun_sig_args c i else Fn.id in
-      box_if box
-        (if Option.is_some pro && c.conf.ocp_indent_compat then -2 else 0)
-        ( ( match pro with
-          | Some pro when c.conf.ocp_indent_compat ->
-              fits_breaks ""
-                (String.make (Int.max 1 (indent - String.length pro)) ' ')
-          | _ ->
-              fmt_if_k
-                Poly.(c.conf.break_separators = `Before)
-                (fmt_or_k c.conf.ocp_indent_compat (fits_breaks "" "")
-                   (fits_breaks "" "   ")) )
-        $ list xt1N
-            ( if Poly.(c.conf.break_separators = `Before) then
-              if parens then "@;<1 1>-> " else "@ -> "
-            else " ->@;<1 0>" )
-            (fun (lI, xtI) -> hvbox 0 (arg_label lI $ fmt_core_type c xtI))
-        )
+      ( match pro with
+      | Some pro when c.conf.ocp_indent_compat ->
+          fits_breaks ""
+            (String.make (Int.max 1 (indent - String.length pro)) ' ')
+      | _ ->
+          fmt_if_k
+            Poly.(c.conf.break_separators = `Before)
+            (fmt_or_k c.conf.ocp_indent_compat (fits_breaks "" "")
+               (fits_breaks "" "   ")) )
+      $ list xt1N
+          ( if Poly.(c.conf.break_separators = `Before) then
+            if parens then "@;<1 1>-> " else "@ -> "
+          else " ->@;<1 0>" )
+          (fun (lI, xtI) -> hvbox 0 (arg_label lI $ fmt_core_type c xtI))
   | Ptyp_constr (lid, []) -> fmt_longident_loc c lid
   | Ptyp_constr (lid, [t1]) ->
       fmt_core_type c (sub_typ ~ctx t1) $ fmt "@ " $ fmt_longident_loc c lid

--- a/test/passing/break_fun_decl-fit_or_vertical.ml.opts
+++ b/test/passing/break_fun_decl-fit_or_vertical.ml.opts
@@ -1,1 +1,1 @@
---break-fun-decl=fit-or-vertical
+--break-fun-decl=fit-or-vertical --break-fun-sig=fit-or-vertical

--- a/test/passing/break_fun_decl-fit_or_vertical.ml.ref
+++ b/test/passing/break_fun_decl-fit_or_vertical.ml.ref
@@ -77,3 +77,37 @@ let fffffffffffffffffffffffffffffffffff
     yyyyyyyyyyyyyyyyyyyyyyyyyyy
     yyyyyyyyyyyyyyyyyyyyyyyyyyy =
   ()
+
+class ffffffffffffffffffff =
+  object
+    method ffffffffffffffffffff
+        :    aaaaaaaaaaaaaaaaaaaaaa
+          -> bbbbbbbbbbbbbbbbbbbbbb
+          -> cccccccccccccccccccccc
+          -> dddddddddddddddddddddd =
+      g
+
+    val ffffffffffffffffffff
+        :    aaaaaaaaaaaaaaaaaaaaaa
+          -> bbbbbbbbbbbbbbbbbbbbbb
+          -> cccccccccccccccccccccc
+          -> dddddddddddddddddddddd =
+      g
+  end
+
+class type ffffffffffffffffffff =
+  object
+    method
+      ffffffffffffffffffff :
+         aaaaaaaaaaaaaaaaaaaaaa
+      -> bbbbbbbbbbbbbbbbbbbbbb
+      -> cccccccccccccccccccccc
+      -> dddddddddddddddddddddd
+
+    val
+      ffffffffffffffffffff :
+         aaaaaaaaaaaaaaaaaaaaaa
+      -> bbbbbbbbbbbbbbbbbbbbbb
+      -> cccccccccccccccccccccc
+      -> dddddddddddddddddddddd
+  end

--- a/test/passing/break_fun_decl-fit_or_vertical.ml.ref
+++ b/test/passing/break_fun_decl-fit_or_vertical.ml.ref
@@ -108,4 +108,13 @@ class type ffffffffffffffffffff =
       -> bbbbbbbbbbbbbbbbbbbbbb
       -> cccccccccccccccccccccc
       -> dddddddddddddddddddddd
+
+    val ffffffffffffffffffff :
+         (   aaaaaaaaaaaaaaaaaaaaaa
+          -> bbbbbbbbbbbbbbbbbbbbbb
+          -> cccccccccccccccccccccc
+          -> dddddddddddddddddddddd)
+      -> bbbbbbbbbbbbbbbbbbbbbb
+      -> cccccccccccccccccccccc
+      -> dddddddddddddddddddddd
   end

--- a/test/passing/break_fun_decl-fit_or_vertical.ml.ref
+++ b/test/passing/break_fun_decl-fit_or_vertical.ml.ref
@@ -97,15 +97,13 @@ class ffffffffffffffffffff =
 
 class type ffffffffffffffffffff =
   object
-    method
-      ffffffffffffffffffff :
+    method ffffffffffffffffffff :
          aaaaaaaaaaaaaaaaaaaaaa
       -> bbbbbbbbbbbbbbbbbbbbbb
       -> cccccccccccccccccccccc
       -> dddddddddddddddddddddd
 
-    val
-      ffffffffffffffffffff :
+    val ffffffffffffffffffff :
          aaaaaaaaaaaaaaaaaaaaaa
       -> bbbbbbbbbbbbbbbbbbbbbb
       -> cccccccccccccccccccccc

--- a/test/passing/break_fun_decl-smart.ml.opts
+++ b/test/passing/break_fun_decl-smart.ml.opts
@@ -1,1 +1,1 @@
---break-fun-decl=smart
+--break-fun-decl=smart --break-fun-sig=smart

--- a/test/passing/break_fun_decl-smart.ml.ref
+++ b/test/passing/break_fun_decl-smart.ml.ref
@@ -102,4 +102,13 @@ class type ffffffffffffffffffff =
       -> bbbbbbbbbbbbbbbbbbbbbb
       -> cccccccccccccccccccccc
       -> dddddddddddddddddddddd
+
+    val ffffffffffffffffffff :
+         (   aaaaaaaaaaaaaaaaaaaaaa
+          -> bbbbbbbbbbbbbbbbbbbbbb
+          -> cccccccccccccccccccccc
+          -> dddddddddddddddddddddd)
+      -> bbbbbbbbbbbbbbbbbbbbbb
+      -> cccccccccccccccccccccc
+      -> dddddddddddddddddddddd
   end

--- a/test/passing/break_fun_decl-smart.ml.ref
+++ b/test/passing/break_fun_decl-smart.ml.ref
@@ -71,3 +71,35 @@ let fffffffffffffffffffffffffffffffffff x yyyyyyyyyyyyyyyyyyyyyyyyyyy = ()
 let fffffffffffffffffffffffffffffffffff
     x yyyyyyyyyyyyyyyyyyyyyyyyyyy yyyyyyyyyyyyyyyyyyyyyyyyyyy =
   ()
+
+class ffffffffffffffffffff =
+  object
+    method ffffffffffffffffffff
+        :    aaaaaaaaaaaaaaaaaaaaaa
+          -> bbbbbbbbbbbbbbbbbbbbbb
+          -> cccccccccccccccccccccc
+          -> dddddddddddddddddddddd =
+      g
+
+    val ffffffffffffffffffff
+        :    aaaaaaaaaaaaaaaaaaaaaa
+          -> bbbbbbbbbbbbbbbbbbbbbb
+          -> cccccccccccccccccccccc
+          -> dddddddddddddddddddddd =
+      g
+  end
+
+class type ffffffffffffffffffff =
+  object
+    method ffffffffffffffffffff :
+         aaaaaaaaaaaaaaaaaaaaaa
+      -> bbbbbbbbbbbbbbbbbbbbbb
+      -> cccccccccccccccccccccc
+      -> dddddddddddddddddddddd
+
+    val ffffffffffffffffffff :
+         aaaaaaaaaaaaaaaaaaaaaa
+      -> bbbbbbbbbbbbbbbbbbbbbb
+      -> cccccccccccccccccccccc
+      -> dddddddddddddddddddddd
+  end

--- a/test/passing/break_fun_decl-wrap.ml.opts
+++ b/test/passing/break_fun_decl-wrap.ml.opts
@@ -1,1 +1,1 @@
---break-fun-decl=wrap
+--break-fun-decl=wrap --break-fun-sig=wrap

--- a/test/passing/break_fun_decl-wrap.ml.ref
+++ b/test/passing/break_fun_decl-wrap.ml.ref
@@ -53,3 +53,35 @@ let fffffffffffffffffffffffffffffffffff x yyyyyyyyyyyyyyyyyyyyyyyyyyy = ()
 let fffffffffffffffffffffffffffffffffff x yyyyyyyyyyyyyyyyyyyyyyyyyyy
     yyyyyyyyyyyyyyyyyyyyyyyyyyy =
   ()
+
+class ffffffffffffffffffff =
+  object
+    method ffffffffffffffffffff
+        :    aaaaaaaaaaaaaaaaaaaaaa
+          -> bbbbbbbbbbbbbbbbbbbbbb
+          -> cccccccccccccccccccccc
+          -> dddddddddddddddddddddd =
+      g
+
+    val ffffffffffffffffffff
+        :    aaaaaaaaaaaaaaaaaaaaaa
+          -> bbbbbbbbbbbbbbbbbbbbbb
+          -> cccccccccccccccccccccc
+          -> dddddddddddddddddddddd =
+      g
+  end
+
+class type ffffffffffffffffffff =
+  object
+    method ffffffffffffffffffff :
+         aaaaaaaaaaaaaaaaaaaaaa
+      -> bbbbbbbbbbbbbbbbbbbbbb
+      -> cccccccccccccccccccccc
+      -> dddddddddddddddddddddd
+
+    val ffffffffffffffffffff :
+         aaaaaaaaaaaaaaaaaaaaaa
+      -> bbbbbbbbbbbbbbbbbbbbbb
+      -> cccccccccccccccccccccc
+      -> dddddddddddddddddddddd
+  end

--- a/test/passing/break_fun_decl-wrap.ml.ref
+++ b/test/passing/break_fun_decl-wrap.ml.ref
@@ -84,4 +84,13 @@ class type ffffffffffffffffffff =
       -> bbbbbbbbbbbbbbbbbbbbbb
       -> cccccccccccccccccccccc
       -> dddddddddddddddddddddd
+
+    val ffffffffffffffffffff :
+         (   aaaaaaaaaaaaaaaaaaaaaa
+          -> bbbbbbbbbbbbbbbbbbbbbb
+          -> cccccccccccccccccccccc
+          -> dddddddddddddddddddddd)
+      -> bbbbbbbbbbbbbbbbbbbbbb
+      -> cccccccccccccccccccccc
+      -> dddddddddddddddddddddd
   end

--- a/test/passing/break_fun_decl.ml
+++ b/test/passing/break_fun_decl.ml
@@ -53,3 +53,35 @@ let fffffffffffffffffffffffffffffffffff x yyyyyyyyyyyyyyyyyyyyyyyyyyy = ()
 let fffffffffffffffffffffffffffffffffff x yyyyyyyyyyyyyyyyyyyyyyyyyyy
     yyyyyyyyyyyyyyyyyyyyyyyyyyy =
   ()
+
+class ffffffffffffffffffff =
+  object
+    method ffffffffffffffffffff
+        :    aaaaaaaaaaaaaaaaaaaaaa
+          -> bbbbbbbbbbbbbbbbbbbbbb
+          -> cccccccccccccccccccccc
+          -> dddddddddddddddddddddd =
+      g
+
+    val ffffffffffffffffffff
+        :    aaaaaaaaaaaaaaaaaaaaaa
+          -> bbbbbbbbbbbbbbbbbbbbbb
+          -> cccccccccccccccccccccc
+          -> dddddddddddddddddddddd =
+      g
+  end
+
+class type ffffffffffffffffffff =
+  object
+    method ffffffffffffffffffff :
+         aaaaaaaaaaaaaaaaaaaaaa
+      -> bbbbbbbbbbbbbbbbbbbbbb
+      -> cccccccccccccccccccccc
+      -> dddddddddddddddddddddd
+
+    val ffffffffffffffffffff :
+         aaaaaaaaaaaaaaaaaaaaaa
+      -> bbbbbbbbbbbbbbbbbbbbbb
+      -> cccccccccccccccccccccc
+      -> dddddddddddddddddddddd
+  end

--- a/test/passing/break_fun_decl.ml
+++ b/test/passing/break_fun_decl.ml
@@ -84,4 +84,13 @@ class type ffffffffffffffffffff =
       -> bbbbbbbbbbbbbbbbbbbbbb
       -> cccccccccccccccccccccc
       -> dddddddddddddddddddddd
+
+    val ffffffffffffffffffff :
+         (   aaaaaaaaaaaaaaaaaaaaaa
+          -> bbbbbbbbbbbbbbbbbbbbbb
+          -> cccccccccccccccccccccc
+          -> dddddddddddddddddddddd)
+      -> bbbbbbbbbbbbbbbbbbbbbb
+      -> cccccccccccccccccccccc
+      -> dddddddddddddddddddddd
   end

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -23,9 +23,7 @@ end [@foo]
 [@@@foo]
 
 type 'a with_default =
-  ?size:int (** default [42] *)
-  -> ?resizable:bool (** default [true] *)
-  -> 'a
+  ?size:int (** default [42] *) -> ?resizable:bool (** default [true] *) -> 'a
 
 type obj = < meth1 : int -> int (** method 1 *) ; meth2 : unit -> float (** method 2 *) >
 
@@ -1465,7 +1463,7 @@ let ty_abc : (([ `A of int | `B of string | `C ] as 'a), 'e) ty =
 
        method inj
            : type c.  (int -> string -> noarg -> unit, c) ty_sel * c
-                   -> [ `A of int | `B of string | `C ] =
+                     -> [ `A of int | `B of string | `C ] =
          function
          | Thd, v -> `A v
          | Ttl Thd, v -> `B v
@@ -1781,10 +1779,7 @@ let rec elem : type h. int -> h avl -> bool =
 
 let rec rotr
     : type n.
-      n succ succ avl
-      -> int
-      -> n avl
-      -> (n succ succ avl, n succ succ succ avl) sum
+      n succ succ avl -> int -> n avl -> (n succ succ avl, n succ succ succ avl) sum
   =
  fun tL y tR ->
   match tL with
@@ -1800,10 +1795,7 @@ let rec rotr
 
 let rec rotl
     : type n.
-      n avl
-      -> int
-      -> n succ succ avl
-      -> (n succ succ avl, n succ succ succ avl) sum
+      n avl -> int -> n succ succ avl -> (n succ succ avl, n succ succ succ avl) sum
   =
  fun tL u tR ->
   match tR with

--- a/test/passing/ocp_indent_compat.ml
+++ b/test/passing/ocp_indent_compat.ml
@@ -60,8 +60,7 @@ let long_function_name
 [@@@ocamlformat "ocp-indent-compat=false"]
 
 module type M = sig
-  val transl_modtype_longident
-    (* from Typemod *) :
+  val transl_modtype_longident (* from Typemod *) :
     (Location.t -> Env.t -> Longident.t -> Path.t) ref
 
   val transl_modtype_longident


### PR DESCRIPTION
Follow-up on https://github.com/ocaml-ppx/ocamlformat/pull/884 which removes the use of `Location.is_single_line` on a related function.