### PR TITLE
Fix linebreak between or-cases with comments when break-cases=all

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1063,7 +1063,9 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
         match ctx0 with
         | Exp {pexp_desc= Pexp_function _ | Pexp_match _ | Pexp_try _; _}
           when Poly.(c.conf.break_cases <> `Nested) -> (
-            fmt_if Poly.(c.conf.break_cases = `All) "@;<1000 0>"
+            fmt_if_k
+              Poly.(c.conf.break_cases = `All)
+              (break_unless_newline 1000 0)
             $
             match c.conf.indicate_nested_or_patterns with
             | `Space when space -> or_newline "| " " | "

--- a/test/passing/break_cases-align.ml.ref
+++ b/test/passing/break_cases-align.ml.ref
@@ -199,3 +199,14 @@ let _ =
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo )
+
+let handler =
+  object
+    method at_expr x =
+      match x with
+      | Call Thing
+      (* isset($var::thing) but not isset($foo::$bar) *)
+      | Call OtherThing ->
+          Errors.isset_in_strict p
+      | _ -> ()
+  end

--- a/test/passing/break_cases-all.ml.ref
+++ b/test/passing/break_cases-all.ml.ref
@@ -199,3 +199,14 @@ let _ =
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo )
+
+let handler =
+  object
+    method at_expr x =
+      match x with
+      | Call Thing
+      (* isset($var::thing) but not isset($foo::$bar) *)
+      | Call OtherThing ->
+          Errors.isset_in_strict p
+      | _ -> ()
+  end

--- a/test/passing/break_cases-closing_on_separate_line.ml.ref
+++ b/test/passing/break_cases-closing_on_separate_line.ml.ref
@@ -206,3 +206,14 @@ let _ =
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo
       )
+
+let handler =
+  object
+    method at_expr x =
+      match x with
+      | Call Thing
+      (* isset($var::thing) but not isset($foo::$bar) *)
+      | Call OtherThing ->
+          Errors.isset_in_strict p
+      | _ -> ()
+  end

--- a/test/passing/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref
+++ b/test/passing/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref
@@ -205,3 +205,14 @@ let _ =
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo
       )
+
+let handler =
+  object
+    method at_expr x =
+      match x with
+      | Call Thing
+      (* isset($var::thing) but not isset($foo::$bar) *)
+      | Call OtherThing ->
+          Errors.isset_in_strict p
+      | _ -> ()
+  end

--- a/test/passing/break_cases-cosl_lnmp_cmei.ml.ref
+++ b/test/passing/break_cases-cosl_lnmp_cmei.ml.ref
@@ -205,3 +205,14 @@ let _ =
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo
       )
+
+let handler =
+  object
+    method at_expr x =
+      match x with
+      | Call Thing
+      (* isset($var::thing) but not isset($foo::$bar) *)
+      | Call OtherThing ->
+          Errors.isset_in_strict p
+      | _ -> ()
+  end

--- a/test/passing/break_cases-fit_or_vertical.ml.ref
+++ b/test/passing/break_cases-fit_or_vertical.ml.ref
@@ -165,3 +165,13 @@ let _ =
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo )
+
+let handler =
+  object
+    method at_expr x =
+      match x with
+      | Call Thing
+      (* isset($var::thing) but not isset($foo::$bar) *)
+      | Call OtherThing -> Errors.isset_in_strict p
+      | _ -> ()
+  end

--- a/test/passing/break_cases-nested.ml.ref
+++ b/test/passing/break_cases-nested.ml.ref
@@ -168,3 +168,15 @@ let _ =
             fooooooooooo
         | foooooooooo ->
             fooooooooooo )
+
+let handler =
+  object
+    method at_expr x =
+      match x with
+      | Call Thing
+      (* isset($var::thing) but not isset($foo::$bar) *)
+      | Call OtherThing ->
+          Errors.isset_in_strict p
+      | _ ->
+          ()
+  end

--- a/test/passing/break_cases-normal_indent.ml.ref
+++ b/test/passing/break_cases-normal_indent.ml.ref
@@ -199,3 +199,14 @@ let _ =
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo )
+
+let handler =
+  object
+    method at_expr x =
+      match x with
+      | Call Thing
+      (* isset($var::thing) but not isset($foo::$bar) *)
+      | Call OtherThing ->
+          Errors.isset_in_strict p
+      | _ -> ()
+  end

--- a/test/passing/break_cases-toplevel.ml.ref
+++ b/test/passing/break_cases-toplevel.ml.ref
@@ -167,3 +167,14 @@ let _ =
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo )
+
+let handler =
+  object
+    method at_expr x =
+      match x with
+      | Call Thing
+      (* isset($var::thing) but not isset($foo::$bar) *)
+      | Call OtherThing ->
+          Errors.isset_in_strict p
+      | _ -> ()
+  end

--- a/test/passing/break_cases.ml
+++ b/test/passing/break_cases.ml
@@ -177,3 +177,14 @@ let _ =
        | foooooooooo -> fooooooooooo
        | foooooooooo -> fooooooooooo
        | foooooooooo -> fooooooooooo )
+
+let handler =
+  object
+    method at_expr x =
+      match x with
+      | Call Thing
+      (* isset($var::thing) but not isset($foo::$bar) *)
+      |Call OtherThing ->
+          Errors.isset_in_strict p
+      | _ -> ()
+  end

--- a/test/passing/break_cases.ml.ref
+++ b/test/passing/break_cases.ml.ref
@@ -144,3 +144,14 @@ let _ =
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo
         | foooooooooo -> fooooooooooo )
+
+let handler =
+  object
+    method at_expr x =
+      match x with
+      | Call Thing
+      (* isset($var::thing) but not isset($foo::$bar) *)
+      | Call OtherThing ->
+          Errors.isset_in_strict p
+      | _ -> ()
+  end


### PR DESCRIPTION
Fix #1001 

Diff with test_branch when `break-cases=all`:
```ocaml
diff --git a/infer/src/biabduction/Prop.ml b/infer/src/biabduction/Prop.ml
index 7390dcc9c..23599165f 100644
--- a/infer/src/biabduction/Prop.ml
+++ b/infer/src/biabduction/Prop.ml
@@ -1100,12 +1100,10 @@ module Normalize = struct
       match eq with
       | BinOp (PlusA _, e1, Const (Cint n1)), Const (Cint n2)
       (* e1+n1==n2 ---> e1==n2-n1 *)
-      
        |BinOp (PlusPI, e1, Const (Cint n1)), Const (Cint n2) ->
           (e1, Exp.int (n2 -- n1))
       | BinOp (MinusA _, e1, Const (Cint n1)), Const (Cint n2)
       (* e1-n1==n2 ---> e1==n1+n2 *)
-      
        |BinOp (MinusPI, e1, Const (Cint n1)), Const (Cint n2) ->
           (e1, Exp.int (n1 ++ n2))
       | BinOp (MinusA _, Const (Cint n1), e1), Const (Cint n2) ->
diff --git a/infer/src/bufferoverrun/symb.ml b/infer/src/bufferoverrun/symb.ml
index 3d5529f6b..5414473e3 100644
--- a/infer/src/bufferoverrun/symb.ml
+++ b/infer/src/bufferoverrun/symb.ml
@@ -181,7 +181,6 @@ module SymbolPath = struct
         true
     | Deref (Deref_CPointer, p)
     (* Deref_CPointer is unsound here but avoids many FPs for non-array pointers *)
-    
      |Deref ((Deref_COneValuePointer | Deref_JavaPointer), p)
      |Field {prefix= p} ->
         represents_multiple_values p
diff --git a/infer/src/clang/cGeneral_utils.ml b/infer/src/clang/cGeneral_utils.ml
index 50a854eea..5a9b168de 100644
--- a/infer/src/clang/cGeneral_utils.ml
+++ b/infer/src/clang/cGeneral_utils.ml
@@ -107,7 +107,6 @@ let mk_sil_global_var {CFrontend_config.source_file} ?(mk_name = fun _ x -> x) d
         None
     | true, Some _
     (* "extern" variables with initialisation code are not extern at all, but compilers accept this *)
-    
      |false, _ ->
         Some source_file
   in
diff --git a/infer/src/clang/cTrans.ml b/infer/src/clang/cTrans.ml
index 49d8f0629..d7f1330e2 100644
--- a/infer/src/clang/cTrans.ml
+++ b/infer/src/clang/cTrans.ml
@@ -1689,7 +1689,6 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
     (* Skip destructors of temporaries inside conditionals otherwise
        we would destroy them before dereferencing them in the prune
        nodes. A better fix probably exists. *)
-    
      |s ->
         no_short_circuit_cond ~is_cmp:false s
 
@@ -2747,10 +2746,8 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
         match lci_capture_kind with
         | `LCK_ByRef
         (* explicit with [&x] or implicit with [&] *)
-        
          |`LCK_This
         (* explicit with [this] or implicit with [&] *)
-        
          |`LCK_VLAType
         (* capture a variable-length array by reference. we probably don't handle
                             this correctly elsewhere, but it's definitely not captured by value! *)
diff --git a/infer/src/quandary/ClangTrace.ml b/infer/src/quandary/ClangTrace.ml
index e34e19789..3a91a0e05 100644
--- a/infer/src/quandary/ClangTrace.ml
+++ b/infer/src/quandary/ClangTrace.ml
@@ -295,7 +295,6 @@ module SinkKind = struct
           let controls_request = function
             | 10002
             (* CURLOPT_URL *)
-            
              |10015 (* CURLOPT_POSTFIELDS *) ->
                 true
             | _ -> false
diff --git a/sledge/src/symbheap/exec.ml b/sledge/src/symbheap/exec.ml
index bc874685f..bbea5a8d6 100644
--- a/sledge/src/symbheap/exec.ml
+++ b/sledge/src/symbheap/exec.ml
@@ -701,7 +701,6 @@ let intrinsic ~skip_throw :
   (* void* malloc(size_t size) *)
   | Some reg, "malloc", [size]
   (* void* aligned_alloc(size_t alignment, size_t size) *)
-  
    |Some reg, "aligned_alloc", [size; _] ->
       Some (exec_spec pre (malloc_spec us reg size))
   (* void* calloc(size_t number, size_t size) *)
@@ -731,7 +730,6 @@ let intrinsic ~skip_throw :
   (* void dallocx(void* ptr, int flags) *)
   | None, "dallocx", [_; ptr]
   (* void sdallocx(void* ptr, size_t size, int flags) *)
-  
    |None, "sdallocx", [_; _; ptr] ->
       Some (exec_spec pre (dallocx_spec us ptr))
   (* size_t nallocx(size_t size, int flags) *)
diff --git a/compiler/lib/eval.ml b/compiler/lib/eval.ml
index bcd4436c2..05236ca6f 100644
--- a/compiler/lib/eval.ml
+++ b/compiler/lib/eval.ml
@@ -263,7 +263,6 @@ let eval_instr info i =
                       | Some _
                       (* do not be duplicated other constant as
                           they're not represented with constant in javascript. *)
-                      
                        |None ->
                           arg) ) ))
   | _ -> i
diff --git a/compiler/lib/js_output.ml b/compiler/lib/js_output.ml
index 10ff7cf5d..f2e94664c 100644
--- a/compiler/lib/js_output.ml
+++ b/compiler/lib/js_output.ml
@@ -1218,7 +1218,6 @@ let need_space a b =
   match a, b with
   | '/', '/'
   (* https://github.com/ocsigen/js_of_ocaml/issues/507 *)
-  
    |'-', '-'
    |'+', '+' ->
       true
```