### PR TITLE
Fix unstable comment in variant decl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 #### Bug fixes
 
-  + Fix: Unstable comment in variant declarations (#1108) (Jules Aguillon)
+  + Fix unstable comment in variant declarations (#1108) (Jules Aguillon)
   + Fix: break multiline comments (#1122) (Guillaume Petiot)
   + Fix: types on named arguments were wrapped incorrectly when preceding comments (#1124) (Guillaume Petiot)
   + Fix the indentation produced by max-indent (#1118) (Guillaume Petiot)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 #### Bug fixes
 
+  + Fix: Unstable comment in variant declarations (#1108) (Jules Aguillon)
   + Fix: types on named arguments were wrapped incorrectly when preceding comments (#1124) (Guillaume Petiot)
   + Fix the indentation produced by max-indent (#1118) (Guillaume Petiot)
   + Fix break after Psig_include depending on presence of docstring (#1125) (Guillaume Petiot)

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3091,6 +3091,8 @@ and fmt_constructor_declaration c ctx ~max_len_name ~first ~last:_ cstr_decl
   in
   let has_cmt_before = Cmts.has_before c.cmts pcd_loc in
   let sparse = Poly.( = ) c.conf.type_decl `Sparse in
+  (* Force break if comment before pcd_loc, it would interfere with an
+     eventual comment placed after the previous constructor *)
   fmt_if_k (not first) (fmt_or (sparse || has_cmt_before) "@;<1000 0>" "@ ")
   $ Cmts.fmt_before ~epi:(break 1000 0) c pcd_loc
   $ Cmts.fmt_before c loc

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3089,11 +3089,13 @@ and fmt_constructor_declaration c ctx ~max_len_name ~first ~last:_ cstr_decl
          (str pad)
          (fits_breaks ~level:3 "" pad))
   in
-  fmt_if (not first)
-    (match c.conf.type_decl with `Sparse -> "@;<1000 0>" | `Compact -> "@ ")
-  $ Cmts.fmt_before c pcd_loc $ Cmts.fmt_before c loc
+  let has_cmt_before = Cmts.has_before c.cmts pcd_loc in
+  let sparse = Poly.( = ) c.conf.type_decl `Sparse in
+  fmt_if_k (not first) (fmt_or (sparse || has_cmt_before) "@;<1000 0>" "@ ")
+  $ Cmts.fmt_before ~epi:(break 1000 0) c pcd_loc
+  $ Cmts.fmt_before c loc
   $ fmt_or_k first (if_newline "| ") (str "| ")
-  $ hvbox 0
+  $ hvbox ~name:"constructor_decl" 0
       ( hovbox 2
           ( hvbox 2
               ( Cmts.fmt c loc

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -206,3 +206,17 @@ type prefix = {
   sib_extend : int; (* extended sib index bit *)
   (** add more as needed *)
 }
+
+type t =
+  | A (* A *)
+  (* | B *)
+  | C
+
+type t =
+  (* | B *)
+  | A (* A *)
+  | C
+
+type t =
+  | A (* A *) (* | B *)
+  | C

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -287,3 +287,19 @@ let _ =
 
 type prefix =
   {sib_extend: int  (** add more as needed *) (* extended sib index bit *)}
+
+type t =
+  | A (* A *)
+  (* | B *)
+  | C
+
+type t =
+  (* | B *)
+  | A
+  (* A *)
+  | C
+
+type t =
+  | A (* A *)
+  (* | B *)
+  | C


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/989

There is a regression:

Surprisingly, it appears only once with `test_branch`

```diff
-type blabla = Constr_a (* constr a *) | Constr_b
+type blabla =
+  | Constr_a
+  (* constr a *)
+  | Constr_b
```

The example from the issue formats badly, but that's unrelated:

```diff
 and b =
   | A (* A *)
   | B (* B *)
-    (* C ? *)
-  | D (* D *)
-    (* E *)
+  (* C ? *)
+  | D
+
+(* D *)
+(* E *)
```