### PR TITLE
Improve: preserve begin-end keywords in if-then-else

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -184,13 +184,9 @@ let parens_or_begin_end c ~loc =
       let str = String.lstrip (Source.string_at c.source loc) in
       if String.is_prefix ~prefix:"begin" str then `Begin_end else `Parens
 
-let wrap_exp c ?disambiguate ?fits_breaks ~parens ~loc k =
+let wrap_exp c ?disambiguate ?fits_breaks ~parens ~loc =
   let exp_grouping = parens_or_begin_end c ~loc in
-  let exp_wrap =
-    Params.get_exp_wrap c.conf ?disambiguate ?fits_breaks ~parens
-      ~exp_grouping
-  in
-  exp_wrap k
+  Params.get_exp_wrap c.conf ?disambiguate ?fits_breaks ~parens ~exp_grouping
 
 let drop_while ~f s =
   let i = ref 0 in

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -177,13 +177,6 @@ let sugar_pmod_functor c ~for_functor_kw pmod =
   let source_is_long = Source.is_long_pmod_functor c.source in
   Sugar.functor_ c.cmts ~for_functor_kw ~source_is_long pmod
 
-let wrap_fits_breaks_exp_begin_end ~parens k =
-  vbox 2
-    (wrap_if_k parens
-       (fits_breaks "begin " "begin" $ break_unless_newline 0 0)
-       (break_unless_newline 0 (-2) $ fits_breaks " end" "end")
-       (cbox 0 k))
-
 let parens_or_begin_end c ~loc =
   match c.conf.exp_grouping with
   | `Parens -> `Parens
@@ -191,20 +184,13 @@ let parens_or_begin_end c ~loc =
       let str = String.lstrip (Source.string_at c.source loc) in
       if String.is_prefix ~prefix:"begin" str then `Begin_end else `Parens
 
-let wrap_fits_breaks_exp_if ?(space = true) ?(disambiguate = false) c ~parens
-    ~loc k =
-  match parens_or_begin_end c ~loc with
-  | `Parens when disambiguate && c.conf.disambiguate_non_breaking_match ->
-      wrap_if_fits_or parens "(" ")" k
-  | `Parens -> wrap_fits_breaks_if ~space c.conf parens "(" ")" k
-  | `Begin_end -> wrap_fits_breaks_exp_begin_end ~parens k
-
-let wrap_exp_if ?(disambiguate = false) c ~parens ~loc k =
-  match parens_or_begin_end c ~loc with
-  | `Parens when disambiguate && c.conf.disambiguate_non_breaking_match ->
-      wrap_if_fits_or parens "(" ")" k
-  | `Parens -> wrap_if parens "(" ")" k
-  | `Begin_end -> wrap_fits_breaks_exp_begin_end ~parens k
+let wrap_exp c ?disambiguate ?fits_breaks ~parens ~loc k =
+  let exp_grouping = parens_or_begin_end c ~loc in
+  let exp_wrap =
+    Params.get_exp_wrap c.conf ?disambiguate ?fits_breaks ~parens
+      ~exp_grouping
+  in
+  exp_wrap k
 
 let drop_while ~f s =
   let i = ref 0 in
@@ -1374,7 +1360,7 @@ and fmt_sequence c ?ext parens width xexp pexp_loc fmt_atrs =
     Option.value_map prev ~default:noop ~f $ list_pn x fmt_seq
   in
   hvbox 0
-    ( wrap_fits_breaks_exp_if ~space:false c ~loc:pexp_loc ~parens
+    ( wrap_exp c ~loc:pexp_loc ~parens
         (hvbox_if parens 0 @@ list_pn grps fmt_seq_list)
     $ fmt_atrs )
 
@@ -1547,7 +1533,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             ; _ } ) ] ) ->
       let xargs, xbody = Sugar.fun_ c.cmts (sub_exp ~ctx:(Str pld) retn) in
       hvbox 0
-        (wrap_fits_breaks_exp_if ~space:false c ~loc:pexp_loc ~parens
+        (wrap_exp c ~loc:pexp_loc ~parens
            ( fmt_expression c (sub_exp ~ctx e0)
            $ fmt "@\n"
            $ Cmts.fmt c loc (fmt "|>@\n")
@@ -1732,7 +1718,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       fmt_index_op c ctx ~parens {txt= index_op; loc} s [i] ~set:e
   | Pexp_apply (e0, [(Nolabel, e1)]) when is_prefix e0 ->
       hvbox 2
-        (wrap_fits_breaks_exp_if ~space:false c ~loc:pexp_loc ~parens
+        (wrap_exp c ~loc:pexp_loc ~parens
            ( fmt_expression c ~box (sub_exp ~ctx e0)
            $ fmt_expression c ~box (sub_exp ~ctx e1)
            $ fmt_atrs ))
@@ -1978,7 +1964,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let default_indent = if Option.is_none eol then 2 else 1 in
       let indent = function_indent c ~ctx ~default:default_indent in
       hvbox_if box indent
-        (wrap_exp_if c ~loc:pexp_loc ~parens ~disambiguate:true
+        (wrap_exp c ~loc:pexp_loc ~parens ~disambiguate:true
+           ~fits_breaks:false
            ( hovbox 2
                ( hovbox 4
                    ( str "fun "
@@ -1991,7 +1978,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
            $ fmt "@ " $ body ))
   | Pexp_function cs ->
       let indent = function_indent c ~ctx ~default:0 in
-      wrap_exp_if c ~loc:pexp_loc ~parens ~disambiguate:true
+      wrap_exp c ~loc:pexp_loc ~parens ~disambiguate:true ~fits_breaks:false
         ( hvbox 2
             ( str "function"
             $ fmt_extension_suffix c ext
@@ -2015,7 +2002,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let cnd_exps = Sugar.ite c.cmts xexp in
       let parens_prev_bch = ref false in
       hvbox 0
-        (wrap_fits_breaks_exp_if ~space:false c ~loc:pexp_loc ~parens
+        (wrap_exp c ~loc:pexp_loc ~parens
            (list_fl cnd_exps
               (fun ~first ~last (xcond, xbch, pexp_attributes) ->
                 let parens_bch = parenze_exp xbch in
@@ -2029,6 +2016,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                          pexp_attributes)
                     ~fmt_cond:(fmt_expression c)
                     ~exp_grouping:(parens_or_begin_end c ~loc:pexp_loc)
+                    ~exp_grouping_bch:
+                      (parens_or_begin_end c ~loc:xbch.ast.pexp_loc)
                 in
                 parens_prev_bch := parens_bch ;
                 p.box_branch
@@ -2193,8 +2182,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
           let leading_cmt = Cmts.fmt_before c e0.pexp_loc in
           let indent = match_indent c ~ctx:xexp.ctx ~default:0 in
           hvbox indent
-            (wrap_fits_breaks_exp_if ~space:false c ~loc:pexp_loc ~parens
-               ~disambiguate:true
+            (wrap_exp c ~loc:pexp_loc ~parens ~disambiguate:true
                ( leading_cmt
                $ hvbox 0
                    ( str keyword
@@ -2213,8 +2201,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             if c.conf.leading_nested_match_parens then (false, None)
             else (parenze_exp xpc_rhs, Some false)
           in
-          wrap_fits_breaks_exp_if ~space:false c ~loc:pexp_loc ~parens
-            ~disambiguate:true
+          wrap_exp c ~loc:pexp_loc ~parens ~disambiguate:true
             (hovbox 2
                ( hvbox 0
                    ( str keyword
@@ -2244,8 +2231,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    | `Closing_on_separate_line -> "@;<1000 -2>)" ) )) )
   | Pexp_pack me ->
       let fmt_mod m =
-        wrap_fits_breaks_exp_if ~space:false c ~parens:true ~loc:pexp_loc
-          (str "module " $ m $ fmt_atrs)
+        wrap_exp c ~parens:true ~loc:pexp_loc (str "module " $ m $ fmt_atrs)
       in
       hovbox 0
         (compose_module (fmt_module_expr c (sub_mod ~ctx me)) ~f:fmt_mod)
@@ -2314,7 +2300,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       fmt_sequence c parens width xexp pexp_loc fmt_atrs ?ext
   | Pexp_setfield (e1, lid, e2) ->
       hvbox 0
-        (wrap_fits_breaks_exp_if ~space:false c ~loc:pexp_loc ~parens
+        (wrap_exp c ~loc:pexp_loc ~parens
            ( fmt_expression c (sub_exp ~ctx e1)
            $ str "." $ fmt_longident_loc c lid $ fmt_assign_arrow c
            $ fmt_expression c (sub_exp ~ctx e2)
@@ -2338,7 +2324,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         $ fmt_atrs )
   | Pexp_lazy e ->
       hvbox 2
-        (wrap_fits_breaks_exp_if ~space:false c ~loc:pexp_loc ~parens
+        (wrap_exp c ~loc:pexp_loc ~parens
            (fmt "lazy@ " $ fmt_expression c (sub_exp ~ctx e) $ fmt_atrs))
   | Pexp_extension
       ( ext
@@ -2363,12 +2349,12 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         $ fmt_atrs )
   | Pexp_extension ext ->
       hvbox 0
-        (wrap_fits_breaks_exp_if ~space:false c ~loc:pexp_loc ~parens
+        (wrap_exp c ~loc:pexp_loc ~parens
            ( hvbox c.conf.extension_indent (fmt_extension c ctx "%" ext)
            $ fmt_atrs ))
   | Pexp_for (p1, e1, e2, dir, e3) ->
       hvbox 0
-        (wrap_fits_breaks_exp_if ~space:false c ~loc:pexp_loc ~parens
+        (wrap_exp c ~loc:pexp_loc ~parens
            ( hovbox 0
                ( hvbox 2
                    ( hvbox 0
@@ -2396,7 +2382,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
            $ fmt_atrs ))
   | Pexp_while (e1, e2) ->
       hvbox 0
-        (wrap_fits_breaks_exp_if ~space:false c ~loc:pexp_loc ~parens
+        (wrap_exp c ~loc:pexp_loc ~parens
            ( hovbox 0
                ( hvbox 2
                    ( hvbox 0
@@ -2458,7 +2444,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                   (list l "@;<0 1>; " fmt_field))) )
   | Pexp_setinstvar (name, expr) ->
       hvbox 0
-        (wrap_fits_breaks_exp_if ~space:false c ~loc:pexp_loc ~parens
+        (wrap_exp c ~loc:pexp_loc ~parens
            ( fmt_str_loc c name $ fmt_assign_arrow c
            $ hvbox 2 (fmt_expression c (sub_exp ~ctx expr)) ))
   | Pexp_poly _ ->
@@ -4158,8 +4144,9 @@ and fmt_let c ctx ~ext ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr ~loc
         | `Sparse -> "@;<1000 0>"
         | `Compact -> "@ " )
   in
-  wrap_exp_if c ~loc
+  wrap_exp c ~loc
     ~parens:(parens || not (List.is_empty attributes))
+    ~fits_breaks:false
     (vbox 0
        ( hvbox 0 (list_fl bindings fmt_binding)
        $ break 1000 indent_after_in

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -255,7 +255,8 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
     | `Parens -> wrap "(" ")" (wrap_breaks k)
     | `Begin_end -> wrap "begin" "end" (wrap_breaks k)
   in
-  let get_parens_breaks ~opn_hint:(oh_space, oh_other) ~cls_hint:(ch_sp, ch_sl) =
+  let get_parens_breaks ~opn_hint:(oh_space, oh_other)
+      ~cls_hint:(ch_sp, ch_sl) =
     let brk hint = fits_breaks "" ~hint "" in
     match (exp_grouping_bch, imd) with
     | `Parens, `Space -> wrap_k (brk oh_space) (brk ch_sp)
@@ -289,7 +290,11 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
       ; box_keyword_and_expr= Fn.id
       ; branch_pro= fmt_or parens_bch " " "@ "
       ; wrap_parens=
-          wrap_parens ~wrap_breaks:(get_parens_breaks ~opn_hint:((1, 0), (0, 0)) ~cls_hint:((1, 0), (1000, -2)))
+          wrap_parens
+            ~wrap_breaks:
+              (get_parens_breaks
+                 ~opn_hint:((1, 0), (0, 0))
+                 ~cls_hint:((1, 0), (1000, -2)))
       ; expr_pro= None
       ; expr_eol= None
       ; break_end_branch= noop
@@ -299,8 +304,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
       ; branch_pro
-      ; wrap_parens=
-          wrap_parens ~wrap_breaks:(wrap_k (break 1000 2) noop)
+      ; wrap_parens= wrap_parens ~wrap_breaks:(wrap_k (break 1000 2) noop)
       ; expr_pro= None
       ; expr_eol= Some (fmt "@;<1 2>")
       ; break_end_branch= fmt_if_k (parens_bch || not last) (break 1000 0)
@@ -315,9 +319,11 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
       ; box_keyword_and_expr= Fn.id
       ; branch_pro
       ; wrap_parens=
-          wrap_parens ~wrap_breaks:(get_parens_breaks
-            ~opn_hint:((1, 2), (0, 2))
-            ~cls_hint:((1, 0), (1000, 0)))
+          wrap_parens
+            ~wrap_breaks:
+              (get_parens_breaks
+                 ~opn_hint:((1, 2), (0, 2))
+                 ~cls_hint:((1, 0), (1000, 0)))
       ; expr_pro=
           Some
             (fmt_if_k
@@ -345,9 +351,11 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
             hvbox 2 (fmt_or (Option.is_some xcond) "then" "else" $ k))
       ; branch_pro= fmt_or parens_bch " " "@ "
       ; wrap_parens=
-          wrap_parens ~wrap_breaks:(get_parens_breaks
-            ~opn_hint:((1, 0), (0, 0))
-            ~cls_hint:((1, 0), (1000, -2)))
+          wrap_parens
+            ~wrap_breaks:
+              (get_parens_breaks
+                 ~opn_hint:((1, 0), (0, 0))
+                 ~cls_hint:((1, 0), (1000, -2)))
       ; expr_pro= None
       ; expr_eol= None
       ; break_end_branch= noop

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -13,6 +13,19 @@ module Format = Format_
 open Migrate_ast
 open Fmt
 
+type exp_wrap = Fmt.t -> Fmt.t
+
+let get_exp_wrap c ?(disambiguate = false) ?(fits_breaks = true) ~parens
+    ~exp_grouping k =
+  match exp_grouping with
+  | `Parens when disambiguate && c.Conf.disambiguate_non_breaking_match ->
+      wrap_if_fits_or parens "(" ")" k
+  | (`Parens | `Begin_end) when not parens -> k
+  | `Parens when fits_breaks -> wrap_fits_breaks ~space:false c "(" ")" k
+  | `Parens -> wrap "(" ")" k
+  | `Begin_end ->
+      vbox 2 (wrap "begin" "end" (wrap_k (break 1 0) (break 1000 ~-2) k))
+
 type cases =
   { leading_space: Fmt.t
   ; bar: Fmt.t
@@ -234,8 +247,22 @@ type if_then_else =
 
 let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
     ~parens_prev_bch ~xcond ~expr_loc ~fmt_extension_suffix ~fmt_attributes
-    ~fmt_cond ~exp_grouping =
+    ~fmt_cond ~exp_grouping ~exp_grouping_bch =
   let imd = c.indicate_multiline_delimiters in
+  let wrap_parens ~wrap_breaks k =
+    match exp_grouping_bch with
+    | (`Parens | `Begin_end) when not parens_bch -> k
+    | `Parens -> wrap "(" ")" (wrap_breaks k)
+    | `Begin_end -> wrap "begin" "end" (wrap_breaks k)
+  in
+  let get_parens_breaks ~opn_hint:(oh_space, oh_other) ~cls_hint:(ch_sp, ch_sl) =
+    let brk hint = fits_breaks "" ~hint "" in
+    match (exp_grouping_bch, imd) with
+    | `Parens, `Space -> wrap_k (brk oh_space) (brk ch_sp)
+    | `Parens, `No -> wrap_k (brk oh_other) noop
+    | `Parens, `Closing_on_separate_line | `Begin_end, _ ->
+        wrap_k (brk oh_other) (brk ch_sl)
+  in
   let cond () =
     match xcond with
     | Some xcnd ->
@@ -250,34 +277,19 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
           $ fmt "@ then" )
     | None -> str "else"
   in
-  let wrap_parens ~opn_hint:(oh_space, oh_other) ~cls_hint:(ch_sp, ch_sl) k =
-    fmt_if_k parens_bch
-      ( str "("
-      $
-      match imd with
-      | `Space -> fits_breaks "" ~hint:oh_space ""
-      | `No | `Closing_on_separate_line -> fits_breaks "" ~hint:oh_other ""
-      )
-    $ k
-    $ fmt_if_k parens_bch
-        ( ( match imd with
-          | `Space -> fits_breaks "" ~hint:ch_sp ""
-          | `No -> noop
-          | `Closing_on_separate_line -> fits_breaks "" ~hint:ch_sl "" )
-        $ str ")" )
-  in
   let branch_pro = fmt_or parens_bch " " "@;<1 2>" in
   match c.if_then_else with
   | `Compact ->
-      { box_branch=
-          hovbox
-            ( if first && parens && Poly.(exp_grouping = `Parens) then 0
-            else 2 )
+      let box_branch =
+        if first && parens && Poly.(exp_grouping = `Parens) then hovbox 0
+        else hovbox 2
+      in
+      { box_branch
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
       ; branch_pro= fmt_or parens_bch " " "@ "
       ; wrap_parens=
-          wrap_parens ~opn_hint:((1, 0), (0, 0)) ~cls_hint:((1, 0), (1000, 0))
+          wrap_parens ~wrap_breaks:(get_parens_breaks ~opn_hint:((1, 0), (0, 0)) ~cls_hint:((1, 0), (1000, -2)))
       ; expr_pro= None
       ; expr_eol= None
       ; break_end_branch= noop
@@ -287,7 +299,8 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
       ; branch_pro
-      ; wrap_parens= wrap_if parens_bch "(@;<0 2>" ")"
+      ; wrap_parens=
+          wrap_parens ~wrap_breaks:(wrap_k (break 1000 2) noop)
       ; expr_pro= None
       ; expr_eol= Some (fmt "@;<1 2>")
       ; break_end_branch= fmt_if_k (parens_bch || not last) (break 1000 0)
@@ -302,7 +315,9 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
       ; box_keyword_and_expr= Fn.id
       ; branch_pro
       ; wrap_parens=
-          wrap_parens ~opn_hint:((1, 2), (0, 2)) ~cls_hint:((1, 0), (1000, 0))
+          wrap_parens ~wrap_breaks:(get_parens_breaks
+            ~opn_hint:((1, 2), (0, 2))
+            ~cls_hint:((1, 0), (1000, 0)))
       ; expr_pro=
           Some
             (fmt_if_k
@@ -330,9 +345,9 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
             hvbox 2 (fmt_or (Option.is_some xcond) "then" "else" $ k))
       ; branch_pro= fmt_or parens_bch " " "@ "
       ; wrap_parens=
-          wrap_parens
+          wrap_parens ~wrap_breaks:(get_parens_breaks
             ~opn_hint:((1, 0), (0, 0))
-            ~cls_hint:((1, 0), (1000, -2))
+            ~cls_hint:((1, 0), (1000, -2)))
       ; expr_pro= None
       ; expr_eol= None
       ; break_end_branch= noop

--- a/src/Params.mli
+++ b/src/Params.mli
@@ -11,6 +11,16 @@
 
 module Format = Format_
 
+type exp_wrap = Fmt.t -> Fmt.t
+
+val get_exp_wrap :
+     Conf.t
+  -> ?disambiguate:bool
+  -> ?fits_breaks:bool
+  -> parens:bool
+  -> exp_grouping:[`Parens | `Begin_end]
+  -> exp_wrap
+
 type cases =
   { leading_space: Fmt.t
   ; bar: Fmt.t
@@ -85,4 +95,5 @@ val get_if_then_else :
   -> fmt_attributes:Fmt.t
   -> fmt_cond:(Migrate_ast.Parsetree.expression Ast.xt -> Fmt.t)
   -> exp_grouping:[`Parens | `Begin_end]
+  -> exp_grouping_bch:[`Parens | `Begin_end]
   -> if_then_else

--- a/test/passing/exp_grouping-parens.ml.ref
+++ b/test/passing/exp_grouping-parens.ml.ref
@@ -201,3 +201,45 @@ let _ =
 let _ =
   [| (let a = b in
       c) |]
+
+[@@@ocamlformat "if-then-else=compact"]
+
+let _ =
+  if x then (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo )
+  else (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo )
+
+[@@@ocamlformat "if-then-else=fit-or-vertical"]
+
+let _ =
+  if x then (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo )
+  else (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo )
+
+[@@@ocamlformat "if-then-else=keyword-first"]
+
+let _ =
+  if x
+  then (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo )
+  else (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo )
+
+[@@@ocamlformat "if-then-else=k-r"]
+
+let _ =
+  if x then (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo
+  ) else (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo
+  )

--- a/test/passing/exp_grouping.ml
+++ b/test/passing/exp_grouping.ml
@@ -121,3 +121,55 @@ let _ = let a = b in c :: d
 let _ = a :: ( let a = b in c )
 let _ = [ ( let a = b in c ) ]
 let _ = [| ( let a = b in c ) |]
+
+[@@@ocamlformat "if-then-else=compact"]
+
+let _ =
+  if x
+  then begin
+    foo.fooooo <- Fooo.foo fooo foo.fooooo;
+    Fooo fooo
+  end
+  else begin
+    foo.fooooo <- Fooo.foo fooo foo.fooooo;
+    Fooo fooo
+  end
+
+[@@@ocamlformat "if-then-else=fit-or-vertical"]
+
+let _ =
+  if x
+  then begin
+    foo.fooooo <- Fooo.foo fooo foo.fooooo;
+    Fooo fooo
+  end
+  else begin
+    foo.fooooo <- Fooo.foo fooo foo.fooooo;
+    Fooo fooo
+  end
+
+[@@@ocamlformat "if-then-else=keyword-first"]
+
+let _ =
+  if x
+  then begin
+    foo.fooooo <- Fooo.foo fooo foo.fooooo;
+    Fooo fooo
+  end
+  else begin
+    foo.fooooo <- Fooo.foo fooo foo.fooooo;
+    Fooo fooo
+  end
+
+[@@@ocamlformat "if-then-else=k-r"]
+
+let _ =
+  if x
+  then begin
+    foo.fooooo <- Fooo.foo fooo foo.fooooo;
+    Fooo fooo
+  end
+  else begin
+    foo.fooooo <- Fooo.foo fooo foo.fooooo;
+    Fooo fooo
+  end

--- a/test/passing/exp_grouping.ml.ref
+++ b/test/passing/exp_grouping.ml.ref
@@ -212,3 +212,45 @@ let _ =
 let _ =
   [| (let a = b in
       c) |]
+
+[@@@ocamlformat "if-then-else=compact"]
+
+let _ =
+  if x then (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo )
+  else (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo )
+
+[@@@ocamlformat "if-then-else=fit-or-vertical"]
+
+let _ =
+  if x then (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo )
+  else (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo )
+
+[@@@ocamlformat "if-then-else=keyword-first"]
+
+let _ =
+  if x
+  then (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo )
+  else (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo )
+
+[@@@ocamlformat "if-then-else=k-r"]
+
+let _ =
+  if x then (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo
+  ) else (
+    foo.fooooo <- Fooo.foo fooo foo.fooooo ;
+    Fooo fooo
+  )

--- a/test/passing/exp_grouping.ml.ref
+++ b/test/passing/exp_grouping.ml.ref
@@ -216,41 +216,47 @@ let _ =
 [@@@ocamlformat "if-then-else=compact"]
 
 let _ =
-  if x then (
+  if x then begin
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
-    Fooo fooo )
-  else (
+    Fooo fooo
+  end
+  else begin
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
-    Fooo fooo )
+    Fooo fooo
+  end
 
 [@@@ocamlformat "if-then-else=fit-or-vertical"]
 
 let _ =
-  if x then (
+  if x then begin
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
-    Fooo fooo )
-  else (
+    Fooo fooo
+  end
+  else begin
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
-    Fooo fooo )
+    Fooo fooo
+  end
 
 [@@@ocamlformat "if-then-else=keyword-first"]
 
 let _ =
   if x
-  then (
+  then begin
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
-    Fooo fooo )
-  else (
+    Fooo fooo
+  end
+  else begin
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
-    Fooo fooo )
+    Fooo fooo
+  end
 
 [@@@ocamlformat "if-then-else=k-r"]
 
 let _ =
-  if x then (
+  if x then begin
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
     Fooo fooo
-  ) else (
+  end else begin
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
     Fooo fooo
-  )
+  end

--- a/test/passing/ite-compact.ml.opts
+++ b/test/passing/ite-compact.ml.opts
@@ -1,0 +1,1 @@
+--if-then-else=compact

--- a/test/passing/ite-compact.ml.ref
+++ b/test/passing/ite-compact.ml.ref
@@ -1,0 +1,119 @@
+let _ = if b then e else (e1 ; e2)
+
+let _ =
+  if b then e
+  else (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more )
+
+let _ =
+  if b then (e1 ; e2)
+  else (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more )
+
+let _ =
+  if b then (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more )
+  else if b1 then (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more )
+  else e
+
+;;
+f
+  ( if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooong then ()
+  else () )
+
+;;
+f
+  ( if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then ()
+  else () )
+
+;;
+f
+  ( if even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  then ()
+  else () )
+
+;;
+f
+  ( if
+    and_ even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  then ()
+  else () )
+
+let () = if [@test] true then () else if [@other] true then ()
+
+let foo = if cond1 then arm1 else if cond2 then arm2 else arm3
+
+let _ =
+  if condition then
+    let a = 1 in
+    let b = 2 in
+    a + b
+  else if other_condition then 12
+  else 0
+
+let _ =
+  if foo then
+    let a = 1 in
+    let b = 2 in
+    a + b
+  else if foo then 12
+  else 0
+
+let foo =
+  if is_sugared_list e2 then Some (Semi, Non)
+  else Some (ColonColon, if exp == e2 then Right else Left)
+
+let foo =
+  if is_sugared_list e2 then Some (Semi, Non)
+  else
+    Some
+      ( ColonColon
+      , if exp == e2 then Right
+        else (Left foooooo, foooo, fooo, foooooo, fooooooo, foooooooo) )
+
+let foo =
+  if cond1 then (
+    arm1 ;
+    foooooooooooooo ;
+    fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
+    List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
+        fooooooooooooo) )
+  else if cond2 then (
+    arm2 ;
+    foooooooooooooo ;
+    fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
+    List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
+        fooooooooooooo) )
+  else (
+    arm3 ;
+    foooooooooooooo ;
+    fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
+    List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
+        fooooooooooooo) )
+
+let foo =
+  if some condition then
+    if some nested condition then some action else some other action
+  else some default action
+
+let foo =
+  if some condition then
+    if some nested condition then
+      some action + foooo + foooo + foooooooo + foooo + foooooo
+    else some other action
+  else some default action
+
+let foo = if cmp < 0 then (* foo *) a + b else (* foo *) a - b
+
+let foo =
+  if cmp < 0 then (* ast higher precedence than context: no parens *)
+    false
+  else if cmp > 0 then (* context higher prec than ast: add parens *)
+    true
+  else if Poly.(assoc_of_prec prec_ast = which_child && which_child <> Non)
+  then foo

--- a/test/passing/ite-compact_closing.ml.opts
+++ b/test/passing/ite-compact_closing.ml.opts
@@ -1,0 +1,2 @@
+--if-then-else=compact
+--indicate-multiline-delimiters=closing-on-separate-line

--- a/test/passing/ite-compact_closing.ml.ref
+++ b/test/passing/ite-compact_closing.ml.ref
@@ -1,0 +1,130 @@
+let _ = if b then e else (e1 ; e2)
+
+let _ =
+  if b then e
+  else (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more
+  )
+
+let _ =
+  if b then (e1 ; e2)
+  else (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more
+  )
+
+let _ =
+  if b then (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more
+  )
+  else if b1 then (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more
+  )
+  else e
+
+;;
+f
+  ( if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooong then ()
+  else ()
+  )
+
+;;
+f
+  ( if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then ()
+  else ()
+  )
+
+;;
+f
+  ( if even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  then ()
+  else ()
+  )
+
+;;
+f
+  ( if
+    and_ even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  then ()
+  else ()
+  )
+
+let () = if [@test] true then () else if [@other] true then ()
+
+let foo = if cond1 then arm1 else if cond2 then arm2 else arm3
+
+let _ =
+  if condition then
+    let a = 1 in
+    let b = 2 in
+    a + b
+  else if other_condition then 12
+  else 0
+
+let _ =
+  if foo then
+    let a = 1 in
+    let b = 2 in
+    a + b
+  else if foo then 12
+  else 0
+
+let foo =
+  if is_sugared_list e2 then Some (Semi, Non)
+  else Some (ColonColon, if exp == e2 then Right else Left)
+
+let foo =
+  if is_sugared_list e2 then Some (Semi, Non)
+  else
+    Some
+      ( ColonColon
+      , if exp == e2 then Right
+        else (Left foooooo, foooo, fooo, foooooo, fooooooo, foooooooo) )
+
+let foo =
+  if cond1 then (
+    arm1 ;
+    foooooooooooooo ;
+    fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
+    List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
+        fooooooooooooo)
+  )
+  else if cond2 then (
+    arm2 ;
+    foooooooooooooo ;
+    fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
+    List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
+        fooooooooooooo)
+  )
+  else (
+    arm3 ;
+    foooooooooooooo ;
+    fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
+    List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
+        fooooooooooooo)
+  )
+
+let foo =
+  if some condition then
+    if some nested condition then some action else some other action
+  else some default action
+
+let foo =
+  if some condition then
+    if some nested condition then
+      some action + foooo + foooo + foooooooo + foooo + foooooo
+    else some other action
+  else some default action
+
+let foo = if cmp < 0 then (* foo *) a + b else (* foo *) a - b
+
+let foo =
+  if cmp < 0 then (* ast higher precedence than context: no parens *)
+    false
+  else if cmp > 0 then (* context higher prec than ast: add parens *)
+    true
+  else if Poly.(assoc_of_prec prec_ast = which_child && which_child <> Non)
+  then foo


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/965

