### PR TITLE
Fix blank line after comments at the end of lists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### (master)
 
+  + Fix blank line after comments at the end of lists (#1045) (Guillaume Petiot)
   + CI: check the build with OCaml 4.07.1 and 4.08.0 (#1036) (Jules Aguillon)
   + Fix indexing operators precedence (#1039) (Jules Aguillon)
   + Fix dropped comment after infix op (#1030) (Guillaume Petiot)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1864,7 +1864,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                        Cmts.fmt_list c ~eol:cmt_break locs
                        @@ fmt_expression c xexp)
                      p
-                 $ Cmts.fmt_before c ~pro:cmt_break ~epi:noop nil_loc
+                 $ Cmts.fmt_before c ~pro:cmt_break ~epi:noop ~eol:noop
+                     nil_loc
                  $ Cmts.fmt_after c ~pro:(fmt "@ ") ~epi:noop nil_loc )
              $ fmt_atrs ))
     | None ->

--- a/test/passing/issue77.ml
+++ b/test/passing/issue77.ml
@@ -4,6 +4,5 @@ let div =
         [ Reactive.a_style
             (React.S.map (sprintf "height: %dpx")
                (State.player_height_signal app_state))
-          (* ksprintf a_style "%s" (if_smth "min-height: 300px;" ""); *)
-         ]
+          (* ksprintf a_style "%s" (if_smth "min-height: 300px;" ""); *) ]
       content ]


### PR DESCRIPTION
Fix #1040 
Diff with test_branch:

```
diff --git a/benchmarks/sources/ml/nucleic.ml b/benchmarks/sources/ml/nucleic.ml
index 3f6a93112..5907b3401 100644
--- a/benchmarks/sources/ml/nucleic.ml
+++ b/benchmarks/sources/ml/nucleic.ml
@@ -7112,7 +7112,6 @@ let anticodon_domains =
     (*   | Constraint    *)
     p_o3' rUs 33 32;
     (* <-' 3.0 Angstroms *)
-    
   ]
 
 (* Anticodon constraint *)
@@ -7175,7 +7174,6 @@ let pseudoknot_domains =
     (*   | 4.5 Angstroms *)
     stacked5' rC 6 5;
     (* <-'               *)
-    
   ]diff --git a/benchmarks/sources/ml/nucleic.ml b/benchmarks/sources/ml/nucleic.ml
index 3f6a93112..5907b3401 100644
--- a/benchmarks/sources/ml/nucleic.ml
+++ b/benchmarks/sources/ml/nucleic.ml
@@ -7112,7 +7112,6 @@ let anticodon_domains =
     (*   | Constraint    *)
     p_o3' rUs 33 32;
     (* <-' 3.0 Angstroms *)
-    
   ]
 
 (* Anticodon constraint *)
@@ -7175,7 +7174,6 @@ let pseudoknot_domains =
     (*   | 4.5 Angstroms *)
     stacked5' rC 6 5;
     (* <-'               *)
-    
   ]
```

More tests in #1022 to avoid more conflicts than necessary.
