### PR TITLE
Improve: inline extensions that do not break

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### (master)
 
+  + Improve: inline extensions that do not break (#1050) (Guillaume Petiot)
   + Fix: add missing cut before attributes in type declarations (#1051) (Guillaume Petiot)
   + CI: use opam-2.0.5 in Travis (#1044) (Anton Kochkov)
   + Fix alignment of cases (#1046) (Guillaume Petiot)

--- a/test/passing/doc_comments-after.ml.ref
+++ b/test/passing/doc_comments-after.ml.ref
@@ -232,8 +232,7 @@ end = struct
   (* [@@@some attribute] *)
   (* (** Attribute *) *)
 
-  (** Extension *)[%%some
-  extension]
+  (** Extension *)[%%some extension]
 
   (* ;; *)
   (* (** Eval *) *)

--- a/test/passing/doc_comments-before.ml.ref
+++ b/test/passing/doc_comments-before.ml.ref
@@ -232,8 +232,7 @@ end = struct
   (* [@@@some attribute] *)
   (* (** Attribute *) *)
 
-  (** Extension *)[%%some
-  extension]
+  (** Extension *)[%%some extension]
 
   (* ;; *)
   (* (** Eval *) *)

--- a/test/passing/doc_comments.ml.ref
+++ b/test/passing/doc_comments.ml.ref
@@ -232,8 +232,7 @@ end = struct
   (* [@@@some attribute] *)
   (* (** Attribute *) *)
 
-  (** Extension *)[%%some
-  extension]
+  (** Extension *)[%%some extension]
 
   (* ;; *)
   (* (** Eval *) *)

--- a/test/passing/extensions-indent.ml.ref
+++ b/test/passing/extensions-indent.ml.ref
@@ -45,8 +45,7 @@ let invariant t =
 
 let _ = ([%ext? (x : x)] : [%ext? (x : x)])
 
-[%%ext
-11111111111111111111]
+[%%ext 11111111111111111111]
 
 [%%ext
 11111111111111111111111 22222222222222222222222 33333333333333333333333]
@@ -179,3 +178,8 @@ let _ =
        c]
 
 let _ = [%ext "foo" ; "bar"]
+
+let this_function_has_a_long_name plus very many arguments =
+  "and a kind of long body"
+
+[%%expect {||}]

--- a/test/passing/extensions-sugar_always.ml.ref
+++ b/test/passing/extensions-sugar_always.ml.ref
@@ -43,8 +43,7 @@ let invariant t =
 
 let _ = ([%ext? (x : x)] : [%ext? (x : x)])
 
-[%%ext
-11111111111111111111]
+[%%ext 11111111111111111111]
 
 [%%ext
 11111111111111111111111 22222222222222222222222 33333333333333333333333]
@@ -173,3 +172,8 @@ let _ =
     c]
 
 let _ = "foo" ;%ext "bar"
+
+let this_function_has_a_long_name plus very many arguments =
+  "and a kind of long body"
+
+[%%expect {||}]

--- a/test/passing/extensions.ml
+++ b/test/passing/extensions.ml
@@ -188,3 +188,8 @@ let foo =
 let _ = [%ext let+ a = b in c]
 
 let _ = (begin%ext "foo"; "bar" end)
+
+let this_function_has_a_long_name plus very many arguments = "and a kind of long body"
+
+[%%expect
+  {||}]

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -45,8 +45,7 @@ let invariant t =
 
 let _ = ([%ext? (x : x)] : [%ext? (x : x)])
 
-[%%ext
-11111111111111111111]
+[%%ext 11111111111111111111]
 
 [%%ext
 11111111111111111111111 22222222222222222222222 33333333333333333333333]
@@ -179,3 +178,8 @@ let _ =
     c]
 
 let _ = [%ext "foo" ; "bar"]
+
+let this_function_has_a_long_name plus very many arguments =
+  "and a kind of long body"
+
+[%%expect {||}]

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -39,8 +39,7 @@ x]
 
 let ([%foo 2 + 1] : [%foo bar.baz]) = [%foo "foo"]
 
-[%%foo
-module M = [%bar]]
+[%%foo module M = [%bar]]
 
 let ([%foo let () = ()] : [%foo type t = t]) = [%foo class c = object end]
 
@@ -193,36 +192,20 @@ type%foo t = int [@@foo]
 
 and t = int [@@foo]
 
-[%%foo
-type t += T [@@foo]]
-
-[%%foo
-class x = x [@@foo]]
-
-[%%foo
-class type x = x [@@foo]]
-
-[%%foo
-external x : _ = "" [@@foo]]
-
-[%%foo
-exception X [@foo]]
-
-[%%foo
-module M = M [@@foo]]
+[%%foo type t += T [@@foo]]
+[%%foo class x = x [@@foo]]
+[%%foo class type x = x [@@foo]]
+[%%foo external x : _ = "" [@@foo]]
+[%%foo exception X [@foo]]
+[%%foo module M = M [@@foo]]
 
 [%%foo
 module rec M : S = M [@@foo]
 and M : S = M [@@foo]]
 
-[%%foo
-module type S = S [@@foo]]
-
-[%%foo
-include M [@@foo]]
-
-[%%foo
-open M [@@foo]]
+[%%foo module type S = S [@@foo]]
+[%%foo include M [@@foo]]
+[%%foo open M [@@foo]]
 
 (* Signature items *)
 module type S = sig

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -90,23 +90,18 @@ type%foo t = int [@@foo]
 
 and t = int [@@foo]
 
-[%%foo
-type t += T [@@foo]]
+[%%foo type t += T [@@foo]]
 
-[%%foo
-class x = x [@@foo]]
+[%%foo class x = x [@@foo]]
 
-[%%foo
-class type x = x [@@foo]]
+[%%foo class type x = x [@@foo]]
 
 [%%foo
 external x : _ = "" [@@foo]]
 
-[%%foo
-exception X [@@foo]]
+[%%foo exception X [@@foo]]
 
-[%%foo
-module M = M [@@foo]]
+[%%foo module M = M [@@foo]]
 
 [%%foo
 module rec M : S = M [@@foo]
@@ -115,11 +110,9 @@ and M : S = M [@@foo]]
 [%%foo
 module type S = S [@@foo]]
 
-[%%foo
-include M [@@foo]]
+[%%foo include M [@@foo]]
 
-[%%foo
-open M [@@foo]]
+[%%foo open M [@@foo]]
 
 (* Signature items *)
 module type S = sig

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -42,8 +42,7 @@ x]
 
 let ([%foo 2 + 1] : [%foo bar.baz]) = [%foo "foo"]
 
-[%%foo
-module M = [%bar]]
+[%%foo module M = [%bar]]
 
 let ([%foo let () = ()] : [%foo type t = t]) = [%foo class c = object end]
 
@@ -213,23 +212,18 @@ type%foo t = int [@@foo]
 
 and t = int [@@foo]
 
-[%%foo
-type t += T [@@foo]]
+[%%foo type t += T [@@foo]]
 
-[%%foo
-class x = x [@@foo]]
+[%%foo class x = x [@@foo]]
 
-[%%foo
-class type x = x [@@foo]]
+[%%foo class type x = x [@@foo]]
 
 [%%foo
 external x : _ = "" [@@foo]]
 
-[%%foo
-exception X [@foo]]
+[%%foo exception X [@foo]]
 
-[%%foo
-module M = M [@@foo]]
+[%%foo module M = M [@@foo]]
 
 [%%foo
 module rec M : S = M [@@foo]
@@ -238,11 +232,9 @@ and M : S = M [@@foo]]
 [%%foo
 module type S = S [@@foo]]
 
-[%%foo
-include M [@@foo]]
+[%%foo include M [@@foo]]
 
-[%%foo
-open M [@@foo]]
+[%%foo open M [@@foo]]
 
 (* Signature items *)
 module type S = sig


### PR DESCRIPTION
Fix #1048 
We put a box around non-breaking payload of the extensions (the breaking ones must not be boxed)

I think in the future we should replace the calls to `Location.is_single_line` and their friends with `fits` whenever possible, so we rely on the output instead of the input.

No regression with test_branch.