### PR TITLE
Improve: break-string-literals=newlines-and-wrap

### DIFF
--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -101,12 +101,13 @@ OPTIONS (CODE FORMATTING STYLE)
        --break-sequences
            Force sequence expressions to break irrespective of margin.
 
-       --break-string-literals={wrap|newlines|never}
+       --break-string-literals={wrap|newlines|never|newlines-and-wrap}
            Break string literals. wrap mode wraps string literals at the
            margin. Quoted strings such as {id|...|id} are preserved. newlines
            mode breaks lines at newlines. never mode formats string literals
            as they are parsed, in particular, with escape sequences expanded.
-           The default value is wrap.
+           newlines-and-wrap mode breaks lines at newlines and wraps string
+           literals at the margin. The default value is wrap.
 
        --break-struct={force|natural}
            Break struct-end module items. force will break struct-end phrases

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -22,7 +22,7 @@ type t =
   ; break_fun_sig: [`Wrap | `Fit_or_vertical | `Smart]
   ; break_separators: [`Before | `After | `After_and_docked]
   ; break_sequences: bool
-  ; break_string_literals: [`Newlines | `Never | `Wrap]
+  ; break_string_literals: [`Newlines | `Never | `Wrap | `Newlines_and_wrap]
   ; break_struct: bool
   ; cases_exp_indent: int
   ; cases_matching_exp_indent: [`Normal | `Compact]
@@ -758,7 +758,11 @@ module Formatting = struct
       ; ( "never"
         , `Never
         , "$(b,never) mode formats string literals as they are parsed, in \
-           particular, with escape sequences expanded." ) ]
+           particular, with escape sequences expanded." )
+      ; ( "newlines-and-wrap"
+        , `Newlines_and_wrap
+        , "$(b,newlines-and-wrap) mode breaks lines at newlines and wraps \
+           string literals at the margin." ) ]
     in
     C.choice ~names ~all ~doc ~section
       (fun conf x -> {conf with break_string_literals= x})

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -22,7 +22,7 @@ type t =
   ; break_fun_sig: [`Wrap | `Fit_or_vertical | `Smart]
   ; break_separators: [`Before | `After | `After_and_docked]
   ; break_sequences: bool
-  ; break_string_literals: [`Newlines | `Never | `Wrap]
+  ; break_string_literals: [`Newlines | `Never | `Wrap | `Newlines_and_wrap]
         (** How to potentially break string literals into new lines. *)
   ; break_struct: bool
   ; cases_exp_indent: int

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -318,7 +318,7 @@ let fmt_constant c ~loc ?epi const =
   | Pconst_string (s, None) -> (
       let fmt_line mode s =
         match c.conf.break_string_literals with
-        | `Wrap ->
+        | `Wrap | `Newlines_and_wrap ->
             let words = String.split (escape_string mode s) ~on:' ' in
             let fmt_word ?prev:_ curr ?next =
               match next with
@@ -357,7 +357,7 @@ let fmt_constant c ~loc ?epi const =
           match Source.string_literal c.source `Preserve loc with
           | None -> (s, `Decimal)
           | Some s -> (s, `Preserve) )
-        | (`Newlines | `Wrap), `Preserve -> (
+        | (`Newlines | `Wrap | `Newlines_and_wrap), `Preserve -> (
           match Source.string_literal c.source `Normalize loc with
           | None -> (s, `Decimal)
           | Some s -> (s, `Preserve) )
@@ -368,14 +368,15 @@ let fmt_constant c ~loc ?epi const =
         List.exists ["@,"; "@;"] ~f:is_substring
       in
       match c.conf.break_string_literals with
-      | `Newlines when contains_pp_commands ->
+      | (`Newlines | `Newlines_and_wrap) when contains_pp_commands ->
           let break_on_pp_commands in_ pattern =
             String.substr_replace_all in_ ~pattern ~with_:(pattern ^ "\n")
           in
           List.fold_left ["@,"; "@;"; "@\n"] ~init:s ~f:break_on_pp_commands
           |> String.split ~on:'\n'
           |> fmt_lines mode ~break_on_newlines:true
-      | `Newlines | `Wrap -> fmt_lines mode (String.split ~on:'\n' s)
+      | `Newlines | `Wrap | `Newlines_and_wrap ->
+          fmt_lines mode (String.split ~on:'\n' s)
       | `Never -> wrap "\"" "\"" (fmt_line mode s) )
 
 let fmt_variance = function

--- a/test/passing/break_string_literals_never.ml.ref
+++ b/test/passing/break_string_literals_never.ml.ref
@@ -44,3 +44,9 @@ let fooooooooo = Fooooo "[%a]\n@\n"
 let fooooooooo = Fooooo "[%a]@\n\n"
 
 let fooo = Fooo "@\nFooooo: `%s`\n"
+
+let fooooooooooo =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+
+let fooooooooooo =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.@;Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.@;Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.@;Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."

--- a/test/passing/break_string_literals_newlines.ml.ref
+++ b/test/passing/break_string_literals_newlines.ml.ref
@@ -65,3 +65,12 @@ let fooooooooo = Fooooo "[%a]\n@\n"
 let fooooooooo = Fooooo "[%a]@\n\n"
 
 let fooo = Fooo "@\nFooooo: `%s`\n"
+
+let fooooooooooo =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+
+let fooooooooooo =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.@;\
+   Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.@;\
+   Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.@;\
+   Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."

--- a/test/passing/break_string_literals_newlines_and_wrap.ml
+++ b/test/passing/break_string_literals_newlines_and_wrap.ml
@@ -1,0 +1,1 @@
+break_string_literals_wrap.ml

--- a/test/passing/break_string_literals_newlines_and_wrap.ml.opts
+++ b/test/passing/break_string_literals_newlines_and_wrap.ml.opts
@@ -1,0 +1,1 @@
+--break-string-literals=newlines-and-wrap

--- a/test/passing/break_string_literals_newlines_and_wrap.ml.ref
+++ b/test/passing/break_string_literals_newlines_and_wrap.ml.ref
@@ -1,0 +1,67 @@
+let () =
+  if true then
+    (* Shrinking the margin a bit *)
+    Format.printf
+      "@[<v 2>@{<warning>@{<title>Warning@}@}@,\
+       @,\
+      \        These are @{<warning>NOT@} the Droids you are looking for!@,\
+       @,\
+      \        Some more text. Just more letters and words.@,\
+      \        All this text is left-aligned because it's part of the UI.@,\
+      \        It'll be easier for the user to read this message.@]@\n\
+       @."
+
+let fooooooo =
+  "@\n\n\
+  \               [Perf Profiler Log] Function: '%s'  @\n\
+  \               count trace id = %i @\n\
+  \               sum inclusive cpu time = %f@\n\
+  \               avg inclusive time = %f @\n\
+  \               sum exclusive cpu time = %f @\n\
+  \               avg exclusive_time = %f  @\n\
+  \               inclusive p90 = %f  @\n\
+  \               exclusive p90 = %f @\n\
+  \               inclusive p50 = %f  @\n\
+  \               exclusive p50 = %f @\n\
+  \               inclusive p25 = %f  @\n\
+  \               exclusive p25 = %f @\n"
+
+let foooo =
+  Printf.sprintf
+    "%s\n\
+     Usage: infer %s [options]\n\
+     See `infer%s --help` for more information."
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,@\n@\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n@;@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@,@\n"
+
+let pp_sep fmt () = F.fprintf fmt ", @,\n@\n\n@\n\n"
+
+let fooooooooo = Fooooo "[%a]\n"
+
+let fooooooooo = Fooooo "[%a]@\n"
+
+let fooooooooo = Fooooo "[%a]\n@\n"
+
+let fooooooooo = Fooooo "[%a]@\n\n"
+
+let fooo = Fooo "@\nFooooo: `%s`\n"

--- a/test/passing/break_string_literals_newlines_and_wrap.ml.ref
+++ b/test/passing/break_string_literals_newlines_and_wrap.ml.ref
@@ -65,3 +65,22 @@ let fooooooooo = Fooooo "[%a]\n@\n"
 let fooooooooo = Fooooo "[%a]@\n\n"
 
 let fooo = Fooo "@\nFooooo: `%s`\n"
+
+let fooooooooooo =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod \
+   tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim \
+   veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea \
+   commodo consequat. Duis aute irure dolor in reprehenderit in voluptate \
+   velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint \
+   occaecat cupidatat non proident, sunt in culpa qui officia deserunt \
+   mollit anim id est laborum."
+
+let fooooooooooo =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod \
+   tempor incididunt ut labore et dolore magna aliqua.@;\
+   Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi \
+   ut aliquip ex ea commodo consequat.@;\
+   Duis aute irure dolor in reprehenderit in voluptate velit esse cillum \
+   dolore eu fugiat nulla pariatur.@;\
+   Excepteur sint occaecat cupidatat non proident, sunt in culpa qui \
+   officia deserunt mollit anim id est laborum."

--- a/test/passing/break_string_literals_wrap.ml
+++ b/test/passing/break_string_literals_wrap.ml
@@ -60,3 +60,7 @@ let fooooooooo = Fooooo "[%a]\n@\n"
 let fooooooooo = Fooooo "[%a]@\n\n"
 
 let fooo = Fooo "@\nFooooo: `%s`\n"
+
+let fooooooooooo = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+
+let fooooooooooo = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.@;Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.@;Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.@;Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."

--- a/test/passing/break_string_literals_wrap.ml.ref
+++ b/test/passing/break_string_literals_wrap.ml.ref
@@ -63,3 +63,21 @@ let fooooooooo = Fooooo "[%a]\n@\n"
 let fooooooooo = Fooooo "[%a]@\n\n"
 
 let fooo = Fooo "@\nFooooo: `%s`\n"
+
+let fooooooooooo =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod \
+   tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim \
+   veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea \
+   commodo consequat. Duis aute irure dolor in reprehenderit in voluptate \
+   velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint \
+   occaecat cupidatat non proident, sunt in culpa qui officia deserunt \
+   mollit anim id est laborum."
+
+let fooooooooooo =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod \
+   tempor incididunt ut labore et dolore magna aliqua.@;Ut enim ad minim \
+   veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea \
+   commodo consequat.@;Duis aute irure dolor in reprehenderit in voluptate \
+   velit esse cillum dolore eu fugiat nulla pariatur.@;Excepteur sint \
+   occaecat cupidatat non proident, sunt in culpa qui officia deserunt \
+   mollit anim id est laborum."


### PR DESCRIPTION
Follow up on #887, see this suggestion: https://github.com/ocaml-ppx/ocamlformat/pull/887#issuecomment-503344556 of @raphael-proust

The diff of test_branch.sh looks good:
```
diff --git a/src/Translation_unit.ml b/src/Translation_unit.ml
index 33481d3..b5588c3 100644
--- a/src/Translation_unit.ml
+++ b/src/Translation_unit.ml
@@ -242,38 +242,40 @@ let print_error ?(quiet_unstable = false) ?(quiet_comments = false)
                 | Normalize.Moved (loc_before, loc_after, msg) ->
                     if Location.compare loc_before Location.none = 0 then
                       Format.fprintf fmt
-                        "%!@{<loc>%a@}:@,@{<error>Error@}: Docstring (** \
-                         %s *) added.\n\
+                        "%!@{<loc>%a@}:@,\
+                         @{<error>Error@}: Docstring (** %s *) added.\n\
                          %!"
                         Location.print_loc loc_after (ellipsis_cmt msg)
                     else if Location.compare loc_after Location.none = 0
                     then
                       Format.fprintf fmt
-                        "%!@{<loc>%a@}:@,@{<error>Error@}: Docstring (** \
-                         %s *) dropped.\n\
+                        "%!@{<loc>%a@}:@,\
+                         @{<error>Error@}: Docstring (** %s *) dropped.\n\
                          %!"
                         Location.print_loc loc_before (ellipsis_cmt msg)
                     else
                       Format.fprintf fmt
-                        "%!@{<loc>%a@}:@,@{<error>Error@}: Docstring (** \
-                         %s *) moved to @{<loc>%a@}.\n\
+                        "%!@{<loc>%a@}:@,\
+                         @{<error>Error@}: Docstring (** %s *) moved to \
+                         @{<loc>%a@}.\n\
                          %!"
                         Location.print_loc loc_before (ellipsis_cmt msg)
                         Location.print_loc loc_after
                 | Normalize.Unstable (loc, s) ->
                     Format.fprintf fmt
-                      "%!@{<loc>%a@}:@,@{<error>Error@}: Formatting of (** \
-                       %s *) is unstable (e.g. parses as a list or not \
-                       depending on the margin), please tighten up this \
-                       comment in the source or disable the formatting \
-                       using the option --no-parse-docstrings.\n\
+                      "%!@{<loc>%a@}:@,\
+                       @{<error>Error@}: Formatting of (** %s *) is \
+                       unstable (e.g. parses as a list or not depending on \
+                       the margin), please tighten up this comment in the \
+                       source or disable the formatting using the option \
+                       --no-parse-docstrings.\n\
                        %!"
                       Location.print_loc loc (ellipsis_cmt s))
           | `Comment_dropped l when not conf.Conf.quiet ->
               List.iter l ~f:(fun (loc, msg) ->
                   Format.fprintf fmt
-                    "%!@{<loc>%a@}:@,@{<error>Error@}: Comment (* %s *) \
-                     dropped.\n\
+                    "%!@{<loc>%a@}:@,\
+                     @{<error>Error@}: Comment (* %s *) dropped.\n\
                      %!"
                     Location.print_loc loc (ellipsis_cmt msg))
           | `Cannot_parse ((Syntaxerr.Error _ | Lexer.Error _) as exn) ->
diff --git a/infer/src/pulse/PulseAbductiveDomain.ml b/infer/src/pulse/PulseAbductiveDomain.ml
index 8a75b910a..fe5511c2e 100644
--- a/infer/src/pulse/PulseAbductiveDomain.ml
+++ b/infer/src/pulse/PulseAbductiveDomain.ml
@@ -305,8 +305,11 @@ module PrePost = struct
 
   let pp_call_state fmt {astate; subst; rev_subst; visited} =
     F.fprintf fmt
-      "@[<v>{ astate=@[<hv2>%a@];@, subst=@[<hv2>%a@];@, rev_subst=@[<hv2>%a@];@, \
-       visited=@[<hv2>%a@]@, }@]"
+      "@[<v>{ astate=@[<hv2>%a@];@,\
+      \ subst=@[<hv2>%a@];@,\
+      \ rev_subst=@[<hv2>%a@];@,\
+      \ visited=@[<hv2>%a@]@,\
+      \ }@]"
       pp astate
       (AddressMap.pp ~pp_value:AbstractAddress.pp)
       subst
diff --git a/sledge/src/report.ml b/sledge/src/report.ml
index 645c2f1da..f932e306c 100644
--- a/sledge/src/report.ml
+++ b/sledge/src/report.ml
@@ -11,8 +11,8 @@ let unknown_call call =
   [%Trace.kprintf
     (fun _ -> assert false)
       "@\n\
-       @[<v 2>%a Called unknown function %a executing instruction@;<1 \
-       2>@[%a@]@]@."
+       @[<v 2>%a Called unknown function %a executing instruction@;\
+       <1 2>@[%a@]@]@."
       (fun fs call -> Loc.pp fs (Llair.Term.loc call))
       call
       (fun fs (call : Llair.Term.t) ->
@@ -31,8 +31,9 @@ let invalid_access state pp access loc =
   [%Trace.kprintf
     (fun _ -> assert false)
       "@\n\
-       @[<v 2>%a Invalid memory access executing@;<1 2>@[%a@]@ from \
-       symbolic state@;<1 2>@[{ %a@ }@]@]@."
+       @[<v 2>%a Invalid memory access executing@;\
+       <1 2>@[%a@]@ from symbolic state@;\
+       <1 2>@[{ %a@ }@]@]@."
       Loc.pp (loc access) pp access Domain.pp state]
```