### PR TITLE
Fix unstable unattached doc comment in records

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3121,8 +3121,8 @@ and fmt_label_declaration c ctx decl ?(last = false) =
                     $ fmt_semicolon )
                 $ cmt_after_type )
             $ fmt_attributes c ~pre:(fmt "@;<1 1>") ~key:"@" atrs )
-        $ Cmts.fmt_after c pld_loc
-        $ fmt_docstring_padded c doc ) )
+        $ fmt_docstring_padded c doc
+        $ Cmts.fmt_after c pld_loc ) )
 
 and fmt_constructor_declaration c ctx ~max_len_name ~first ~last:_ cstr_decl
     =

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -201,3 +201,8 @@ let _ =
      | Some z -> incr z (* double some *))
   | None -> ()
 ;;
+
+type prefix = {
+  sib_extend : int; (* extended sib index bit *)
+  (** add more as needed *)
+}

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -286,4 +286,4 @@ let _ =
   | None -> ()
 
 type prefix =
-  {sib_extend: int (* extended sib index bit *)  (** add more as needed *)}
+  {sib_extend: int  (** add more as needed *) (* extended sib index bit *)}

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -284,3 +284,6 @@ let _ =
   | Some y -> (
     match y with None -> () | Some z -> incr z (* double some *) )
   | None -> ()
+
+type prefix =
+  {sib_extend: int (* extended sib index bit *)  (** add more as needed *)}


### PR DESCRIPTION
This with `--no-comment-check` is unstable:

```ocaml
type prefix = {
  sib_extend : int; (** extended sib index bit *)
  (** add more as needed *)
}
```

Without `--no-comment-check` this snippet triggers warning 50 and fail.

This has the side effect of moving doc comment before an eventual comment, this looks better to me as the 2 spaces look weird:

```diff
-  {sib_extend: int (* extended sib index bit *)  (** add more as needed *)}
+  {sib_extend: int  (** add more as needed *) (* extended sib index bit *)}
```