### PR TITLE
Internal: replace pre_break and if_newline by cbreak

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 
 #### Internal
 
+  + Sanitizing boxes and getting closer to std Format (#1090) (Guillaume Petiot)
   + Use opt and fmt_opt to simplify formatting (#1150) (Guillaume Petiot)
   + Replace inplace formatting by dune staging for make fmt (#1151) (Guillaume Petiot)
   + Refactor code that interprets CLI options (#1127) (Jules Aguillon)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
 
 #### Internal
 
-  + Sanitizing boxes and getting closer to std Format (#1090) (Guillaume Petiot)
+  + Replace pre_break and if_newline by cbreak (#1090) (Guillaume Petiot)
   + Use opt and fmt_opt to simplify formatting (#1150) (Guillaume Petiot)
   + Replace inplace formatting by dune staging for make fmt (#1151) (Guillaume Petiot)
   + Refactor code that interprets CLI options (#1127) (Jules Aguillon)

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -43,6 +43,8 @@ let pp_color_k color_code k fs =
 
 (** Break hints and format strings --------------------------------------*)
 
+let cbreak ~fits ~breaks fs = Format.pp_print_custom_break fs ~fits ~breaks
+
 let break n o fs = Format.pp_print_break fs n o
 
 let noop (_ : Format.formatter) = ()

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -110,11 +110,6 @@ let break_unless_newline n o fs = Format.pp_print_or_newline fs n o "" ""
 
 let or_newline fits breaks fs = Format.pp_print_or_newline fs 1 0 fits breaks
 
-(** Conditional on immediately preceding a line break -------------------*)
-
-let pre_break n s o fs =
-  Format.pp_print_custom_break fs ~fits:("", n, "") ~breaks:(s, o, "")
-
 (** Conditional on breaking of enclosing box ----------------------------*)
 
 let fits_breaks ?(force_fit_if = false) ?(force_break_if = false)

--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -114,11 +114,6 @@ val or_newline : string -> string -> t
 (** [or_newline fits breaks] prints [fits] if the line has not just been
     broken, and otherwise prints [breaks]. *)
 
-(** Conditional on immediately preceding a line break -------------------*)
-
-val pre_break : int -> string -> int -> t
-(** Format a pre break hint. *)
-
 (** Conditional on breaking of enclosing box ----------------------------*)
 
 val fits_breaks :

--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -42,6 +42,14 @@ val protect : t -> on_error:(exn -> unit) -> t
 val break : int -> int -> t
 (** Format a break hint. *)
 
+val cbreak : fits:string * int * string -> breaks:string * int * string -> t
+(** Format a custom break.
+
+    - [fits = (a, b, c)] formats a string [a], [b] spaces and a string [c] if
+      the line does not break.
+    - [breaks = (d, e, f)] formats a string [d], [e] spaces and a string [f]
+      if the line breaks. *)
+
 val noop : t
 (** Format nothing. *)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -301,7 +301,9 @@ let fmt_constant c ~loc ?epi const =
             else if Char.equal next.[0] ' ' then
               fmt_if_k print_ln (str "\\n")
               $ cbreak ~fits:("", 0, "") ~breaks:("\\", -1, "\\")
-            else fmt_if_k print_ln (str "\\n") $ pre_break 0 "\\" 0
+            else
+              fmt_if_k print_ln (str "\\n")
+              $ cbreak ~fits:("", 0, "") ~breaks:("\\", 0, "")
           in
           let epi = match next with Some _ -> noop | None -> epi in
           fmt_words ~epi mode curr $ opt next fmt_next

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -285,7 +285,8 @@ let fmt_constant c ~loc ?epi const =
           let fmt_word ~prev:_ curr ~next =
             match next with
             | Some "" -> str curr $ str " "
-            | Some _ -> str curr $ pre_break 1 " \\" 0
+            | Some _ ->
+                str curr $ cbreak ~fits:("", 1, "") ~breaks:(" \\", 0, "")
             | _ -> str curr
           in
           hovbox_if (List.length words > 1) 0 (list_pn words fmt_word $ epi)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -300,7 +300,7 @@ let fmt_constant c ~loc ?epi const =
             if String.is_empty next then fmt_if_k print_ln (str "\\n")
             else if Char.equal next.[0] ' ' then
               fmt_if_k print_ln (str "\\n")
-              $ pre_break 0 "\\" (-1) $ if_newline "\\"
+              $ cbreak ~fits:("", 0, "") ~breaks:("\\", -1, "\\")
             else fmt_if_k print_ln (str "\\n") $ pre_break 0 "\\" 0
           in
           let epi = match next with Some _ -> noop | None -> epi in

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -56,8 +56,6 @@ let str_normalized ?(escape = escape_all) s =
   |> List.filter ~f:(Fn.non String.is_empty)
   |> fun s -> list s "@ " (fun s -> escape s |> str)
 
-let fmt_if_not_empty lst fmt = fmt_if (not (List.is_empty lst)) fmt
-
 let ign_loc ~f with_loc = f with_loc.Location_.value
 
 let fmt_verbatim_block s =
@@ -120,59 +118,58 @@ let list_block_elem elems f =
       in
       f elem $ break)
 
-(* Format each element with [fmt_elem] *)
-let fmt_styled style fmt_elem elems =
-  let s =
-    match style with
-    | `Bold -> "b"
-    | `Italic -> "i"
-    | `Emphasis -> "e"
-    | `Superscript -> "^"
-    | `Subscript -> "_"
+let space_elt : inline_element with_location =
+  Location_.(at (span []) (`Space ""))
+
+let rec fmt_inline_elements elements =
+  let wrap_elements opn cls ~always_wrap hd = function
+    | [] -> wrap_if always_wrap opn cls hd
+    | tl -> wrap opn cls (hd $ fmt_inline_elements (space_elt :: tl))
   in
-  wrap "{" "}"
-    (str_normalized s $ fmt_if_not_empty elems "@ " $ list elems "" fmt_elem)
-
-let rec fmt_inline_element ?(space = false) = function
-  | `Space _ -> fmt "@ "
-  | `Word w ->
-      (* Escape lines starting with '+' or '-' *)
-      let escape =
-        if String.length w > 0 && Char.(w.[0] = '+' || w.[0] = '-') then "\\"
-        else ""
-      in
-      let break = cbreak ~fits:("", 1, "") ~breaks:("", 0, escape) in
-      fmt_if_k space break $ str_normalized w
-  | `Code_span s ->
-      let s = escape_brackets s in
-      fmt_if space "@ "
-      $ hovbox 0 (wrap "[" "]" (str_normalized ~escape:escape_brackets s))
-  | `Raw_markup (lang, s) ->
-      let lang =
-        match lang with Some l -> str_normalized l $ str ":" | None -> noop
-      in
-      fmt_if space "@ " $ wrap "{%%" "%%}" (lang $ str s)
-  | `Styled (style, elems) ->
-      fmt_if space "@ "
-      $ fmt_styled style (ign_loc ~f:fmt_inline_element) elems
-  | `Reference (_kind, ref, txt) ->
-      let ref = fmt "{!" $ fmt_reference ref $ fmt "}" in
-      fmt_if space "@ "
-      $
-      if List.is_empty txt then ref
-      else wrap "{" "}" (ref $ fmt_inline_elements ~space:true txt)
-  | `Link (url, txt) -> (
-      let url = wrap "{:" "}" (str_normalized url) in
-      fmt_if space "@ "
-      $
-      match txt with
-      | [] -> url
-      | txt -> wrap "{" "}" (url $ fmt_inline_elements ~space:true txt) )
-
-and fmt_inline_elements ?space txt =
-  list_fl txt (fun ~first ~last:_ x ->
-      let space = if first then space else None in
-      ign_loc ~f:(fmt_inline_element ?space) x)
+  let rec aux space = function
+    | [] -> space
+    | `Space _ :: t -> aux (fmt "@ ") t
+    | `Word w :: t ->
+        (* Escape lines starting with '+' or '-' *)
+        let escape =
+          if String.length w > 0 && Char.(w.[0] = '+' || w.[0] = '-') then
+            "\\"
+          else ""
+        in
+        cbreak ~fits:("", 1, "") ~breaks:("", 0, escape)
+        $ str_normalized w $ aux noop t
+    | `Code_span s :: t ->
+        let s = escape_brackets s in
+        space
+        $ hovbox 0 (wrap "[" "]" (str_normalized ~escape:escape_brackets s))
+        $ aux noop t
+    | `Raw_markup (lang, s) :: t ->
+        let lang =
+          match lang with
+          | Some l -> str_normalized l $ str ":"
+          | None -> noop
+        in
+        space $ wrap "{%%" "%%}" (lang $ str s) $ aux noop t
+    | `Styled (style, elems) :: t ->
+        let s =
+          match style with
+          | `Bold -> "b"
+          | `Italic -> "i"
+          | `Emphasis -> "e"
+          | `Superscript -> "^"
+          | `Subscript -> "_"
+        in
+        space
+        $ wrap_elements "{" "}" ~always_wrap:true (str_normalized s) elems
+        $ aux noop t
+    | `Reference (_kind, rf, txt) :: t ->
+        let rf = wrap "{!" "}" (fmt_reference rf) in
+        space $ wrap_elements "{" "}" ~always_wrap:false rf txt $ aux noop t
+    | `Link (url, txt) :: t ->
+        let url = wrap "{:" "}" (str_normalized url) in
+        space $ wrap_elements "{" "}" ~always_wrap:false url txt $ aux noop t
+  in
+  aux noop (List.map elements ~f:(ign_loc ~f:Fn.id))
 
 and fmt_nestable_block_element c = function
   | `Paragraph elems -> fmt_inline_elements elems
@@ -251,9 +248,10 @@ let fmt_block_element c = function
         | Some lbl -> str ":" $ str_normalized lbl
         | None -> fmt ""
       in
-      hovbox 0
-        (wrap "{" "}"
-           (str lvl $ lbl $ fmt_inline_elements ~space:true elems))
+      let elems =
+        if List.is_empty elems then elems else space_elt :: elems
+      in
+      hovbox 0 (wrap "{" "}" (str lvl $ lbl $ fmt_inline_elements elems))
   | #nestable_block_element as elm ->
       hovbox 0 (fmt_nestable_block_element c elm)
 

--- a/test/passing/doc_comments-after.ml.ref
+++ b/test/passing/doc_comments-after.ml.ref
@@ -256,12 +256,12 @@ exception A of int
 
 module A = struct
   module B = struct
-    (** It does not try to saturate (2) A = B + C /\ B = D + E => A = C + D
-        \+ E Nor combine more than 2 equations (3) A = B + C /\ B = D + E /\
-        F = C + D + E => A = F
+    (** It does not try to saturate (2) A = B + C /\ B = D + E => A = C + D +
+        E Nor combine more than 2 equations (3) A = B + C /\ B = D + E /\ F =
+        C + D + E => A = F
 
-        xxxxxxxxxxxxxxxxxxxxxxxxxxx (2) A = B + C /\ B = D + E => A = C + D
-        \- E *)
+        xxxxxxxxxxxxxxxxxxxxxxxxxxx (2) A = B + C /\ B = D + E => A = C + D -
+        E *)
     let a b = ()
   end
 end

--- a/test/passing/doc_comments-after.ml.ref
+++ b/test/passing/doc_comments-after.ml.ref
@@ -256,12 +256,12 @@ exception A of int
 
 module A = struct
   module B = struct
-    (** It does not try to saturate (2) A = B + C /\ B = D + E => A = C + D +
-        E Nor combine more than 2 equations (3) A = B + C /\ B = D + E /\ F =
-        C + D + E => A = F
+    (** It does not try to saturate (1a) A = B + C /\ B = D + E => A = C + D
+        \+ E Nor combine more than 2 equations (1b) A = B + C /\ B = D + E /\
+        F = C + D + E => A = F
 
-        xxxxxxxxxxxxxxxxxxxxxxxxxxx (2) A = B + C /\ B = D + E => A = C + D -
-        E *)
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxx (2) A = B + C /\ B = D + E => A = C + D
+        \- E *)
     let a b = ()
   end
 end

--- a/test/passing/doc_comments-before.ml.ref
+++ b/test/passing/doc_comments-before.ml.ref
@@ -256,12 +256,12 @@ exception A of int
 
 module A = struct
   module B = struct
-    (** It does not try to saturate (2) A = B + C /\ B = D + E => A = C + D
-        \+ E Nor combine more than 2 equations (3) A = B + C /\ B = D + E /\
-        F = C + D + E => A = F
+    (** It does not try to saturate (2) A = B + C /\ B = D + E => A = C + D +
+        E Nor combine more than 2 equations (3) A = B + C /\ B = D + E /\ F =
+        C + D + E => A = F
 
-        xxxxxxxxxxxxxxxxxxxxxxxxxxx (2) A = B + C /\ B = D + E => A = C + D
-        \- E *)
+        xxxxxxxxxxxxxxxxxxxxxxxxxxx (2) A = B + C /\ B = D + E => A = C + D -
+        E *)
     let a b = ()
   end
 end

--- a/test/passing/doc_comments-before.ml.ref
+++ b/test/passing/doc_comments-before.ml.ref
@@ -256,12 +256,12 @@ exception A of int
 
 module A = struct
   module B = struct
-    (** It does not try to saturate (2) A = B + C /\ B = D + E => A = C + D +
-        E Nor combine more than 2 equations (3) A = B + C /\ B = D + E /\ F =
-        C + D + E => A = F
+    (** It does not try to saturate (1a) A = B + C /\ B = D + E => A = C + D
+        \+ E Nor combine more than 2 equations (1b) A = B + C /\ B = D + E /\
+        F = C + D + E => A = F
 
-        xxxxxxxxxxxxxxxxxxxxxxxxxxx (2) A = B + C /\ B = D + E => A = C + D -
-        E *)
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxx (2) A = B + C /\ B = D + E => A = C + D
+        \- E *)
     let a b = ()
   end
 end

--- a/test/passing/doc_comments.ml
+++ b/test/passing/doc_comments.ml
@@ -257,11 +257,11 @@ exception A of int
 module A = struct
   module B = struct
     (** It does not try to saturate
-        (2) A = B + C  /\  B = D + E  =>  A = C + D + E
+        (1a) A = B + C  /\  B = D + E  =>  A = C + D + E
         Nor combine more than 2 equations
-        (3) A = B + C  /\  B = D + E  /\  F = C + D + E  =>  A = F
+        (1b) A = B + C  /\  B = D + E  /\  F = C + D + E  =>  A = F
 
-        xxxxxxxxxxxxxxxxxxxxxxxxxxx
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxx
         (2) A = B + C  /\  B = D + E  =>  A = C + D - E
     *)
     let a b = ()

--- a/test/passing/doc_comments.ml.ref
+++ b/test/passing/doc_comments.ml.ref
@@ -256,12 +256,12 @@ exception A of int
 
 module A = struct
   module B = struct
-    (** It does not try to saturate (2) A = B + C /\ B = D + E => A = C + D
-        \+ E Nor combine more than 2 equations (3) A = B + C /\ B = D + E /\
-        F = C + D + E => A = F
+    (** It does not try to saturate (2) A = B + C /\ B = D + E => A = C + D +
+        E Nor combine more than 2 equations (3) A = B + C /\ B = D + E /\ F =
+        C + D + E => A = F
 
-        xxxxxxxxxxxxxxxxxxxxxxxxxxx (2) A = B + C /\ B = D + E => A = C + D
-        \- E *)
+        xxxxxxxxxxxxxxxxxxxxxxxxxxx (2) A = B + C /\ B = D + E => A = C + D -
+        E *)
     let a b = ()
   end
 end

--- a/test/passing/doc_comments.ml.ref
+++ b/test/passing/doc_comments.ml.ref
@@ -256,12 +256,12 @@ exception A of int
 
 module A = struct
   module B = struct
-    (** It does not try to saturate (2) A = B + C /\ B = D + E => A = C + D +
-        E Nor combine more than 2 equations (3) A = B + C /\ B = D + E /\ F =
-        C + D + E => A = F
+    (** It does not try to saturate (1a) A = B + C /\ B = D + E => A = C + D
+        \+ E Nor combine more than 2 equations (1b) A = B + C /\ B = D + E /\
+        F = C + D + E => A = F
 
-        xxxxxxxxxxxxxxxxxxxxxxxxxxx (2) A = B + C /\ B = D + E => A = C + D -
-        E *)
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxx (2) A = B + C /\ B = D + E => A = C + D
+        \- E *)
     let a b = ()
   end
 end

--- a/test/passing/doc_comments.mli
+++ b/test/passing/doc_comments.mli
@@ -440,3 +440,5 @@ let fooooooooooooooooo =
     oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
 
 (** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooo {b eee + eee eee} *)
+
+(** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooooooo {b + eee + eee eee} *)

--- a/test/passing/doc_comments.mli
+++ b/test/passing/doc_comments.mli
@@ -438,3 +438,5 @@ let fooooooooooooooooo =
 
 (** {e foooooooo oooooooooo ooooooooo ooooooooo} {{!some ref} fooooooooooooo
     oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
+
+(** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooo {b eee + eee eee} *)

--- a/test/passing/doc_comments.mli.ref
+++ b/test/passing/doc_comments.mli.ref
@@ -406,3 +406,6 @@ end
 
 (** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooo {b eee
     \+ eee eee} *)
+
+(** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooooooo {b
+    \+ eee + eee eee} *)

--- a/test/passing/doc_comments.mli.ref
+++ b/test/passing/doc_comments.mli.ref
@@ -403,3 +403,6 @@ end
 
 (** {e foooooooo oooooooooo ooooooooo ooooooooo} {{!some ref} fooooooooooooo
     oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
+
+(** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooo {b eee
+    \+ eee eee} *)


### PR DESCRIPTION
- export a function `Fmt.cbreak` to have a direct interface to the swiss army knife `custom_break` function from Format, the objective is to use this function instead of the `if_newline`, `or_newline` and `fits_breaks` functions to get closer to the original Format library. If we manage to achieve this, only `max-indent` would have to either be merged into Format or me implemented in another way.
- some calls to `if_newline` are removed
- all calls to `pre_break` are removed (often used in addition to `if_newline` so they can be merged by using `cbreak`)
- the diff in `doc_comments` is a fix as we now reach the 77 col margin

No diff with the `conventional` and `ocamlformat` profiles.

diff with `janestreet` profile: (we now reach the 90 col margin)
```diff
diff --git a/infer/src/integration/Driver.ml b/infer/src/integration/Driver.ml
index 2b6f00462..44161fc96 100644
--- a/infer/src/integration/Driver.ml
+++ b/infer/src/integration/Driver.ml
@@ -158,11 +158,7 @@ let command_error_handling ~always_die ~prog ~args = function
         L.external_error
       else L.die InternalError
     in
-    log
-      "%a:@\n  %s"
-      Pp.cli_args
-      (prog :: args)
-      (Unix.Exit_or_signal.to_string_hum status)
+    log "%a:@\n  %s" Pp.cli_args (prog :: args) (Unix.Exit_or_signal.to_string_hum status)
 ;;
diff --git a/src/jbuild_support/string_with_vars.ml b/src/jbuild_support/string_with_vars.ml
index 67455697..f77d875c 100644
--- a/src/jbuild_support/string_with_vars.ml
+++ b/src/jbuild_support/string_with_vars.ml
@@ -95,9 +95,8 @@ module Upgrade_var = struct
     let static_vars =
       [ ( "<"
         , Deleted
-            "Use a named dependency instead:\n\n\
-            \  (deps (:x <dep>) ...)\n\
-            \   ... %{x} ..." )
+            "Use a named dependency instead:\n\n  (deps (:x <dep>) ...)\n   ... %{x} ..."
+        )
       ; "@", Renamed_to "targets"
```

Regression with test_branch with no option selected:
```diff
diff --git a/infer/src/clang/cFrontend.ml b/infer/src/clang/cFrontend.ml
index 26631c440..38fd771db 100644
--- a/infer/src/clang/cFrontend.ml
+++ b/infer/src/clang/cFrontend.ml
@@ -50,8 +50,7 @@ let do_source_file (translation_unit_context : CFrontend_config.translation_unit
   L.(debug Capture Verbose)
     "@\n Start building call/cfg graph for '%a'....@\n" SourceFile.pp source_file ;
   let cfg = compute_icfg translation_unit_context tenv ast in
-  L.(debug Capture Verbose)
-    "@\n End building call/cfg graph for '%a'.@\n" SourceFile.pp source_file ;
+  L.(debug Capture Verbose) "@\n End building call/cfg graph for '%a'.@\n" SourceFile.pp source_file ;
   (* This part below is a boilerplate in every frontends. *)
   (* This could be moved in the cfg_infer module *)
   NullabilityPreanalysis.analysis cfg tenv ;
```