### PR TITLE
Improve: break with labeled arrow type

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -666,8 +666,8 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
       let arg_label lbl =
         match lbl with
         | Nolabel -> noop
-        | Labelled l -> str l $ str ":"
-        | Optional l -> str "?" $ str l $ str ":"
+        | Labelled l -> str l $ str ":" $ fmt "@,"
+        | Optional l -> str "?" $ str l $ str ":" $ fmt "@,"
       in
       let xt1N = Sugar.arrow_typ c.cmts xtyp in
       let indent =
@@ -686,7 +686,11 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
           ( if Poly.(c.conf.break_separators = `Before) then
             if parens then "@;<1 1>-> " else "@ -> "
           else " ->@;<1 0>" )
-          (fun (lI, xtI) -> hvbox 0 (arg_label lI $ fmt_core_type c xtI))
+          (fun (lI, xtI) ->
+            hvbox_if
+              Poly.(lI <> Nolabel)
+              2
+              (arg_label lI $ hvbox 0 (fmt_core_type c xtI)))
   | Ptyp_constr (lid, []) -> fmt_longident_loc c lid
   | Ptyp_constr (lid, [t1]) ->
       fmt_core_type c (sub_typ ~ctx t1) $ fmt "@ " $ fmt_longident_loc c lid

--- a/test/passing/types-compact-space_around-docked.ml.ref
+++ b/test/passing/types-compact-space_around-docked.ml.ref
@@ -194,3 +194,16 @@ module type A = sig
 end
 
 type t = [ `A  (** A *) | `B[@b]  (** B *) | (p[@p]) (* P *) ]
+
+type foooooooooooooooo =
+  ?fooooooooo:(string -> unit) ->
+  ?fooooooooooooo:
+    (string ->
+    string ->
+    int ->
+    string ->
+    string option foooooooooooooooooooooooo) ->
+  fooooo:string ->
+  ?fooooooooo:(unit -> unit Fooo.t) ->
+  ?fooooooo:bool ->
+  string option Foooooooo.t

--- a/test/passing/types-compact-space_around.ml.ref
+++ b/test/passing/types-compact-space_around.ml.ref
@@ -192,3 +192,16 @@ module type A = sig
 end
 
 type t = [ `A  (** A *) | `B[@b]  (** B *) | (p[@p]) (* P *) ]
+
+type foooooooooooooooo =
+     ?fooooooooo:(string -> unit)
+  -> ?fooooooooooooo:
+       (   string
+        -> string
+        -> int
+        -> string
+        -> string option foooooooooooooooooooooooo)
+  -> fooooo:string
+  -> ?fooooooooo:(unit -> unit Fooo.t)
+  -> ?fooooooo:bool
+  -> string option Foooooooo.t

--- a/test/passing/types-compact.ml.ref
+++ b/test/passing/types-compact.ml.ref
@@ -190,3 +190,16 @@ module type A = sig
 end
 
 type t = [`A  (** A *) | `B[@b]  (** B *) | (p[@p]) (* P *)]
+
+type foooooooooooooooo =
+     ?fooooooooo:(string -> unit)
+  -> ?fooooooooooooo:
+       (   string
+        -> string
+        -> int
+        -> string
+        -> string option foooooooooooooooooooooooo)
+  -> fooooo:string
+  -> ?fooooooooo:(unit -> unit Fooo.t)
+  -> ?fooooooo:bool
+  -> string option Foooooooo.t

--- a/test/passing/types-sparse-space_around.ml.ref
+++ b/test/passing/types-sparse-space_around.ml.ref
@@ -238,3 +238,16 @@ type t =
   | `B[@b]  (** B *)
   | (p[@p]) (* P *)
   ]
+
+type foooooooooooooooo =
+     ?fooooooooo:(string -> unit)
+  -> ?fooooooooooooo:
+       (   string
+        -> string
+        -> int
+        -> string
+        -> string option foooooooooooooooooooooooo)
+  -> fooooo:string
+  -> ?fooooooooo:(unit -> unit Fooo.t)
+  -> ?fooooooo:bool
+  -> string option Foooooooo.t

--- a/test/passing/types-sparse.ml.ref
+++ b/test/passing/types-sparse.ml.ref
@@ -219,3 +219,16 @@ type t =
   [ `A  (** A *)
   | `B[@b]  (** B *)
   | (p[@p]) (* P *) ]
+
+type foooooooooooooooo =
+     ?fooooooooo:(string -> unit)
+  -> ?fooooooooooooo:
+       (   string
+        -> string
+        -> int
+        -> string
+        -> string option foooooooooooooooooooooooo)
+  -> fooooo:string
+  -> ?fooooooooo:(unit -> unit Fooo.t)
+  -> ?fooooooo:bool
+  -> string option Foooooooo.t

--- a/test/passing/types.ml
+++ b/test/passing/types.ml
@@ -190,3 +190,16 @@ module type A = sig
 end
 
 type t = [`A  (** A *) | `B[@b]  (** B *) | (p[@p]) (* P *)]
+
+type foooooooooooooooo =
+     ?fooooooooo:(string -> unit)
+  -> ?fooooooooooooo:
+       (   string
+        -> string
+        -> int
+        -> string
+        -> string option foooooooooooooooooooooooo)
+  -> fooooo:string
+  -> ?fooooooooo:(unit -> unit Fooo.t)
+  -> ?fooooooo:bool
+  -> string option Foooooooo.t

--- a/test/passing/types_indent.ml.ref
+++ b/test/passing/types_indent.ml.ref
@@ -190,3 +190,16 @@ module type A = sig
 end
 
 type t = [`A  (** A *) | `B[@b]  (** B *) | (p[@p]) (* P *)]
+
+type foooooooooooooooo =
+         ?fooooooooo:(string -> unit)
+      -> ?fooooooooooooo:
+           (   string
+            -> string
+            -> int
+            -> string
+            -> string option foooooooooooooooooooooooo)
+      -> fooooo:string
+      -> ?fooooooooo:(unit -> unit Fooo.t)
+      -> ?fooooooo:bool
+      -> string option Foooooooo.t


### PR DESCRIPTION
Fix the last part of #925 
The diff of test_branch looks good:
```ocaml
diff --git a/infer/src/checkers/loopInvariant.mli b/infer/src/checkers/loopInvariant.mli
index d2cbb978b..1ab94c0d1 100644
--- a/infer/src/checkers/loopInvariant.mli
+++ b/infer/src/checkers/loopInvariant.mli
@@ -27,9 +27,9 @@ val get_inv_vars_in_loop :
      Tenv.t
   -> ReachingDefs.invariant_map
   -> is_pure_by_default:bool
-  -> get_callee_purity:(   Typ.Procname.t
-                        -> PurityDomain.ModifiedParamIndices.t AbstractDomain.Types.top_lifted
-                           sexp_option)
+  -> get_callee_purity:
+       (   Typ.Procname.t
+        -> PurityDomain.ModifiedParamIndices.t AbstractDomain.Types.top_lifted sexp_option)
   -> Procdesc.Node.t
   -> LoopNodes.t
   -> VarSet.t
diff --git a/infer/src/pulse/PulseDomain.ml b/infer/src/pulse/PulseDomain.ml
index bad6948cc..be332fcde 100644
--- a/infer/src/pulse/PulseDomain.ml
+++ b/infer/src/pulse/PulseDomain.ml
@@ -745,7 +745,8 @@ module GraphVisit : sig
        var_filter:(Var.t -> bool)
     -> t
     -> init:'accum
-    -> f:(   'accum
+    -> f:
+         (   'accum
           -> AbstractAddress.t
           -> Var.t
           -> Memory.Access.t list
diff --git a/lib/lwt/lwt_xmlHttpRequest.mli b/lib/lwt/lwt_xmlHttpRequest.mli
index 5df688f91..edc566543 100644
--- a/lib/lwt/lwt_xmlHttpRequest.mli
+++ b/lib/lwt/lwt_xmlHttpRequest.mli
@@ -49,10 +49,11 @@ val perform_raw :
                      int -> (string -> string option) -> bool)
   -> ?progress:(int -> int -> unit)
   -> ?upload_progress:(int -> int -> unit)
-  -> ?contents:[< `POST_form of (string * Form.form_elt) list
-               | `Form_contents of Form.form_contents
-               | `String of string
-               | `Blob of #File.blob Js.t ]
+  -> ?contents:
+       [< `POST_form of (string * Form.form_elt) list
+       | `Form_contents of Form.form_contents
+       | `String of string
+       | `Blob of #File.blob Js.t ]
   -> ?override_mime_type:string
   -> ?override_method:[< `GET | `POST | `HEAD | `PUT | `DELETE | `OPTIONS | `PATCH]
   -> ?with_credentials:bool
@@ -72,10 +73,11 @@ val perform_raw_url :
                      int -> (string -> string option) -> bool)
   -> ?progress:(int -> int -> unit)
   -> ?upload_progress:(int -> int -> unit)
-  -> ?contents:[< `POST_form of (string * Form.form_elt) list
-               | `Form_contents of Form.form_contents
-               | `String of string
-               | `Blob of #File.blob Js.t ]
+  -> ?contents:
+       [< `POST_form of (string * Form.form_elt) list
+       | `Form_contents of Form.form_contents
+       | `String of string
+       | `Blob of #File.blob Js.t ]
   -> ?override_mime_type:string
   -> ?override_method:[< `GET | `POST | `HEAD | `PUT | `DELETE | `OPTIONS | `PATCH]
   -> ?with_credentials:bool
@@ -100,10 +102,11 @@ val perform :
                      int -> (string -> string option) -> bool)
   -> ?progress:(int -> int -> unit)
   -> ?upload_progress:(int -> int -> unit)
-  -> ?contents:[< `POST_form of (string * Form.form_elt) list
-               | `Form_contents of Form.form_contents
-               | `String of string
-               | `Blob of #File.blob Js.t ]
+  -> ?contents:
+       [< `POST_form of (string * Form.form_elt) list
+       | `Form_contents of Form.form_contents
+       | `String of string
+       | `Blob of #File.blob Js.t ]
   -> ?override_mime_type:string
   -> ?override_method:[< `GET | `POST | `HEAD | `PUT | `DELETE | `OPTIONS | `PATCH]
   -> ?with_credentials:bool
```

With `max-indent=2` on the example of #925 we get:
```ocaml
type source_request =  
     ?pdebug:(string -> unit)
  -> ?version_conflict_handler:
    (string -> string -> int -> string -> string option Web.Http_lwt.IO.t)
  -> name:string
  -> ?should_exit:(unit -> unit Lwt.t)
  -> ?verbose:bool
  -> ?once:bool
  -> ?timeout:int
  -> ?retries:int
  -> ?body:string
  -> ?request_id:string
  -> Web.http_action
  -> string list
  -> ?args:(string * string) list
  -> unit
  -> string option Lwt.t
```