### PR TITLE
Fix indexing operators precedence

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### (master)
 
+  + Fix indexing operators precedence (#1039) (Jules Aguillon)
   + Fix dropped comment after infix op (#1030) (Guillaume Petiot)
   + Fix: no newline if the input is empty (#1031) (Guillaume Petiot)
   + Fix unstable comments around attributes (#1029) (Guillaume Petiot)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1670,26 +1670,6 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                      , (fmt_op, args) )
                  | None -> (false, noop, noop, (noop, args))))
         $ fmt_atrs )
-  | Pexp_apply
-      ( { pexp_desc= Pexp_ident {txt= id; loc}
-        ; pexp_loc
-        ; pexp_attributes= _
-        ; _ }
-      , (Nolabel, s) :: (Nolabel, i) :: _ )
-    when Option.is_some (index_op_get_lid id) ->
-      let index_op = Option.value_exn (index_op_get_lid id) in
-      Cmts.relocate c.cmts ~src:pexp_loc ~before:loc ~after:loc ;
-      fmt_index_op c ctx ~parens {txt= index_op; loc} s [i]
-  | Pexp_apply
-      ( { pexp_desc= Pexp_ident {txt= id; loc}
-        ; pexp_loc
-        ; pexp_attributes= _
-        ; _ }
-      , (Nolabel, s) :: (Nolabel, i) :: (Nolabel, e) :: _ )
-    when Option.is_some (index_op_set_lid id) ->
-      let index_op = Option.value_exn (index_op_set_lid id) in
-      Cmts.relocate c.cmts ~src:pexp_loc ~before:loc ~after:loc ;
-      fmt_index_op c ctx ~parens {txt= index_op; loc} s [i] ~set:e
   | Pexp_apply (e0, [(Nolabel, e1)]) when is_prefix e0 ->
       hvbox 2
         (wrap_exp c ~loc:pexp_loc ~parens

--- a/test/passing/index_op.ml
+++ b/test/passing/index_op.ml
@@ -17,7 +17,7 @@ let h = Hashtbl.create 17
 ;;
 h.@("One") <- 1 ;
 assert (h.@{"One"} = 1) ;
-print_int (h.@{"One"}) ;
+print_int h.@{"One"} ;
 assert (h.?["Two"] = None)
 
 (* from GPR#1392 *)
@@ -81,3 +81,35 @@ let () =
   m.Mat.${[[2]; [5]]} |> ignore ;
   let open Mat in
   m.${[[2]; [5]]} |> ignore
+
+let _ = (x.*{(y, z)} <- w) @ []
+
+let _ = (x.{y, z} <- w) @ []
+
+let _ = (x.*(y) <- z) @ []
+
+let _ = (x.*(y) <- z) := []
+
+let _ = ((x.*(y) <- z), [])
+
+let _ = x.*(y) <- z ; []
+
+let _ = (x.(y) <- z) @ []
+
+let _ = (x.(y) <- z) := []
+
+let _ = ((x.(y) <- z), [])
+
+let _ = x.(y) <- z ; []
+
+let _ = (x.y <- z) @ []
+
+let _ = (x.y <- z) := []
+
+let _ = ((x.y <- z), [])
+
+let _ =
+  x.y <- z ;
+  []
+
+let _ = x.(y) <- (z.(w) <- u)


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/1037

The precedence of indexing operators was not right (was Comma). Also, custom index operators are not represented the same as for array or string by the OCaml parser and were not handled correctly.