### PR TITLE
Fix type variable

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -646,8 +646,8 @@ and fmt_record_field c ?typ ?rhs ?(type_first = false) lid1 =
 
 and fmt_type_var s =
   str "'"
-  (* [' a'] is a valid type variable, the space is required to not lex as
-     a char. https://github.com/ocaml/ocaml/pull/2034 *)
+  (* [' a'] is a valid type variable, the space is required to not lex as a
+     char. https://github.com/ocaml/ocaml/pull/2034 *)
   $ fmt_if (String.length s > 1 && Char.equal s.[1] '\'') " "
   $ str s
 
@@ -680,7 +680,8 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
   let ctx = Typ typ in
   match ptyp_desc with
   | Ptyp_alias (typ, txt) ->
-      hvbox 0 (fmt_core_type c (sub_typ ~ctx typ) $ fmt "@ as@ " $ fmt_type_var txt)
+      hvbox 0
+        (fmt_core_type c (sub_typ ~ctx typ) $ fmt "@ as@ " $ fmt_type_var txt)
   | Ptyp_any -> str "_"
   | Ptyp_arrow _ ->
       let arg_label lbl =
@@ -730,7 +731,7 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
       impossible "produced by the parser, handled elsewhere"
   | Ptyp_poly (a1N, t) ->
       hovbox_if box 0
-        ( list a1N "@ " (fun {txt;_} -> fmt_type_var txt)
+        ( list a1N "@ " (fun {txt; _} -> fmt_type_var txt)
         $ fmt ".@ "
         $ fmt_core_type c ~box:false (sub_typ ~ctx t) )
   | Ptyp_tuple typs ->

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -730,7 +730,7 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
       impossible "produced by the parser, handled elsewhere"
   | Ptyp_poly (a1N, t) ->
       hovbox_if box 0
-        ( list a1N "@ " (fmt_str_loc c ~pre:(str "'"))
+        ( list a1N "@ " (fun {txt;_} -> fmt_type_var txt)
         $ fmt ".@ "
         $ fmt_core_type c ~box:false (sub_typ ~ctx t) )
   | Ptyp_tuple typs ->

--- a/test/passing/types-compact-space_around-docked.ml.ref
+++ b/test/passing/types-compact-space_around-docked.ml.ref
@@ -207,3 +207,9 @@ type foooooooooooooooo =
   ?fooooooooo:(unit -> unit Fooo.t) ->
   ?fooooooo:bool ->
   string option Foooooooo.t
+
+type ' a' t = ' a'
+
+type ' a' t = ' a' option
+
+type ' a' t = int as ' a'

--- a/test/passing/types-compact-space_around-docked.ml.ref
+++ b/test/passing/types-compact-space_around-docked.ml.ref
@@ -213,3 +213,5 @@ type ' a' t = ' a'
 type ' a' t = ' a' option
 
 type ' a' t = int as ' a'
+
+type t = { a: ' a'. ' a' t' }

--- a/test/passing/types-compact-space_around.ml.ref
+++ b/test/passing/types-compact-space_around.ml.ref
@@ -211,3 +211,5 @@ type ' a' t = ' a'
 type ' a' t = ' a' option
 
 type ' a' t = int as ' a'
+
+type t = { a: ' a'. ' a' t' }

--- a/test/passing/types-compact-space_around.ml.ref
+++ b/test/passing/types-compact-space_around.ml.ref
@@ -205,3 +205,9 @@ type foooooooooooooooo =
   -> ?fooooooooo:(unit -> unit Fooo.t)
   -> ?fooooooo:bool
   -> string option Foooooooo.t
+
+type ' a' t = ' a'
+
+type ' a' t = ' a' option
+
+type ' a' t = int as ' a'

--- a/test/passing/types-compact.ml.ref
+++ b/test/passing/types-compact.ml.ref
@@ -203,3 +203,9 @@ type foooooooooooooooo =
   -> ?fooooooooo:(unit -> unit Fooo.t)
   -> ?fooooooo:bool
   -> string option Foooooooo.t
+
+type ' a' t = ' a'
+
+type ' a' t = ' a' option
+
+type ' a' t = int as ' a'

--- a/test/passing/types-compact.ml.ref
+++ b/test/passing/types-compact.ml.ref
@@ -209,3 +209,5 @@ type ' a' t = ' a'
 type ' a' t = ' a' option
 
 type ' a' t = int as ' a'
+
+type t = {a: ' a'. ' a' t'}

--- a/test/passing/types-indent.ml.ref
+++ b/test/passing/types-indent.ml.ref
@@ -203,3 +203,9 @@ type foooooooooooooooo =
       -> ?fooooooooo:(unit -> unit Fooo.t)
       -> ?fooooooo:bool
       -> string option Foooooooo.t
+
+type ' a' t = ' a'
+
+type ' a' t = ' a' option
+
+type ' a' t = int as ' a'

--- a/test/passing/types-indent.ml.ref
+++ b/test/passing/types-indent.ml.ref
@@ -209,3 +209,5 @@ type ' a' t = ' a'
 type ' a' t = ' a' option
 
 type ' a' t = int as ' a'
+
+type t = {a: ' a'. ' a' t'}

--- a/test/passing/types-sparse-space_around.ml.ref
+++ b/test/passing/types-sparse-space_around.ml.ref
@@ -251,3 +251,9 @@ type foooooooooooooooo =
   -> ?fooooooooo:(unit -> unit Fooo.t)
   -> ?fooooooo:bool
   -> string option Foooooooo.t
+
+type ' a' t = ' a'
+
+type ' a' t = ' a' option
+
+type ' a' t = int as ' a'

--- a/test/passing/types-sparse-space_around.ml.ref
+++ b/test/passing/types-sparse-space_around.ml.ref
@@ -257,3 +257,5 @@ type ' a' t = ' a'
 type ' a' t = ' a' option
 
 type ' a' t = int as ' a'
+
+type t = { a: ' a'. ' a' t' }

--- a/test/passing/types-sparse.ml.ref
+++ b/test/passing/types-sparse.ml.ref
@@ -232,3 +232,9 @@ type foooooooooooooooo =
   -> ?fooooooooo:(unit -> unit Fooo.t)
   -> ?fooooooo:bool
   -> string option Foooooooo.t
+
+type ' a' t = ' a'
+
+type ' a' t = ' a' option
+
+type ' a' t = int as ' a'

--- a/test/passing/types-sparse.ml.ref
+++ b/test/passing/types-sparse.ml.ref
@@ -238,3 +238,5 @@ type ' a' t = ' a'
 type ' a' t = ' a' option
 
 type ' a' t = int as ' a'
+
+type t = {a: ' a'. ' a' t'}

--- a/test/passing/types.ml
+++ b/test/passing/types.ml
@@ -203,3 +203,9 @@ type foooooooooooooooo =
   -> ?fooooooooo:(unit -> unit Fooo.t)
   -> ?fooooooo:bool
   -> string option Foooooooo.t
+
+type ' a' t = ' a'
+
+type ' a' t = ' a' option
+
+type ' a' t = int as ' a'

--- a/test/passing/types.ml
+++ b/test/passing/types.ml
@@ -209,3 +209,5 @@ type ' a' t = ' a'
 type ' a' t = ' a' option
 
 type ' a' t = int as ' a'
+
+type t = {a: ' a'. ' a' t'}


### PR DESCRIPTION
Fix invalid syntax generated for this two examples:

```ocaml
type ' a' t = int as ' a'
```

```ocaml
type t = {a: ' a'. ' a' t'}
```