### PR TITLE
API: change the type of fmt-code

### DIFF
--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -511,7 +511,7 @@ let fmt_cmt (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
     let dollar_last = Char.equal str.[String.length str - 1] '$' in
     let len = String.length str - if dollar_last then 2 else 1 in
     let source = String.sub ~pos:1 ~len str in
-    match fmt_code source with
+    match fmt_code conf source with
     | Ok formatted ->
         let cls : Fmt.s = if dollar_last then "$*)" else "*)" in
         hvbox 2 (wrap "(*$" cls (fmt "@;" $ formatted $ fmt "@;<1 -2>"))

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -512,7 +512,7 @@ let fmt_cmt (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
     let len = String.length str - if dollar_last then 2 else 1 in
     let source = String.sub ~pos:1 ~len str in
     try
-      let formatted = fmt_code conf source in
+      let formatted = fmt_code source in
       let cls : Fmt.s = if dollar_last then "$*)" else "*)" in
       hvbox 2 (wrap "(*$" cls (fmt "@;" $ formatted $ fmt "@;<1 -2>"))
     with _ -> fmt_non_code cmt

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -511,11 +511,11 @@ let fmt_cmt (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
     let dollar_last = Char.equal str.[String.length str - 1] '$' in
     let len = String.length str - if dollar_last then 2 else 1 in
     let source = String.sub ~pos:1 ~len str in
-    try
-      let formatted = fmt_code source in
-      let cls : Fmt.s = if dollar_last then "$*)" else "*)" in
-      hvbox 2 (wrap "(*$" cls (fmt "@;" $ formatted $ fmt "@;<1 -2>"))
-    with _ -> fmt_non_code cmt
+    match fmt_code source with
+    | Ok formatted ->
+        let cls : Fmt.s = if dollar_last then "$*)" else "*)" in
+        hvbox 2 (wrap "(*$" cls (fmt "@;" $ formatted $ fmt "@;<1 -2>"))
+    | Error () -> fmt_non_code cmt
   in
   match Cmt.txt cmt with
   | "" | "$" -> fmt_non_code cmt

--- a/src/Cmts.mli
+++ b/src/Cmts.mli
@@ -56,7 +56,7 @@ val relocate :
 val fmt_before :
      t
   -> Conf.t
-  -> fmt_code:(string -> Fmt.t)
+  -> fmt_code:(string -> (Fmt.t, unit) Result.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> ?eol:Fmt.t
@@ -69,7 +69,7 @@ val fmt_before :
 val fmt_after :
      t
   -> Conf.t
-  -> fmt_code:(string -> Fmt.t)
+  -> fmt_code:(string -> (Fmt.t, unit) Result.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> Location.t
@@ -80,7 +80,7 @@ val fmt_after :
 val fmt_within :
      t
   -> Conf.t
-  -> fmt_code:(string -> Fmt.t)
+  -> fmt_code:(string -> (Fmt.t, unit) Result.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> Location.t
@@ -91,7 +91,7 @@ val fmt_within :
 val fmt :
      t
   -> Conf.t
-  -> fmt_code:(string -> Fmt.t)
+  -> fmt_code:(string -> (Fmt.t, unit) Result.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> ?eol:Fmt.t
@@ -105,7 +105,7 @@ val fmt :
 val fmt_list :
      t
   -> Conf.t
-  -> fmt_code:(string -> Fmt.t)
+  -> fmt_code:(string -> (Fmt.t, unit) Result.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> ?eol:Fmt.t

--- a/src/Cmts.mli
+++ b/src/Cmts.mli
@@ -56,7 +56,7 @@ val relocate :
 val fmt_before :
      t
   -> Conf.t
-  -> fmt_code:(Conf.t -> string -> Fmt.t)
+  -> fmt_code:(string -> Fmt.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> ?eol:Fmt.t
@@ -69,7 +69,7 @@ val fmt_before :
 val fmt_after :
      t
   -> Conf.t
-  -> fmt_code:(Conf.t -> string -> Fmt.t)
+  -> fmt_code:(string -> Fmt.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> Location.t
@@ -80,7 +80,7 @@ val fmt_after :
 val fmt_within :
      t
   -> Conf.t
-  -> fmt_code:(Conf.t -> string -> Fmt.t)
+  -> fmt_code:(string -> Fmt.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> Location.t
@@ -91,7 +91,7 @@ val fmt_within :
 val fmt :
      t
   -> Conf.t
-  -> fmt_code:(Conf.t -> string -> Fmt.t)
+  -> fmt_code:(string -> Fmt.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> ?eol:Fmt.t
@@ -105,7 +105,7 @@ val fmt :
 val fmt_list :
      t
   -> Conf.t
-  -> fmt_code:(Conf.t -> string -> Fmt.t)
+  -> fmt_code:(string -> Fmt.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> ?eol:Fmt.t

--- a/src/Cmts.mli
+++ b/src/Cmts.mli
@@ -56,7 +56,7 @@ val relocate :
 val fmt_before :
      t
   -> Conf.t
-  -> fmt_code:(string -> (Fmt.t, unit) Result.t)
+  -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> ?eol:Fmt.t
@@ -69,7 +69,7 @@ val fmt_before :
 val fmt_after :
      t
   -> Conf.t
-  -> fmt_code:(string -> (Fmt.t, unit) Result.t)
+  -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> Location.t
@@ -80,7 +80,7 @@ val fmt_after :
 val fmt_within :
      t
   -> Conf.t
-  -> fmt_code:(string -> (Fmt.t, unit) Result.t)
+  -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> Location.t
@@ -91,7 +91,7 @@ val fmt_within :
 val fmt :
      t
   -> Conf.t
-  -> fmt_code:(string -> (Fmt.t, unit) Result.t)
+  -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> ?eol:Fmt.t
@@ -105,7 +105,7 @@ val fmt :
 val fmt_list :
      t
   -> Conf.t
-  -> fmt_code:(string -> (Fmt.t, unit) Result.t)
+  -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
   -> ?eol:Fmt.t

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -4417,16 +4417,16 @@ let fmt_file ~ctx ~f ~fmt_code source cmts conf itms =
   match itms with [] -> Cmts.fmt_after c Location.none | l -> f c ctx l
 
 let rec fmt_code conf s =
-  try
-    let ({ast; comments; _} : _ Parse_with_comments.with_comments) =
-      Parse_with_comments.parse Migrate_ast.Parse.implementation conf
-        ~source:s
-    in
-    let source = Source.create s in
-    let cmts = Cmts.init_impl source ast comments in
-    let ctx = Pld (PStr ast) in
-    Ok (fmt_file ~f:fmt_structure ~ctx source cmts conf ast ~fmt_code)
-  with _ -> Error ()
+  match
+    Parse_with_comments.parse Migrate_ast.Parse.implementation conf
+      ~source:s
+  with
+  | {ast; comments; _} ->
+      let source = Source.create s in
+      let cmts = Cmts.init_impl source ast comments in
+      let ctx = Pld (PStr ast) in
+      Ok (fmt_file ~f:fmt_structure ~ctx source cmts conf ast ~fmt_code)
+  | exception _ -> Error ()
 
 let entry_point ~f ~ctx source cmts conf l =
   (* [Ast.init] should be called only once per file. In particular, we don't

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -28,15 +28,15 @@ type c =
 module Cmts = struct
   include Cmts
 
-  let fmt c = fmt c.cmts c.conf ~fmt_code:c.fmt_code
+  let fmt c = fmt c.cmts c.conf ~fmt_code:(c.fmt_code c.conf)
 
-  let fmt_before c = fmt_before c.cmts c.conf ~fmt_code:c.fmt_code
+  let fmt_before c = fmt_before c.cmts c.conf ~fmt_code:(c.fmt_code c.conf)
 
-  let fmt_within c = fmt_within c.cmts c.conf ~fmt_code:c.fmt_code
+  let fmt_within c = fmt_within c.cmts c.conf ~fmt_code:(c.fmt_code c.conf)
 
-  let fmt_after c = fmt_after c.cmts c.conf ~fmt_code:c.fmt_code
+  let fmt_after c = fmt_after c.cmts c.conf ~fmt_code:(c.fmt_code c.conf)
 
-  let fmt_list c = fmt_list c.cmts c.conf ~fmt_code:c.fmt_code
+  let fmt_list c = fmt_list c.cmts c.conf ~fmt_code:(c.fmt_code c.conf)
 end
 
 type block =

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -28,15 +28,15 @@ type c =
 module Cmts = struct
   include Cmts
 
-  let fmt c = fmt c.cmts c.conf ~fmt_code:(c.fmt_code c.conf)
+  let fmt c = fmt c.cmts c.conf ~fmt_code:c.fmt_code
 
-  let fmt_before c = fmt_before c.cmts c.conf ~fmt_code:(c.fmt_code c.conf)
+  let fmt_before c = fmt_before c.cmts c.conf ~fmt_code:c.fmt_code
 
-  let fmt_within c = fmt_within c.cmts c.conf ~fmt_code:(c.fmt_code c.conf)
+  let fmt_within c = fmt_within c.cmts c.conf ~fmt_code:c.fmt_code
 
-  let fmt_after c = fmt_after c.cmts c.conf ~fmt_code:(c.fmt_code c.conf)
+  let fmt_after c = fmt_after c.cmts c.conf ~fmt_code:c.fmt_code
 
-  let fmt_list c = fmt_list c.cmts c.conf ~fmt_code:(c.fmt_code c.conf)
+  let fmt_list c = fmt_list c.cmts c.conf ~fmt_code:c.fmt_code
 end
 
 type block =

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -457,7 +457,7 @@ let fmt_parsed_docstring c ~loc ?pro ~epi str_cmt parsed =
   in
   let fmt_parsed parsed =
     fmt_if (space_i 0) " "
-    $ Fmt_odoc.fmt c.conf ~fmt_code:c.fmt_code parsed
+    $ Fmt_odoc.fmt ~fmt_code:(c.fmt_code c.conf) parsed
     $ fmt_if (space_i (String.length str_cmt - 1)) " "
   in
   let fmt_raw str_cmt =

--- a/src/Fmt_odoc.ml
+++ b/src/Fmt_odoc.ml
@@ -13,7 +13,7 @@ open Fmt
 open Odoc_parser.Ast
 module Location_ = Odoc_model.Location_
 
-type conf = {fmt_code: string -> Fmt.t}
+type conf = {fmt_code: string -> (Fmt.t, unit) Result.t}
 
 (** Escape characters if they are not already escaped. [escapeworthy] should
     be [true] if the character should be escaped, [false] otherwise. *)
@@ -70,17 +70,18 @@ let fmt_verbatim_block s =
   hvbox 0 (wrap "{v" "v}" content)
 
 let fmt_code_block conf s =
-  try hvbox 0 (wrap "{[@;<1 2>" "@ ]}" (conf.fmt_code s))
-  with _ ->
-    let fmt_line ~first ~last:_ l =
-      let l = String.rstrip l in
-      if first then str l
-      else if String.length l = 0 then str "\n"
-      else fmt "@," $ str l
-    in
-    let lines = String.split_lines s in
-    let box = match lines with _ :: _ :: _ -> vbox 0 | _ -> hvbox 0 in
-    box (wrap "{[@;<1 2>" "@ ]}" (vbox 0 (list_fl lines fmt_line)))
+  match conf.fmt_code s with
+  | Ok formatted -> hvbox 0 (wrap "{[@;<1 2>" "@ ]}" formatted)
+  | Error () ->
+      let fmt_line ~first ~last:_ l =
+        let l = String.rstrip l in
+        if first then str l
+        else if String.length l = 0 then str "\n"
+        else fmt "@," $ str l
+      in
+      let lines = String.split_lines s in
+      let box = match lines with _ :: _ :: _ -> vbox 0 | _ -> hvbox 0 in
+      box (wrap "{[@;<1 2>" "@ ]}" (vbox 0 (list_fl lines fmt_line)))
 
 let fmt_reference = ign_loc ~f:str_normalized
 

--- a/src/Fmt_odoc.ml
+++ b/src/Fmt_odoc.ml
@@ -13,7 +13,7 @@ open Fmt
 open Odoc_parser.Ast
 module Location_ = Odoc_model.Location_
 
-type conf = {conf: Conf.t; fmt_code: Conf.t -> string -> Fmt.t}
+type conf = {fmt_code: string -> Fmt.t}
 
 (** Escape characters if they are not already escaped. [escapeworthy] should
     be [true] if the character should be escaped, [false] otherwise. *)
@@ -70,7 +70,7 @@ let fmt_verbatim_block s =
   hvbox 0 (wrap "{v" "v}" content)
 
 let fmt_code_block conf s =
-  try hvbox 0 (wrap "{[@;<1 2>" "@ ]}" (conf.fmt_code conf.conf s))
+  try hvbox 0 (wrap "{[@;<1 2>" "@ ]}" (conf.fmt_code s))
   with _ ->
     let fmt_line ~first ~last:_ l =
       let l = String.rstrip l in
@@ -249,9 +249,8 @@ let fmt_block_element c = function
   | #nestable_block_element as elm ->
       hovbox 0 (fmt_nestable_block_element c elm)
 
-let fmt conf ~fmt_code (docs : docs) =
-  let c = {conf; fmt_code} in
-  vbox 0 (list_block_elem docs (fmt_block_element c))
+let fmt ~fmt_code (docs : docs) =
+  vbox 0 (list_block_elem docs (fmt_block_element {fmt_code}))
 
 let diff c x y =
   let norm z =

--- a/src/Fmt_odoc.mli
+++ b/src/Fmt_odoc.mli
@@ -9,7 +9,10 @@
  *                                                                    *
  **********************************************************************)
 
-val fmt : fmt_code:(string -> Fmt.t) -> Odoc_parser.Ast.docs -> Fmt.t
+val fmt :
+     fmt_code:(string -> (Fmt.t, unit) Result.t)
+  -> Odoc_parser.Ast.docs
+  -> Fmt.t
 
 val diff :
   Conf.t -> Cmt.t list -> Cmt.t list -> (string, string) Either.t Sequence.t

--- a/src/Fmt_odoc.mli
+++ b/src/Fmt_odoc.mli
@@ -9,11 +9,7 @@
  *                                                                    *
  **********************************************************************)
 
-val fmt :
-     Conf.t
-  -> fmt_code:(Conf.t -> string -> Fmt.t)
-  -> Odoc_parser.Ast.docs
-  -> Fmt.t
+val fmt : fmt_code:(string -> Fmt.t) -> Odoc_parser.Ast.docs -> Fmt.t
 
 val diff :
   Conf.t -> Cmt.t list -> Cmt.t list -> (string, string) Either.t Sequence.t


### PR DESCRIPTION
Follow-up on #941 
Change the signature of the `fmt_code` function

from `Conf.t -> string -> Fmt.t`

to `string -> (Fmt.t, unit) Result.t`.