### PR TITLE
Fix flag of git-worktree in test_branch.sh and bisect.sh

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ### (master)
 
+  + Fix test_branch.sh (#1027) (Guillaume Petiot)
+  + Improve: remove the bisect_ppx dependency and clean Makefile (#1005) (Jules Aguillon)
   + Project: use a CHANGES.md log file again (#1023) (Guillaume Petiot)
   + Support OCaml 4.09.0 (add the odoc.1.4.2 dependency) (#1024) (Guillaume Petiot)
   + Parse toplevel directives (#1020) (Jules Aguillon)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ### (master)
 
-  + Fix test_branch.sh (#1027) (Guillaume Petiot)
+  + Fix flag of git-worktree in test_branch.sh and bisect.sh (#1027) (Guillaume Petiot)
   + Improve: remove the bisect_ppx dependency and clean Makefile (#1005) (Jules Aguillon)
   + Project: use a CHANGES.md log file again (#1023) (Guillaume Petiot)
   + Support OCaml 4.09.0 (add the odoc.1.4.2 dependency) (#1024) (Guillaume Petiot)

--- a/tools/bisect.sh
+++ b/tools/bisect.sh
@@ -38,4 +38,4 @@ bisect-ppx-report -I "$tmp/_build/default" -html "$dst" `find "$tmp" -name 'bise
 echo "Coverage report generated in $dst/"
 echo " => open $dst/index.html"
 
-git worktree remove -f "$tmp"
+git worktree remove --force "$tmp"

--- a/tools/test_branch.sh
+++ b/tools/test_branch.sh
@@ -40,7 +40,7 @@ run_in_worktree ()
   make -C "$tmp"
   local exe=`ls "$tmp"/_build/{default,dev}/src/ocamlformat.exe 2>/dev/null | head -n1`
   OCAMLFORMAT_EXE=$exe make -C test-extra "$@"
-  git worktree remove -f "$tmp"
+  git worktree remove --force "$tmp"
 }
 
 OCAMLFORMAT="$2" run_in_worktree "$base" test_setup test_unstage test_clean test_pull test test_stage


### PR DESCRIPTION
`-f` is not a valid flag for `git worktree`

The check of CHANGES.md does not seem to work, although we use the same env variables than ocaml/ocaml, should we just remove this check?