### PR TITLE
Improve the documentation of --doc-comments

### DIFF
--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -152,8 +152,11 @@ OPTIONS (CODE FORMATTING STYLE)
 
        --doc-comments={after|before}
            Doc comments position. after puts doc comments after the
-           corresponding code. before puts comments before the corresponding
-           code. The default value is after.
+           corresponding code. This option has no effect on variant
+           declarations because that would change their meaning and on
+           structure, signature and object for readability. before puts
+           comments before the corresponding code. The default value is
+           after.
 
        --doc-comments-padding=PADDING
            Add PADDING spaces before doc comments in type declarations. The

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -448,7 +448,10 @@ module Formatting = struct
     let all =
       [ ( "after"
         , `After
-        , "$(b,after) puts doc comments after the corresponding code." )
+        , "$(b,after) puts doc comments after the corresponding code. This \
+           option has no effect on variant declarations because that would \
+           change their meaning and on structure, signature and object for \
+           readability." )
       ; ( "before"
         , `Before
         , "$(b,before) puts comments before the corresponding code." ) ]


### PR DESCRIPTION
Quickly explain why `--doc-comments=after` (the default) is not working on variants, structures, signatures and objects.

Fixes https://github.com/ocaml-ppx/ocamlformat/issues/981