### PR TITLE
Internal: API for safe boxes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 
 #### Internal
 
-  + Improve: API for safe boxes (#1074) (Guillaume Petiot)
+  + API for safe boxes (#1074) (Guillaume Petiot)
   + Add dune to repositories checked for regressions (#1129) (Jules Aguillon)
   + Use an expect test for cli tests (#1126) (Etienne Millon)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 
 #### Internal
 
+  + Improve: API for safe boxes (#1074) (Guillaume Petiot)
   + Add dune to repositories checked for regressions (#1129) (Jules Aguillon)
   + Use an expect test for cli tests (#1126) (Etienne Millon)
 

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -230,30 +230,17 @@ and close_box fs = debug_box_close fs ; Format.pp_close_box fs ()
 (** Wrapping boxes ------------------------------------------------------*)
 
 module Safe = struct
-  type sep =
-    | Cut
-    | Space
-    | Break of int * int
-    | Linebreak of int
-    | Double_linebreak
+  type sep = t
 
-  let cut = Cut
+  let cut fs = Format.pp_print_cut fs ()
 
-  let space = Space
+  let space fs = Format.pp_print_space fs ()
 
-  let break n o = Break (n, o)
+  let break n o fs = Format.pp_print_break fs n o
 
-  let linebreak o = Linebreak o
+  let linebreak o fs = Format.pp_print_break fs 1000 o
 
-  let double_linebreak = Double_linebreak
-
-  let sep s fs =
-    match s with
-    | Cut -> Format.pp_print_cut fs ()
-    | Space -> Format.pp_print_space fs ()
-    | Break (n, o) -> Format.pp_print_break fs n o
-    | Linebreak o -> Format.pp_print_break fs 1000 o
-    | Double_linebreak -> Format.fprintf fs "\n@;<1000 0>"
+  let double_linebreak fs = Format.fprintf fs "\n@;<1000 0>"
 
   type boxed = One of t | Cons of boxed * sep * t
 
@@ -267,7 +254,7 @@ module Safe = struct
     let can_box = match boxed with One _ -> false | Cons _ -> true in
     let rec aux = function
       | One t -> t
-      | Cons (b, s, t) -> aux b $ sep s $ t
+      | Cons (b, s, t) -> aux b $ s $ t
     in
     wrap_if_k (cnd && can_box) opn cls (aux boxed)
 

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -230,7 +230,12 @@ and close_box fs = debug_box_close fs ; Format.pp_close_box fs ()
 (** Wrapping boxes ------------------------------------------------------*)
 
 module Safe = struct
-  type sep = Cut | Space | Break of int * int | Linebreak of int
+  type sep =
+    | Cut
+    | Space
+    | Break of int * int
+    | Linebreak of int
+    | Double_linebreak
 
   let cut = Cut
 
@@ -240,12 +245,15 @@ module Safe = struct
 
   let linebreak o = Linebreak o
 
+  let double_linebreak = Double_linebreak
+
   let sep s fs =
     match s with
     | Cut -> Format.pp_print_cut fs ()
     | Space -> Format.pp_print_space fs ()
     | Break (n, o) -> Format.pp_print_break fs n o
     | Linebreak o -> Format.pp_print_break fs 1000 o
+    | Double_linebreak -> Format.fprintf fs "\n@;<1000 0>"
 
   type boxed = One of t | Cons of boxed * sep * t
 

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -244,35 +244,26 @@ module Safe = struct
 
   type boxed = One of t | Cons of boxed * sep * t
 
-  type box = boxed -> t
-
   let one t = One t
 
   let add b s t = Cons (b, s, t)
 
-  let box ?(cnd = true) opn cls boxed =
+  type box_kind = ?name:string -> int -> t
+
+  let cbox ?name = open_box ?name
+
+  let vbox ?name = open_vbox ?name
+
+  let hvbox ?name = open_hvbox ?name
+
+  let hovbox ?name = open_hovbox ?name
+
+  let box_if ?name cnd kind n boxed =
     let can_box = match boxed with One _ -> false | Cons _ -> true in
-    let rec aux = function
-      | One t -> t
-      | Cons (b, s, t) -> aux b $ s $ t
-    in
-    wrap_if_k (cnd && can_box) opn cls (aux boxed)
+    let rec aux = function One t -> t | Cons (b, s, t) -> aux b $ s $ t in
+    wrap_if_k (cnd && can_box) (kind ?name n) close_box (aux boxed)
 
-  let cbox ?name n = box (open_box ?name n) close_box
-
-  and vbox ?name n = box (open_vbox ?name n) close_box
-
-  and hvbox ?name n = box (open_hvbox ?name n) close_box
-
-  and hovbox ?name n = box (open_hovbox ?name n) close_box
-
-  and cbox_if ?name cnd n = box ~cnd (open_box ?name n) close_box
-
-  and vbox_if ?name cnd n = box ~cnd (open_vbox ?name n) close_box
-
-  and hvbox_if ?name cnd n = box ~cnd (open_hvbox ?name n) close_box
-
-  and hovbox_if ?name cnd n = box ~cnd (open_hovbox ?name n) close_box
+  let box ?name = box_if ?name true
 end
 
 let cbox ?name n = wrap_k (open_box ?name n) close_box

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -205,6 +205,9 @@ module Safe : sig
   val linebreak : int -> sep
   (** Format a linebreak. *)
 
+  val double_linebreak : sep
+  (** Format a double linebreak. *)
+
   type boxed
 
   type box = boxed -> t

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -190,6 +190,60 @@ val close_box : t
 
 (** Wrapping boxes ------------------------------------------------------*)
 
+module Safe : sig
+  type sep
+
+  val cut : sep
+  (** Format a cut. *)
+
+  val space : sep
+  (** Format a space. *)
+
+  val break : int -> int -> sep
+  (** Format a break hint. *)
+
+  val linebreak : int -> sep
+  (** Format a linebreak. *)
+
+  type boxed
+
+  type box = boxed -> t
+
+  val one : t -> boxed
+
+  val add : boxed -> sep -> t -> boxed
+  (** [add b s t] adds the format [t] preceded by separator [s] after the
+      other formats of the box [b]. *)
+
+  val cbox : ?name:string -> int -> box
+  (** Wrap a format thunk with a compacting box with specified indentation. *)
+
+  val vbox : ?name:string -> int -> box
+  (** Wrap a format thunk with a vbox with specified indentation. *)
+
+  val hvbox : ?name:string -> int -> box
+  (** Wrap a format thunk with an hvbox with specified indentation. *)
+
+  val hovbox : ?name:string -> int -> box
+  (** Wrap a format thunk with an hovbox with specified indentation. *)
+
+  val cbox_if : ?name:string -> bool -> int -> box
+  (** Conditionally wrap a format thunk with a compacting sbox with specified
+      indentation. *)
+
+  val vbox_if : ?name:string -> bool -> int -> box
+  (** Conditionally wrap a format thunk with a vbox with specified
+      indentation. *)
+
+  val hvbox_if : ?name:string -> bool -> int -> box
+  (** Conditionally wrap a format thunk with an hvbox with specified
+      indentation. *)
+
+  val hovbox_if : ?name:string -> bool -> int -> box
+  (** Conditionally wrap a format thunk with an hovbox with specified
+      indentation. *)
+end
+
 val cbox : ?name:string -> int -> t -> t
 (** Wrap a format thunk with a compacting box with specified indentation. *)
 

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -208,7 +208,17 @@ module Safe : sig
   val double_linebreak : sep
   (** Format a double linebreak. *)
 
+  type 'a non_empty
+
   type boxed
+
+  val one : t -> t non_empty
+
+  val add : t non_empty -> sep -> t -> t non_empty
+  (** [add b s t] adds the format [t] preceded by separator [s] after the
+      other formats of the box [b]. *)
+
+  val boxing : t non_empty -> boxed
 
   type box_kind
 
@@ -223,12 +233,6 @@ module Safe : sig
 
   val hovbox : box_kind
   (** Horizontal or vertical box. *)
-
-  val one : t -> boxed
-
-  val add : boxed -> sep -> t -> boxed
-  (** [add b s t] adds the format [t] preceded by separator [s] after the
-      other formats of the box [b]. *)
 
   val of_list : 'a list -> sep -> f:('a -> t) -> boxed
   (** [of_list xs s] generates a boxed value containing the elements of the

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -210,7 +210,19 @@ module Safe : sig
 
   type boxed
 
-  type box = boxed -> t
+  type box_kind
+
+  val cbox : box_kind
+  (** Compacting box. *)
+
+  val vbox : box_kind
+  (** Vertical box. *)
+
+  val hvbox : box_kind
+  (** Horizontal/vertical box. *)
+
+  val hovbox : box_kind
+  (** Horizontal or vertical box. *)
 
   val one : t -> boxed
 
@@ -218,32 +230,11 @@ module Safe : sig
   (** [add b s t] adds the format [t] preceded by separator [s] after the
       other formats of the box [b]. *)
 
-  val cbox : ?name:string -> int -> box
-  (** Wrap a format thunk with a compacting box with specified indentation. *)
+  val box : ?name:string -> box_kind -> int -> boxed -> t
+  (** Wrap a format thunk with a box with specified indentation. *)
 
-  val vbox : ?name:string -> int -> box
-  (** Wrap a format thunk with a vbox with specified indentation. *)
-
-  val hvbox : ?name:string -> int -> box
-  (** Wrap a format thunk with an hvbox with specified indentation. *)
-
-  val hovbox : ?name:string -> int -> box
-  (** Wrap a format thunk with an hovbox with specified indentation. *)
-
-  val cbox_if : ?name:string -> bool -> int -> box
-  (** Conditionally wrap a format thunk with a compacting sbox with specified
-      indentation. *)
-
-  val vbox_if : ?name:string -> bool -> int -> box
-  (** Conditionally wrap a format thunk with a vbox with specified
-      indentation. *)
-
-  val hvbox_if : ?name:string -> bool -> int -> box
-  (** Conditionally wrap a format thunk with an hvbox with specified
-      indentation. *)
-
-  val hovbox_if : ?name:string -> bool -> int -> box
-  (** Conditionally wrap a format thunk with an hovbox with specified
+  val box_if : ?name:string -> bool -> box_kind -> int -> boxed -> t
+  (** Conditionally wrap a format thunk with a box with specified
       indentation. *)
 end
 

--- a/src/Fmt.mli
+++ b/src/Fmt.mli
@@ -230,10 +230,22 @@ module Safe : sig
   (** [add b s t] adds the format [t] preceded by separator [s] after the
       other formats of the box [b]. *)
 
-  val box : ?name:string -> box_kind -> int -> boxed -> t
+  val of_list : 'a list -> sep -> f:('a -> t) -> boxed
+  (** [of_list xs s] generates a boxed value containing the elements of the
+      list [xs] each separated with separator [s]. *)
+
+  val box :
+    ?name:string -> ?box_singleton:bool -> box_kind -> int -> boxed -> t
   (** Wrap a format thunk with a box with specified indentation. *)
 
-  val box_if : ?name:string -> bool -> box_kind -> int -> boxed -> t
+  val box_if :
+       ?name:string
+    -> ?box_singleton:bool
+    -> bool
+    -> box_kind
+    -> int
+    -> boxed
+    -> t
   (** Conditionally wrap a format thunk with a box with specified
       indentation. *)
 end

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3335,9 +3335,9 @@ and fmt_signature c ctx itms =
     @@ fun c -> fmt_signature_item c (sub_sig ~ctx i)
   in
   let fmt_grp itms = list itms "@\n" fmt_grp in
-  Safe.(
-    box ~box_singleton:true hvbox 0
-      (of_list grps double_linebreak ~f:fmt_grp))
+  let open Safe in
+  box ~box_singleton:true hvbox 0
+    (of_list grps double_linebreak ~f:fmt_grp)
 
 and fmt_signature_item c ?ext {ast= si; _} =
   protect (Sig si)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3336,8 +3336,7 @@ and fmt_signature c ctx itms =
   in
   let fmt_grp itms = list itms "@\n" fmt_grp in
   let open Safe in
-  box ~box_singleton:true hvbox 0
-    (of_list grps double_linebreak ~f:fmt_grp)
+  box ~box_singleton:true hvbox 0 (of_list grps double_linebreak ~f:fmt_grp)
 
 and fmt_signature_item c ?ext {ast= si; _} =
   protect (Sig si)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -534,13 +534,12 @@ and fmt_attributes c ?(pre = noop) ?(suf = noop) ~key attrs =
         fmt_attribute_or_extension c pre (hvbox indent) (name, pld)
   in
   let num = List.length attrs in
-  let fmt_attr ~first ~last {attr_name; attr_payload; attr_loc} =
-    fmt_or_k first (open_hvbox 0) (fmt "@ ")
-    $ hvbox 0
-        (Cmts.fmt c attr_loc (fmt_attribute c key (attr_name, attr_payload)))
-    $ fmt_if_k last (close_box $ suf)
+  let fmt_attr {attr_name; attr_payload; attr_loc} =
+    hvbox 0
+      (Cmts.fmt c attr_loc (fmt_attribute c key (attr_name, attr_payload)))
   in
-  fmt_if_k (num > 0) (pre $ hvbox_if (num > 1) 0 (list_fl attrs fmt_attr))
+  let open Safe in
+  wrap_if_k (num > 0) pre suf (box hvbox 0 (of_list attrs space ~f:fmt_attr))
 
 and fmt_payload c ctx pld =
   protect (Pld pld)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3335,7 +3335,9 @@ and fmt_signature c ctx itms =
     @@ fun c -> fmt_signature_item c (sub_sig ~ctx i)
   in
   let fmt_grp itms = list itms "@\n" fmt_grp in
-  hvbox 0 (list grps "\n@;<1000 0>" fmt_grp)
+  Safe.(
+    box ~box_singleton:true hvbox 0
+      (of_list grps double_linebreak ~f:fmt_grp))
 
 and fmt_signature_item c ?ext {ast= si; _} =
   protect (Sig si)


### PR DESCRIPTION
I started working on a better way to use boxes:
- no box if there is less than 2 elements (we still need to detect `Fmt.noop` later), but can box 1 element if we use a flag (we should try to eliminate these cases later)
- enforce the use of a separator between 2 elements
- still compatible with the type `Fmt.t`

So far it is used inside a `Safe` module to distinguish with the legacy (soon unsafe) functions, the substitutions in legacy code would be done step by step as there is a lot of code to be modified, but it would be nice to use this API for bugfixes and new developments.

Add box names after #1083 is merged.