### PR TITLE
Support OCaml 4.09.0 (add the odoc.1.4.2 dependency)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 env:
   - OCAML_VERSION=4.08.0
+  - OCAML_VERSION=4.09.0
 cache:
   directories:
     - ${HOME}/.opam

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: c
 env:
-  - OCAML_VERSION=4.08.0
   - OCAML_VERSION=4.09.0
 cache:
   directories:

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -30,7 +30,7 @@ depends: [
   "dune" {>= "1.11.1"}
   "fpath"
   "ocaml-migrate-parsetree" {>= "1.3.1"}
-  "odoc" {>= "1.4.1"}
+  "odoc" {>= "1.4.2"}
   "re"
   "stdio"
   "uuseg" {>= "10.0.0"}

--- a/ocamlformat_reason.opam
+++ b/ocamlformat_reason.opam
@@ -24,7 +24,7 @@ depends: [
   "dune" {>= "1.11.1"}
   "fpath"
   "ocaml-migrate-parsetree" {>= "1.0.10"}
-  "odoc" {>= "1.4.1"}
+  "odoc" {>= "1.4.2"}
   "re"
   "stdio"
   "uutf"

--- a/test/passing/doc_comments.mli.ref
+++ b/test/passing/doc_comments.mli.ref
@@ -285,15 +285,15 @@ end
     ]}
     {[
       First line
-            on the same line
-            as opening
+      on the same line
+      as opening
     ]} *)
 
 module X : sig
   (** {[
         First line
-                on the same line
-                as opening
+        on the same line
+        as opening
       ]} *)
 end
 


### PR DESCRIPTION
- [x] wait for https://github.com/ocaml/odoc/issues/386
- [ ] wait for #1023 
- [ ] make a 0.12 release (for 4.08.0)

then we can make a 0.12.1 release (for 4.09.0) after this PR is merged.