### PR TITLE
Fix position of expressions regarding of comments in infix-op expressions

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -2370,8 +2370,7 @@ end = struct
   let parenze_nested_exp {ctx; ast= exp} =
     let infix_prec ast =
       match ast with
-      | Exp {pexp_desc= Pexp_apply (e, _); _} when is_infix e ->
-          prec_ast ast
+      | Exp {pexp_desc= Pexp_apply (e, _); _} when is_infix e -> prec_ast ast
       | Exp
           ( { pexp_desc=
                 Pexp_construct

--- a/src/Ast.mli
+++ b/src/Ast.mli
@@ -206,6 +206,10 @@ val parenze_exp : expression xt -> bool
 (** [parenze_exp xexp] holds when expression-in-context [xexp] should be
     parenthesized. *)
 
+val parenze_nested_exp : expression xt -> bool
+(** [parenze_nested_exp xexp] holds when nested expression-in-context [xexp]
+    should be parenthesized. *)
+
 val parenze_mty : module_type xt -> bool
 (** [parenze_mty xmty] holds when module_type-in-context [xmty] should be
     parenthesized. *)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1385,20 +1385,20 @@ and fmt_op_args c ~parens xexp op_args =
     | `No -> (0, 0)
     | `Closing_on_separate_line -> (1000, 0)
   in
-  let fmt_arg ~last_op ~first:_ ~last lbl_xarg =
-    let _, ({ast= arg; _} as xarg) = lbl_xarg in
-    let parens =
-      ((not last_op) && exposed_right_exp Ast.Non_apply arg)
-      || parenze_exp xarg
-    in
-    let box =
-      match (snd lbl_xarg).ast.pexp_desc with
-      | Pexp_fun _ | Pexp_function _ -> Some (not last)
-      | _ -> None
-    in
-    fmt_label_arg c ?box ~parens lbl_xarg $ fmt_if (not last) "@ "
+  let fmt_args ~last_op xargs =
+    list_fl xargs (fun ~first:_ ~last lbl_xarg ->
+        let _, ({ast= arg; _} as xarg) = lbl_xarg in
+        let parens =
+          ((not last_op) && exposed_right_exp Ast.Non_apply arg)
+          || parenze_exp xarg
+        in
+        let box =
+          match arg.pexp_desc with
+          | Pexp_fun _ | Pexp_function _ -> Some (not last)
+          | _ -> None
+        in
+        fmt_label_arg c ?box ~parens lbl_xarg $ fmt_if (not last) "@ ")
   in
-  let fmt_args ~last_op xargs = list_fl xargs (fmt_arg ~last_op) in
   let fmt_op_args_ ~first ~last (fmt_op, xargs) =
     let final_break =
       match xargs with

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1271,7 +1271,7 @@ and fmt_label_arg ?(box = true) ?epi ?parens ?eol c
   | (Labelled l | Optional l), Pexp_ident {txt= Lident i; loc}
     when String.equal l i && List.is_empty arg.pexp_attributes ->
       Cmts.fmt c loc @@ Cmts.fmt c ?eol arg.pexp_loc @@ fmt_label lbl ""
-  | _ -> fmt_label lbl ":@," $ fmt_expression c ~box ?epi ?parens xarg
+  | _ -> fmt_label lbl ":@," $ fmt_expression c ~box ?epi ?eol ?parens xarg
 
 and fmt_args ~first:first_grp ~last:last_grp c ctx args =
   let fmt_arg ~first:_ ~last (lbl, arg) =
@@ -1383,7 +1383,8 @@ and fmt_infix_op_args c ~parens xexp op_args =
       | Pexp_fun _ | Pexp_function _ -> Some (not last)
       | _ -> None
     in
-    fmt_label_arg c ?box ~parens lbl_xarg $ fmt_if (not last) "@ "
+    fmt_label_arg c ?box ~parens ~eol:(fmt "@;<1000 0>") lbl_xarg
+    $ fmt_if (not last) "@ "
   in
   let fmt_op_arg_group ~first:first_grp ~last:last_grp args =
     let indent = if first_grp && parens then -2 else 0 in

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1375,16 +1375,6 @@ and fmt_op_args c ~parens xexp op_args =
       | `Preserve -> Source.is_long_pexp_open c.source exp )
     | _ -> false
   in
-  let parens_or_nested = parens || Ast.parenze_nested_exp xexp in
-  let parens_or_forced =
-    parens || Poly.(c.conf.infix_precedence = `Parens)
-  in
-  let hint =
-    match c.conf.indicate_multiline_delimiters with
-    | `Space -> (1, 0)
-    | `No -> (0, 0)
-    | `Closing_on_separate_line -> (1000, 0)
-  in
   let fmt_args ~last_op xargs =
     list_fl xargs (fun ~first:_ ~last lbl_xarg ->
         let _, ({ast= arg; _} as xarg) = lbl_xarg in
@@ -1435,16 +1425,14 @@ and fmt_op_args c ~parens xexp op_args =
         List.group op_args ~break
     | `Fit_or_vertical -> List.map ~f:(fun x -> [x]) op_args
   in
-  fits_breaks_if parens_or_nested "("
-    ( if parens_or_forced then
-      match c.conf.indicate_multiline_delimiters with
-      | `Space -> "( "
-      | `No | `Closing_on_separate_line -> "("
-    else "" )
-  $ list_fl op_args_grouped fmt_op_arg_group
-  $ fmt_or_k parens_or_forced
-      (fits_breaks_if parens_or_nested ")" ~hint ")")
-      (fits_breaks_if parens_or_nested ")" "")
+  let nested = Ast.parenze_nested_exp xexp in
+  let forced = Poly.(c.conf.infix_precedence = `Parens) in
+  let wrap =
+    if parens then wrap_fits_breaks ~space:false c.conf
+    else if forced then wrap_fits_breaks_if ~space:false c.conf nested
+    else wrap_if_fits_and nested
+  in
+  wrap "(" ")" (list_fl op_args_grouped fmt_op_arg_group)
 
 and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
     ?ext ({ast= exp; _} as xexp) =

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1631,6 +1631,13 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                         is important *)
                      let has_cmts = Cmts.has_before c.cmts pexp_loc in
                      let fmt_before_cmts = Cmts.fmt_before c pexp_loc in
+                     (* The comments before the first arg are put there, so
+                        that they are printed after the operator and the box
+                        is correctly broken before the following arguments.
+                        Keeping the comments in the arg box would not break
+                        properly the current box. OTOH, relocating the
+                        comments would put them before the operator in some
+                        cases and make the formatting unstable. *)
                      let fmt_after_cmts =
                        Cmts.fmt_after c pexp_loc
                        $ opt (List.hd args) (fun (_, {ast= e; _}) ->

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1279,14 +1279,7 @@ and fmt_args ~first:first_grp ~last:last_grp c ctx args =
   let fmt_arg ?prev (lbl, arg) ?next =
     let ({ast; _} as xarg) = sub_exp ~ctx arg in
     let openbox = open_hovbox (if first_grp then 2 else 0) in
-    let consecutive_prefix_ops =
-      match next with
-      | Some (_, e) -> is_prefix ast && exposed_left_exp e
-      | _ -> false
-    in
-    let spc =
-      consecutive_prefix_ops || Option.is_some next || not last_grp
-    in
+    let spc = Option.is_some next || not last_grp in
     let box =
       match ast.pexp_desc with
       | Pexp_fun _ | Pexp_function _ -> Some false

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1412,37 +1412,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         $ hovbox_if (not last) 2 (fmt_args ~last_op:last xargs) )
       $ fmt_if_k (not last) (break 0 0)
     in
-    let is_nested_diff_prec_infix_ops =
-      let infix_prec ast =
-        match ast with
-        | Exp {pexp_desc= Pexp_apply (e, _); _} when is_infix e ->
-            prec_ast ast
-        | Exp
-            ( { pexp_desc=
-                  Pexp_construct
-                    ( {txt= Lident "::"; loc= _}
-                    , Some
-                        { pexp_desc= Pexp_tuple [_; _]
-                        ; pexp_loc= _
-                        ; pexp_attributes= _
-                        ; _ } )
-              ; pexp_loc= _
-              ; pexp_attributes= _
-              ; _ } as exp )
-          when not (is_sugared_list exp) ->
-            prec_ast ast
-        | _ -> None
-      in
-      (* Make the precedence explicit for infix operators *)
-      match (infix_prec xexp.ctx, infix_prec (Exp xexp.ast)) with
-      | Some (InfixOp0 | ColonEqual), _ | _, Some (InfixOp0 | ColonEqual) ->
-          (* special case for refs update and all InfixOp0 to reduce parens
-             noise *)
-          false
-      | None, _ | _, None -> false
-      | Some p1, Some p2 -> Poly.(p1 <> p2)
-    in
-    let parens_or_nested = parens || is_nested_diff_prec_infix_ops in
+    let parens_or_nested = parens || Ast.parenze_nested_exp xexp in
     let parens_or_forced =
       parens || Poly.(c.conf.infix_precedence = `Parens)
     in

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1402,19 +1402,18 @@ and fmt_op_args c ~parens xexp op_args =
     $ fmt_if_k (not last) (break 0 0)
   in
   let fmt_op_arg_group ~first:first_grp ~last:last_grp args =
-    list_fl args
-      (fun ~first ~last (_, fmt_before_cmts, fmt_after_cmts, op_args) ->
-        let very_first = first_grp && first in
-        let very_last = last_grp && last in
-        fmt_before_cmts
-        $ fmt_if_k first
-            (open_hovbox (if first_grp && parens then -2 else 0))
-        $ fmt_after_cmts
-        $ fmt_op_args_ ~first:very_first op_args ~last:very_last
-        $ fmt_if_k last close_box
-        $ fmt_if_k (not very_last) (break_unless_newline 1 0))
+    hovbox
+      (if first_grp && parens then -2 else 0)
+      (list_fl args
+         (fun ~first ~last (_, fmt_before_cmts, fmt_after_cmts, op_args) ->
+           let very_first = first_grp && first in
+           let very_last = last_grp && last in
+           fmt_before_cmts $ fmt_after_cmts
+           $ fmt_op_args_ ~first:very_first op_args ~last:very_last
+           $ fmt_if_k (not last) (break_unless_newline 1 0)))
+    $ fmt_if_k (not last_grp) (break_unless_newline 1 0)
   in
-  let op_args_grouped =
+  let groups =
     match c.conf.break_infix with
     | `Wrap ->
         let not_simple (_, arg) = not (is_simple c.conf width arg) in
@@ -1432,7 +1431,7 @@ and fmt_op_args c ~parens xexp op_args =
     else if forced then wrap_fits_breaks_if ~space:false c.conf nested
     else wrap_if_fits_and nested
   in
-  wrap "(" ")" (list_fl op_args_grouped fmt_op_arg_group)
+  wrap "(" ")" (list_fl groups fmt_op_arg_group)
 
 and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
     ?ext ({ast= exp; _} as xexp) =

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1375,6 +1375,16 @@ and fmt_op_args c ~parens xexp op_args =
       | `Preserve -> Source.is_long_pexp_open c.source exp )
     | _ -> false
   in
+  let parens_or_nested = parens || Ast.parenze_nested_exp xexp in
+  let parens_or_forced =
+    parens || Poly.(c.conf.infix_precedence = `Parens)
+  in
+  let hint =
+    match c.conf.indicate_multiline_delimiters with
+    | `Space -> (1, 0)
+    | `No -> (0, 0)
+    | `Closing_on_separate_line -> (1000, 0)
+  in
   let fmt_args ~last_op xargs =
     list_fl xargs (fun ~first:_ ~last lbl_xarg ->
         let _, ({ast= arg; _} as xarg) = lbl_xarg in
@@ -1419,14 +1429,16 @@ and fmt_op_args c ~parens xexp op_args =
         List.group op_args ~break
     | `Fit_or_vertical -> List.map ~f:(fun x -> [x]) op_args
   in
-  let nested = Ast.parenze_nested_exp xexp in
-  let forced = Poly.(c.conf.infix_precedence = `Parens) in
-  let wrap =
-    if parens then wrap_fits_breaks ~space:false c.conf
-    else if forced then wrap_fits_breaks_if ~space:false c.conf nested
-    else wrap_if_fits_and nested
-  in
-  wrap "(" ")" (list_fl groups fmt_op_arg_group)
+  fits_breaks_if parens_or_nested "("
+    ( if parens_or_forced then
+      match c.conf.indicate_multiline_delimiters with
+      | `Space -> "( "
+      | `No | `Closing_on_separate_line -> "("
+    else "" )
+  $ list_fl groups fmt_op_arg_group
+  $ fmt_or_k parens_or_forced
+      (fits_breaks_if parens_or_nested ")" ~hint ")")
+      (fits_breaks_if parens_or_nested ")" "")
 
 and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
     ?ext ({ast= exp; _} as xexp) =

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1375,21 +1375,21 @@ and fmt_op_args c ~parens xexp op_args =
     in
     fmt_label_arg c ?box ~parens lbl_xarg $ fmt_if (not last) "@ "
   in
+  let is_not_indented exp =
+    match exp.pexp_desc with
+    | Pexp_ifthenelse _ | Pexp_let _ | Pexp_letexception _
+     |Pexp_letmodule _ | Pexp_match _ | Pexp_newtype _ | Pexp_sequence _
+     |Pexp_try _ ->
+        true
+    | Pexp_open _ -> (
+      match c.conf.let_open with
+      | `Auto | `Long -> true
+      | `Short -> false
+      | `Preserve -> Source.is_long_pexp_open c.source exp )
+    | _ -> false
+  in
   let fmt_args ~last_op xargs = list_fl xargs (fmt_arg ~last_op) in
   let fmt_op_args_ ~first ~last (fmt_op, xargs) =
-    let is_not_indented exp =
-      match exp.pexp_desc with
-      | Pexp_ifthenelse _ | Pexp_let _ | Pexp_letexception _
-       |Pexp_letmodule _ | Pexp_match _ | Pexp_newtype _ | Pexp_sequence _
-       |Pexp_try _ ->
-          true
-      | Pexp_open _ -> (
-        match c.conf.let_open with
-        | `Auto | `Long -> true
-        | `Short -> false
-        | `Preserve -> Source.is_long_pexp_open c.source exp )
-      | _ -> false
-    in
     let final_break =
       match xargs with
       | (_, {ast= a0; _}) :: _ -> last && is_not_indented a0
@@ -1405,17 +1405,17 @@ and fmt_op_args c ~parens xexp op_args =
   let parens_or_forced =
     parens || Poly.(c.conf.infix_precedence = `Parens)
   in
+  let hint =
+    match c.conf.indicate_multiline_delimiters with
+    | `Space -> (1, 0)
+    | `No -> (0, 0)
+    | `Closing_on_separate_line -> (1000, 0)
+  in
   let fmt_op_arg_group ~first:first_grp ~last:last_grp args =
     list_fl args
       (fun ~first ~last (_, fmt_before_cmts, fmt_after_cmts, op_args) ->
         let very_first = first_grp && first in
         let very_last = last_grp && last in
-        let hint =
-          match c.conf.indicate_multiline_delimiters with
-          | `Space -> (1, 0)
-          | `No -> (0, 0)
-          | `Closing_on_separate_line -> (1000, 0)
-        in
         fmt_if_k very_first
           (fits_breaks_if parens_or_nested "("
              ( if parens_or_forced then

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1627,8 +1627,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             (List.map op_args ~f:(fun (op, args) ->
                  match op with
                  | Some ({ast= {pexp_loc; _}; _} as op) ->
-                     (* side effects of Cmts.fmt_before before
-                        fmt_expression is important *)
+                     (* side effects of Cmts.fmt_before before fmt_expression
+                        is important *)
                      let has_cmts = Cmts.has_before c.cmts pexp_loc in
                      let fmt_before_cmts = Cmts.fmt_before c pexp_loc in
                      let fmt_after_cmts =
@@ -3768,8 +3768,8 @@ and fmt_module_expr ?(can_break_before_struct = false) c ({ast= m; _} as xmod)
                 (Option.call ~f:blk_f.pro $ blk_f.psp $ blk_f.bdy $ blk_f.esp)
             $ Option.call ~f:blk_f.epi
             $ wrap "@ (" ")"
-                ( Option.call ~f:blk_a.pro $ blk_a.psp $ blk_a.bdy $ blk_a.esp
-                $ Option.call ~f:blk_a.epi ) )
+                ( Option.call ~f:blk_a.pro $ blk_a.psp $ blk_a.bdy
+                $ blk_a.esp $ Option.call ~f:blk_a.epi ) )
       ; cls= close_box $ blk_f.cls $ blk_a.cls
       ; epi=
           Option.some_if has_epi

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1416,24 +1416,13 @@ and fmt_op_args c ~parens xexp op_args =
       (fun ~first ~last (_, fmt_before_cmts, fmt_after_cmts, op_args) ->
         let very_first = first_grp && first in
         let very_last = last_grp && last in
-        fmt_if_k very_first
-          (fits_breaks_if parens_or_nested "("
-             ( if parens_or_forced then
-               match c.conf.indicate_multiline_delimiters with
-               | `Space -> "( "
-               | `No | `Closing_on_separate_line -> "("
-             else "" ))
-        $ fmt_before_cmts
+        fmt_before_cmts
         $ fmt_if_k first
             (open_hovbox (if first_grp && parens then -2 else 0))
         $ fmt_after_cmts
         $ fmt_op_args_ ~first:very_first op_args ~last:very_last
         $ fmt_if_k last close_box
-        $ fmt_or_k very_last
-            (fmt_or_k parens_or_forced
-               (fits_breaks_if parens_or_nested ")" ~hint ")")
-               (fits_breaks_if parens_or_nested ")" ""))
-            (break_unless_newline 1 0))
+        $ fmt_if_k (not very_last) (break_unless_newline 1 0))
   in
   let op_args_grouped =
     match c.conf.break_infix with
@@ -1446,7 +1435,16 @@ and fmt_op_args c ~parens xexp op_args =
         List.group op_args ~break
     | `Fit_or_vertical -> List.map ~f:(fun x -> [x]) op_args
   in
-  list_fl op_args_grouped fmt_op_arg_group
+  fits_breaks_if parens_or_nested "("
+    ( if parens_or_forced then
+      match c.conf.indicate_multiline_delimiters with
+      | `Space -> "( "
+      | `No | `Closing_on_separate_line -> "("
+    else "" )
+  $ list_fl op_args_grouped fmt_op_arg_group
+  $ fmt_or_k parens_or_forced
+      (fits_breaks_if parens_or_nested ")" ~hint ")")
+      (fits_breaks_if parens_or_nested ")" "")
 
 and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
     ?ext ({ast= exp; _} as xexp) =

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1353,7 +1353,7 @@ and fmt_sequence c ?ext parens width xexp pexp_loc fmt_atrs =
         (hvbox_if parens 0 @@ list_pn grps fmt_seq_list)
     $ fmt_atrs )
 
-and fmt_op_args c ~parens xexp op_args =
+and fmt_infix_op_args c ~parens xexp op_args =
   let width xe = String.length (Cmts.preserve (fmt_expression c) xe) in
   let is_not_indented {ast= exp; _} =
     match exp.pexp_desc with
@@ -1635,7 +1635,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
     when is_infix_id id && not (is_monadic_binding_id id) ->
       let op_args = Sugar.infix c.cmts (prec_ast (Exp exp)) xexp in
       hvbox indent_wrap
-        ( fmt_op_args c ~parens xexp
+        ( fmt_infix_op_args c ~parens xexp
             (List.map op_args ~f:(fun (op, args) ->
                  match op with
                  | Some ({ast= {pexp_loc; _}; _} as op) ->
@@ -1874,7 +1874,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
     | None ->
         let loc_args = Sugar.infix_cons xexp in
         hvbox indent_wrap
-          ( fmt_op_args c ~parens xexp
+          ( fmt_infix_op_args c ~parens xexp
               (List.mapi loc_args ~f:(fun i (locs, arg) ->
                    let f l = Cmts.has_before c.cmts l in
                    let has_cmts = List.exists ~f locs in

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1271,9 +1271,7 @@ and fmt_label_arg ?(box = true) ?epi ?parens ?eol c
   | (Labelled l | Optional l), Pexp_ident {txt= Lident i; loc}
     when String.equal l i && List.is_empty arg.pexp_attributes ->
       Cmts.fmt c loc @@ Cmts.fmt c ?eol arg.pexp_loc @@ fmt_label lbl ""
-  | _ ->
-      hvbox_if box 2
-        (fmt_label lbl ":@," $ fmt_expression c ~box ?epi ?parens xarg)
+  | _ -> fmt_label lbl ":@," $ fmt_expression c ~box ?epi ?parens xarg
 
 and fmt_args ~first:first_grp ~last:last_grp c ctx args =
   let fmt_arg ~first:_ ~last (lbl, arg) =

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1630,7 +1630,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                      (* side effects of Cmts.fmt_before before fmt_expression
                         is important *)
                      let has_cmts = Cmts.has_before c.cmts pexp_loc in
-                     let fmt_before_cmts = Cmts.fmt_before c pexp_loc in
+                     let adj = break_unless_newline 1000 0 in
+                     let fmt_before_cmts = Cmts.fmt_before ~adj c pexp_loc in
                      (* The comments before the first arg are put there, so
                         that they are printed after the operator and the box
                         is correctly broken before the following arguments.
@@ -1641,9 +1642,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                      let fmt_after_cmts =
                        Cmts.fmt_after c pexp_loc
                        $ opt (List.hd args) (fun (_, {ast= e; _}) ->
-                             Cmts.fmt_before
-                               ~adj:(break_unless_newline 1000 0)
-                               c e.pexp_loc)
+                             Cmts.fmt_before ~adj c e.pexp_loc)
                      in
                      let fmt_op = fmt_expression c op in
                      ( has_cmts

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1385,19 +1385,17 @@ and fmt_op_args c ~parens xexp op_args =
     | `No -> (0, 0)
     | `Closing_on_separate_line -> (1000, 0)
   in
-  let fmt_args ~last_op xargs =
-    list_fl xargs (fun ~first:_ ~last lbl_xarg ->
-        let _, ({ast= arg; _} as xarg) = lbl_xarg in
-        let parens =
-          ((not last_op) && exposed_right_exp Ast.Non_apply arg)
-          || parenze_exp xarg
-        in
-        let box =
-          match arg.pexp_desc with
-          | Pexp_fun _ | Pexp_function _ -> Some (not last)
-          | _ -> None
-        in
-        fmt_label_arg c ?box ~parens lbl_xarg $ fmt_if (not last) "@ ")
+  let fmt_arg very_last ~first:_ ~last ((_, xarg) as lbl_xarg) =
+    let parens =
+      ((not very_last) && exposed_right_exp Ast.Non_apply xarg.ast)
+      || parenze_exp xarg
+    in
+    let box =
+      match xarg.ast.pexp_desc with
+      | Pexp_fun _ | Pexp_function _ -> Some (not last)
+      | _ -> None
+    in
+    fmt_label_arg c ?box ~parens lbl_xarg $ fmt_if (not last) "@ "
   in
   let fmt_op_arg_group ~first:first_grp ~last:last_grp args =
     let indent = if first_grp && parens then -2 else 0 in
@@ -1414,7 +1412,7 @@ and fmt_op_args c ~parens xexp op_args =
                      fmt "@ "
                  | _ -> fmt_if (not very_first) " " )
                $ hovbox_if (not very_last) 2
-                   (fmt_args ~last_op:very_last xargs) )
+                   (list_fl xargs (fmt_arg very_last)) )
            $ fmt_if_k (not last) (break_unless_newline 1 0)))
     $ fmt_if_k (not last_grp) (break_unless_newline 1 0)
   in

--- a/test/passing/apply.ml
+++ b/test/passing/apply.ml
@@ -49,7 +49,7 @@ let whatever_labelled a_function_name long_list_one some_other_thing =
 
 let cartesian_product' long_list_one long_list_two =
   List.concat
-    ( long_list_one
+    (long_list_one
     |> List.map (fun v1 -> long_list_two |> List.map (fun v2 -> (v1, v2)))
     )
 

--- a/test/passing/apply.ml
+++ b/test/passing/apply.ml
@@ -49,7 +49,7 @@ let whatever_labelled a_function_name long_list_one some_other_thing =
 
 let cartesian_product' long_list_one long_list_two =
   List.concat
-    (long_list_one
+    ( long_list_one
     |> List.map (fun v1 -> long_list_two |> List.map (fun v2 -> (v1, v2)))
     )
 

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -186,12 +186,12 @@ type t =
 let () =
   xxxxxxxxxx
   || (* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx *)
-     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 let () =
   xxxxxxxxxx
   land (* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx *)
-       xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 let rec fooooooooooo = function
   (*XX*)

--- a/test/passing/infix_arg_grouping.ml
+++ b/test/passing/infix_arg_grouping.ml
@@ -95,7 +95,7 @@ let sigma_seed =
 match
   "\"" ^ line ^ " \""
   |> (* split by whitespace *)
-     Str.split (Str.regexp_string "\" \"")
+  Str.split (Str.regexp_string "\" \"")
 with
 | prog :: args -> fooooooooooooooooooooo
 
@@ -103,9 +103,9 @@ let () =
   (* Open the repo *)
   initialise
   >>= (* Perform a subsequent action *)
-      subsequent_action
+  subsequent_action
   >|= (* Keep going... *)
-      another_action
+  another_action
   |> fun t ->
   (* And finally do this *)
   final_action t

--- a/test/passing/infix_arg_grouping.ml
+++ b/test/passing/infix_arg_grouping.ml
@@ -85,3 +85,27 @@ let _ =
       ; ddddddddddddddd
       ; eeeeeeeeeeeeeee ]
     @ l )
+
+let sigma_seed =
+  create_seed_vars
+    ( (* formals already there plus new ones *)
+      prop.Prop.sigma @ sigma_new_formals )
+
+;;
+match
+  "\"" ^ line ^ " \""
+  |> (* split by whitespace *)
+     Str.split (Str.regexp_string "\" \"")
+with
+| prog :: args -> fooooooooooooooooooooo
+
+let () =
+  (* Open the repo *)
+  initialise
+  >>= (* Perform a subsequent action *)
+      subsequent_action
+  >|= (* Keep going... *)
+      another_action
+  |> fun t ->
+  (* And finally do this *)
+  final_action t

--- a/test/passing/infix_arg_grouping.ml
+++ b/test/passing/infix_arg_grouping.ml
@@ -109,3 +109,13 @@ let () =
   |> fun t ->
   (* And finally do this *)
   final_action t
+
+let () =
+  (* Open the repo *)
+  initialise
+  (* Perform a subsequent action *)
+  >>= subsequent_action
+  (* Keep going... *)
+  >|= another_action
+  (* And finally do this *)
+  |> fun t -> final_action t

--- a/test/passing/wrap_comments.ml.ref
+++ b/test/passing/wrap_comments.ml.ref
@@ -14,7 +14,9 @@ type t =
 
 let rex =
   Pcre.regexp
-    ( "^[0-9]{2}" (* xxxxxxxxxxx               *) ^ "(.{12})"
+    ( "^[0-9]{2}"
+    (* xxxxxxxxxxx               *)
+    ^ "(.{12})"
     (* xxxxxxxxxxxxxxxxxx        *)
     ^ "(.{4})"
     (* xxxxxxxxxxxx              *)


### PR DESCRIPTION
Alternative fix to #961 (could replace #970)

It is enough to review commit 6bceb0e4adbb5546c7a55abcc1c6b48fabb21082, bf9b0465b20f5b738446dc15f73fa2b69e09cc34 is the last exploitable base from the branch of PR #970

cc @craigfe for feedback

Diff with test_branch: (long but looks good)

```ocaml
diff --git a/infer/src/IR/Attributes.ml b/infer/src/IR/Attributes.ml
index 761e4679b..96c0e2aa0 100644
--- a/infer/src/IR/Attributes.ml
+++ b/infer/src/IR/Attributes.ml
@@ -103,7 +103,7 @@ let should_try_to_update pname_blob akind =
       SqliteUtils.result_single_column_option ~finalize:false ~log:"Attributes.replace" db
         find_stmt
       |> (* there is no entry with a strictly larger "definedness" for that proc name *)
-         Option.is_none)
+      Option.is_none)
 
 
 let select_statement =
diff --git a/infer/src/backend/ondemand.ml b/infer/src/backend/ondemand.ml
index 2587e399d..d268b7d54 100644
--- a/infer/src/backend/ondemand.ml
+++ b/infer/src/backend/ondemand.ml
@@ -265,7 +265,7 @@ let dump_duplicate_procs source_file procs =
           when (* defined in another file *)
                (not (SourceFile.equal source_file translation_unit))
                && (* really defined in that file and not in an include *)
-                  SourceFile.equal translation_unit loc.file ->
+               SourceFile.equal translation_unit loc.file ->
             Some (pname, translation_unit)
         | _ ->
             None)
diff --git a/infer/src/biabduction/Abs.ml b/infer/src/biabduction/Abs.ml
index 3bedc6414..84316bb64 100644
--- a/infer/src/biabduction/Abs.ml
+++ b/infer/src/biabduction/Abs.ml
@@ -90,8 +90,8 @@ let create_condition_ls ids_private id_base p_leftover (inst : Sil.subst) =
   (* [fav_insts_of_private_ids] does not intersect the free vars in [p_leftover.sigma] *)
   Prop.sigma_free_vars p_leftover.Prop.sigma |> Fn.non intersects_fav_insts_of_private_ids
   && (* [fav_insts_of_private_ids] does not intersect the free vars in [insts_of_public_ids] *)
-     List.for_all insts_of_public_ids ~f:(fun e ->
-         Exp.free_vars e |> Fn.non intersects_fav_insts_of_private_ids)
+  List.for_all insts_of_public_ids ~f:(fun e ->
+      Exp.free_vars e |> Fn.non intersects_fav_insts_of_private_ids)
 
 
 let mk_rule_ptspts_ls tenv impl_ok1 impl_ok2 (para : Sil.hpara) =
@@ -912,7 +912,7 @@ let abstract_gc tenv p =
   let check fav_seq =
     Sequence.is_empty fav_seq
     || (* non-empty intersection with [fav_p_without_pi] *)
-       Sequence.exists fav_seq ~f:(fun id -> Ident.Set.mem id fav_p_without_pi)
+    Sequence.exists fav_seq ~f:(fun id -> Ident.Set.mem id fav_p_without_pi)
   in
   let strong_filter = function
     | Sil.Aeq (e1, e2) | Sil.Aneq (e1, e2) ->
@@ -1114,7 +1114,7 @@ let check_junk pname tenv prop =
               in
               (is_none alloc_attribute && !leaks_reported <> [])
               || (* None attribute only reported if it's the first one *)
-                 List.mem ~equal:attr_opt_equal !leaks_reported alloc_attribute
+              List.mem ~equal:attr_opt_equal !leaks_reported alloc_attribute
             in
             let ignore_leak =
               !BiabductionConfig.allow_leak || ignore_resource || is_undefined
diff --git a/infer/src/biabduction/BuiltinDefn.ml b/infer/src/biabduction/BuiltinDefn.ml
index f2122d6aa..64f38f837 100644
--- a/infer/src/biabduction/BuiltinDefn.ml
+++ b/infer/src/biabduction/BuiltinDefn.ml
@@ -514,12 +514,12 @@ let execute_free mk ?(mark_as_freed = true) {Builtin.summary; instr; tenv; prop_
       let plist =
         prop_zero
         @ (* model: if 0 then skip else execute_free_nonzero_ *)
-          List.concat_map
-            ~f:(fun p ->
-              execute_free_nonzero_ mk ~mark_as_freed (Summary.get_proc_desc summary) tenv instr p
-                (Prop.exp_normalize_prop tenv p lexp)
-                typ loc)
-            prop_nonzero
+        List.concat_map
+          ~f:(fun p ->
+            execute_free_nonzero_ mk ~mark_as_freed (Summary.get_proc_desc summary) tenv instr p
+              (Prop.exp_normalize_prop tenv p lexp)
+              typ loc)
+          prop_nonzero
       in
       List.map ~f:(fun p -> (p, path)) plist
   | _ ->
diff --git a/infer/src/biabduction/Rearrange.ml b/infer/src/biabduction/Rearrange.ml
index ed9729a30..aa301e1e7 100644
--- a/infer/src/biabduction/Rearrange.ml
+++ b/infer/src/biabduction/Rearrange.ml
@@ -44,7 +44,7 @@ let check_bad_index tenv pname p len index loc =
     let index_nonnegative = Prop.mk_inequality tenv (Exp.BinOp (Binop.Le, Exp.zero, index)) in
     Prover.check_zero tenv index
     || (* index 0 always in bound, even when we know nothing about len *)
-       (Prover.check_atom tenv p index_not_too_large && Prover.check_atom tenv p index_nonnegative)
+    (Prover.check_atom tenv p index_not_too_large && Prover.check_atom tenv p index_nonnegative)
   in
   let index_has_bounds () =
     match Prover.get_bounds tenv p index with Some _, Some _ -> true | _ -> false
@@ -919,9 +919,9 @@ let add_guarded_by_constraints tenv prop lexp pdesc =
          | _ ->
              false )
       || (* or the prop says we already have the lock *)
-         List.exists
-           ~f:(function Sil.Apred (Alocked, _) -> true | _ -> false)
-           (Attribute.get_for_exp tenv prop guarded_by_exp)
+      List.exists
+        ~f:(function Sil.Apred (Alocked, _) -> true | _ -> false)
+        (Attribute.get_for_exp tenv prop guarded_by_exp)
     in
     let guardedby_is_self_referential =
       String.equal "itself" (String.lowercase guarded_by_str)
diff --git a/infer/src/bufferoverrun/bufferOverrunProofObligations.ml b/infer/src/bufferoverrun/bufferOverrunProofObligations.ml
index 8951ec2b4..5e1de3f65 100644
--- a/infer/src/bufferoverrun/bufferOverrunProofObligations.ml
+++ b/infer/src/bufferoverrun/bufferOverrunProofObligations.ml
@@ -337,22 +337,22 @@ module ArrayAccessCondition = struct
     (* basically, alarms involving infinity are filtered *)
     ((not (ItvPure.is_finite real_idx)) || not (ItvPure.is_finite c.size))
     && (* except the following cases *)
-       not
-         ( Bound.is_not_infty (ItvPure.lb real_idx)
-           && (* idx non-infty lb < 0 *)
-              Bound.lt (ItvPure.lb real_idx) Bound.zero
-         || Bound.is_not_infty (ItvPure.lb real_idx)
-            && (* idx non-infty lb > size lb *)
-               Bound.gt (ItvPure.lb real_idx) (ItvPure.lb c.size)
-         || Bound.is_not_infty (ItvPure.lb real_idx)
-            && (* idx non-infty lb > size ub *)
-               Bound.gt (ItvPure.lb real_idx) (ItvPure.ub c.size)
-         || Bound.is_not_infty (ItvPure.ub real_idx)
-            && (* idx non-infty ub > size lb *)
-               Bound.gt (ItvPure.ub real_idx) (ItvPure.lb c.size)
-         || Bound.is_not_infty (ItvPure.ub real_idx)
-            && (* idx non-infty ub > size ub *)
-               Bound.gt (ItvPure.ub real_idx) (ItvPure.ub c.size) )
+    not
+      ( Bound.is_not_infty (ItvPure.lb real_idx)
+        && (* idx non-infty lb < 0 *)
+        Bound.lt (ItvPure.lb real_idx) Bound.zero
+      || Bound.is_not_infty (ItvPure.lb real_idx)
+         && (* idx non-infty lb > size lb *)
+         Bound.gt (ItvPure.lb real_idx) (ItvPure.lb c.size)
+      || Bound.is_not_infty (ItvPure.lb real_idx)
+         && (* idx non-infty lb > size ub *)
+         Bound.gt (ItvPure.lb real_idx) (ItvPure.ub c.size)
+      || Bound.is_not_infty (ItvPure.ub real_idx)
+         && (* idx non-infty ub > size lb *)
+         Bound.gt (ItvPure.ub real_idx) (ItvPure.lb c.size)
+      || Bound.is_not_infty (ItvPure.ub real_idx)
+         && (* idx non-infty ub > size ub *)
+         Bound.gt (ItvPure.ub real_idx) (ItvPure.ub c.size) )
 
 
   (* check buffer overrun and return its confidence *)
diff --git a/infer/src/checkers/Litho.ml b/infer/src/checkers/Litho.ml
index 4ecdeb061..c0ea53aeb 100644
--- a/infer/src/checkers/Litho.ml
+++ b/infer/src/checkers/Litho.ml
@@ -97,7 +97,7 @@ module RequiredProps = struct
         ~f:(fun ({Annot.class_name; parameters}, _) ->
           String.is_suffix class_name ~suffix:Annotations.prop
           && (* Don't count as required if it's @Prop(optional = true) *)
-             not (List.exists ~f:(fun annot_string -> String.equal annot_string "true") parameters))
+          not (List.exists ~f:(fun annot_string -> String.equal annot_string "true") parameters))
         annot_list
     in
     match Tenv.lookup tenv typename with
@@ -227,8 +227,8 @@ module TransferFunctions (CFG : ProcCfg.S) = struct
           (* track Builder's in order to check required prop's *)
           || GraphQLGetters.is_function callee_procname domain_summary
           || (* track GraphQL getters in order to report graphql field accesses *)
-             Domain.mem receiver astate
-             (* track anything called on a receiver we're already tracking *) )
+          Domain.mem receiver astate
+          (* track anything called on a receiver we're already tracking *) )
           && (not (Typ.Procname.Java.is_static java_callee_procname))
           && not
                ( LithoFramework.is_function callee_procname
diff --git a/infer/src/checkers/NullabilityPreanalysis.ml b/infer/src/checkers/NullabilityPreanalysis.ml
index 3010bd572..e926173ef 100644
--- a/infer/src/checkers/NullabilityPreanalysis.ml
+++ b/infer/src/checkers/NullabilityPreanalysis.ml
@@ -49,7 +49,7 @@ module TransferFunctions (CFG : ProcCfg.S) = struct
       | Typ.Tptr ({desc= Tfun _}, _)
         when Typ.is_objc_class typ && is_self proc_data.extras lhs_id
              && (* lhs is self, rhs is not null *)
-                not (exp_is_null proc_data.extras rhs) ->
+             not (exp_is_null proc_data.extras rhs) ->
           FieldsAssignedInConstructors.add (name, typ) astate
       | _ ->
           astate )
diff --git a/infer/src/checkers/Siof.ml b/infer/src/checkers/Siof.ml
index dec7fa0bf..2c7b18eb0 100644
--- a/infer/src/checkers/Siof.ml
+++ b/infer/src/checkers/Siof.ml
@@ -198,11 +198,11 @@ module TransferFunctions (CFG : ProcCfg.S) = struct
         add_actuals_globals astate summary loc actuals
         annot_list
     in
     match Tenv.lookup tenv typename with
@@ -227,8 +227,8 @@ module TransferFunctions (CFG : ProcCfg.S) = struct
           (* track Builder's in order to check required prop's *)
           || GraphQLGetters.is_function callee_procname domain_summary
           || (* track GraphQL getters in order to report graphql field accesses
 *)
-             Domain.mem receiver astate
-             (* track anything called on a receiver we're already tracking *) )
+          Domain.mem receiver astate
+          (* track anything called on a receiver we're already tracking *) )
           && (not (Typ.Procname.Java.is_static java_callee_procname))
           && not
                ( LithoFramework.is_function callee_procname
diff --git a/infer/src/checkers/NullabilityPreanalysis.ml b/infer/src/checkers/N
ullabilityPreanalysis.ml
index 3010bd572..e926173ef 100644
--- a/infer/src/checkers/NullabilityPreanalysis.ml
+++ b/infer/src/checkers/NullabilityPreanalysis.ml
@@ -49,7 +49,7 @@ module TransferFunctions (CFG : ProcCfg.S) = struct
       | Typ.Tptr ({desc= Tfun _}, _)
         when Typ.is_objc_class typ && is_self proc_data.extras lhs_id
              && (* lhs is self, rhs is not null *)
-                not (exp_is_null proc_data.extras rhs) ->
+             not (exp_is_null proc_data.extras rhs) ->
           FieldsAssignedInConstructors.add (name, typ) astate
       | _ ->
           astate )
diff --git a/infer/src/checkers/Siof.ml b/infer/src/checkers/Siof.ml
index dec7fa0bf..2c7b18eb0 100644
--- a/infer/src/checkers/Siof.ml
+++ b/infer/src/checkers/Siof.ml
@@ -198,11 +198,11 @@ module TransferFunctions (CFG : ProcCfg.S) = struct
         add_actuals_globals astate summary loc actuals
         |> Domain.join callee_astate
         |> (* make sure it's not Bottom: we made a function call so this needs initialization *)
-           at_least_nonbottom
+        at_least_nonbottom
     | Call (_, _, actuals, loc, _) ->
         add_actuals_globals astate summary loc actuals
         |> (* make sure it's not Bottom: we made a function call so this needs initialization *)
-           at_least_nonbottom
+        at_least_nonbottom
     | Metadata _ ->
         astate
 
diff --git a/infer/src/checkers/hoisting.ml b/infer/src/checkers/hoisting.ml
index 85aa9d21d..1b8a2f123 100644
--- a/infer/src/checkers/hoisting.ml
+++ b/infer/src/checkers/hoisting.ml
@@ -39,7 +39,7 @@ let add_if_hoistable inv_vars instr node source_nodes idom hoistable_calls =
     when (* Check condition (1); N dominates all loop sources *)
          List.for_all ~f:(fun source -> Dominators.dominates idom node source) source_nodes
          && (* Check condition (2); id should be invariant already *)
-            LoopInvariant.InvariantVars.mem (Var.of_id ret_id) inv_vars ->
+         LoopInvariant.InvariantVars.mem (Var.of_id ret_id) inv_vars ->
       HoistCalls.add {pname; loc; node; params; ret} hoistable_calls
   | _ ->
       hoistable_calls
diff --git a/infer/src/checkers/loopInvariant.ml b/infer/src/checkers/loopInvariant.ml
index e67d4a297..350f73938 100644
--- a/infer/src/checkers/loopInvariant.ml
+++ b/infer/src/checkers/loopInvariant.ml
@@ -61,7 +61,7 @@ let is_def_unique_and_satisfy tenv var (loop_nodes : LoopNodes.t) ~is_pure_by_de
                PurityDomain.is_pure
                  (get_purity tenv ~is_pure_by_default ~get_callee_purity callee_pname)
                && (* check if all params are invariant *)
-                  List.for_all ~f:(fun (exp, _) -> is_exp_invariant exp) args
+               List.for_all ~f:(fun (exp, _) -> is_exp_invariant exp) args
            | _ ->
                false)
   | _ ->
diff --git a/infer/src/clang/ClangCommand.ml b/infer/src/clang/ClangCommand.ml
index 6fb79dca4..a0226802b 100644
--- a/infer/src/clang/ClangCommand.ml
+++ b/infer/src/clang/ClangCommand.ml
@@ -202,7 +202,7 @@ let clang_cc1_cmd_sanitizer cmd =
        are appended at the end to override previous opposite settings.  How it's done: suppress
        all the warnings, since there are no warnings, compiler can't elevate them to error
        level. *)
-       argv_cons "-Wno-everything"
+    argv_cons "-Wno-everything"
   in
   let clang_arguments =
     filter_and_replace_unsupported_args ~replace_options_arg ~post_args:(List.rev post_args_rev)
@@ -247,7 +247,7 @@ let with_plugin_args args =
   let args_before_rev =
     []
     |> (* -cc1 has to be the first argument or clang will think it runs in driver mode *)
-       argv_cons "-cc1"
+    argv_cons "-cc1"
     |> List.rev_append
          [ "-load"
          ; plugin_path
diff --git a/infer/src/clang/ClangWrapper.ml b/infer/src/clang/ClangWrapper.ml
index 450b693b3..c7dde556c 100644
--- a/infer/src/clang/ClangWrapper.ml
+++ b/infer/src/clang/ClangWrapper.ml
@@ -72,14 +72,14 @@ let clang_driver_action_items : ClangCommand.t -> action_item list =
            reason that flag is the only one to show up *after* the source file name in the -cc1
            commands emitted by [clang -### ...]. Passing [-fno-addrsig] ensures that the source
            path is always the last argument.  *)
-         ClangCommand.append_args
-           [ "-fno-cxx-modules"
-           ; "-Qunused-arguments"
-           ; "-Wno-ignored-optimization-argument"
-           ; "-fno-addrsig" ]
+      ClangCommand.append_args
+        [ "-fno-cxx-modules"
+        ; "-Qunused-arguments"
+        ; "-Wno-ignored-optimization-argument"
+        ; "-fno-addrsig" ]
       |> (* If -fembed-bitcode is passed, it leads to multiple cc1 commands, which try to read .bc
             files that don't get generated, and fail. So pass -fembed-bitcode=off to disable. *)
-         ClangCommand.append_args ["-fembed-bitcode=off"]
+      ClangCommand.append_args ["-fembed-bitcode=off"]
       |> ClangCommand.command_to_run )
   in
   L.(debug Capture Medium) "clang -### invocation: %s@\n" clang_hashhashhash ;
@@ -89,8 +89,9 @@ let clang_driver_action_items : ClangCommand.t -> action_item list =
       CanonicalCommand
         ( (* massage line to remove edge-cases for splitting *)
         match
-          "\"" ^ line ^ " \"" |> (* split by whitespace *)
-                                 Str.split (Str.regexp_string "\" \"")
+          "\"" ^ line ^ " \""
+          |> (* split by whitespace *)
+          Str.split (Str.regexp_string "\" \"")
         with
         | prog :: args ->
             ClangCommand.mk ~is_driver:false ClangQuotes.EscapedDoubleQuotes ~prog ~args
diff --git a/infer/src/clang/cTrans.ml b/infer/src/clang/cTrans.ml
index 80041478a..3873f056a 100644
--- a/infer/src/clang/cTrans.ml
+++ b/infer/src/clang/cTrans.ml
@@ -2317,7 +2317,7 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
           if
             is_var_unused
             || (* variable might be initialized already - do nothing in that case*)
-               List.exists ~f:(Exp.equal var_exp) res_trans_ie.control.initd_exps
+            List.exists ~f:(Exp.equal var_exp) res_trans_ie.control.initd_exps
           then None
           else
             let sil_e1', ie_typ = res_trans_ie.return in
diff --git a/infer/src/concurrency/starvation.ml b/infer/src/concurrency/starvation.ml
index 6ca11481f..2369eaddd 100644
--- a/infer/src/concurrency/starvation.ml
+++ b/infer/src/concurrency/starvation.ml
@@ -89,8 +89,9 @@ let clang_driver_action_items : ClangCommand.t -> action_item 
list =
       CanonicalCommand
         ( (* massage line to remove edge-cases for splitting *)
         match
-          "\"" ^ line ^ " \"" |> (* split by whitespace *)
-                                 Str.split (Str.regexp_string "\" \"")
+          "\"" ^ line ^ " \""
+          |> (* split by whitespace *)
+          Str.split (Str.regexp_string "\" \"")
         with
         | prog :: args ->
             ClangCommand.mk ~is_driver:false ClangQuotes.EscapedDoubleQuotes ~p
rog ~args
diff --git a/infer/src/clang/cTrans.ml b/infer/src/clang/cTrans.ml
index 80041478a..3873f056a 100644
--- a/infer/src/clang/cTrans.ml
+++ b/infer/src/clang/cTrans.ml
@@ -2317,7 +2317,7 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule
_type.CTranslation = s
           if
             is_var_unused
             || (* variable might be initialized already - do nothing in that ca
se*)
-               List.exists ~f:(Exp.equal var_exp) res_trans_ie.control.initd_ex
ps
+            List.exists ~f:(Exp.equal var_exp) res_trans_ie.control.initd_exps
           then None
           else
             let sil_e1', ie_typ = res_trans_ie.return in
diff --git a/infer/src/concurrency/starvation.ml b/infer/src/concurrency/starvat
ion.ml
index 6ca11481f..2369eaddd 100644
--- a/infer/src/concurrency/starvation.ml
+++ b/infer/src/concurrency/starvation.ml
@@ -310,9 +310,9 @@ let should_report_deadlock_on_current_proc current_elem endpoint_elem =
       c < 0
       || Int.equal 0 c
          && (* same class, so choose depending on location *)
-            Location.compare current_elem.Order.elem.eventually.Event.loc
-              endpoint_elem.Order.elem.eventually.Event.loc
-            < 0
+         Location.compare current_elem.Order.elem.eventually.Event.loc
+           endpoint_elem.Order.elem.eventually.Event.loc
+         < 0
 
 
 let should_report pdesc =
diff --git a/infer/src/integration/CaptureCompilationDatabase.ml b/infer/src/integration/CaptureCompilationDatabase.ml
index eebf31039..124d0cf23 100644
--- a/infer/src/integration/CaptureCompilationDatabase.ml
+++ b/infer/src/integration/CaptureCompilationDatabase.ml
@@ -83,8 +83,8 @@ let get_compilation_database_files_buck ~prog ~args =
       let build_args =
         (command :: List.rev_append rev_not_targets (List.rev Config.buck_build_args_no_inline))
         @ (* Infer doesn't support C++ modules nor precompiled headers yet (T35656509) *)
-          "--config" :: "*//cxx.pch_enabled=false" :: "--config" :: "*//cxx.modules_default=false"
-          :: "--config" :: "*//cxx.modules=False" :: targets_args
+        "--config" :: "*//cxx.pch_enabled=false" :: "--config" :: "*//cxx.modules_default=false"
+        :: "--config" :: "*//cxx.modules=False" :: targets_args
       in
       Logging.(debug Linters Quiet)
         "Processed buck command is: 'buck %a'@\n" (Pp.seq F.pp_print_string) build_args ;
diff --git a/compiler/lib/driver.ml b/compiler/lib/driver.ml
index dee8f58ee..870672728 100644
--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -99,11 +99,11 @@ let o1 : 'a -> 'a =
   >> tailcall
   >> flow_simple
   >> (* flow simple to keep information for future tailcall opt *)
-     specialize'
+  specialize'
   >> eval
   >> inline
   >> (* inlining may reveal new tailcall opt *)
-     deadcode
+  deadcode
   >> tailcall
   >> phi
   >> flow
@@ -133,11 +133,11 @@ let round1 : 'a -> 'a =
   >> tailcall
   >> inline
   >> (* inlining may reveal new tailcall opt *)
-     deadcode
+  deadcode
   >> (* deadcode required before flow simple -> provided by constant *)
-     flow_simple
+  flow_simple
   >> (* flow simple to keep information for future tailcall opt *)
-     specialize'
+  specialize'
   >> eval
   >> identity
 
diff --git a/compiler/lib/generate.ml b/compiler/lib/generate.ml
index 728cf7e7b..22c886acf 100644
--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -1835,9 +1835,9 @@ let generate_shared_value ctx =
             | None -> []
             | Some v ->
                 [J.V v, Some (J.EDot (s_var Constant.global_object, "jsoo_runtime"), J.N)])
-          @ List.map
-              (StringMap.bindings ctx.Ctx.share.Share.vars.Share.strings)
-              ~f:(fun (s, v) -> v, Some (str_js s, J.N))
+           @ List.map
+               (StringMap.bindings ctx.Ctx.share.Share.vars.Share.strings)
+               ~f:(fun (s, v) -> v, Some (str_js s, J.N))
            @ List.map
                (StringMap.bindings ctx.Ctx.share.Share.vars.Share.prims)
                ~f:(fun (s, v) -> v, Some (runtime_fun ctx s, J.N))))
diff --git a/lambda/matching.ml b/lambda/matching.ml
index 2a7b8858d..d3ee47b80 100644
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1093,12 +1093,12 @@ module Or_matrix = struct
       (* check append condition for head of O *)
       safe_below_or_matrix not_e (p, ps)
       && (* check insert condition for tail of O *)
-         List.for_all
-           (fun cl ->
-             match cl with
-             | q :: _, _ -> disjoint p q
-             | _ -> assert false)
-           seen
+      List.for_all
+        (fun cl ->
+          match cl with
+          | q :: _, _ -> disjoint p q
+          | _ -> assert false)
+        seen
     in
     let rec attempt seen = function
       (* invariant: the new clause is safe to append at the end of
@@ -3310,10 +3310,10 @@ let check_partial is_mutable is_lazy pat_act_list = function
       if
         pat_act_list = []
         || (* allow empty case list *)
-           List.exists
-             (fun (pats, lam) ->
-               is_mutable pats && (is_guarded lam || is_lazy pats))
-             pat_act_list
+        List.exists
+          (fun (pats, lam) ->
+            is_mutable pats && (is_guarded lam || is_lazy pats))
+          pat_act_list
       then
         Partial
       else
```