### PR TITLE
Improve: force break after an infix op only if followed by another one

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1614,7 +1614,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                            4 (fmt_fun_args c xargs)
                        $ fmt "@ ->" ) )
                $ pre_body )
-           $ fmt "@;<1000 0>" $ body ))
+           $ fmt "@ " $ body ))
   | Pexp_apply
       ( ( { pexp_desc= Pexp_ident {txt= Lident id; loc}
           ; pexp_attributes= []

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1598,6 +1598,17 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let xargs, xbody = Sugar.fun_ c.cmts (sub_exp ~ctx r) in
       let indent_wrap = if parens then -2 else 0 in
       let pre_body, body = fmt_body c ?ext xbody in
+      let followed_by_infix_op =
+        match xbody.ast.pexp_desc with
+        | Pexp_apply
+            ( { pexp_desc= Pexp_ident {txt= Lident id; loc= _}
+              ; pexp_attributes= []
+              ; _ }
+            , [(Nolabel, _); (Nolabel, {pexp_desc= Pexp_fun _; _})] )
+          when is_infix_id id ->
+            true
+        | _ -> false
+      in
       wrap_fits_breaks_if c.conf parens "(" ")"
         (hovbox 0
            ( hvbox 2
@@ -1614,7 +1625,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                            4 (fmt_fun_args c xargs)
                        $ fmt "@ ->" ) )
                $ pre_body )
-           $ fmt "@ " $ body ))
+           $ fmt_or followed_by_infix_op "@;<1000 0>" "@ "
+           $ body ))
   | Pexp_apply
       ( ( { pexp_desc= Pexp_ident {txt= Lident id; loc}
           ; pexp_attributes= []

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1604,7 +1604,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             ( { pexp_desc= Pexp_ident {txt= Lident id; loc= _}
               ; pexp_attributes= []
               ; _ }
-            , [(Nolabel, _); (Nolabel, {pexp_desc= Pexp_fun _; _})] )
+            , [ (Nolabel, _)
+              ; (Nolabel, {pexp_desc= Pexp_fun _ | Pexp_function _; _}) ] )
           when is_infix_id id ->
             true
         | _ -> false

--- a/test/passing/infix_bind.ml
+++ b/test/passing/infix_bind.ml
@@ -23,11 +23,7 @@ f x
 ;;
 f x >>= fun y ->
 g y >>= fun () ->
-f x >>= fun y ->
-g y >>= fun () ->
-f x >>= fun y ->
-g y >>= fun () ->
-y ()
+f x >>= fun y -> g y >>= fun () -> f x >>= fun y -> g y >>= fun () -> y ()
 
 ;;
 f x >>= function
@@ -35,24 +31,19 @@ f x >>= function
     g y >>= fun () ->
     f x >>= fun y ->
     g y >>= function
-    | x -> (
-        f x >>= fun y ->
-        g y >>= function _ -> y () ) )
+    | x -> ( f x >>= fun y -> g y >>= function _ -> y () ) )
 
 ;;
-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> fun x ->
-x
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> fun x -> x
 
 ;;
 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-|> fun xxxxxx xxxxxxxxxx xxxxxxxx xxxxxxxx ->
-x
+|> fun xxxxxx xxxxxxxxxx xxxxxxxx xxxxxxxx -> x
 
 ;;
 eeeeeeeeeeeee eeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeeee
   eeeeeeeeeeee eeeeeeeeee
-|> fun x ->
-x
+|> fun x -> x
 
 ;;
 eeeeeeeeeeeee eeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeeee
@@ -61,22 +52,18 @@ eeeeeeeeeeeee eeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeeee
 xxxxxxxxxxx xxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxx xxxxxxxxxxx
 
 ;;
-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> fun x ->
-x
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> fun x -> x
 
 ;;
 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-|> fun xxxxxx xxxxxxxxxx xxxxxxxx xxxxxxxx ->
-x
+|> fun xxxxxx xxxxxxxxxx xxxxxxxx xxxxxxxx -> x
 
 ;;
-eeeeeeeeeeeee eeeeeeeeeeeeeeeeee |> fun xxxxxxxxx xxxxxxxxxxxxx ->
-x
+eeeeeeeeeeeee eeeeeeeeeeeeeeeeee |> fun xxxxxxxxx xxxxxxxxxxxxx -> x
 
 ;;
 eeeeeeeeeeeee eeeeeeeeeeeeeeeeee eeeeeeeeeeeeeeeeeee
-|> fun xxxxxxxx xxxxxxxxx xxxxxxxxxxxxx ->
-x
+|> fun xxxxxxxx xxxxxxxxx xxxxxxxxxxxxx -> x
 
 ;;
 eeeeeeeeeeeee eeeeeeeeeeeeeeeeee |> fun xxxxxxxxxxxxx ->
@@ -166,17 +153,13 @@ let end_gen_implementation ?toplevel ~ppf_dump
   ( clambda
   ++ Profile.record "cmm" (Cmmgen.compunit ~ppf_dump)
   ++ Profile.record "compile_phrases" (List.iter (compile_phrase ~ppf_dump))
-  ++ fun () ->
-    () ) ;
+  ++ fun () -> () ) ;
   fooooooooooooooo
 
 let foo =
   (* get the tree origin *)
   get_store_tree s >>= function
-  | None ->
-      f t >|= fun x ->
-      Ok x
-      (* no transaction is needed *)
+  | None -> f t >|= fun x -> Ok x (* no transaction is needed *)
   | Some (origin, old_tree) ->
       let batch = {repo; tree= old_tree; origin} in
       let b = Batch batch in
@@ -189,9 +172,7 @@ let _ =
   | Afoooooooooooooooooo fooooooooo -> false
   | Bfoooooooooooooooooooooo fooooooooo -> true
 
-let _ =
-  foo >>= fun [@warning "-4"] x ->
-  fooooooooooooooooooooooo
+let _ = foo >>= fun [@warning "-4"] x -> fooooooooooooooooooooooo
 
 let _ =
   foo >>= fun [@warning "-4"] x y ->

--- a/test/passing/infix_bind.ml
+++ b/test/passing/infix_bind.ml
@@ -34,7 +34,9 @@ f x >>= function
     g y >>= fun () ->
     f x >>= fun y ->
     g y >>= function
-    | x -> ( f x >>= fun y -> g y >>= function _ -> y () ) )
+    | x -> (
+        f x >>= fun y ->
+        g y >>= function _ -> y () ) )
 
 ;;
 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee |> fun x -> x

--- a/test/passing/infix_bind.ml
+++ b/test/passing/infix_bind.ml
@@ -23,7 +23,10 @@ f x
 ;;
 f x >>= fun y ->
 g y >>= fun () ->
-f x >>= fun y -> g y >>= fun () -> f x >>= fun y -> g y >>= fun () -> y ()
+f x >>= fun y ->
+g y >>= fun () ->
+f x >>= fun y ->
+g y >>= fun () -> y ()
 
 ;;
 f x >>= function


### PR DESCRIPTION
Forcing the break was a bit too aggressive and generates unnecessary diffs with 0.9
cc @samoht 