### PR TITLE
Fix break-string-literals=newlines

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -332,7 +332,7 @@ let fmt_constant c ~loc ?epi const =
         | _ -> str (escape_string mode s)
       in
       let fmt_lines ?(break_on_newlines = false) mode lines =
-        let delim = ["@,"; "@;"; "@\\n"] in
+        let delim = ["@,"; "@;"] in
         let fmt_line ?prev:_ curr ?next =
           let fmt_next next =
             let not_suffix suffix = not (String.is_suffix curr ~suffix) in
@@ -367,14 +367,12 @@ let fmt_constant c ~loc ?epi const =
       in
       let contains_pp_commands =
         let is_substring substring = String.is_substring s ~substring in
-        List.exists ["@,"; "@;"; "@\\n"] ~f:is_substring
+        List.exists ["@,"; "@;"] ~f:is_substring
       in
       match c.conf.break_string_literals with
       | `Newlines when contains_pp_commands ->
-          let break_on_pp_commands in_ delim =
-            let pat = String.Search_pattern.create delim in
-            let with_ = delim ^ "\n" in
-            String.Search_pattern.replace_all pat ~in_ ~with_
+          let break_on_pp_commands in_ pattern =
+            String.substr_replace_all in_ ~pattern ~with_:(pattern ^ "\n")
           in
           List.fold_left ["@,"; "@;"; "@\n"] ~init:s ~f:break_on_pp_commands
           |> String.split ~on:'\n'

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -367,7 +367,7 @@ let fmt_constant c ~loc ?epi const =
       in
       let contains_pp_commands =
         let is_substring substring = String.is_substring s ~substring in
-        List.exists ["@,"; "@;"; "@\n"] ~f:is_substring
+        List.exists ["@,"; "@;"; "@\\n"] ~f:is_substring
       in
       match c.conf.break_string_literals with
       | `Newlines when contains_pp_commands ->

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -365,8 +365,12 @@ let fmt_constant c ~loc ?epi const =
           | Some s -> (s, `Preserve) )
         | _ -> (s, c.conf.escape_strings)
       in
+      let contains_pp_commands =
+        let is_substring substring = String.is_substring s ~substring in
+        List.exists ["@,"; "@;"; "@\n"] ~f:is_substring
+      in
       match c.conf.break_string_literals with
-      | `Newlines ->
+      | `Newlines when contains_pp_commands ->
           let break_on_pp_commands in_ delim =
             let pat = String.Search_pattern.create delim in
             let with_ = delim ^ "\n" in
@@ -375,7 +379,7 @@ let fmt_constant c ~loc ?epi const =
           List.fold_left ["@,"; "@;"; "@\n"] ~init:s ~f:break_on_pp_commands
           |> String.split ~on:'\n'
           |> fmt_lines mode ~break_on_newlines:true
-      | `Wrap -> fmt_lines mode (String.split ~on:'\n' s)
+      | `Newlines | `Wrap -> fmt_lines mode (String.split ~on:'\n' s)
       | `Never -> wrap "\"" "\"" (fmt_line mode s) )
 
 let fmt_variance = function

--- a/test/passing/break_string_literals_never.ml
+++ b/test/passing/break_string_literals_never.ml
@@ -1,0 +1,1 @@
+break_string_literals_wrap.ml

--- a/test/passing/break_string_literals_never.ml.opts
+++ b/test/passing/break_string_literals_never.ml.opts
@@ -1,0 +1,1 @@
+--break-string-literals=never

--- a/test/passing/break_string_literals_never.ml.ref
+++ b/test/passing/break_string_literals_never.ml.ref
@@ -34,3 +34,11 @@ let pp_sep fmt () = F.fprintf fmt ", @,\n@\n@;@\n"
 let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@,@\n"
 
 let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"
+
+let fooooooooo = Fooooo "[%a]\n"
+
+let fooooooooo = Fooooo "[%a]@\n"
+
+let fooooooooo = Fooooo "[%a]\n@\n"
+
+let fooooooooo = Fooooo "[%a]@\n\n"

--- a/test/passing/break_string_literals_never.ml.ref
+++ b/test/passing/break_string_literals_never.ml.ref
@@ -42,3 +42,5 @@ let fooooooooo = Fooooo "[%a]@\n"
 let fooooooooo = Fooooo "[%a]\n@\n"
 
 let fooooooooo = Fooooo "[%a]@\n\n"
+
+let fooo = Fooo "@\nFooooo: `%s`\n"

--- a/test/passing/break_string_literals_never.ml.ref
+++ b/test/passing/break_string_literals_never.ml.ref
@@ -1,0 +1,36 @@
+let () =
+  if true then
+    (* Shrinking the margin a bit *)
+    Format.printf
+      "@[<v 2>@{<warning>@{<title>Warning@}@}@,@,\        These are @{<warning>NOT@} the Droids you are looking for!@,@,\        Some more text. Just more letters and words.@,\        All this text is left-aligned because it's part of the UI.@,\        It'll be easier for the user to read this message.@]@\n@."
+
+let fooooooo =
+  "@\n\n\               [Perf Profiler Log] Function: '%s'  @\n\               count trace id = %i @\n\               sum inclusive cpu time = %f@\n\               avg inclusive time = %f @\n\               sum exclusive cpu time = %f @\n\               avg exclusive_time = %f  @\n\               inclusive p90 = %f  @\n\               exclusive p90 = %f @\n\               inclusive p50 = %f  @\n\               exclusive p50 = %f @\n\               inclusive p25 = %f  @\n\               exclusive p25 = %f @\n"
+
+let foooo =
+  Printf.sprintf
+    "%s\nUsage: infer %s [options]\nSee `infer%s --help` for more information."
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n@\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n@;@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@,@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"

--- a/test/passing/break_string_literals_newlines.ml
+++ b/test/passing/break_string_literals_newlines.ml
@@ -1,0 +1,1 @@
+break_string_literals_wrap.ml

--- a/test/passing/break_string_literals_newlines.ml.opts
+++ b/test/passing/break_string_literals_newlines.ml.opts
@@ -1,0 +1,1 @@
+--break-string-literals=newlines

--- a/test/passing/break_string_literals_newlines.ml.ref
+++ b/test/passing/break_string_literals_newlines.ml.ref
@@ -63,3 +63,5 @@ let fooooooooo = Fooooo "[%a]@\n"
 let fooooooooo = Fooooo "[%a]\n@\n"
 
 let fooooooooo = Fooooo "[%a]@\n\n"
+
+let fooo = Fooo "@\nFooooo: `%s`\n"

--- a/test/passing/break_string_literals_newlines.ml.ref
+++ b/test/passing/break_string_literals_newlines.ml.ref
@@ -55,3 +55,11 @@ let pp_sep fmt () = F.fprintf fmt ", @,\n@\n@;@\n"
 let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@,@\n"
 
 let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"
+
+let fooooooooo = Fooooo "[%a]\n"
+
+let fooooooooo = Fooooo "[%a]@\n"
+
+let fooooooooo = Fooooo "[%a]\n@\n"
+
+let fooooooooo = Fooooo "[%a]@\n\n"

--- a/test/passing/break_string_literals_newlines.ml.ref
+++ b/test/passing/break_string_literals_newlines.ml.ref
@@ -1,0 +1,57 @@
+let () =
+  if true then
+    (* Shrinking the margin a bit *)
+    Format.printf
+      "@[<v 2>@{<warning>@{<title>Warning@}@}@,\
+       @,\
+      \        These are @{<warning>NOT@} the Droids you are looking for!@,\
+       @,\
+      \        Some more text. Just more letters and words.@,\
+      \        All this text is left-aligned because it's part of the UI.@,\
+      \        It'll be easier for the user to read this message.@]@\n\
+       @."
+
+let fooooooo =
+  "@\n\n\
+  \               [Perf Profiler Log] Function: '%s'  @\n\
+  \               count trace id = %i @\n\
+  \               sum inclusive cpu time = %f@\n\
+  \               avg inclusive time = %f @\n\
+  \               sum exclusive cpu time = %f @\n\
+  \               avg exclusive_time = %f  @\n\
+  \               inclusive p90 = %f  @\n\
+  \               exclusive p90 = %f @\n\
+  \               inclusive p50 = %f  @\n\
+  \               exclusive p50 = %f @\n\
+  \               inclusive p25 = %f  @\n\
+  \               exclusive p25 = %f @\n"
+
+let foooo =
+  Printf.sprintf
+    "%s\n\
+     Usage: infer %s [options]\n\
+     See `infer%s --help` for more information."
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n@\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n@;@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@,@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"

--- a/test/passing/break_string_literals_wrap.ml
+++ b/test/passing/break_string_literals_wrap.ml
@@ -50,3 +50,11 @@ let pp_sep fmt () = F.fprintf fmt ", @,\n@\n@;@\n"
 let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@,@\n"
 
 let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"
+
+let fooooooooo = Fooooo "[%a]\n"
+
+let fooooooooo = Fooooo "[%a]@\n"
+
+let fooooooooo = Fooooo "[%a]\n@\n"
+
+let fooooooooo = Fooooo "[%a]@\n\n"

--- a/test/passing/break_string_literals_wrap.ml
+++ b/test/passing/break_string_literals_wrap.ml
@@ -58,3 +58,5 @@ let fooooooooo = Fooooo "[%a]@\n"
 let fooooooooo = Fooooo "[%a]\n@\n"
 
 let fooooooooo = Fooooo "[%a]@\n\n"
+
+let fooo = Fooo "@\nFooooo: `%s`\n"

--- a/test/passing/break_string_literals_wrap.ml
+++ b/test/passing/break_string_literals_wrap.ml
@@ -1,0 +1,52 @@
+let () =
+  if true then (* Shrinking the margin a bit *)
+    Format.printf
+      "@[<v 2>@{<warning>@{<title>Warning@}@}@,@,\
+      \        These are @{<warning>NOT@} the Droids you are looking for!@,\
+       @,\
+      \        Some more text. Just more letters and words.@,\
+      \        All this text is left-aligned because it's part of the UI.@,\
+      \        It'll be easier for the user to read this message.@]@\n@."
+
+let fooooooo =
+  "@\n\n\
+    \               [Perf Profiler Log] Function: '%s'  @\n\
+    \               count trace id = %i @\n\
+    \               sum inclusive cpu time = %f@\n\
+    \               avg inclusive time = %f @\n\
+    \               sum exclusive cpu time = %f @\n\
+    \               avg exclusive_time = %f  @\n\
+    \               inclusive p90 = %f  @\n\
+    \               exclusive p90 = %f @\n\
+    \               inclusive p50 = %f  @\n\
+    \               exclusive p50 = %f @\n\
+    \               inclusive p25 = %f  @\n\
+    \               exclusive p25 = %f @\n"
+
+let foooo =
+  Printf.sprintf
+    "%s\nUsage: infer %s [options]\nSee `infer%s --help` for more information."
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n@\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n@;@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@,@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"

--- a/test/passing/break_string_literals_wrap.ml.opts
+++ b/test/passing/break_string_literals_wrap.ml.opts
@@ -1,0 +1,1 @@
+--break-string-literals=wrap

--- a/test/passing/break_string_literals_wrap.ml.ref
+++ b/test/passing/break_string_literals_wrap.ml.ref
@@ -53,3 +53,11 @@ let pp_sep fmt () = F.fprintf fmt ", @,\n@\n@;@\n"
 let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@,@\n"
 
 let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"
+
+let fooooooooo = Fooooo "[%a]\n"
+
+let fooooooooo = Fooooo "[%a]@\n"
+
+let fooooooooo = Fooooo "[%a]\n@\n"
+
+let fooooooooo = Fooooo "[%a]@\n\n"

--- a/test/passing/break_string_literals_wrap.ml.ref
+++ b/test/passing/break_string_literals_wrap.ml.ref
@@ -61,3 +61,5 @@ let fooooooooo = Fooooo "[%a]@\n"
 let fooooooooo = Fooooo "[%a]\n@\n"
 
 let fooooooooo = Fooooo "[%a]@\n\n"
+
+let fooo = Fooo "@\nFooooo: `%s`\n"

--- a/test/passing/break_string_literals_wrap.ml.ref
+++ b/test/passing/break_string_literals_wrap.ml.ref
@@ -1,0 +1,55 @@
+let () =
+  if true then
+    (* Shrinking the margin a bit *)
+    Format.printf
+      "@[<v 2>@{<warning>@{<title>Warning@}@}@,@,        These are \
+       @{<warning>NOT@} the Droids you are looking for!@,@,        Some \
+       more text. Just more letters and words.@,        All this text is \
+       left-aligned because it's part of the UI.@,        It'll be easier \
+       for the user to read this message.@]@\n\
+       @."
+
+let fooooooo =
+  "@\n\n\
+  \               [Perf Profiler Log] Function: '%s'  @\n\
+  \               count trace id = %i @\n\
+  \               sum inclusive cpu time = %f@\n\
+  \               avg inclusive time = %f @\n\
+  \               sum exclusive cpu time = %f @\n\
+  \               avg exclusive_time = %f  @\n\
+  \               inclusive p90 = %f  @\n\
+  \               exclusive p90 = %f @\n\
+  \               inclusive p50 = %f  @\n\
+  \               exclusive p50 = %f @\n\
+  \               inclusive p25 = %f  @\n\
+  \               exclusive p25 = %f @\n"
+
+let foooo =
+  Printf.sprintf
+    "%s\n\
+     Usage: infer %s [options]\n\
+     See `infer%s --help` for more information."
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n@\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n@;@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@,@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"


### PR DESCRIPTION
Progress on #868 but there is still a lot of work to do, I'm not satisfied with this implementation, the cases are too specific and it still fails on basic examples like `let pp_sep fmt () = F.fprintf fmt ", @,\n"`.
Feel free to commit if anyone has new ideas.

Edit: this bug is fixed, and more tests added.