### PR TITLE
Fix doc comments on exceptions

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -193,9 +193,9 @@ let is_sugared_list =
           List.iter ~f:(fun e -> Hashtbl.set memo ~key:e ~data:true) l ;
           true )
 
-let doc_atrs atrs =
+let doc_atrs ?(acc = []) atrs =
   let docs, rev_atrs =
-    List.fold atrs ~init:([], []) ~f:(fun (docs, rev_atrs) atr ->
+    List.fold atrs ~init:(acc, []) ~f:(fun (docs, rev_atrs) atr ->
         let open Asttypes in
         match atr with
         | { attr_name=

--- a/src/Ast.mli
+++ b/src/Ast.mli
@@ -51,7 +51,9 @@ val is_sugared_list : expression -> bool
 (** Holds of expressions that can be sugared into [\[e1; ...; eN\]] form. *)
 
 val doc_atrs :
-  attributes -> (string Location.loc * bool) list option * attributes
+     ?acc:(string Location.loc * bool) list
+  -> attributes
+  -> (string Location.loc * bool) list option * attributes
 
 val longident_is_simple : Conf.t -> Longident.t -> bool
 

--- a/test/passing/doc_comments.after.ml.ref
+++ b/test/passing/doc_comments.after.ml.ref
@@ -54,7 +54,8 @@ module Comment_placement : sig
   val a : b
   (** Val *)
 
-  exception E  (** Exception *)
+  exception E
+  (** Exception *)
 
   include M
   (** Include *)
@@ -137,7 +138,8 @@ end = struct
   (** Let *)
   let a = b
 
-  exception E  (** Exception *)
+  exception E
+  (** Exception *)
 
   include M
   (** Include *)
@@ -215,3 +217,7 @@ end = struct
   external a : b = "double_comment"
   (** B *)
 end
+
+(** A *)
+exception A of int
+(** C *)

--- a/test/passing/doc_comments.before.ml.ref
+++ b/test/passing/doc_comments.before.ml.ref
@@ -54,7 +54,8 @@ module Comment_placement : sig
   (** Val *)
   val a : b
 
-  exception E  (** Exception *)
+  (** Exception *)
+  exception E
 
   (** Include *)
   include M
@@ -137,7 +138,8 @@ end = struct
   (** Let *)
   let a = b
 
-  exception E  (** Exception *)
+  (** Exception *)
+  exception E
 
   (** Include *)
   include M
@@ -215,3 +217,7 @@ end = struct
   external a : b = "double_comment"
   (** B *)
 end
+
+(** A *)
+exception A of int
+(** C *)

--- a/test/passing/doc_comments.ml
+++ b/test/passing/doc_comments.ml
@@ -54,7 +54,8 @@ module Comment_placement : sig
   val a : b
   (** Val *)
 
-  exception E  (** Exception *)
+  exception E
+  (** Exception *)
 
   include M
   (** Include *)
@@ -137,7 +138,8 @@ end = struct
   (** Let *)
   let a = b
 
-  exception E  (** Exception *)
+  exception E
+  (** Exception *)
 
   include M
   (** Include *)
@@ -215,3 +217,7 @@ end = struct
   external a : b = "double_comment"
   (** B *)
 end
+
+(** A *)
+exception A of int
+(** C *)


### PR DESCRIPTION
With 4.08 the doc comment is attached to the constructor instead of the declaration.

In this example with 4.07:
```ocaml
(** A *)
exception A of int
(** C *)
```

the C comment will be moved to the right of the constructor. Is this an issue?