### PR TITLE
Parse toplevel directives

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -696,6 +696,7 @@ let break_between s ~cmts ~has_cmts_before ~has_cmts_after (i1, c1) (i2, c2)
   | Mod _, Mod _ ->
       break_between_modules ~cmts ~has_cmts_before ~has_cmts_after (i1, c1)
         (i2, c2)
+  | Top, _ | _, Top -> true
   | _ -> assert false
 
 (** Precedence levels of Ast terms. *)

--- a/src/Ast.mli
+++ b/src/Ast.mli
@@ -71,6 +71,9 @@ val class_type_is_simple : class_type -> bool
 
 val type_decl_is_simple : type_declaration -> bool
 
+type toplevel_item =
+  [`Item of structure_item | `Directive of toplevel_directive]
+
 (** Ast terms of various forms. *)
 type t =
   | Pld of payload
@@ -83,6 +86,7 @@ type t =
   | Mod of module_expr
   | Sig of signature_item
   | Str of structure_item
+  | Tli of toplevel_item
   | Top
 
 val break_between :

--- a/src/Conf.ml
+++ b/src/Conf.ml
@@ -1248,13 +1248,13 @@ let inputs =
   mk ~default
     Arg.(value & pos_all file_or_dash default & info [] ~doc ~docv ~docs)
 
-let kind : [`Impl | `Intf | `Use_file] option ref =
+let kind : [`Impl | `Intf] option ref =
   let doc = "Parse file with unrecognized extension as an implementation." in
   let impl = (Some `Impl, Arg.info ["impl"] ~doc ~docs) in
   let doc = "Parse file with unrecognized extension as an interface." in
   let intf = (Some `Intf, Arg.info ["intf"] ~doc ~docs) in
-  let doc = "Parse file with unrecognized extension as a use_file." in
-  let use_file = (Some `Use_file, Arg.info ["use-file"] ~doc ~docs) in
+  let doc = "Deprecated. Same as $(b,impl)." in
+  let use_file = (Some `Impl, Arg.info ["use-file"] ~doc ~docs) in
   let default = None in
   mk ~default Arg.(value & vflag default [impl; intf; use_file])
 
@@ -1896,9 +1896,9 @@ let update_using_env conf =
 type 'a input = {kind: 'a; name: string; file: file; conf: t}
 
 type action =
-  | In_out of [`Impl | `Intf | `Use_file] input * string option
-  | Inplace of [`Impl | `Intf | `Use_file] input list
-  | Check of [`Impl | `Intf | `Use_file] input list
+  | In_out of [`Impl | `Intf] input * string option
+  | Inplace of [`Impl | `Intf] input list
+  | Check of [`Impl | `Intf] input list
 
 let kind_of file =
   match !kind with
@@ -1910,7 +1910,6 @@ let kind_of file =
       match Filename.extension fname with
       | ".ml" -> `Impl
       | ".mli" -> `Intf
-      | ".mlt" -> `Use_file
       | _ -> `Impl ) )
 
 let name_of file =

--- a/src/Conf.mli
+++ b/src/Conf.mli
@@ -91,12 +91,12 @@ type file = Stdin | File of string
 type 'a input = {kind: 'a; name: string; file: file; conf: t}
 
 type action =
-  | In_out of [`Impl | `Intf | `Use_file] input * string option
+  | In_out of [`Impl | `Intf] input * string option
       (** Format input file (or [-] for stdin) of given kind to output file,
           or stdout if None. *)
-  | Inplace of [`Impl | `Intf | `Use_file] input list
+  | Inplace of [`Impl | `Intf] input list
       (** Format in-place, overwriting input file(s). *)
-  | Check of [`Impl | `Intf | `Use_file] input list
+  | Check of [`Impl | `Intf] input list
       (** Check whether the input files already are formatted. *)
 
 val action : action

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -4326,8 +4326,7 @@ let fmt_use_file c ctx itms =
     | `Item {pstr_desc= Pstr_attribute atr; _} -> update_config c [atr]
     | _ -> c
   in
-  let ptop_ctx = function `Item x -> Str x | `Directive _ -> Top in
-  let grps = make_groups c itms ptop_ctx update_config in
+  let grps = make_groups c itms (fun x -> Tli x) update_config in
   let break_struct = c.conf.break_struct || Poly.(ctx = Top) in
   let fmt_item c ~last = function
     | `Item i ->

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -4367,6 +4367,4 @@ let entry_point ~f ~ctx source cmts conf l =
 
 let fmt_signature = entry_point ~f:fmt_signature ~ctx:Top
 
-let fmt_structure = entry_point ~f:fmt_structure ~ctx:Top
-
 let fmt_use_file = entry_point ~f:fmt_use_file ~ctx:Top

--- a/src/Fmt_ast.mli
+++ b/src/Fmt_ast.mli
@@ -18,9 +18,6 @@ open Parsetree
 val fmt_signature : Source.t -> Cmts.t -> Conf.t -> signature -> Fmt.t
 (** Format a signature. *)
 
-val fmt_structure : Source.t -> Cmts.t -> Conf.t -> structure -> Fmt.t
-(** Format a structure. *)
-
 val fmt_use_file :
   Source.t -> Cmts.t -> Conf.t -> toplevel_phrase list -> Fmt.t
 (** Format a use_file. *)

--- a/src/Migrate_ast.ml
+++ b/src/Migrate_ast.ml
@@ -98,6 +98,9 @@ module Pprintast = struct
   let expression f x = expression f (to_current.copy_expression x)
 
   let pattern f x = pattern f (to_current.copy_pattern x)
+
+  let toplevel_phrase f x =
+    toplevel_phrase f (to_current.copy_toplevel_phrase x)
 end
 
 module Position = struct

--- a/src/Normalize.ml
+++ b/src/Normalize.ml
@@ -371,14 +371,6 @@ let use_file c = Mapper.use_file (mapper c)
 
 let mapper_ignore_doc_comment c = make_mapper c ~ignore_doc_comment:true
 
-let equal_impl ~ignore_doc_comments c ast1 ast2 =
-  let map =
-    if ignore_doc_comments then
-      Mapper.structure (mapper_ignore_doc_comment c)
-    else Mapper.structure (mapper c)
-  in
-  Poly.(map ast1 = map ast2)
-
 let equal_intf ~ignore_doc_comments c ast1 ast2 =
   let map =
     if ignore_doc_comments then
@@ -436,13 +428,6 @@ let make_docstring_mapper c docstrings =
   in
   {Ast_mapper.default_mapper with attribute; attributes}
 
-let docstrings_impl c s =
-  let docstrings = ref [] in
-  let (_ : structure) =
-    Mapper.structure (make_docstring_mapper c docstrings) s
-  in
-  !docstrings
-
 let docstrings_intf c s =
   let docstrings = ref [] in
   let (_ : signature) =
@@ -495,8 +480,6 @@ let moved_docstrings c get_docstrings s1 s2 =
       let l1 = List.map ~f:unstable l1 in
       let l2 = List.map ~f:unstable l2 in
       List.rev_append both (List.rev_append l1 l2)
-
-let moved_docstrings_impl c s1 s2 = moved_docstrings c docstrings_impl s1 s2
 
 let moved_docstrings_intf c s1 s2 = moved_docstrings c docstrings_intf s1 s2
 

--- a/src/Normalize.mli
+++ b/src/Normalize.mli
@@ -32,10 +32,6 @@ val intf : Conf.t -> signature -> signature
 val use_file : Conf.t -> toplevel_phrase list -> toplevel_phrase list
 (** Normalize a use_file. *)
 
-val equal_impl :
-  ignore_doc_comments:bool -> Conf.t -> structure -> structure -> bool
-(** Compare structures for equality up to normalization. *)
-
 val equal_intf :
   ignore_doc_comments:bool -> Conf.t -> signature -> signature -> bool
 (** Compare signatures for equality up to normalization. *)
@@ -54,9 +50,6 @@ val mapper : Conf.t -> Ast_mapper.mapper
 type docstring_error =
   | Moved of Location.t * Location.t * string
   | Unstable of Location.t * string
-
-val moved_docstrings_impl :
-  Conf.t -> structure -> structure -> docstring_error list
 
 val moved_docstrings_intf :
   Conf.t -> signature -> signature -> docstring_error list

--- a/src/ocamlformat.ml
+++ b/src/ocamlformat.ml
@@ -22,13 +22,13 @@ let moved_docstrings f c a b =
 
 (** Operations on implementation files. *)
 let impl : _ Translation_unit.t =
-  { parse= Migrate_ast.Parse.implementation
-  ; init_cmts= Cmts.init_impl
-  ; fmt= Fmt_ast.fmt_structure
-  ; equal= equal Normalize.equal_impl
-  ; moved_docstrings= moved_docstrings Normalize.moved_docstrings_impl
-  ; normalize= normalize Normalize.impl
-  ; printast= Migrate_ast.Printast.implementation }
+  { parse= Migrate_ast.Parse.use_file
+  ; init_cmts= Cmts.init_use_file
+  ; fmt= Fmt_ast.fmt_use_file
+  ; equal= equal Normalize.equal_use_file
+  ; moved_docstrings= moved_docstrings Normalize.moved_docstrings_use_file
+  ; normalize= normalize Normalize.use_file
+  ; printast= Migrate_ast.Printast.use_file }
 
 (** Operations on interface files. *)
 let intf : _ Translation_unit.t =
@@ -40,16 +40,6 @@ let intf : _ Translation_unit.t =
   ; normalize= normalize Normalize.intf
   ; printast= Migrate_ast.Printast.interface }
 
-(** Operations on use_file files. *)
-let use_file : _ Translation_unit.t =
-  { parse= Migrate_ast.Parse.use_file
-  ; init_cmts= Cmts.init_use_file
-  ; fmt= Fmt_ast.fmt_use_file
-  ; equal= equal Normalize.equal_use_file
-  ; moved_docstrings= moved_docstrings Normalize.moved_docstrings_use_file
-  ; normalize= normalize Normalize.use_file
-  ; printast= Migrate_ast.Printast.use_file }
-
 ;;
 Caml.at_exit (Format.pp_print_flush Format.err_formatter)
 
@@ -60,7 +50,6 @@ let format ~kind =
   match kind with
   | `Impl -> Translation_unit.parse_and_format impl
   | `Intf -> Translation_unit.parse_and_format intf
-  | `Use_file -> Translation_unit.parse_and_format use_file
 
 let to_output_file output_file data =
   match output_file with
@@ -94,10 +83,7 @@ match Conf.action with
     in
     if List.is_empty errors then Caml.exit 0 else Caml.exit 1
 | In_out
-    ( { kind= (`Impl | `Intf | `Use_file) as kind
-      ; file= Stdin
-      ; name= input_name
-      ; conf }
+    ( {kind= (`Impl | `Intf) as kind; file= Stdin; name= input_name; conf}
     , output_file ) -> (
     let source = In_channel.input_all In_channel.stdin in
     let result = format conf ?output_file ~kind ~input_name ~source () in
@@ -107,7 +93,7 @@ match Conf.action with
         Caml.exit 0
     | Error _ -> Caml.exit 1 )
 | In_out
-    ( { kind= (`Impl | `Intf | `Use_file) as kind
+    ( { kind= (`Impl | `Intf) as kind
       ; file= File input_file
       ; name= input_name
       ; conf }


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/1011

This PR fixes the formatting of use-files and parse/format implementations as use-files.

This is WIP