### PR TITLE
Fix unstable comments around attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ### (master)
 
-  + Fix unsable comments around attributes (#1029) (Guillaume Petiot)
+  + Fix unstable comments around attributes (#1029) (Guillaume Petiot)
   + Fix test_branch.sh and CI checking of CHANGES.md (#1032) (Jules Aguillon)
   + Fix flag of git-worktree in test_branch.sh and bisect.sh (#1027) (Guillaume Petiot)
   + Improve: remove the bisect_ppx dependency and clean Makefile (#1005) (Jules Aguillon)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### (master)
 
+  + Fix unsable comments around attributes (#1029) (Guillaume Petiot)
   + Fix test_branch.sh and CI checking of CHANGES.md (#1032) (Jules Aguillon)
   + Fix flag of git-worktree in test_branch.sh and bisect.sh (#1027) (Guillaume Petiot)
   + Improve: remove the bisect_ppx dependency and clean Makefile (#1005) (Jules Aguillon)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2988,8 +2988,7 @@ and fmt_class_params c ctx params =
     (hvbox 0
        (wrap_fits_breaks c.conf "[" "]" (list_fl params fmt_param) $ fmt "@ "))
 
-and fmt_type_declaration c ?ext ?(pre = "") ?(brk = noop) ctx ?fmt_name
-    ?(eq = "=") decl =
+and fmt_type_declaration c ?ext ?(pre = "") ctx ?fmt_name ?(eq = "=") decl =
   let { ptype_name= {txt; loc}
       ; ptype_params
       ; ptype_cstrs
@@ -3098,7 +3097,6 @@ and fmt_type_declaration c ?ext ?(pre = "") ?(brk = noop) ctx ?fmt_name
                $ fmt_cstrs ptype_cstrs )
            $ fmt_attributes c ~pre:(fmt "@ ") ~key:"@@" atrs )
        $ doc_after )
-  $ brk
 
 and fmt_label_declaration c ctx decl ?(last = false) =
   let {pld_mutable; pld_name; pld_type; pld_loc; pld_attributes} = decl in
@@ -3983,10 +3981,9 @@ and fmt_type c ?ext ?eq rec_flag decls ctx =
       if first then
         if Poly.(rec_flag = Recursive) then "type" else "type nonrec"
       else "and"
-    and brk = fmt_if (not last) "\n" in
+    in
     let ext = if first then ext else None in
-    fmt_type_declaration c ~pre ?eq ?ext ~brk ctx decl
-    $ fmt_if (not last) "@ "
+    fmt_type_declaration c ~pre ?eq ?ext ctx decl $ fmt_if (not last) "\n@ "
   in
   vbox 0 (list_fl decls fmt_decl)
 

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -616,7 +616,8 @@ and fmt_attributes c ?(pre = noop) ?(suf = noop) ~key attrs =
   let num = List.length attrs in
   let fmt_attr ~first ~last {attr_name; attr_payload; attr_loc} =
     fmt_or_k first (open_hvbox 0) (fmt "@ ")
-    $ Cmts.fmt c attr_loc (fmt_attribute c key (attr_name, attr_payload))
+    $ hvbox 0
+        (Cmts.fmt c attr_loc (fmt_attribute c key (attr_name, attr_payload)))
     $ fmt_if_k last (close_box $ suf)
   in
   fmt_if_k (num > 0) (pre $ hvbox_if (num > 1) 0 (list_fl attrs fmt_attr))

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -178,3 +178,10 @@ type t = {a: int}
 module type A = sig
   module A := A.B [@@attr]
 end
+
+module M = struct
+  type t
+  [@@immediate]
+  (* ______________________________________ *)
+  [@@deriving variants, sexp_of]
+end

--- a/test/passing/js_source.ml
+++ b/test/passing/js_source.ml
@@ -7417,3 +7417,10 @@ exception First_exception
 
 (** Second documentation comment. *)
 exception Second_exception
+
+module M = struct
+  type t
+  [@@immediate]
+  (* ______________________________________ *)
+  [@@deriving variants, sexp_of]
+end

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -9806,3 +9806,9 @@ exception First_exception
 
 (** Second documentation comment. *)
 exception Second_exception
+
+module M = struct
+  type t
+  [@@immediate] (* ______________________________________ *)
+  [@@deriving variants, sexp_of]
+end


### PR DESCRIPTION
Fix #1025
also contains some simplfications to `fmt_type_declaration` that are small enough to be squeezed in this PR (I thought the issue was specific to type declarations at first so I started cleaning a bit).

No diff with test_branch with and without using the janestreet profile (the issue is due to the `margin=90` actually).