### PR TITLE
Fix alignment of cases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### (master)
 
+  + Fix alignment of cases (#1046) (Guillaume Petiot)
   + CI: check the build with OCaml 4.07.1 and 4.08.0 (#1036) (Jules Aguillon)
   + Fix indexing operators precedence (#1039) (Jules Aguillon)
   + Fix dropped comment after infix op (#1030) (Guillaume Petiot)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2812,7 +2812,9 @@ and fmt_cases c ctx cs =
   let pattern_len pat =
     let xpat = sub_pat ~ctx pat in
     let fmted = Cmts.preserve (fmt_pattern c) xpat in
-    if String.contains fmted '\n' then None else Some (String.length fmted)
+    let len = String.length fmted in
+    if len * 3 >= c.conf.margin || String.contains fmted '\n' then None
+    else Some len
   in
   let fold_pattern_len ~f ps =
     List.fold_until ~init:0 ps

--- a/test/passing/align_cases-break_all.ml.ref
+++ b/test/passing/align_cases-break_all.ml.ref
@@ -100,6 +100,18 @@ let _ =
   | `Foo     -> toto
   | `Bar ijx -> bar ijx
 
+let _ =
+  match (foooooooooooooo, foooooooooooooo) with
+  | Some a, Some b -> a + b
+  | None, _        -> 1
+  | Some _, None   -> 2
+
+let _ =
+  match (foooooooooooooo, foooooooooooooo) with
+  | [x]    -> x
+  | [_; x] -> x
+  | _      -> 0
+
 type x = Foooooooo of int | Fooooooooooooo of int
 
 type x = [`Foooooooo of int | `Fooooooooooooo of int]

--- a/test/passing/align_cases.ml
+++ b/test/passing/align_cases.ml
@@ -83,6 +83,18 @@ let _ = match f with Foo -> toto | Bar ijx -> bar ijx
 
 let _ = match f with `Foo -> toto | `Bar ijx -> bar ijx
 
+let _ =
+  match (foooooooooooooo, foooooooooooooo) with
+  | Some a, Some b -> a + b
+  | None, _        -> 1
+  | Some _, None   -> 2
+
+let _ =
+  match (foooooooooooooo, foooooooooooooo) with
+  | [x]    -> x
+  | [_; x] -> x
+  | _      -> 0
+
 type x = Foooooooo of int | Fooooooooooooo of int
 
 type x = [`Foooooooo of int | `Fooooooooooooo of int]


### PR DESCRIPTION
Fix #1041, the diff of `tools/test_branch.sh fix-align-cases 'align-cases=true'` is too big to check everything but a lot of cases are fixed.

Using the direct output of the formatting instead of duplicating the logic of what does this option do in this case, etc. or approximating.