### PR TITLE
Fix break in variant type definition to not exceed the margin

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -726,9 +726,11 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
       let closing =
         let empty = List.is_empty rfs in
         let breaks = Poly.(c.conf.type_decl = `Sparse) && space_around in
-        let nspaces = if breaks then 1000 else 1 in
+        let nspaces = if empty then 0 else 1 in
         let space = (protect_token || space_around) && not empty in
-        fits_breaks (if space then " ]" else "]") ~hint:(nspaces, 0) "]"
+        fits_breaks
+          (if space && not empty then " ]" else "]")
+          ~hint:(nspaces, 0) "]" ~force_break_if:breaks
       in
       hvbox 0
         ( match (flag, lbls, rfs) with

--- a/test/passing/js_source.ml
+++ b/test/passing/js_source.ml
@@ -7424,3 +7424,15 @@ module M = struct
   (* ______________________________________ *)
   [@@deriving variants, sexp_of]
 end
+
+module type Basic3 = sig
+  type ('a, 'd, 'e) t
+
+  val return : 'a -> ('a, _, _) t
+  val apply : ('a -> 'b, 'd, 'e) t -> ('a, 'd, 'e) t -> ('b, 'd, 'e) t
+
+  val map
+    : [ `Define_using_apply
+      | `Custom of ('a, 'd, 'e) t -> f:('a -> 'b) -> ('b, 'd, 'e) t
+      ]
+end


### PR DESCRIPTION
Fix #1061 

No diff with test_branch on the default profile, some fixes on the janestreet profile:

```
diff --git a/infer/src/base/CommandLineOption.ml b/infer/src/base/CommandLineOption.ml
index affd0015d..d58557e7d 100644
--- a/infer/src/base/CommandLineOption.ml
+++ b/infer/src/base/CommandLineOption.ml
@@ -88,7 +88,9 @@ type command_doc =
   { title : Cmdliner.Manpage.title
   ; manual_before_options : Cmdliner.Manpage.block list
   ; manual_options :
-      [ `Prepend of Cmdliner.Manpage.block list | `Replace of Cmdliner.Manpage.block list ]
+      [ `Prepend of Cmdliner.Manpage.block list
+      | `Replace of Cmdliner.Manpage.block list
+      ]
   ; manual_after_options : Cmdliner.Manpage.block list
   }
 
diff --git a/ppx/ppx_js/lib_internal/ppx_js_internal.ml b/ppx/ppx_js/lib_internal/ppx_js_internal.ml
index 98c4ce8c0..0b78104ae 100644
--- a/ppx/ppx_js/lib_internal/ppx_js_internal.ml
+++ b/ppx/ppx_js/lib_internal/ppx_js_internal.ml
@@ -490,7 +490,8 @@ let filter_map f l =
   List.rev l
 ;;
 
-let preprocess_literal_object mappper fields : [ `Fields of field_desc list | `Error of _ ]
+let preprocess_literal_object mappper fields
+    : [ `Fields of field_desc list | `Error of _ ]
   =
   let check_name id names =
     let txt = unescape id.txt in
```