### PR TITLE
Improve: don't require --name, require kind, forbid --inplace, allow --check, make --enable-outside-detected-project implicit when reading from stdin

### DIFF
--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -1629,8 +1629,8 @@ let validate () =
     `Error (false, "Must specify at least one input file, or `-` for stdin")
   else if has_stdin && inputs_len > 1 then
     `Error (false, "Cannot specify stdin together with other inputs")
-  else if has_stdin && Option.is_none !name then
-    `Error (false, "Must specify name when reading from stdin")
+  else if has_stdin && !inplace then
+    `Error (false, "Cannot specific stdin together with --inplace")
   else if !inplace && Option.is_some !output then
     `Error (false, "Cannot specify --output with --inplace")
   else if !check && !inplace then

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -1641,6 +1641,11 @@ let validate () =
     `Error (false, "Must specify at least one input file, or `-` for stdin")
   else if has_stdin && inputs_len > 1 then
     `Error (false, "Cannot specify stdin together with other inputs")
+  else if has_stdin && Option.is_none !kind then
+    `Error
+      ( false
+      , "Must specify at least one of --impl, --intf or --use-file when \
+         reading from stdin" )
   else if has_stdin && !inplace then
     `Error (false, "Cannot specify stdin together with --inplace")
   else if !inplace && Option.is_some !output then
@@ -1889,7 +1894,7 @@ let kind_of file =
   | Some kind -> kind
   | None -> (
     match file with
-    | Stdin -> `Impl
+    | Stdin -> impossible "checked by validate"
     | File fname -> (
       match Filename.extension fname with
       | ".ml" -> `Impl

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -1632,7 +1632,7 @@ let validate () =
   else if has_stdin && inputs_len > 1 then
     `Error (false, "Cannot specify stdin together with other inputs")
   else if has_stdin && !inplace then
-    `Error (false, "Cannot specific stdin together with --inplace")
+    `Error (false, "Cannot specify stdin together with --inplace")
   else if !inplace && Option.is_some !output then
     `Error (false, "Cannot specify --output with --inplace")
   else if !check && !inplace then

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -1219,7 +1219,7 @@ let inputs =
   let docv = "SRC" in
   let file_or_dash =
     let parse, print = Arg.non_dir_file in
-    let parse = function "-" -> `Ok "-" | s -> parse s in
+    let parse = function "-" -> `Ok "<standard input>" | s -> parse s in
     (parse, print)
   in
   let doc =
@@ -1617,9 +1617,11 @@ let (_profile : t option C.t) =
       {new_conf with quiet= new_conf.quiet || conf.quiet})
     (fun _ -> !selected_profile_ref)
 
+let is_stdin = String.equal "<standard input>"
+
 let validate () =
   let inputs_len = List.length !inputs in
-  let has_stdin = List.exists ~f:(String.equal "-") !inputs in
+  let has_stdin = List.exists ~f:is_stdin !inputs in
   if !disable_outside_detected_project then
     warn
       "option `--disable-outside-detected-project` is deprecated and will \

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -96,6 +96,10 @@ type action =
   | Check of [`Impl | `Intf | `Use_file] input list
       (** Check whether the input files already are formatted. *)
 
+val is_stdin : string -> bool
+(** Whether the string is equal to the symbolic name given to standard input
+    in warnings and error messages. *)
+
 val action : action
 (** Formatting action: input type and source, and output destination. *)
 

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -85,7 +85,9 @@ type t =
   ; wrap_comments: bool  (** Wrap comments at margin. *)
   ; wrap_fun_args: bool }
 
-type 'a input = {kind: 'a; name: string; file: string; conf: t}
+type file = Stdin | File of string
+
+type 'a input = {kind: 'a; name: string; file: file; conf: t}
 
 type action =
   | In_out of [`Impl | `Intf | `Use_file] input * string option
@@ -95,10 +97,6 @@ type action =
       (** Format in-place, overwriting input file(s). *)
   | Check of [`Impl | `Intf | `Use_file] input list
       (** Check whether the input files already are formatted. *)
-
-val is_stdin : string -> bool
-(** Whether the string is equal to the symbolic name given to standard input
-    in warnings and error messages. *)
 
 val action : action
 (** Formatting action: input type and source, and output destination. *)

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -90,10 +90,11 @@ match Conf.action with
     if List.is_empty errors then Caml.exit 0 else Caml.exit 1
 | In_out
     ( { kind= (`Impl | `Intf | `Use_file) as kind
-      ; file= "-"
+      ; file
       ; name= input_name
       ; conf }
-    , output_file ) -> (
+    , output_file )
+  when Conf.is_stdin file -> (
     let source = In_channel.input_all In_channel.stdin in
     let result = format conf ?output_file ~kind ~input_name ~source () in
     match result with
@@ -116,9 +117,10 @@ match Conf.action with
     | Error _ -> Caml.exit 1 )
 | Check
     [ { kind= (`Impl | `Intf | `Use_file) as kind
-      ; file= "-"
+      ; file
       ; name= input_name
-      ; conf } ] ->
+      ; conf } ]
+  when Conf.is_stdin file ->
     let source = In_channel.input_all In_channel.stdin in
     let checked =
       match format conf ~kind ~input_name ~source () with

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -114,6 +114,18 @@ match Conf.action with
         to_output_file output_file s ;
         Caml.exit 0
     | Error _ -> Caml.exit 1 )
+| Check
+    [ { kind= (`Impl | `Intf | `Use_file) as kind
+      ; file= "-"
+      ; name= input_name
+      ; conf } ] ->
+    let source = In_channel.input_all In_channel.stdin in
+    let checked =
+      match format conf ~kind ~input_name ~source () with
+      | Ok res -> String.equal res source
+      | Error _ -> false
+    in
+    Caml.exit (if checked then 0 else 1)
 | Check inputs ->
     let f {Conf.kind; name= input_name; file; conf} =
       let source = In_channel.with_file file ~f:In_channel.input_all in

--- a/src/ocamlformat_reason.ml
+++ b/src/ocamlformat_reason.ml
@@ -61,9 +61,8 @@ match Conf.action with
 | Inplace _ -> user_error "Cannot convert Reason code with --inplace" []
 | Check _ -> user_error "Cannot check Reason code with --check" []
 | In_out
-    ( {kind= (`Impl | `Intf) as kind; file; name= input_name; conf}
-    , output_file )
-  when Conf.is_stdin file -> (
+    ( {kind= (`Impl | `Intf) as kind; file= Stdin; name= input_name; conf}
+    , output_file ) -> (
     let result =
       let (Pack {parse; xunit}) = pack_of_kind kind in
       let t = parse In_channel.stdin in
@@ -79,7 +78,7 @@ match Conf.action with
 | In_out
     ( { kind= (`Impl | `Intf) as kind
       ; name= input_name
-      ; file= input_file
+      ; file= File input_file
       ; conf }
     , output_file ) -> (
     let result =

--- a/src/ocamlformat_reason.ml
+++ b/src/ocamlformat_reason.ml
@@ -61,8 +61,9 @@ match Conf.action with
 | Inplace _ -> user_error "Cannot convert Reason code with --inplace" []
 | Check _ -> user_error "Cannot check Reason code with --check" []
 | In_out
-    ( {kind= (`Impl | `Intf) as kind; file= "-"; name= input_name; conf}
-    , output_file ) -> (
+    ( {kind= (`Impl | `Intf) as kind; file; name= input_name; conf}
+    , output_file )
+  when Conf.is_stdin file -> (
     let result =
       let (Pack {parse; xunit}) = pack_of_kind kind in
       let t = parse In_channel.stdin in


### PR DESCRIPTION
Fix #1016 and fix #1015 

- [x] do not force the user to provide `--name` when the input is read from stdin, force the use of `--impl` or `--intf` or `--use-file` instead
- [x] check that we do not use `--inplace` when using stdin
- [x] allow `--check` when using stdin
- [x] better error messages when the input is read from stdin (use `<standard input>` instead of `-` in messages, can still be overriden by `--name`)
- [x] make `--enable-outside-detected-project` implicit when reading from stdin

each commit can be reviewed separately
