### PR TITLE
Fix test_branch.sh and CI checking of CHANGES.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - opam pin add --no-action ocamlformat .
   - opam install --deps-only ocamlformat
 script:
-  - ! git diff --exit-code "$TRAVIS_MERGE_BASE..$TRAVIS_PR_HEAD" -- CHANGES.md >/dev/null
+  - if [ $TRAVIS_BRANCH = master ]; then ! git diff --exit-code $TRAVIS_BRANCH...$TRAVIS_COMMIT -- CHANGES.md >/dev/null; fi
   - opam switch ${OCAML_VERSION}
   - opam exec -- make test
   - opam install ocamlformat

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### (master)
 
+  + Fix test_branch.sh and CI checking of CHANGES.md (#1032) (Jules Aguillon)
   + Fix flag of git-worktree in test_branch.sh and bisect.sh (#1027) (Guillaume Petiot)
   + Improve: remove the bisect_ppx dependency and clean Makefile (#1005) (Jules Aguillon)
   + Project: use a CHANGES.md log file again (#1023) (Guillaume Petiot)

--- a/tools/test_branch.sh
+++ b/tools/test_branch.sh
@@ -39,7 +39,7 @@ run_in_worktree ()
   shift
   make -C "$tmp"
   local exe=`ls "$tmp"/_build/{default,dev}/src/ocamlformat.exe 2>/dev/null | head -n1`
-  OCAMLFORMAT_EXE=$exe make -C test-extra "$@"
+  make -C test-extra "OCAMLFORMAT_EXE=$exe" "$@"
   git worktree remove --force "$tmp"
 }
 


### PR DESCRIPTION
`test_branch.sh` never report any diffs.
The path to ocamlformat binary was not passed correctly and it was using the same binary twice.