### PR TITLE
Doc: enable-outside-detected-project necessary for global conf file

### DIFF
--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -24,7 +24,8 @@ OPTIONS (CODE FORMATTING STYLE)
        defined in $XDG_CONFIG_HOME or in $HOME/.config if $XDG_CONFIG_HOME is
        undefined. The global ocamlformat file has the lowest priority, then
        the closer the directory is to the processed file, the higher the
-       priority.
+       priority. The global ocamlformat file is only used when the option
+       enable-outside-detected-project is set.
 
        If the disable option is not set, an .ocamlformat-ignore file
        specifies files that OCamlFormat should ignore. Each line in an

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -118,7 +118,8 @@ let info =
          $(b,\\$HOME/.config) if $(b,\\$XDG_CONFIG_HOME) is undefined. The \
          global $(b,ocamlformat) file has the lowest priority, then the \
          closer the directory is to the processed file, the higher the \
-         priority."
+         priority. The global $(b,ocamlformat) file is only used when the \
+         option $(b,enable-outside-detected-project) is set."
     ; `P
         "If the $(b,disable) option is not set, an \
          $(b,.ocamlformat-ignore) file specifies files that OCamlFormat \


### PR DESCRIPTION
As suggested in #943