### PR TITLE
Improve: specify break hint in fits_breaks

### DIFF
--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -103,18 +103,16 @@ let pre_break n s o fs = Format.pp_print_pre_break fs n s o
 (** Conditional on breaking of enclosing box ----------------------------*)
 
 let fits_breaks ?(force_fit_if = false) ?(force_break_if = false)
-    ?(nspaces = 0) ?(offset = Int.min_value) fits breaks fs =
+    ?(hint = (0, Int.to_int Int.min_value)) fits breaks fs =
+  let nspaces, offset = hint in
   if force_fit_if then Format.pp_print_string fs fits
   else if force_break_if then (
     if offset >= 0 then Format.pp_print_break fs nspaces offset ;
     Format.pp_print_string fs breaks )
   else Format.pp_print_fits_or_breaks fs fits nspaces offset breaks
 
-let fits_breaks_if ?force_fit_if ?force_break_if ?nspaces ?offset cnd fits
-    breaks fs =
-  if cnd then
-    fits_breaks ?force_fit_if ?force_break_if ?nspaces ?offset fits breaks
-      fs
+let fits_breaks_if ?force_fit_if ?force_break_if ?hint cnd fits breaks fs =
+  if cnd then fits_breaks ?force_fit_if ?force_break_if ?hint fits breaks fs
 
 (** Wrapping ------------------------------------------------------------*)
 
@@ -135,7 +133,7 @@ let wrap_fits_breaks_if ?(space = true) c cnd pre suf k =
   else
     fits_breaks_if cnd pre (pre ^ " ")
     $ k
-    $ fits_breaks_if cnd suf ~nspaces:1 ~offset:0 suf
+    $ fits_breaks_if cnd suf ~hint:(1, 0) suf
 
 let wrap_fits_breaks ?(space = true) conf x =
   wrap_fits_breaks_if ~space conf true x

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -103,7 +103,7 @@ let pre_break n s o fs = Format.pp_print_pre_break fs n s o
 (** Conditional on breaking of enclosing box ----------------------------*)
 
 let fits_breaks ?(force_fit_if = false) ?(force_break_if = false)
-    ?(hint = (0, Int.to_int Int.min_value)) fits breaks fs =
+    ?(hint = (0, Int.min_value)) fits breaks fs =
   let nspaces, offset = hint in
   if force_fit_if then Format.pp_print_string fs fits
   else if force_break_if then (

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -102,29 +102,19 @@ let pre_break n s o fs = Format.pp_print_pre_break fs n s o
 
 (** Conditional on breaking of enclosing box ----------------------------*)
 
-let fits_breaks ?(force_fit_if = false) ?(force_break_if = false) fits
-    breaks fs =
-  let n, o, b =
-    let len = String.length breaks in
-    if len >= 2 && Char.equal breaks.[0] '@' then
-      let b = String.sub breaks ~pos:2 ~len:(len - 2) in
-      match breaks.[1] with
-      | ';' -> (
-        try Scanf.sscanf breaks "@;<%d %d>%s" (fun x y z -> (x, y, z))
-        with Scanf.Scan_failure _ | End_of_file -> (1, 0, b) )
-      | ',' -> (0, 0, b)
-      | ' ' -> (1, 0, b)
-      | _ -> (0, Int.min_value, breaks)
-    else (0, Int.min_value, breaks)
-  in
+let fits_breaks ?(force_fit_if = false) ?(force_break_if = false)
+    ?(nspaces = 0) ?(offset = Int.min_value) fits breaks fs =
   if force_fit_if then Format.pp_print_string fs fits
   else if force_break_if then (
-    if o >= 0 then Format.pp_print_break fs n o ;
-    Format.pp_print_string fs b )
-  else Format.pp_print_fits_or_breaks fs fits n o b
+    if offset >= 0 then Format.pp_print_break fs nspaces offset ;
+    Format.pp_print_string fs breaks )
+  else Format.pp_print_fits_or_breaks fs fits nspaces offset breaks
 
-let fits_breaks_if ?force_fit_if ?force_break_if cnd fits breaks fs =
-  if cnd then fits_breaks ?force_fit_if ?force_break_if fits breaks fs
+let fits_breaks_if ?force_fit_if ?force_break_if ?nspaces ?offset cnd fits
+    breaks fs =
+  if cnd then
+    fits_breaks ?force_fit_if ?force_break_if ?nspaces ?offset fits breaks
+      fs
 
 (** Wrapping ------------------------------------------------------------*)
 
@@ -136,8 +126,6 @@ let wrap_if cnd pre suf = wrap_if_k cnd (fmt pre) (fmt suf)
 
 and wrap pre suf = wrap_k (fmt pre) (fmt suf)
 
-let wrap_if_breaks pre suf k = fits_breaks "" pre $ k $ fits_breaks "" suf
-
 let wrap_if_fits_and cnd pre suf k =
   fits_breaks_if cnd pre "" $ k $ fits_breaks_if cnd suf ""
 
@@ -147,7 +135,7 @@ let wrap_fits_breaks_if ?(space = true) c cnd pre suf k =
   else
     fits_breaks_if cnd pre (pre ^ " ")
     $ k
-    $ fits_breaks_if cnd suf ("@ " ^ suf)
+    $ fits_breaks_if cnd suf ~nspaces:1 ~offset:0 suf
 
 let wrap_fits_breaks ?(space = true) conf x =
   wrap_fits_breaks_if ~space conf true x

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -104,21 +104,20 @@ val pre_break : int -> string -> int -> t
 val fits_breaks :
      ?force_fit_if:bool
   -> ?force_break_if:bool
-  -> ?nspaces:int
-  -> ?offset:int
+  -> ?hint:int * int
   -> string
   -> string
   -> t
 (** [fits_breaks fits nspaces offset breaks] prints [fits] if the enclosing
     box fits on one line, and otherwise prints [breaks], which is a string
-    that optionally follows a break hint equivalent to
-    ["@;<nspaces offset>"]. *)
+    that optionally follows a break [hint] (that is a pair
+    [(nspaces, offset)] equivalent to the break hint
+    ["@;<nspaces offset>"]). *)
 
 val fits_breaks_if :
      ?force_fit_if:bool
   -> ?force_break_if:bool
-  -> ?nspaces:int
-  -> ?offset:int
+  -> ?hint:int * int
   -> bool
   -> string
   -> string

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -102,15 +102,23 @@ val pre_break : int -> string -> int -> t
 (** Conditional on breaking of enclosing box ----------------------------*)
 
 val fits_breaks :
-  ?force_fit_if:bool -> ?force_break_if:bool -> string -> string -> t
-(** [fits_breaks fits breaks] prints [fits] if the enclosing box fits on one
-    line, and otherwise prints [breaks], which is a string that optionally
-    starts with a break hint specification such as ["@ "], ["@,"], or
+     ?force_fit_if:bool
+  -> ?force_break_if:bool
+  -> ?nspaces:int
+  -> ?offset:int
+  -> string
+  -> string
+  -> t
+(** [fits_breaks fits nspaces offset breaks] prints [fits] if the enclosing
+    box fits on one line, and otherwise prints [breaks], which is a string
+    that optionally follows a break hint equivalent to
     ["@;<nspaces offset>"]. *)
 
 val fits_breaks_if :
      ?force_fit_if:bool
   -> ?force_break_if:bool
+  -> ?nspaces:int
+  -> ?offset:int
   -> bool
   -> string
   -> string
@@ -131,10 +139,6 @@ val wrap_if : bool -> s -> s -> t -> t
 
 val wrap_if_k : bool -> t -> t -> t -> t
 (** As [wrap_if], but prologue and epilogue may be arbitrary format thunks. *)
-
-val wrap_if_breaks : string -> string -> t -> t
-(** As [wrap], but prologue and epilogue are only formatted if the enclosing
-    box breaks. *)
 
 val wrap_if_fits_and : bool -> string -> string -> t -> t
 (** As [wrap_if_fits], but prologue and epilogue are formatted subject to

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -406,8 +406,7 @@ let wrap_record (c : Conf.t) =
 let wrap_tuple ~parens ~no_parens_if_break c =
   if parens then wrap_fits_breaks c.conf "(" ")"
   else if no_parens_if_break then Fn.id
-  else
-    wrap_k (fits_breaks "" "( ") (fits_breaks "" ~nspaces:1 ~offset:0 ")")
+  else wrap_k (fits_breaks "" "( ") (fits_breaks "" ~hint:(1, 0) ")")
 
 let parse_docstring str_cmt =
   match Octavius.parse (Lexing.from_string str_cmt) with
@@ -729,14 +728,15 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
       let space_around = c.conf.space_around_variants in
       let closing =
         let empty = List.is_empty rfs in
-        let nspaces =
-          if Poly.(c.conf.type_decl = `Sparse) && space_around then 1000
-          else 1
-        in
-        fits_breaks ~nspaces ~offset:0
+        fits_breaks
           ( if (protect_token || space_around) && not empty then " ]"
           else "]" )
           "]"
+          ~hint:
+            ( ( if Poly.(c.conf.type_decl = `Sparse) && space_around then
+                1000
+              else 1 )
+            , 0 )
       in
       hvbox 0
         ( match (flag, lbls, rfs) with
@@ -1051,9 +1051,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
                   $ fmt_if_k last close_box))
         $ fmt_or_k nested
             (fits_breaks (if parens then ")" else "") "")
-            (fits_breaks
-               (if parens then ")" else "")
-               ")" ~nspaces:1 ~offset:2) )
+            (fits_breaks (if parens then ")" else "") ~hint:(1, 2) ")") )
   | Ppat_constraint
       ( {ppat_desc= Ppat_unpack name; ppat_attributes= []; ppat_loc; _}
       , ( { ptyp_desc= Ptyp_package (id, cnstrs)
@@ -1240,8 +1238,8 @@ and fmt_args ~first:first_grp ~last:last_grp c ctx args =
     let epi =
       match (lbl, next) with
       | _, None -> None
-      | Nolabel, _ -> Some (fits_breaks "" ~nspaces:1000 ~offset:(-1) "")
-      | _ -> Some (fits_breaks "" ~nspaces:1000 ~offset:(-3) "")
+      | Nolabel, _ -> Some (fits_breaks "" ~hint:(1000, -1) "")
+      | _ -> Some (fits_breaks "" ~hint:(1000, -3) "")
     in
     fmt_if_k (Option.is_none prev) openbox
     $ hovbox 2 (fmt_label_arg c ?box ?epi (lbl, xarg))
@@ -1353,11 +1351,11 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
           $ fmt_if_k last close_box
           $ fmt_or_k very_last
               (fmt_or_k parens_or_forced
-                 (fmt_or_k c.conf.indicate_multiline_delimiters
-                    (fits_breaks_if parens_or_nested ")" ~nspaces:1
-                       ~offset:0 ")")
-                    (fits_breaks_if parens_or_nested ")" ~nspaces:0
-                       ~offset:0 ")"))
+                 (fits_breaks_if parens_or_nested ")" ")"
+                    ~hint:
+                      ( ( if c.conf.indicate_multiline_delimiters then 1
+                        else 0 )
+                      , 0 ))
                  (fits_breaks_if parens_or_nested ")" ""))
               (break_unless_newline 1 0))
     in
@@ -1743,10 +1741,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
               ( hvbox 2
                   ( fmt_or paren_body "assert (@," "assert@ "
                   $ fmt_expression c ~parens:false (sub_exp ~ctx e0) )
-              $ fits_breaks_if paren_body ")"
-                  ~nspaces:
-                    (if c.conf.indicate_multiline_delimiters then 1 else 0)
-                  ~offset:0 ")"
+              $ fits_breaks_if paren_body ")" ")"
+                  ~hint:
+                    ( (if c.conf.indicate_multiline_delimiters then 1 else 0)
+                    , 0 )
               $ fmt_atrs )))
   | Pexp_constant const ->
       wrap_if
@@ -1765,7 +1763,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let imd = c.conf.indicate_multiline_delimiters in
       let opn_paren = fmt_or_k imd (fits_breaks "(" "( ") (str "(") in
       let cls_paren =
-        fmt_or_k imd (fits_breaks ")" ~nspaces:1 ~offset:0 ")") (str ")")
+        fmt_or_k imd (fits_breaks ")" ~hint:(1, 0) ")") (str ")")
       in
       hovbox 0
         (compose_module
@@ -2036,7 +2034,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                 (sub_mod ~ctx popen_expr) )
         $ fits_breaks opn " in"
         $ fmt_or_k force_fit_if (fmt "@;<0 2>")
-            (fits_breaks "" ~nspaces:1000 ~offset:0 "")
+            (fits_breaks "" ~hint:(1000, 0) "")
         $ fmt_expression c (sub_exp ~ctx e0)
         $ fits_breaks cls ""
         $ fits_breaks_if parens "" ")"
@@ -3207,7 +3205,7 @@ and fmt_module_type c ({ast= mty; _} as xmty) =
       ; epi= Some (Option.call ~f:blk.epi $ Cmts.fmt_after c pmty_loc)
       ; psp=
           fmt_or_k (Option.is_none blk.pro)
-            (fits_breaks " " ~nspaces:1 ~offset:2 "")
+            (fits_breaks " " ~hint:(1, 2) "")
             blk.psp }
   | Pmty_with _ ->
       let wcs, mt = Sugar.mod_with (sub_mty ~ctx mty) in
@@ -3950,7 +3948,7 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
                   Some (fits_breaks ~force_fit_if "" "\n")
               | `Double_semicolon ->
                   Option.some_if (last && last_grp)
-                    (fits_breaks "" ~nspaces:1000 ~offset:(-2) ";;")
+                    (fits_breaks "" ~hint:(1000, -2) ";;")
             in
             let {pvb_pat; pvb_expr; pvb_attributes= attributes; pvb_loc= loc}
                 =
@@ -3983,7 +3981,7 @@ and fmt_let c ctx ~ext ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr
   let fmt_in indent =
     match c.conf.break_before_in with
     | `Fit_or_vertical -> break 1 (-indent) $ fmt "in"
-    | `Auto -> fits_breaks " in" ~nspaces:1 ~offset:(-indent) "in"
+    | `Auto -> fits_breaks " in" ~hint:(1, -indent) "in"
   in
   let fmt_binding ~first ~last binding =
     let ext = if first then ext else None in
@@ -4088,7 +4086,7 @@ and fmt_value_binding c let_op ~rec_flag ?ext ?in_ ?epi ctx ~attributes ~loc
             let fmt_cstr_and_xbody typ exp =
               ( Some
                   ( fmt_or_k c.conf.ocp_indent_compat
-                      (fits_breaks " " ~nspaces:1000 ~offset:0 "")
+                      (fits_breaks " " ~hint:(1000, 0) "")
                       (fmt "@;<0 -1>")
                   $ cbox_if c.conf.ocp_indent_compat 0
                       (fmt_core_type c ~pro:":"
@@ -4154,7 +4152,7 @@ and fmt_value_binding c let_op ~rec_flag ?ext ?in_ ?epi ctx ~attributes ~loc
                       $ wrap_fun_decl_args c (fmt_fun_args c xargs) ) )
               $ Option.call ~f:fmt_cstr )
           $ fmt_or_k c.conf.ocp_indent_compat
-              (fits_breaks " =" ~nspaces:1000 ~offset:0 "=")
+              (fits_breaks " =" ~hint:(1000, 0) "=")
               (fmt "@;<1 2>=")
           $ pre_body )
       $ fmt "@ " $ body $ Cmts.fmt_after c loc

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -124,15 +124,12 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch ~xcond
           $ fmt "@ then" )
     | None -> str "else"
   in
-  let wrap_parens ~opn_hint:((n_ohimd, o_ohmid), (n_ohno, o_ohno)) k =
+  let wrap_parens ~opn_hint:(ohimd, ohno) k =
     fmt_if_k parens_bch
-      ( str "("
-      $ fmt_or_k imd
-          (fits_breaks "" ~nspaces:n_ohimd ~offset:o_ohmid "")
-          (fits_breaks "" ~nspaces:n_ohno ~offset:o_ohno "") )
+      (str "(" $ fits_breaks "" ~hint:(if imd then ohimd else ohno) "")
     $ k
     $ fmt_if_k parens_bch
-        (fmt_if_k imd (fits_breaks "" ~nspaces:1 ~offset:0 "") $ str ")")
+        (fmt_if_k imd (fits_breaks "" ~hint:(1, 0) "") $ str ")")
   in
   let branch_pro = fmt_or parens_bch " " "@;<1 2>" in
   match c.if_then_else with

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -124,11 +124,15 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch ~xcond
           $ fmt "@ then" )
     | None -> str "else"
   in
-  let wrap_parens ~opn_hint:(ohimd, ohno) ~cls_hint k =
+  let wrap_parens ~opn_hint:((n_ohimd, o_ohmid), (n_ohno, o_ohno)) k =
     fmt_if_k parens_bch
-      (str "(" $ fmt_or_k imd (fits_breaks "" ohimd) (fits_breaks "" ohno))
+      ( str "("
+      $ fmt_or_k imd
+          (fits_breaks "" ~nspaces:n_ohimd ~offset:o_ohmid "")
+          (fits_breaks "" ~nspaces:n_ohno ~offset:o_ohno "") )
     $ k
-    $ fmt_if_k parens_bch (fmt_if_k imd (fits_breaks "" cls_hint) $ str ")")
+    $ fmt_if_k parens_bch
+        (fmt_if_k imd (fits_breaks "" ~nspaces:1 ~offset:0 "") $ str ")")
   in
   let branch_pro = fmt_or parens_bch " " "@;<1 2>" in
   match c.if_then_else with
@@ -137,7 +141,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch ~xcond
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
       ; branch_pro= fmt_or parens_bch " " "@ "
-      ; wrap_parens= wrap_parens ~opn_hint:("@ ", "@,") ~cls_hint:"@ "
+      ; wrap_parens= wrap_parens ~opn_hint:((1, 0), (0, 0))
       ; expr_pro= None
       ; expr_eol= None
       ; break_end_branch= noop
@@ -157,8 +161,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch ~xcond
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
       ; branch_pro
-      ; wrap_parens=
-          wrap_parens ~opn_hint:("@;<1 2>", "@;<0 2>") ~cls_hint:"@ "
+      ; wrap_parens= wrap_parens ~opn_hint:((1, 2), (0, 2))
       ; expr_pro=
           Some
             (fmt_if_k
@@ -181,7 +184,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch ~xcond
           (fun k ->
             hvbox 2 (fmt_or (Option.is_some xcond) "then" "else" $ k))
       ; branch_pro= fmt_or parens_bch " " "@ "
-      ; wrap_parens= wrap_parens ~opn_hint:("@ ", "@,") ~cls_hint:"@ "
+      ; wrap_parens= wrap_parens ~opn_hint:((1, 0), (0, 0))
       ; expr_pro= None
       ; expr_eol= None
       ; break_end_branch= noop


### PR DESCRIPTION
Removing the parsing of `fits_breaks` second argument.
Using a pair to always specify both nspaces and offset.