### PR TITLE
Fix: no box around inline odoc styles

### DIFF
--- a/src/Fmt_odoc.ml
+++ b/src/Fmt_odoc.ml
@@ -193,7 +193,7 @@ and fmt_list_light c kind items =
     match kind with `Unordered -> fmt "- " | `Ordered -> fmt "+ "
   in
   let fmt_item elems =
-    line_start $ vbox 0 (fmt_nestable_block_elements c elems)
+    line_start $ hovbox 0 (fmt_nestable_block_elements c elems)
   in
   vbox 0 (list items "@," fmt_item)
 

--- a/src/Fmt_odoc.ml
+++ b/src/Fmt_odoc.ml
@@ -157,8 +157,7 @@ let rec fmt_inline_element : inline_element -> Fmt.t = function
   | `Reference (_kind, ref, txt) ->
       let ref = fmt "{!" $ fmt_reference ref $ fmt "}" in
       if List.is_empty txt then ref
-      else
-        hovbox 0 (wrap "{" "}" (ref $ fmt "@ " $ fmt_inline_elements txt))
+      else wrap "{" "}" (ref $ fmt "@ " $ fmt_inline_elements txt)
   | `Link (url, txt) -> (
       let url = wrap "{:" "}" (str_normalized url) in
       match txt with

--- a/src/Fmt_odoc.ml
+++ b/src/Fmt_odoc.ml
@@ -129,11 +129,8 @@ let fmt_styled style fmt_elem elems =
     | `Superscript -> "^"
     | `Subscript -> "_"
   in
-  hovbox 0
-    (wrap "{" "}"
-       ( str_normalized s
-       $ fmt_if_not_empty elems "@ "
-       $ list elems "" fmt_elem ))
+  wrap "{" "}"
+    (str_normalized s $ fmt_if_not_empty elems "@ " $ list elems "" fmt_elem)
 
 let rec fmt_inline_element : inline_element -> Fmt.t = function
   | `Space _ -> fmt "@ "
@@ -171,7 +168,7 @@ let rec fmt_inline_element : inline_element -> Fmt.t = function
 and fmt_inline_elements txt = list txt "" (ign_loc ~f:fmt_inline_element)
 
 and fmt_nestable_block_element c = function
-  | `Paragraph elems -> hovbox 0 (fmt_inline_elements elems)
+  | `Paragraph elems -> fmt_inline_elements elems
   | `Code_block s -> fmt_code_block c s
   | `Verbatim s -> fmt_verbatim_block s
   | `Modules mods ->

--- a/test/passing/doc_comments.mli
+++ b/test/passing/doc_comments.mli
@@ -432,3 +432,6 @@ let fooooooooooooooooo =
 *)
 
 (** {e foooooooo oooooooooo ooooooooo ooooooooo} {i fooooooooooooo oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
+
+(** {e foooooooo oooooooooo ooooooooo ooooooooo} {{!some ref} fooooooooooooo
+    oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)

--- a/test/passing/doc_comments.mli
+++ b/test/passing/doc_comments.mli
@@ -430,3 +430,5 @@ let fooooooooooooooooo =
     let code inside (* comment   *) = f inside
   ]}
 *)
+
+(** {e foooooooo oooooooooo ooooooooo ooooooooo} {i fooooooooooooo oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)

--- a/test/passing/doc_comments.mli.ref
+++ b/test/passing/doc_comments.mli.ref
@@ -145,153 +145,21 @@ val x : x
 
     list with long lines:
 
-    - xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-    - yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-    - zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
+    - xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx
+      xxx xxx xxx xxx xxx xxx xxx
+    - yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy
+      yyy yyy yyy yyy yyy yyy yyy
+    - zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
+      zzz zzz zzz zzz zzz zzz zzz
 
     enumerated list with long lines:
 
-    + xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-      xxx
-    + yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-      yyy
-    + zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
-      zzz
+    + xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx
+      xxx xxx xxx xxx xxx xxx xxx
+    + yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy
+      yyy yyy yyy yyy yyy yyy yyy
+    + zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
+      zzz zzz zzz zzz zzz zzz zzz
 
     list with sub lists:
 
@@ -369,9 +237,7 @@ end
 
 (** {[ b ]} *)
 
-(** - Odoc
-      don't
-      parse
+(** - Odoc don't parse
 
     multiple paragraph in a list *)
 

--- a/test/passing/doc_comments.mli.ref
+++ b/test/passing/doc_comments.mli.ref
@@ -145,21 +145,153 @@ val x : x
 
     list with long lines:
 
-    - xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx
-      xxx xxx xxx xxx xxx xxx xxx
-    - yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy
-      yyy yyy yyy yyy yyy yyy yyy
-    - zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
-      zzz zzz zzz zzz zzz zzz zzz
+    - xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+    - yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+    - zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
 
     enumerated list with long lines:
 
-    + xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx
-      xxx xxx xxx xxx xxx xxx xxx
-    + yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy
-      yyy yyy yyy yyy yyy yyy yyy
-    + zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
-      zzz zzz zzz zzz zzz zzz zzz
+    + xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+      xxx
+    + yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+      yyy
+    + zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
+      zzz
 
     list with sub lists:
 
@@ -237,7 +369,9 @@ end
 
 (** {[ b ]} *)
 
-(** - Odoc don't parse
+(** - Odoc
+      don't
+      parse
 
     multiple paragraph in a list *)
 
@@ -394,3 +528,6 @@ end
       (** This is a comment with code inside [let code inside = f inside] *)
       let code inside (* comment *) = f inside
     ]} *)
+
+(** {e foooooooo oooooooooo ooooooooo ooooooooo} {i fooooooooooooo oooooooo
+    oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)

--- a/test/passing/doc_comments.mli.ref
+++ b/test/passing/doc_comments.mli.ref
@@ -397,3 +397,6 @@ end
 
 (** {e foooooooo oooooooooo ooooooooo ooooooooo} {i fooooooooooooo oooooooo
     oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
+
+(** {e foooooooo oooooooooo ooooooooo ooooooooo} {{!some ref} fooooooooooooo
+    oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)

--- a/test/passing/js_sig.mli
+++ b/test/passing/js_sig.mli
@@ -5,3 +5,8 @@ exception First_exception
 
 (** Second documentation comment. *)
 exception Second_exception
+
+[@@@ocamlformat "parse-docstrings=true"]
+[@@@ocamlformat "wrap-comments=true"]
+
+(** {e foooooooo oooooo oooo oooo ooooo oooo ooooo} {i fooooo ooooo ooo oooooo oo oooooo oooo} {b fooooooo oooooo oooooo oooooo oooooo ooooooo} *)

--- a/test/passing/js_sig.mli
+++ b/test/passing/js_sig.mli
@@ -10,3 +10,6 @@ exception Second_exception
 [@@@ocamlformat "wrap-comments=true"]
 
 (** {e foooooooo oooooo oooo oooo ooooo oooo ooooo} {i fooooo ooooo ooo oooooo oo oooooo oooo} {b fooooooo oooooo oooooo oooooo oooooo ooooooo} *)
+
+(** {e foooooooo oooooooooo ooooooooo ooooooooo} {{!some ref} fooooooooooooo
+    oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)

--- a/test/passing/js_sig.mli.ref
+++ b/test/passing/js_sig.mli.ref
@@ -11,3 +11,6 @@ exception Second_exception
 
 (** {e foooooooo oooooo oooo oooo ooooo oooo ooooo} {i fooooo ooooo ooo oooooo oo oooooo
     oooo} {b fooooooo oooooo oooooo oooooo oooooo ooooooo} *)
+
+(** {e foooooooo oooooooooo ooooooooo ooooooooo} {{!some ref} fooooooooooooo oooooooo
+    oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)

--- a/test/passing/js_sig.mli.ref
+++ b/test/passing/js_sig.mli.ref
@@ -5,3 +5,9 @@ exception First_exception
 
 (** Second documentation comment. *)
 exception Second_exception
+
+[@@@ocamlformat "parse-docstrings=true"]
+[@@@ocamlformat "wrap-comments=true"]
+
+(** {e foooooooo oooooo oooo oooo ooooo oooo ooooo} {i fooooo ooooo ooo oooooo oo oooooo
+    oooo} {b fooooooo oooooo oooooo oooooo oooooo ooooooo} *)


### PR DESCRIPTION
Fix #969 