### PR TITLE
Improve: use the same sets of options for both branches by default in test_branch.sh

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ### (master)
 
-  + Improve: use the same sets of options for both branches by default (#1033) (Guillaume Petiot)
+  + Improve: use the same sets of options for both branches by default in test_branch.sh (#1033) (Guillaume Petiot)
   + Fix test_branch.sh and CI checking of CHANGES.md (#1032, #1034) (Jules Aguillon)
   + Fix flag of git-worktree in test_branch.sh and bisect.sh (#1027) (Guillaume Petiot)
   + Improve: remove the bisect_ppx dependency and clean Makefile (#1005) (Jules Aguillon)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### (master)
 
+  + Improve: use the same sets of options for both branches by default (#1033) (Guillaume Petiot)
   + Fix test_branch.sh and CI checking of CHANGES.md (#1032) (Jules Aguillon)
   + Fix flag of git-worktree in test_branch.sh and bisect.sh (#1027) (Guillaume Petiot)
   + Improve: remove the bisect_ppx dependency and clean Makefile (#1005) (Jules Aguillon)

--- a/tools/test_branch.sh
+++ b/tools/test_branch.sh
@@ -19,7 +19,9 @@
 # the merge base of the test branch.
 #
 # The third arg is the value of OCAMLFORMAT to be used when formatting
-# the test branch.
+# the test branch. When this arg is not provided, we use the same value
+# than for the base branch. This arg should be the empty string '' to
+# set OCAMLFORMAT to an empty value.
 
 set -e
 
@@ -27,6 +29,14 @@ if [[ ! -z "$1" ]]; then
     branch="$1"
 else
     branch=$(git rev-parse HEAD)
+fi
+
+opts_base="$2"
+
+if [[ $# -lt 3 ]]; then
+    opts_branch="$opts_base"
+else
+    opts_branch="$3"
 fi
 
 base=$(git merge-base master $branch)
@@ -43,5 +53,5 @@ run_in_worktree ()
   git worktree remove --force "$tmp"
 }
 
-OCAMLFORMAT="$2" run_in_worktree "$base" test_setup test_unstage test_clean test_pull test test_stage
-OCAMLFORMAT="$3" run_in_worktree "$branch" test test_diff
+OCAMLFORMAT="$opts_base" run_in_worktree "$base" test_setup test_unstage test_clean test_pull test test_stage
+OCAMLFORMAT="$opts_branch" run_in_worktree "$branch" test test_diff


### PR DESCRIPTION
The goal is to avoid writing the same list of options twice (error-prone)

Tested on the docked-bindings branch:
- `test_branch.sh docked-branch` no options for both branches
- `test_branch.sh docked-branch '' ''` no options for both branches
- `test_branch.sh docked-branch ''` no options for both branches
- `test_branch.sh docked-branch 'some options' ''` some options only for the base branch
- `test_branch.sh docked-branch 'some options'` some options for both branches
- `test_branch.sh docked-branch 'some options' 'different options'` some options for the base branch, different options for the tested branch