### PR TITLE
Improve: add trailing semicolon inside record when break-separators=after-and-docked

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3122,7 +3122,7 @@ and fmt_label_declaration c ctx decl ?(last = false) =
     | `Before -> noop
     | `After -> fmt_if (not last) ";"
     | `After_and_docked ->
-        fmt_or_k last (fits_breaks ~level:7 "" ";") (str ";")
+        fmt_or_k last (fits_breaks ~level:5 "" ";") (str ";")
   in
   hovbox 0
     ( Cmts.fmt_before c pld_loc

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3116,6 +3116,13 @@ and fmt_label_declaration c ctx decl ?(last = false) =
     | `Loose -> true
     | `Tight_decl | `Tight -> false
   in
+  let fmt_semicolon =
+    match c.conf.break_separators with
+    | `Before -> noop
+    | `After -> fmt_if (not last) ";"
+    | `After_and_docked ->
+        fmt_or_k last (fits_breaks ~level:7 "" ";") (str ";")
+  in
   hovbox 0
     ( Cmts.fmt_before c pld_loc
     $ hvbox 4
@@ -3126,10 +3133,7 @@ and fmt_label_declaration c ctx decl ?(last = false) =
                     $ fmt_str_loc c pld_name $ fmt_if field_loose " "
                     $ fmt ":@ "
                     $ fmt_core_type c (sub_typ ~ctx pld_type)
-                    $ fmt_if
-                        ( Poly.(c.conf.break_separators <> `Before)
-                        && not last )
-                        ";" )
+                    $ fmt_semicolon )
                 $ cmt_after_type )
             $ fmt_attributes c ~pre:(fmt "@;<1 1>") ~key:"@" atrs )
         $ Cmts.fmt_after c pld_loc

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2207,8 +2207,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let fmt_field ~first ~last x =
         fmt_if_k (not first) p.sep_before
         $ fmt_field x
-        $ fmt_if_k (not last) p.sep_after_non_final
-        $ fmt_if_k last p.sep_after_final
+        $ fmt_or_k last p.sep_after_final p.sep_after_non_final
       in
       hvbox 0
         ( p.box

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -98,9 +98,9 @@ let get_record_type (c : Conf.t) =
   | `After ->
       { docked_before= noop
       ; break_before= fmt "@ "
-      ; box_record= (fun k -> hvbox 2 (wrap_record c k))
+      ; box_record= (fun k -> hvbox 0 (wrap_record c k))
       ; sep_before= noop
-      ; sep_after= fmt_or sparse_type_decl "@;<1000 0>" "@ "
+      ; sep_after= fmt_or sparse_type_decl "@;<1000 2>" "@;<1 2>"
       ; break_after= noop
       ; docked_after= noop }
   | `After_and_docked ->
@@ -117,7 +117,8 @@ type record_expr =
   { box: Fmt.t -> Fmt.t
   ; break_after_with: Fmt.t
   ; sep_before: Fmt.t
-  ; sep_after: Fmt.t }
+  ; sep_after_non_final: Fmt.t
+  ; sep_after_final: Fmt.t }
 
 let get_record_expr (c : Conf.t) =
   match c.break_separators with
@@ -125,12 +126,14 @@ let get_record_expr (c : Conf.t) =
       { box= (fun k -> hvbox 0 (wrap_record c k))
       ; break_after_with= break 1 2
       ; sep_before= fmt "@,; "
-      ; sep_after= noop }
+      ; sep_after_non_final= noop
+      ; sep_after_final= noop }
   | `After ->
       { box= (fun k -> hvbox 0 (wrap_record c k))
       ; break_after_with= break 1 2
       ; sep_before= noop
-      ; sep_after= fmt ";@;<1 2>" }
+      ; sep_after_non_final= fmt ";@;<1 2>"
+      ; sep_after_final= noop }
   | `After_and_docked ->
       let space = if c.space_around_records then 1 else 0 in
       { box=
@@ -138,7 +141,8 @@ let get_record_expr (c : Conf.t) =
             hvbox 2 (wrap "{" "}" (break space 0 $ k $ break space (-2))))
       ; break_after_with= break 1 0
       ; sep_before= noop
-      ; sep_after= fmt ";@ " }
+      ; sep_after_non_final= fmt ";@;<1 0>"
+      ; sep_after_final= fits_breaks ~level:1 "" ";" }
 
 type if_then_else =
   { box_branch: Fmt.t -> Fmt.t

--- a/src/Params.mli
+++ b/src/Params.mli
@@ -47,7 +47,8 @@ type record_expr =
   { box: Fmt.t -> Fmt.t
   ; break_after_with: Fmt.t
   ; sep_before: Fmt.t
-  ; sep_after: Fmt.t }
+  ; sep_after_non_final: Fmt.t
+  ; sep_after_final: Fmt.t }
 
 val get_record_expr : Conf.t -> record_expr
 

--- a/src/ocamlformat_reason.ml
+++ b/src/ocamlformat_reason.ml
@@ -38,8 +38,7 @@ let try_read_original_source filename =
 
 type xunit =
   | Pack :
-      { parse: In_channel.t -> 'a Reason.t
-      ; xunit: 'a Translation_unit.t }
+      {parse: In_channel.t -> 'a Reason.t; xunit: 'a Translation_unit.t}
       -> xunit
 
 let pack_of_kind = function

--- a/test/passing/break_separators.ml
+++ b/test/passing/break_separators.ml
@@ -96,6 +96,12 @@ type t = {aaaaaaaaa: aaaa; bbbbbbbbb: bbbb}
 type trace_mod_funs =
   {trace_mod: bool option; trace_funs: bool Map.M(String).t}
 
+module Fooooo = struct
+  type t = {fooooo: fooo; fooooo: fooooooo}
+  (** This is a long docstring so that it cannot be on the same line as the
+      record type. *)
+end
+
 [@@@ocamlformat "type-decl=sparse"]
 
 type t =

--- a/test/passing/break_separators_after.ml.ref
+++ b/test/passing/break_separators_after.ml.ref
@@ -96,6 +96,12 @@ type t = {aaaaaaaaa: aaaa; bbbbbbbbb: bbbb}
 type trace_mod_funs =
   {trace_mod: bool option; trace_funs: bool Map.M(String).t}
 
+module Fooooo = struct
+  type t = {fooooo: fooo; fooooo: fooooooo}
+  (** This is a long docstring so that it cannot be on the same line as the
+      record type. *)
+end
+
 [@@@ocamlformat "type-decl=sparse"]
 
 type t =

--- a/test/passing/break_separators_after_docked.ml.ref
+++ b/test/passing/break_separators_after_docked.ml.ref
@@ -2,7 +2,7 @@ type t = {
   (* fooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
   foooooooooooooooooooooooo: foooooooooooooooooooooooooooooooooooooooo;
   (* foooooooooooooooooooooooooooooooooooooooooooo *)
-  fooooooooooooooooooooooooooooo: fooooooooooooooooooooooooooo
+  fooooooooooooooooooooooooooooo: fooooooooooooooooooooooooooo;
 }
 
 type x =
@@ -10,18 +10,18 @@ type x =
       { (* fooooooooooooooooooooooooooooooooooooooooo *)
         aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
         (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo*)
-        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
+        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb; }
 
 type t = {
   aaaaaaaaaaaaaaaaaaaaaaaaa: aaaa aaaaaaaaaaaaaaaaaaa;
   bbbbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbb bbbb;
-  cccccccccccccccccccccc: ccccccc ccccccccccc cccccccc
+  cccccccccccccccccccccc: ccccccc ccccccccccc cccccccc;
 }
 
 type x =
   | B of
       { aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
-        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
+        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb; }
 
 type t = {
   break_cases: [`Fit | `Nested | `All];
@@ -65,7 +65,7 @@ type t = {
   single_case: [`Compact | `Sparse];
   type_decl: [`Compact | `Sparse];
   wrap_comments: bool;  (** Wrap comments at margin. *)
-  wrap_fun_args: bool
+  wrap_fun_args: bool;
 }
 
 let _ =
@@ -98,19 +98,19 @@ type t = {aaaaaaaaa: aaaa; bbbbbbbbb: bbbb}
 
 type trace_mod_funs = {
   trace_mod: bool option;
-  trace_funs: bool Map.M(String).t
+  trace_funs: bool Map.M(String).t;
 }
 
 [@@@ocamlformat "type-decl=sparse"]
 
 type t = {
   aaaaaaaaa: aaaa;
-  bbbbbbbbb: bbbb
+  bbbbbbbbb: bbbb;
 }
 
 type trace_mod_funs = {
   trace_mod: bool option;
-  trace_funs: bool Map.M(String).t
+  trace_funs: bool Map.M(String).t;
 }
 
 let x {aaaaaaaaaaaaaa; aaaaaaaaaaaaa; aaaaaaaaaa} =
@@ -249,7 +249,7 @@ type t = {
     foooooooooooooo ->
     foooooooooo ->
     fooooooooooooooo;
-  foo: foo
+  foo: foo;
 }
 
 [@@@ocamlformat "ocp-indent-compat"]

--- a/test/passing/break_separators_after_docked.ml.ref
+++ b/test/passing/break_separators_after_docked.ml.ref
@@ -6,11 +6,12 @@ type t = {
 }
 
 type x =
-  | B of
-      { (* fooooooooooooooooooooooooooooooooooooooooo *)
-        aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
-        (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo*)
-        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb; }
+  | B of {
+      (* fooooooooooooooooooooooooooooooooooooooooo *)
+      aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
+      (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo*)
+      bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb;
+    }
 
 type t = {
   aaaaaaaaaaaaaaaaaaaaaaaaa: aaaa aaaaaaaaaaaaaaaaaaa;
@@ -19,9 +20,10 @@ type t = {
 }
 
 type x =
-  | B of
-      { aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
-        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb; }
+  | B of {
+      aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
+      bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb;
+    }
 
 type t = {
   break_cases: [`Fit | `Nested | `All];
@@ -125,7 +127,7 @@ let x
   {
     aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
     bbbbbbbbbbbbb= bbb bb bbbbbb;
-    cccccc= cccc ccccccccccccccccccccccc
+    cccccc= cccc ccccccccccccccccccccccc;
   }
 
 (* this is an array *)
@@ -281,7 +283,7 @@ let x
   {
     aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
     bbbbbbbbbbbbb= bbb bb bbbbbb;
-    cccccc= cccc ccccccccccccccccccccccc
+    cccccc= cccc ccccccccccccccccccccccc;
   }
 
 let foooooooooooooooooooooooooooooooooo =
@@ -290,14 +292,14 @@ let foooooooooooooooooooooooooooooooooo =
     aaaaaaaaaaaa= aaaaaaaaaaaaaaaaa;
     (* fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
     bbbbbbbbbbbbb= bbb bb bbbbbb;
-    cccccc= cccc ccccccccccccccccccccccc
+    cccccc= cccc ccccccccccccccccccccccc;
   }
 
 let foooooooooooo =
   {
     foooooooooooooo with
     fooooooooooooooooooooooooooooo= fooooooooooooo;
-    fooooooooooooo= foooooooooooooo
+    fooooooooooooo= foooooooooooooo;
   }
 
 let foooooooooooo =
@@ -305,7 +307,7 @@ let foooooooooooo =
     foooooooooooooo with
     (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
     fooooooooooooooooooooooooooooo= fooooooooooooo;
-    fooooooooooooo= foooooooooooooo
+    fooooooooooooo= foooooooooooooo;
   }
 
 let fooooooooooo = function
@@ -314,5 +316,5 @@ let fooooooooooo = function
         empty with
         bdy= fmt_longident_loc c lid;
         epi=
-          Some (fmt_attributes c ~key:"@" pmty_attributes ~pre:(fmt "@ "))
+          Some (fmt_attributes c ~key:"@" pmty_attributes ~pre:(fmt "@ "));
       }

--- a/test/passing/break_separators_after_docked.ml.ref
+++ b/test/passing/break_separators_after_docked.ml.ref
@@ -103,6 +103,12 @@ type trace_mod_funs = {
   trace_funs: bool Map.M(String).t;
 }
 
+module Fooooo = struct
+  type t = {fooooo: fooo; fooooo: fooooooo}
+  (** This is a long docstring so that it cannot be on the same line as the
+      record type. *)
+end
+
 [@@@ocamlformat "type-decl=sparse"]
 
 type t = {

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -8076,7 +8076,11 @@ end =
 let _ = test 103 (Lazy.force M3.x) 3
 
 (** Pure type-checking tests: see recmod/*.ml  *)
-type t = A of { x : int; mutable y : int }
+type t =
+  | A of
+      { x : int
+      ; mutable y : int
+      }
 
 let f (A r) = r
 
@@ -8097,7 +8101,12 @@ let f () = A { x = 1; y = 3 }
 
 (* ok *)
 
-type _ t = A : { x : 'a; y : 'b } -> 'a t
+type _ t =
+  | A :
+      { x : 'a
+      ; y : 'b
+      }
+      -> 'a t
 
 let f (A { x; y }) = A { x; y = () }
 

--- a/test/passing/types-compact-space_around-docked.ml.ref
+++ b/test/passing/types-compact-space_around-docked.ml.ref
@@ -18,7 +18,7 @@ type t = [ `A | `B ]
 
 type loooooooooong_type = {
   looooooooooooong_field: looooooooooooong_type;
-  field2: type2
+  field2: type2;
 }
 
 type t = A of (int * int) * int
@@ -135,7 +135,7 @@ type ( 'context,
   on_objc_cpp: 'context -> 'f_in;
   on_objc_cpp: 'context -> 'f_in;
   on_objc_cpp: 'context -> 'f_in;
-  on_objc_cpp: 'context -> 'f_in
+  on_objc_cpp: 'context -> 'f_in;
 }
 
 type ( 'context,
@@ -157,7 +157,7 @@ type ( 'context,
   on_objc_cpp: 'context -> 'f_in;
   on_objc_cpp: 'context -> 'f_in;
   on_objc_cpp: 'context -> 'f_in;
-  on_objc_cpp: 'context -> 'f_in
+  on_objc_cpp: 'context -> 'f_in;
 }
 
 type ( 'context,


### PR DESCRIPTION
Fix #895 (I didn't add any option, I think we always want this behavior).

Cases like this:
```ocaml
type x =
   | B of
       { aaaaaaaaaaaaaaa: aaaaaaaaaaaaaaaa;
-        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb }
+        bbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbb; }
```
will be fixed in another PR (the brackets should obviously be docked but that is not the purpose of this PR).