### PR TITLE
update ocamlformat_reason opam file to 2.0 format

### DIFF
--- a/ocamlformat_reason.opam
+++ b/ocamlformat_reason.opam
@@ -9,17 +9,12 @@
 #                                                                    #
 ######################################################################
 
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
 authors: "Josh Berdine <jjb@fb.com>"
+license: "MIT"
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
-dev-repo: "https://github.com/ocaml-ppx/ocamlformat.git"
-license: "MIT"
-build: [
-  ["ocaml" "tools/gen_version.mlt" "src/Version.ml" version] {pinned}
-  ["dune" "build" "-p" name "-j" jobs]
-]
 depends: [
   "ocaml" {>= "4.06"}
   "base" {>= "v0.11.0"}
@@ -34,5 +29,11 @@ depends: [
   "uutf"
   "reason" {>= "3.2.0"}
 ]
+build: [
+  ["ocaml" "tools/gen_version.mlt" "src/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+synopsis: "Auto-formatter for ReasonML code"
+description: "ocamlformat_reason is a tool to automatically format ReasonML code in a uniform style."
 
-available: [ ocaml-version >= "4.04.1" & ocaml-version < "4.05" ]


### PR DESCRIPTION
I updated the ocaml version to match the main tool... is that right? The old constraints seem out of date.