### PR TITLE
Fix crash on extension sequence

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2290,7 +2290,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             ; pstr_loc= _ } ] )
     when List.is_empty pexp_attributes
          && ( Poly.(c.conf.extension_sugar = `Always)
-            || Source.extension_using_sugar ~name:ext ~payload:e1 ) ->
+            || Source.extension_using_sugar ~name:ext ~payload:e1
+               && List.length (Sugar.sequence c.conf c.cmts xexp) > 1 ) ->
       fmt_sequence c parens width xexp pexp_loc fmt_atrs ~ext
   | Pexp_sequence _ ->
       fmt_sequence c parens width xexp pexp_loc fmt_atrs ?ext

--- a/test/passing/extensions-indent.ml.ref
+++ b/test/passing/extensions-indent.ml.ref
@@ -177,3 +177,5 @@ let _ =
   [%ext
        let+ a = b in
        c]
+
+let _ = [%ext "foo" ; "bar"]

--- a/test/passing/extensions-sugar_always.ml.ref
+++ b/test/passing/extensions-sugar_always.ml.ref
@@ -171,3 +171,5 @@ let _ =
   [%ext
     let+ a = b in
     c]
+
+let _ = "foo" ;%ext "bar"

--- a/test/passing/extensions.ml
+++ b/test/passing/extensions.ml
@@ -186,3 +186,5 @@ let foo =
     foooooooooooooooooooooooooooo]
 
 let _ = [%ext let+ a = b in c]
+
+let _ = (begin%ext "foo"; "bar" end)

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -177,3 +177,5 @@ let _ =
   [%ext
     let+ a = b in
     c]
+
+let _ = [%ext "foo" ; "bar"]


### PR DESCRIPTION
Fix #990, no diff with test_branch.
In the future it would be good to rework `Sugar.sequence` to avoid this kind of workaround, but it would require a lot more work.