### PR TITLE
Improve: implement sequence-blank-line=preserve-one for let bindings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### (master)
 
+  + Improve: Implement sequence-blank-line=preserve-one for let bindings (#1077) (Jules Aguillon)
   + Internal: Cleanup sequence_blank_line (#1075) (Jules Aguillon)
   + Improve: set conventional as the default profile (#1060) (Guillaume Petiot)
   + Fix precedence of Dot wrt Hash (#1058) (Guillaume Petiot)

--- a/test/passing/sequence-preserve.ml.ref
+++ b/test/passing/sequence-preserve.ml.ref
@@ -69,6 +69,7 @@ let foo x y =
 let foo x y =
   do_some_setup x ;
   let () = do_some_setup y in
+
   (* Empty line after let *)
   important_function x ;
   another_important_function x y ;

--- a/test/passing/sequence-preserve.ml.ref
+++ b/test/passing/sequence-preserve.ml.ref
@@ -108,6 +108,13 @@ let foo x y =
   another_important_function x y ;
   cleanup x y
 
+let _ =
+  (* This let will wrap *)
+  let x = 1 in
+
+  (* some comment *)
+  next statement
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/sequence-preserve.ml.ref
+++ b/test/passing/sequence-preserve.ml.ref
@@ -90,6 +90,24 @@ let _ =
   (* comment with an empty line in it tricky *)
   an other statement
 
+let foo x y =
+  do_some_setup x ;
+  let* () = do_some_setup y in
+
+  (* Empty line after letop *)
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
+let foo x y =
+  (* letop in should not cause an empty line *)
+  let* () = do_some_setup x in
+  do_some_setup y ;
+
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/sequence.ml
+++ b/test/passing/sequence.ml
@@ -92,6 +92,24 @@ let _ =
      tricky *)
   an other statement
 
+let foo x y =
+  do_some_setup x ;
+  let* () = do_some_setup y in (* Empty line after letop *)
+
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
+let foo x y =
+  (* letop in should not cause an empty line *)
+  let* () = do_some_setup x
+  in
+  do_some_setup y ;
+
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/sequence.ml
+++ b/test/passing/sequence.ml
@@ -110,6 +110,15 @@ let foo x y =
   another_important_function x y ;
   cleanup x y
 
+let _ =
+  (* This let will wrap *)
+  let x =
+    1
+  in
+
+  (* some comment *)
+  next statement
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/sequence.ml.ref
+++ b/test/passing/sequence.ml.ref
@@ -94,6 +94,12 @@ let foo x y =
   another_important_function x y ;
   cleanup x y
 
+let _ =
+  (* This let will wrap *)
+  let x = 1 in
+  (* some comment *)
+  next statement
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/sequence.ml.ref
+++ b/test/passing/sequence.ml.ref
@@ -78,6 +78,22 @@ let _ =
   (* comment with an empty line in it tricky *)
   an other statement
 
+let foo x y =
+  do_some_setup x ;
+  let* () = do_some_setup y in
+  (* Empty line after letop *)
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
+let foo x y =
+  (* letop in should not cause an empty line *)
+  let* () = do_some_setup x in
+  do_some_setup y ;
+  important_function x ;
+  another_important_function x y ;
+  cleanup x y
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =


### PR DESCRIPTION
On top of https://github.com/ocaml-ppx/ocamlformat/pull/1075
Alternative to https://github.com/ocaml-ppx/ocamlformat/pull/1056

The 2 issues of #1056 are solved here and by #1075, fix #1047 