### PR TITLE
Fix: escape special characters in external declaration

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2992,6 +2992,11 @@ and fmt_value_description c ctx vd =
   let doc_before, doc_after, atrs =
     fmt_docstring_around_item c pval_attributes
   in
+  let fmt_val_prim s =
+    if List.length (String.split_on_chars s ~on:[' '; '\n']) > 1 then
+      wrap "{|" "|}" (str s)
+    else wrap "\"" "\"" (str (String.escaped s))
+  in
   hvbox 0
     ( doc_before
     $ box_fun_sig_args c 2
@@ -3001,10 +3006,8 @@ and fmt_value_description c ctx vd =
             ~box:
               (not (c.conf.ocp_indent_compat && is_arrow_or_poly pval_type))
             ~pro_space:true (sub_typ ~ctx pval_type)
-        $ list_fl pval_prim (fun ~first ~last:_ s ->
-              fmt_if first "@ =" $ fmt " \""
-              $ str (String.escaped s)
-              $ fmt "\"") )
+        $ fmt_if (not (List.is_empty pval_prim)) "@ = "
+        $ list pval_prim " " fmt_val_prim )
     $ fmt_attributes c ~pre:(fmt "@;<1 2>") ~key:"@@" atrs
     $ doc_after )
 

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2993,7 +2993,7 @@ and fmt_value_description c ctx vd =
     fmt_docstring_around_item c pval_attributes
   in
   let fmt_val_prim s =
-    if List.length (String.split_on_chars s ~on:[' '; '\n']) > 1 then
+    if String.exists s ~f:(function ' ' | '\n' -> true | _ -> false) then
       wrap "{|" "|}" (str s)
     else wrap "\"" "\"" (str (String.escaped s))
   in

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3002,7 +3002,9 @@ and fmt_value_description c ctx vd =
               (not (c.conf.ocp_indent_compat && is_arrow_or_poly pval_type))
             ~pro_space:true (sub_typ ~ctx pval_type)
         $ list_fl pval_prim (fun ~first ~last:_ s ->
-              fmt_if first "@ =" $ fmt " \"" $ str s $ fmt "\"") )
+              fmt_if first "@ =" $ fmt " \""
+              $ str (String.escaped s)
+              $ fmt "\"") )
     $ fmt_attributes c ~pre:(fmt "@;<1 2>") ~key:"@@" atrs
     $ doc_after )
 

--- a/test/passing/string.ml
+++ b/test/passing/string.ml
@@ -35,4 +35,7 @@ let f ("test" [@test "test"]) = 2
 external%c print: str:string -> d:int -> void = {|
   printf("%s (%d)\n",$str,$d);
   fflush(stdout);
+|} {|
+  printf("%s (%d)\n",$str,$d);
+  fflush(stdout);
 |}

--- a/test/passing/string.ml
+++ b/test/passing/string.ml
@@ -31,3 +31,8 @@ let f ("test" [@test "test"]) = 2
 ;;
 "@\n \
  xxxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxx xxxxxxxx xxxxxxxxxxx"
+
+external%c print: str:string -> d:int -> void = {|
+  printf("%s (%d)\n",$str,$d);
+  fflush(stdout);
+|}

--- a/test/passing/string.ml.ref
+++ b/test/passing/string.ml.ref
@@ -33,4 +33,10 @@ let f ("test"[@test "test"]) = 2
 
 [%%c
 external print : str:string -> d:int -> void
-  = "\n  printf(\"%s (%d)\\n\",$str,$d);\n  fflush(stdout);\n"]
+  = {|
+  printf("%s (%d)\n",$str,$d);
+  fflush(stdout);
+|} {|
+  printf("%s (%d)\n",$str,$d);
+  fflush(stdout);
+|}]

--- a/test/passing/string.ml.ref
+++ b/test/passing/string.ml.ref
@@ -30,3 +30,7 @@ let f ("test"[@test "test"]) = 2
 "@\n\
 \ xxxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxx \
  xxxxxxxx xxxxxxxxxxx"
+
+[%%c
+external print : str:string -> d:int -> void
+  = "\n  printf(\"%s (%d)\\n\",$str,$d);\n  fflush(stdout);\n"]


### PR DESCRIPTION
Escape special characters in the primitive name. This code appear in `ppx_cstubs`:

```ocaml
external%c print: str:string -> d:int -> void = {|
  printf("%s (%d)\n",$str,$d);
  fflush(stdout);
|}
```

The formatting is ugly, should we improve this ?

Found by https://github.com/ocaml-ppx/ocamlformat/issues/985