### PR TITLE
Fix: adjust definition of Location.is_single_line to reflect margin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@
   + Fix grouping of horizontally aligned comments (#1209) (Guillaume Petiot)
   + Fix dropped comments around module pack expressions (#1214) (Jules Aguillon)
   + Fix regression of comment position in list patterns (#1141) (Josh Berdine)
+  + Fix: adjust definition of Location.is_single_line to reflect margin (#1102) (Josh Berdine)
 
 #### Documentation
 

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -189,6 +189,8 @@ module Location = struct
     Comparable.lexicographic [compare_start; descending compare_end; compare]
 
   let is_single_line x margin =
+    (* The last character of a line can exceed the margin if it is not
+       preceded by a break. Adding 1 here is a workaround for this bug. *)
     width x <= margin + 1 && x.loc_start.pos_lnum = x.loc_end.pos_lnum
 
   let smallest loc stack =

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -189,7 +189,7 @@ module Location = struct
     Comparable.lexicographic [compare_start; descending compare_end; compare]
 
   let is_single_line x margin =
-    width x <= margin && x.loc_start.pos_lnum = x.loc_end.pos_lnum
+    width x <= margin + 1 && x.loc_start.pos_lnum = x.loc_end.pos_lnum
 
   let smallest loc stack =
     let min a b = if width a < width b then a else b in

--- a/test/failing/single_line.mli
+++ b/test/failing/single_line.mli
@@ -1,0 +1,6 @@
+[@@@ocamlformat "module-item-spacing=compact"]
+
+val xx_xxxxxxxx : t -> bool
+val xx_xxxxxxxx : t -> bool
+val xxxxxxxx : t -> [> `Xxxxxxx | `Xxxxxxxxxxx | `Xxxxxxxxxx | `Xxxxxxxxxxxxx]
+val xxxxx : t -> t -> t Xxx.t option


### PR DESCRIPTION
This seems to be needed to be consistent with recent changes to the
handling of the margin. Otherwise, it is possible to have a one-liner
structure item of just the right width that is_single_line does not
hold, resulting in the one-liner being surrounded by open lines.