### PR TITLE
Fix compilation with 4.06 and 4.07

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: c
 env:
-  - OCAML_VERSION=4.06.1
-  - OCAML_VERSION=4.07.1
   - OCAML_VERSION=4.08.0
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 env:
+  - OCAML_VERSION=4.06
+  - OCAML_VERSION=4.07
   - OCAML_VERSION=4.08.0
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 env:
-  - OCAML_VERSION=4.06
-  - OCAML_VERSION=4.07
+  - OCAML_VERSION=4.06.1
+  - OCAML_VERSION=4.07.1
   - OCAML_VERSION=4.08.0
 cache:
   directories:

--- a/vendor/ocamlformat_support/compat/ge_408.ml
+++ b/vendor/ocamlformat_support/compat/ge_408.ml
@@ -11,3 +11,7 @@
 
 open CamlinternalFormat
 let make_printf f x acc fmt = make_printf (f x) acc fmt
+
+module Stack = Stack
+module Queue = Queue
+module Int = Int

--- a/vendor/ocamlformat_support/compat/ge_408.ml
+++ b/vendor/ocamlformat_support/compat/ge_408.ml
@@ -15,3 +15,4 @@ let make_printf f x acc fmt = make_printf (f x) acc fmt
 module Stack = Stack
 module Queue = Queue
 module Int = Int
+module Stdlib = Stdlib

--- a/vendor/ocamlformat_support/compat/lt_408.ml
+++ b/vendor/ocamlformat_support/compat/lt_408.ml
@@ -10,4 +10,33 @@
  **********************************************************************)
 
 open CamlinternalFormat
-let make_printf = make_printf
+
+let make_printf f x acc fmt = make_printf (fun acc -> f acc) x acc fmt
+
+module Stack = struct
+  include Stack
+
+  let top_opt st = try Some (top st) with Stack.Empty -> None
+  let pop_opt st = try Some (pop st) with Stack.Empty -> None
+end
+
+module Queue = struct
+  include Queue
+
+  let take_opt q = try Some (take q) with Queue.Empty -> None
+  let peek_opt q = try Some (peek q) with Queue.Empty -> None
+end
+
+module Int = struct
+  let to_string = string_of_int
+end
+
+module Stdlib = struct
+  type out_channel = Pervasives.out_channel
+
+  external open_descriptor_out : int -> out_channel
+    = "caml_ml_open_descriptor_out"
+
+  let stdout = open_descriptor_out 1
+  let stderr = open_descriptor_out 2
+end

--- a/vendor/ocamlformat_support/compat/lt_408.ml
+++ b/vendor/ocamlformat_support/compat/lt_408.ml
@@ -11,7 +11,7 @@
 
 open CamlinternalFormat
 
-let make_printf f x acc fmt = make_printf (fun acc -> f acc) x acc fmt
+let make_printf = make_printf
 
 module Stack = struct
   include Stack

--- a/vendor/ocamlformat_support/format_.ml
+++ b/vendor/ocamlformat_support/format_.ml
@@ -1399,33 +1399,23 @@ let rec strput_acc ppf acc = match acc with
 
 let kfprintf k ppf (Format (fmt, _)) =
   make_printf
-    (fun acc -> output_acc ppf acc; k ppf)
-    End_of_acc fmt
+    (fun ppf acc -> output_acc ppf acc; k ppf)
+    ppf End_of_acc fmt
 
 and ikfprintf k ppf (Format (fmt, _)) =
   make_iprintf k ppf fmt
-
-let ifprintf _ppf (Format (fmt, _)) =
-  make_iprintf ignore () fmt
 
 let fprintf ppf = kfprintf ignore ppf
 let printf fmt = fprintf std_formatter fmt
 let eprintf fmt = fprintf err_formatter fmt
 
-let kdprintf k (Format (fmt, _)) =
-  make_printf
-    (fun acc -> k (fun ppf -> output_acc ppf acc))
-    End_of_acc fmt
-
-let dprintf fmt = kdprintf (fun i -> i) fmt
-
 let ksprintf k (Format (fmt, _)) =
   let b = pp_make_buffer () in
   let ppf = formatter_of_buffer b in
-  let k acc =
+  let k () acc =
     strput_acc ppf acc;
     k (flush_buffer_formatter b ppf) in
-  make_printf k End_of_acc fmt
+  make_printf k () End_of_acc fmt
 
 
 let sprintf fmt = ksprintf id fmt
@@ -1433,10 +1423,10 @@ let sprintf fmt = ksprintf id fmt
 let kasprintf k (Format (fmt, _)) =
   let b = pp_make_buffer () in
   let ppf = formatter_of_buffer b in
-  let k acc =
+  let k ppf acc =
     output_acc ppf acc;
     k (flush_buffer_formatter b ppf) in
-  make_printf k End_of_acc fmt
+  make_printf k ppf End_of_acc fmt
 
 
 let asprintf fmt = kasprintf id fmt
@@ -1487,8 +1477,8 @@ let get_all_formatter_output_functions =
    then use {!fprintf ppf} as usual. *)
 let bprintf b (Format (fmt, _) : ('a, formatter, unit) format) =
   let ppf = formatter_of_buffer b in
-  let k acc = output_acc ppf acc; pp_flush_queue ppf false in
-  make_printf k End_of_acc fmt
+  let k ppf acc = output_acc ppf acc; pp_flush_queue ppf false in
+  make_printf k ppf End_of_acc fmt
 
 
 (* Deprecated : alias for ksprintf. *)

--- a/vendor/ocamlformat_support/format_.ml
+++ b/vendor/ocamlformat_support/format_.ml
@@ -1310,6 +1310,7 @@ let compute_tag output tag_acc =
 
 open CamlinternalFormatBasics
 open CamlinternalFormat
+open Compat
 
 (* Interpret a formatting entity on a formatter. *)
 let output_formatting_lit ppf fmting_lit = match fmting_lit with

--- a/vendor/ocamlformat_support/format_.ml
+++ b/vendor/ocamlformat_support/format_.ml
@@ -42,7 +42,7 @@ end  = struct
   let is_known n = n >= 0
 end
 
-
+open Compat
 
 (* The pretty-printing boxes definition:
    a pretty-printing box is either

--- a/vendor/ocamlformat_support/format_.mli
+++ b/vendor/ocamlformat_support/format_.mli
@@ -1223,36 +1223,6 @@ val asprintf : ('a, formatter, unit, string) format4 -> 'a
   @since 4.01.0
 *)
 
-val dprintf :
-  ('a, formatter, unit, formatter -> unit) format4 -> 'a
-(** Same as {!fprintf}, except the formatter is the last argument.
-  [dprintf "..." a b c] is a function of type
-  [formatter -> unit] which can be given to a format specifier [%t].
-
-  This can be used as a replacement for {!asprintf} to delay
-  formatting decisions. Using the string returned by {!asprintf} in a
-  formatting context forces formatting decisions to be taken in
-  isolation, and the final string may be created
-  prematurely. {!dprintf} allows delay of formatting decisions until
-  the final formatting context is known.
-  For example:
-{[
-  let t = Format.dprintf "%i@ %i@ %i" 1 2 3 in
-  ...
-  Format.printf "@[<v>%t@]" t
-]}
-
-  @since 4.08.0
-*)
-
-
-val ifprintf : formatter -> ('a, formatter, unit) format -> 'a
-(** Same as [fprintf] above, but does not print anything.
-  Useful to ignore some material when conditionally printing.
-
-  @since 3.10.0
-*)
-
 (** Formatted Pretty-Printing with continuations. *)
 
 val kfprintf :
@@ -1260,15 +1230,6 @@ val kfprintf :
   ('b, formatter, unit, 'a) format4 -> 'b
 (** Same as [fprintf] above, but instead of returning immediately,
   passes the formatter to its first argument at the end of printing. *)
-
-val kdprintf :
-  ((formatter -> unit) -> 'a) ->
-  ('b, formatter, unit, 'a) format4 -> 'b
-(** Same as {!dprintf} above, but instead of returning immediately,
-  passes the suspended printer to its first argument at the end of printing.
-
-  @since 4.08.0
-*)
 
 val ikfprintf :
   (formatter -> 'a) -> formatter ->

--- a/vendor/ocamlformat_support/format_.mli
+++ b/vendor/ocamlformat_support/format_.mli
@@ -107,6 +107,8 @@
 
 *)
 
+open Compat
+
 type formatter
 (** Abstract data corresponding to a pretty-printer (also called a
     formatter) and all its machinery. See also {!section:formatter}. *)


### PR DESCRIPTION
I made some changes in `Format_` to make the code compile with 4.06 and 4.07, however:
- `make fmt` does not produce the same result with 4.06/4.07 and 4.08
- `make test` is only OK for 4.08

So I removed the checks of these 2 switchs from the CI, compiling on these switchs should be enough for `opam-repository` ?
Or maybe we should just enforce the constraint ocaml >= 4.08 ?