### PR TITLE
Check functor arguments when computing placement of doc comments

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -274,22 +274,21 @@ let longident_is_simple c x =
 let rec module_type_is_simple x =
   match x.pmty_desc with
   | Pmty_ident _ | Pmty_alias _ | Pmty_signature [] -> true
-  | Pmty_signature (_ :: _) | Pmty_with (_, _ :: _ :: _) | Pmty_extension _
-    ->
+  | Pmty_signature (_ :: _)
+   |Pmty_with (_, _ :: _ :: _)
+   |Pmty_extension _
+   |Pmty_functor (_, _, _) ->
       false
   | Pmty_typeof e -> module_expr_is_simple e
-  | Pmty_functor (_, Some t1, t2) ->
-      module_type_is_simple t1 && module_type_is_simple t2
-  | Pmty_functor (_, None, t) | Pmty_with (t, ([] | [_])) ->
-      module_type_is_simple t
+  | Pmty_with (t, ([] | [_])) -> module_type_is_simple t
 
 and module_expr_is_simple x =
   match x.pmod_desc with
   | Pmod_ident _ | Pmod_unpack _ | Pmod_structure [] -> true
-  | Pmod_structure (_ :: _) | Pmod_extension _ -> false
-  | Pmod_functor (_, Some t, e) | Pmod_constraint (e, t) ->
+  | Pmod_structure (_ :: _) | Pmod_extension _ | Pmod_functor (_, _, _) ->
+      false
+  | Pmod_constraint (e, t) ->
       module_expr_is_simple e && module_type_is_simple t
-  | Pmod_functor (_, None, e) -> module_expr_is_simple e
   | Pmod_apply (a, b) -> module_expr_is_simple a && module_expr_is_simple b
 
 let rec class_decl_is_simple x =

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3574,6 +3574,8 @@ and fmt_module c ?epi ?(can_sparse = false) keyword ?(eqty = "=") name xargs
   let single_line =
     Option.for_all xbody ~f:(fun x -> module_expr_is_simple x.ast)
     && Option.for_all xmty ~f:(fun x -> module_type_is_simple x.ast)
+    && List.for_all xargs ~f:(fun (_, x) ->
+           Option.for_all x ~f:(fun x -> module_type_is_simple x.ast))
   in
   let compact = Poly.(c.conf.let_module = `Compact) || not can_sparse in
   let fmt_pro = opt blk_b.pro (fun pro -> fmt "@ " $ pro) in

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3574,8 +3574,7 @@ and fmt_module c ?epi ?(can_sparse = false) keyword ?(eqty = "=") name xargs
   let single_line =
     Option.for_all xbody ~f:(fun x -> module_expr_is_simple x.ast)
     && Option.for_all xmty ~f:(fun x -> module_type_is_simple x.ast)
-    && List.for_all xargs ~f:(fun (_, x) ->
-           Option.for_all x ~f:(fun x -> module_type_is_simple x.ast))
+    && List.is_empty xargs
   in
   let compact = Poly.(c.conf.let_module = `Compact) || not can_sparse in
   let fmt_pro = opt blk_b.pro (fun pro -> fmt "@ " $ pro) in

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3574,7 +3574,7 @@ and fmt_module c ?epi ?(can_sparse = false) keyword ?(eqty = "=") name xargs
   let single_line =
     Option.for_all xbody ~f:(fun x -> module_expr_is_simple x.ast)
     && Option.for_all xmty ~f:(fun x -> module_type_is_simple x.ast)
-    && List.is_empty xargs
+    && List.for_all xargs ~f:(fun (_, arg) -> Option.is_none arg)
   in
   let compact = Poly.(c.conf.let_module = `Compact) || not can_sparse in
   let fmt_pro = opt blk_b.pro (fun pro -> fmt "@ " $ pro) in

--- a/test/passing/comment_in_modules.ml.ref
+++ b/test/passing/comment_in_modules.ml.ref
@@ -16,9 +16,9 @@ module Mmmmmmmmmmmmmmmmmmmmmm =
   Aaaaaaaaaaaaaaaaaaaaaa.Bbbbbbbbbbbbbbbbbbbbbbbb
 (** Xxxxxxx xxxxxxxx xx xxxxxxx xxxxxxxxxxxxx xxxxxxxxx xx xxxx *)
 
+(** Xxxxxxx xxxxxxxx xx xxxxxxx xxxxxxxxxxxxx xxxxxxxxx xx xxxx *)
 module Fffffffffffffff (Yyyyyyyyyyyyyyy : Z.S) =
   Gggggggggg (Wwwwwwwwww.Make (Yyyyyyyyyy))
-(** Xxxxxxx xxxxxxxx xx xxxxxxx xxxxxxxxxxxxx xxxxxxxxx xx xxxx *)
 
 module A ((* comment *) A : sig end) : sig end = struct end
 

--- a/test/passing/doc_comments-after.ml.ref
+++ b/test/passing/doc_comments-after.ml.ref
@@ -107,6 +107,30 @@ module Comment_placement : sig
   (** A *)
   external a : b = "double_comment"
   (** B *)
+
+  (** This comment goes before *)
+  module S_ext : sig
+    type t
+  end
+
+  module Index : Index.S
+  (** This one goes after *)
+
+  module Index2
+      (Paramater_module : BAR_LONG_MODULE_TYPE_NAME)
+      (Foo : BAR)
+      (Foo : BAR)
+      (Foo : BAR)
+      (Foo : BAR)
+      (Foo : BAR) : sig end
+  (** This one _still_ goes after *)
+
+  module Make (Config : sig
+    val blah : string
+
+    (* this could be a really long signature *)
+  end) : S
+  (** Doc comment still goes after *)
 end = struct
   type t = {a: int}
   (** Type *)

--- a/test/passing/doc_comments-after.ml.ref
+++ b/test/passing/doc_comments-after.ml.ref
@@ -125,12 +125,12 @@ module Comment_placement : sig
       (Foo : BAR) : sig end
   (** This one _still_ goes after *)
 
+  (** Doc comment still goes after *)
   module Make (Config : sig
     val blah : string
 
     (* this could be a really long signature *)
   end) : S
-  (** Doc comment still goes after *)
 end = struct
   type t = {a: int}
   (** Type *)

--- a/test/passing/doc_comments-after.ml.ref
+++ b/test/passing/doc_comments-after.ml.ref
@@ -116,6 +116,7 @@ module Comment_placement : sig
   module Index : Index.S
   (** This one goes after *)
 
+  (** This one _still_ goes after *)
   module Index2
       (Paramater_module : BAR_LONG_MODULE_TYPE_NAME)
       (Foo : BAR)
@@ -123,7 +124,6 @@ module Comment_placement : sig
       (Foo : BAR)
       (Foo : BAR)
       (Foo : BAR) : sig end
-  (** This one _still_ goes after *)
 
   (** Doc comment still goes after *)
   module Make (Config : sig

--- a/test/passing/doc_comments-after.ml.ref
+++ b/test/passing/doc_comments-after.ml.ref
@@ -131,6 +131,9 @@ module Comment_placement : sig
 
     (* this could be a really long signature *)
   end) : S
+
+  module Gen () : S
+  (** Generative functor *)
 end = struct
   type t = {a: int}
   (** Type *)

--- a/test/passing/doc_comments-before.ml.ref
+++ b/test/passing/doc_comments-before.ml.ref
@@ -107,6 +107,30 @@ module Comment_placement : sig
   (** A *)
   external a : b = "double_comment"
   (** B *)
+
+  (** This comment goes before *)
+  module S_ext : sig
+    type t
+  end
+
+  (** This one goes after *)
+  module Index : Index.S
+
+  (** This one _still_ goes after *)
+  module Index2
+      (Paramater_module : BAR_LONG_MODULE_TYPE_NAME)
+      (Foo : BAR)
+      (Foo : BAR)
+      (Foo : BAR)
+      (Foo : BAR)
+      (Foo : BAR) : sig end
+
+  (** Doc comment still goes after *)
+  module Make (Config : sig
+    val blah : string
+
+    (* this could be a really long signature *)
+  end) : S
 end = struct
   (** Type *)
   type t = {a: int}

--- a/test/passing/doc_comments-before.ml.ref
+++ b/test/passing/doc_comments-before.ml.ref
@@ -131,6 +131,9 @@ module Comment_placement : sig
 
     (* this could be a really long signature *)
   end) : S
+
+  (** Generative functor *)
+  module Gen () : S
 end = struct
   (** Type *)
   type t = {a: int}

--- a/test/passing/doc_comments.ml
+++ b/test/passing/doc_comments.ml
@@ -132,6 +132,9 @@ module Comment_placement : sig
   end) : S
   (** Doc comment still goes after *)
 
+  module Gen () : S
+  (** Generative functor *)
+
 end = struct
   type t = {a: int}
   (** Type *)

--- a/test/passing/doc_comments.ml
+++ b/test/passing/doc_comments.ml
@@ -107,6 +107,31 @@ module Comment_placement : sig
   (** A *)
   external a : b = "double_comment"
   (** B *)
+
+  (** This comment goes before *)
+  module S_ext : sig
+    type t
+  end
+
+  module Index : Index.S
+  (** This one goes after *)
+
+  module Index2
+      (Paramater_module : BAR_LONG_MODULE_TYPE_NAME)
+      (Foo : BAR)
+      (Foo : BAR)
+      (Foo : BAR)
+      (Foo : BAR)
+      (Foo : BAR) : sig end
+  (** This one _still_ goes after *)
+
+  module Make (Config : sig
+    val blah : string
+
+    (* this could be a really long signature *)
+  end) : S
+  (** Doc comment still goes after *)
+
 end = struct
   type t = {a: int}
   (** Type *)

--- a/test/passing/doc_comments.ml.ref
+++ b/test/passing/doc_comments.ml.ref
@@ -107,6 +107,30 @@ module Comment_placement : sig
   (** A *)
   external a : b = "double_comment"
   (** B *)
+
+  (** This comment goes before *)
+  module S_ext : sig
+    type t
+  end
+
+  module Index : Index.S
+  (** This one goes after *)
+
+  module Index2
+      (Paramater_module : BAR_LONG_MODULE_TYPE_NAME)
+      (Foo : BAR)
+      (Foo : BAR)
+      (Foo : BAR)
+      (Foo : BAR)
+      (Foo : BAR) : sig end
+  (** This one _still_ goes after *)
+
+  module Make (Config : sig
+    val blah : string
+
+    (* this could be a really long signature *)
+  end) : S
+  (** Doc comment still goes after *)
 end = struct
   type t = {a: int}
   (** Type *)

--- a/test/passing/doc_comments.ml.ref
+++ b/test/passing/doc_comments.ml.ref
@@ -125,12 +125,12 @@ module Comment_placement : sig
       (Foo : BAR) : sig end
   (** This one _still_ goes after *)
 
+  (** Doc comment still goes after *)
   module Make (Config : sig
     val blah : string
 
     (* this could be a really long signature *)
   end) : S
-  (** Doc comment still goes after *)
 end = struct
   type t = {a: int}
   (** Type *)

--- a/test/passing/doc_comments.ml.ref
+++ b/test/passing/doc_comments.ml.ref
@@ -116,6 +116,7 @@ module Comment_placement : sig
   module Index : Index.S
   (** This one goes after *)
 
+  (** This one _still_ goes after *)
   module Index2
       (Paramater_module : BAR_LONG_MODULE_TYPE_NAME)
       (Foo : BAR)
@@ -123,7 +124,6 @@ module Comment_placement : sig
       (Foo : BAR)
       (Foo : BAR)
       (Foo : BAR) : sig end
-  (** This one _still_ goes after *)
 
   (** Doc comment still goes after *)
   module Make (Config : sig

--- a/test/passing/doc_comments.ml.ref
+++ b/test/passing/doc_comments.ml.ref
@@ -131,6 +131,9 @@ module Comment_placement : sig
 
     (* this could be a really long signature *)
   end) : S
+
+  module Gen () : S
+  (** Generative functor *)
 end = struct
   type t = {a: int}
   (** Type *)


### PR DESCRIPTION
Partial fix to https://github.com/ocaml-ppx/ocamlformat/issues/1010

Functor arguments are not checked to compute the `force_before` value.

In this example, the comment should be before:

```ocaml
module Make (Config : sig
  val blah : string

  (* this could be a really long signature *)
end) : S
(** Doc comment still goes after *)
```