### PR TITLE
Fix monadic bindings (new 4.08 syntax)

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -49,6 +49,18 @@ let is_infix_symbol = function
       true
   | _ -> false
 
+let is_monadic_binding_id s =
+  String.length s > 3
+  && (String.is_prefix s ~prefix:"let" || String.is_prefix s ~prefix:"and")
+  && String.for_all
+       (String.sub s ~pos:3 ~len:(String.length s - 3))
+       ~f:is_infix_symbol
+
+let is_monadic_binding e =
+  match e.pexp_desc with
+  | Pexp_ident {txt= Lident i; _} -> is_monadic_binding_id i
+  | _ -> false
+
 let is_infix_id i =
   match (i.[0], i) with
   | ( ( '$' | '%' | '*' | '+' | '-' | '/' | '<' | '=' | '>' | '|' | '&'
@@ -58,13 +70,7 @@ let is_infix_id i =
     , ( "!=" | "land" | "lor" | "lxor" | "mod" | "::" | ":=" | "asr" | "lsl"
       | "lsr" | "or" | "||" ) ) ->
       true
-  | _ ->
-      String.length i > 3
-      && ( String.is_prefix i ~prefix:"let"
-         || String.is_prefix i ~prefix:"and" )
-      && String.for_all
-           (String.sub i ~pos:3 ~len:(String.length i - 3))
-           ~f:is_infix_symbol
+  | _ -> is_monadic_binding_id i
 
 let is_infix e =
   match e.pexp_desc with

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -44,6 +44,11 @@ let is_prefix exp =
   | Pexp_ident {txt= Lident i; _} -> is_prefix_id i
   | _ -> false
 
+let is_infix_symbol = function
+  | '$' | '&' | '*' | '+' | '-' | '/' | '<' | '=' | '>' | '@' | '^' | '|' ->
+      true
+  | _ -> false
+
 let is_infix_id i =
   match (i.[0], i) with
   | ( ( '$' | '%' | '*' | '+' | '-' | '/' | '<' | '=' | '>' | '|' | '&'
@@ -53,7 +58,13 @@ let is_infix_id i =
     , ( "!=" | "land" | "lor" | "lxor" | "mod" | "::" | ":=" | "asr" | "lsl"
       | "lsr" | "or" | "||" ) ) ->
       true
-  | _ -> false
+  | _ ->
+      String.length i > 3
+      && ( String.is_substring i ~substring:"let"
+         || String.is_substring i ~substring:"and" )
+      && String.for_all
+           (String.sub i ~pos:3 ~len:(String.length i - 3))
+           ~f:is_infix_symbol
 
 let is_infix e =
   match e.pexp_desc with

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -60,8 +60,8 @@ let is_infix_id i =
       true
   | _ ->
       String.length i > 3
-      && ( String.is_substring i ~substring:"let"
-         || String.is_substring i ~substring:"and" )
+      && ( String.is_prefix i ~prefix:"let"
+         || String.is_prefix i ~prefix:"and" )
       && String.for_all
            (String.sub i ~pos:3 ~len:(String.length i - 3))
            ~f:is_infix_symbol

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -44,8 +44,9 @@ let is_prefix exp =
   | Pexp_ident {txt= Lident i; _} -> is_prefix_id i
   | _ -> false
 
-let is_infix_symbol = function
-  | '$' | '&' | '*' | '+' | '-' | '/' | '<' | '=' | '>' | '@' | '^' | '|' ->
+let is_kwdopchar = function
+  | '$' | '&' | '*' | '+' | '-' | '/' | '<' | '=' | '>' | '@' | '^' | '|'
+   |'!' | '%' | ':' | '?' ->
       true
   | _ -> false
 
@@ -54,7 +55,7 @@ let is_monadic_binding_id s =
   && (String.is_prefix s ~prefix:"let" || String.is_prefix s ~prefix:"and")
   && String.for_all
        (String.sub s ~pos:3 ~len:(String.length s - 3))
-       ~f:is_infix_symbol
+       ~f:is_kwdopchar
 
 let is_monadic_binding e =
   match e.pexp_desc with

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -53,9 +53,8 @@ let is_kwdopchar = function
 let is_monadic_binding_id s =
   String.length s > 3
   && (String.is_prefix s ~prefix:"let" || String.is_prefix s ~prefix:"and")
-  && String.for_all
-       (String.sub s ~pos:3 ~len:(String.length s - 3))
-       ~f:is_kwdopchar
+  && Option.is_none
+       (String.lfindi s ~pos:3 ~f:(fun _ c -> not (is_kwdopchar c)))
 
 let is_monadic_binding e =
   match e.pexp_desc with

--- a/src/Ast.mli
+++ b/src/Ast.mli
@@ -41,6 +41,10 @@ val index_op_set_sugar :
   -> ((string * Char.t * Char.t) Location.loc * expression list * expression)
      option
 
+val is_monadic_binding_id : string -> bool
+
+val is_monadic_binding : expression -> bool
+
 val is_symbol_id : string -> bool
 (** Holds of prefix or infix symbols. *)
 

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1618,7 +1618,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         ; pexp_loc= _
         ; _ }
       , [(Nolabel, _); (Nolabel, _)] )
-    when is_infix_id id ->
+    when is_infix_id id && not (is_monadic_binding_id id) ->
       let op_args = Sugar.infix c.cmts (prec_ast (Exp exp)) xexp in
       fmt_op_args
         (List.map op_args ~f:(fun (op, args) ->
@@ -1923,6 +1923,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let wrap, wrap_ident =
         if is_symbol exp && not (List.is_empty pexp_attributes) then
           (wrap "( " " )", true)
+        else if is_monadic_binding exp then (wrap "( " " )", false)
         else if is_symbol exp then (wrap_if parens "( " " )", false)
         else (wrap_if parens "(" ")", false)
       in

--- a/test/passing/monadic_binding.ml
+++ b/test/passing/monadic_binding.ml
@@ -5,3 +5,11 @@ let ( and* ) t1 t2 = foooooo
 let map f t =
   let* a = t in
   pure (f a)
+
+let ( and+ ) t1 t2 = ( and* ) t1 t2
+
+let ( and+ ) t1 t2 = ( and* ) t1 t2 x
+
+let ( and+ ) t1 t2 =
+  ( and* ) t1 t2 x foooooooooooooooooo foooooooooooooooooooo
+    foooooooooooooooooo foooooooooooooooooo

--- a/test/passing/monadic_binding.ml
+++ b/test/passing/monadic_binding.ml
@@ -1,0 +1,7 @@
+let ( let* ) t f = fooooooo
+
+let ( and* ) t1 t2 = foooooo
+
+let map f t =
+  let* a = t in
+  pure (f a)


### PR DESCRIPTION
Fix #907
The rules for the indent names are from https://github.com/ocaml/ocaml/pull/1947

@hakuch feel free to give us some feedback before we merge this branch.