### PR TITLE
Improve and cleanup sequence_blank_line (fix empty_line_between)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### (master)
 
+  + Internal: Cleanup sequence_blank_line (#1075) (Jules Aguillon)
   + Improve: set conventional as the default profile (#1060) (Guillaume Petiot)
   + Fix precedence of Dot wrt Hash (#1058) (Guillaume Petiot)
   + Fix break in variant type definition to not exceed the margin (#1064) (Guillaume Petiot)

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -414,7 +414,7 @@ module Structure_item : Module_item with type t = structure_item = struct
     ||
     match Conf.(c1.module_item_spacing, c2.module_item_spacing) with
     | `Preserve, `Preserve ->
-        Source.empty_line_between s i1.pstr_loc i2.pstr_loc
+        Source.empty_line_between s i1.pstr_loc.loc_end i2.pstr_loc.loc_start
     | _ ->
         (not (is_simple (i1, c1)))
         || (not (is_simple (i2, c2)))
@@ -498,7 +498,7 @@ module Signature_item : Module_item with type t = signature_item = struct
     ||
     match Conf.(c1.module_item_spacing, c2.module_item_spacing) with
     | `Preserve, `Preserve ->
-        Source.empty_line_between s i1.psig_loc i2.psig_loc
+        Source.empty_line_between s i1.psig_loc.loc_end i2.psig_loc.loc_start
     | _ ->
         (not (is_simple (i1, c1)))
         || (not (is_simple (i2, c2)))

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -241,8 +241,8 @@ end
     [|] character and the first location begins a line and the start column
     of the first location is not greater than that of the second location. *)
 let is_adjacent t (l1 : Location.t) (l2 : Location.t) =
-  Option.value_map (Source.string_between t.source l1.loc_end l2.loc_start) ~default:false
-    ~f:(fun btw ->
+  Option.value_map (Source.string_between t.source l1.loc_end l2.loc_start)
+    ~default:false ~f:(fun btw ->
       match String.strip btw with
       | "" -> true
       | "|" ->

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -259,8 +259,7 @@ let infix_symbol_before t (loc : Location.t) =
   match Source.position_before t.source loc_end with
   | Some loc_start ->
       if loc_start.pos_cnum < loc.loc_end.pos_cnum then
-        let op_loc = {loc with loc_start} in
-        let str = Source.string_at t.source op_loc in
+        let str = Source.string_at t.source loc_start loc.loc_end in
         String.equal str ";" || Ast.is_infix_id str
       else false
   | None -> false

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -241,7 +241,7 @@ end
     [|] character and the first location begins a line and the start column
     of the first location is not greater than that of the second location. *)
 let is_adjacent t (l1 : Location.t) (l2 : Location.t) =
-  Option.value_map (Source.string_between t.source l1 l2) ~default:false
+  Option.value_map (Source.string_between t.source l1.loc_end l2.loc_start) ~default:false
     ~f:(fun btw ->
       match String.strip btw with
       | "" -> true
@@ -304,7 +304,7 @@ let add_cmts t ?prev ?next tbl loc cmts =
     if Conf.debug then
       List.iter cmtl ~f:(fun {Cmt.txt= cmt_txt; loc= cmt_loc} ->
           let string_between (l1 : Location.t) (l2 : Location.t) =
-            match Source.string_between t.source l1 l2 with
+            match Source.string_between t.source l1.loc_end l2.loc_start with
             | None -> "swapped"
             | Some s -> s
           in

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -136,7 +136,7 @@ let maybe_disabled_k c (loc : Location.t) (l : attributes) f k =
   else
     let loc = Source.extend_loc_to_include_attributes c.source loc l in
     Cmts.drop_inside c.cmts loc ;
-    let s = Source.string_at c.source loc in
+    let s = Source.string_at c.source loc.loc_start loc.loc_end in
     let indent_of_first_line = Position.column loc.loc_start in
     let l = String.split ~on:'\n' s in
     let l =

--- a/src/Params.ml
+++ b/src/Params.ml
@@ -17,7 +17,10 @@ let parens_or_begin_end (c : Conf.t) source ~loc =
   match c.exp_grouping with
   | `Parens -> `Parens
   | `Preserve ->
-      let str = String.lstrip (Source.string_at source loc) in
+      let str =
+        String.lstrip
+          (Source.string_at source loc.Location.loc_start loc.loc_end)
+      in
       if String.is_prefix ~prefix:"begin" str then `Begin_end else `Parens
 
 let wrap_exp (c : Conf.t) ?(disambiguate = false) ?(fits_breaks = true)

--- a/src/Source.ml
+++ b/src/Source.ml
@@ -28,9 +28,9 @@ let position_before t (pos : Lexing.position) =
   let pos_cnum_opt = String.rfindi t ~pos:pos.pos_cnum ~f in
   Option.map pos_cnum_opt ~f:(fun x -> {pos with pos_cnum= x + 1})
 
-let string_between t (l1 : Location.t) (l2 : Location.t) =
-  let pos = l1.loc_end.pos_cnum in
-  let len = Position.distance l1.loc_end l2.loc_start in
+let string_between t (p1 : Lexing.position) (p2 : Lexing.position) =
+  let pos = p1.pos_cnum in
+  let len = Position.distance p1 p2 in
   if
     len < 0 || pos < 0
     (* can happen e.g. if comment is within a parenthesized expression *)
@@ -41,11 +41,11 @@ let string_between t (l1 : Location.t) (l2 : Location.t) =
   then None
   else Some (String.sub t ~pos ~len)
 
-let empty_line_between t l1 l2 =
+let empty_line_between t p1 p2 =
   let non_whitespace _ c = not (Char.is_whitespace c) in
   let is_empty s = String.lfindi s ~f:non_whitespace |> Option.is_none in
-  Location.(l2.loc_end.pos_lnum - l1.loc_start.pos_lnum) > 1
-  && Option.for_all (string_between t l1 l2) ~f:is_empty
+  Lexing.(p2.pos_lnum - p1.pos_lnum) > 1
+  && Option.for_all (string_between t p1 p2) ~f:is_empty
 
 let string_at t loc_start loc_end =
   let pos = loc_start.Lexing.pos_cnum

--- a/src/Source.mli
+++ b/src/Source.mli
@@ -16,6 +16,9 @@ type t
 val create : string -> t
 
 val empty_line_between : t -> Lexing.position -> Lexing.position -> bool
+(** [empty_line_between t p1 p2] is [true] if there is an empty line between
+    [p1] and [p2]. The lines containing [p1] and [p2] are not considered
+    empty. *)
 
 val string_between : t -> Lexing.position -> Lexing.position -> string option
 

--- a/src/Source.mli
+++ b/src/Source.mli
@@ -21,7 +21,7 @@ val string_between : t -> Location.t -> Location.t -> string option
 
 val has_cmt_same_line_after : t -> Location.t -> bool
 
-val string_at : t -> Location.t -> string
+val string_at : t -> Lexing.position -> Lexing.position -> string
 
 val string_literal :
   t -> [`Normalize | `Preserve] -> Location.t -> string option
@@ -38,18 +38,14 @@ val position_before : t -> Lexing.position -> Lexing.position option
 (** [position_before s pos] returns the starting position of the token
     preceding the position [pos]. *)
 
-val loc_between : from:Location.t -> upto:Location.t -> Location.t
-(** [loc_between ~from ~upto] returns a location starting from [from] and
-    ending before [upto]. *)
-
 val tokens_between :
      t
   -> ?filter:(Parser.token -> bool)
-  -> from:Location.t
-  -> upto:Location.t
+  -> Lexing.position
+  -> Lexing.position
   -> (Parser.token * Location.t) list
-(** [tokens_between s ~filter ~from ~upto] returns the list of tokens
-    starting from [from] and ending before [upto] and respecting the [filter]
+(** [tokens_between s ~filter from upto] returns the list of tokens starting
+    from [from] and ending before [upto] and respecting the [filter]
     property. [from] must start before [upto]. *)
 
 val is_long_pexp_open : t -> Parsetree.expression -> bool

--- a/src/Source.mli
+++ b/src/Source.mli
@@ -15,9 +15,9 @@ type t
 
 val create : string -> t
 
-val empty_line_between : t -> Location.t -> Location.t -> bool
+val empty_line_between : t -> Lexing.position -> Lexing.position -> bool
 
-val string_between : t -> Location.t -> Location.t -> string option
+val string_between : t -> Lexing.position -> Lexing.position -> string option
 
 val has_cmt_same_line_after : t -> Location.t -> bool
 

--- a/test/passing/module_item_spacing-preserve.ml.ref
+++ b/test/passing/module_item_spacing-preserve.ml.ref
@@ -126,4 +126,5 @@ let cr0_em = 1 lsl 2
 (* with double semicolons *)
 
 let foo = fooooooooooooooooooooooooooooo
+
 let foo = fooooooooooooooooooooooooooooo

--- a/test/passing/module_item_spacing-preserve.ml.ref
+++ b/test/passing/module_item_spacing-preserve.ml.ref
@@ -1,7 +1,6 @@
 let z = this one is pretty looooooooooooooooooooooooooooooooooong
 
 and z = so is this oooooooooooooooooooooooooooooooooooooooooooone
-
 let f x = x + 1
 let z = this one is pretty looooooooooooooooooooooooooooooooooong
 let z = so is this oooooooooooooooooooooooooooooooooooooooooooone
@@ -18,7 +17,6 @@ let f = function
 let x = 1
 
 and y = 2
-
 let z = this one is pretty looooooooooooooooooooooooooooooooooong
 let z = so is this oooooooooooooooooooooooooooooooooooooooooooone
 
@@ -36,7 +34,6 @@ module M =
 
 let x = 1
 let y = 2
-
 let x = 1
 
 and y = 2
@@ -50,15 +47,11 @@ and z = so is this oooooooooooooooooooooooooooooooooooooooooooone
 type k = A | B | K of int * char * string | E
 
 let x = 1
-
 let z = this one (is short)
-
 let y = 2
-
 let w =
   this one is toooooooooooooooooooooooooo
     (looooooooooooooooooooooooog but is (originally a one - liner))
-
 let k = z
 
 module N = struct

--- a/test/passing/sequence-preserve.ml.opts
+++ b/test/passing/sequence-preserve.ml.opts
@@ -1,1 +1,1 @@
---sequence-blank-line=preserve-one
+--sequence-blank-line=preserve-one --max-iter=3

--- a/test/passing/sequence-preserve.ml.ref
+++ b/test/passing/sequence-preserve.ml.ref
@@ -60,7 +60,6 @@ let foo x y =
 let foo x y =
   (* Break should not cause an empty line *)
   do_some_setup x ;
-
   do_some_setup y ;
 
   important_function x ;

--- a/test/passing/sequence-preserve.ml.ref
+++ b/test/passing/sequence-preserve.ml.ref
@@ -86,7 +86,6 @@ let foo x y =
 (* This test require --max-iter=3 *)
 let _ =
   some statement ;
-
   (* comment with an empty line in it tricky *)
   an other statement
 

--- a/test/passing/sequence-preserve.ml.ref
+++ b/test/passing/sequence-preserve.ml.ref
@@ -57,6 +57,33 @@ let foo x y =
   another_important_function x y ;
   cleanup x y
 
+let foo x y =
+  (* Break should not cause an empty line *)
+  do_some_setup x ;
+
+  do_some_setup y ;
+
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
+let foo x y =
+  do_some_setup x ;
+  let () = do_some_setup y in
+  (* Empty line after let *)
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
+let foo x y =
+  (* in should not cause an empty line *)
+  let () = do_some_setup x in
+  do_some_setup y ;
+
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/sequence-preserve.ml.ref
+++ b/test/passing/sequence-preserve.ml.ref
@@ -83,6 +83,13 @@ let foo x y =
   another_important_function x y ;
   cleanup x y
 
+(* This test require --max-iter=3 *)
+let _ =
+  some statement ;
+
+  (* comment with an empty line in it tricky *)
+  an other statement
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/sequence.ml
+++ b/test/passing/sequence.ml
@@ -84,6 +84,14 @@ let foo x y =
   another_important_function x y ;
   cleanup x y
 
+(* This test require --max-iter=3 *)
+let _ =
+  some statement;
+  (* comment with an empty line in it
+
+     tricky *)
+  an other statement
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/sequence.ml
+++ b/test/passing/sequence.ml
@@ -56,6 +56,34 @@ let foo x y =
   another_important_function x y ;
   cleanup x y
 
+let foo x y =
+  (* Break should not cause an empty line *)
+  do_some_setup x
+  ;
+  do_some_setup y ;
+
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
+let foo x y =
+  do_some_setup x ;
+  let () = do_some_setup y in (* Empty line after let *)
+
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
+let foo x y =
+  (* in should not cause an empty line *)
+  let () = do_some_setup x
+  in
+  do_some_setup y ;
+
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/sequence.ml.opts
+++ b/test/passing/sequence.ml.opts
@@ -1,1 +1,1 @@
---sequence-blank-line=compact
+--sequence-blank-line=compact --max-iter=3

--- a/test/passing/sequence.ml.ref
+++ b/test/passing/sequence.ml.ref
@@ -48,6 +48,30 @@ let foo x y =
   another_important_function x y ;
   cleanup x y
 
+let foo x y =
+  (* Break should not cause an empty line *)
+  do_some_setup x ;
+  do_some_setup y ;
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
+let foo x y =
+  do_some_setup x ;
+  let () = do_some_setup y in
+  (* Empty line after let *)
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
+let foo x y =
+  (* in should not cause an empty line *)
+  let () = do_some_setup x in
+  do_some_setup y ;
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/sequence.ml.ref
+++ b/test/passing/sequence.ml.ref
@@ -72,6 +72,12 @@ let foo x y =
   another_important_function x y ;
   cleanup x y
 
+(* This test require --max-iter=3 *)
+let _ =
+  some statement ;
+  (* comment with an empty line in it tricky *)
+  an other statement
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =


### PR DESCRIPTION
This PR does:
- Change the API of Source a little to avoid creating `Location.t` values.
  I think we should only read those values, we should manipulate pairs of `Lexing.position` instead.
- Use `Lexing` internals to set the starting location to avoid offsetting them.
- Fix `Source.empty_line_between` to be `true` if there is at least one empty line instead of if all lines are empty.
- Change `sequence_blank_line` to use `Source.empty_line_between`