### PR TITLE
Build: use short form for action in src/dune

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### (master)
 
+  + Build: use short form for action in src/dune (#1076) (Etienne Millon)
   + Improve: Implement sequence-blank-line=preserve-one for let bindings (#1077) (Jules Aguillon)
   + Internal: Cleanup sequence_blank_line (#1075) (Jules Aguillon)
   + Improve: set conventional as the default profile (#1060) (Guillaume Petiot)

--- a/src/dune
+++ b/src/dune
@@ -22,9 +22,7 @@
  (libraries format_ import ocaml-migrate-parsetree odoc.model odoc.parser re uuseg uuseg.string))
 
 (rule
- (targets ocamlformat.1)
- (deps ocamlformat.exe)
- (action (with-stdout-to %{targets} (run ./ocamlformat.exe --help=groff))))
+ (with-stdout-to ocamlformat.1 (run ./ocamlformat.exe --help=groff)))
 
 (install
  (section bin)


### PR DESCRIPTION
Hi,

Just a small simplification:
- `(run)` always sets its first argument as dependency
- when the short form is used, targets are inferred from `(with-stdout-to)`

Thanks!