### PR TITLE
Fix the indentation produced by max-indent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### Bug fixes
 
+  + Fix the indentation produced by max-indent (#1118) (Guillaume Petiot)
   + Fix break after Psig_include depending on presence of docstring (#1125) (Guillaume Petiot)
 
 #### Internal
@@ -47,7 +48,6 @@
 
 #### Bug fixes
 
-  + Fix the indentation produced by max-indent (#997) (Guillaume Petiot)
   + Fix unstabilizing comments on assignments (#1093) (Guillaume Petiot)
   + Fix the default value documentation for `max-indent` (#1105) (Guillaume Petiot)
   + Fix closing parenthesis exceeding the margin in function application (#1098) (Jules Aguillon)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@
 
 #### Bug fixes
 
+  + Fix the indentation produced by max-indent (#997) (Guillaume Petiot)
   + Fix unstabilizing comments on assignments (#1093) (Guillaume Petiot)
   + Fix the default value documentation for `max-indent` (#1105) (Guillaume Petiot)
   + Fix closing parenthesis exceeding the margin in function application (#1098) (Jules Aguillon)

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -23,7 +23,11 @@ let ( >$ ) f g x = f $ g x
 
 let set_margin n fs = Format.pp_set_geometry fs ~max_indent:n ~margin:(n + 1)
 
-let set_max_indent n fs = Format.pp_set_max_newline_offset fs n
+let max_indent = ref None
+
+let set_max_indent n fs =
+  ignore fs ;
+  max_indent := Some n
 
 let eval fs t = t fs
 
@@ -201,19 +205,25 @@ let debug_box_close fs =
         (fun fs -> Format.fprintf fs "@<0>]")
         fs )
 
+let apply_max_indent n = Option.value_map !max_indent ~f:(min n) ~default:n
+
 let open_box ?name n fs =
+  let n = apply_max_indent n in
   debug_box_open ?name "b" n fs ;
   Format.pp_open_box fs n
 
 and open_vbox ?name n fs =
+  let n = apply_max_indent n in
   debug_box_open ?name "v" n fs ;
   Format.pp_open_vbox fs n
 
 and open_hvbox ?name n fs =
+  let n = apply_max_indent n in
   debug_box_open ?name "hv" n fs ;
   Format.pp_open_hvbox fs n
 
 and open_hovbox ?name n fs =
+  let n = apply_max_indent n in
   debug_box_open ?name "hov" n fs ;
   Format.pp_open_hovbox fs n
 

--- a/src/Fmt.ml
+++ b/src/Fmt.ml
@@ -25,9 +25,7 @@ let set_margin n fs = Format.pp_set_geometry fs ~max_indent:n ~margin:(n + 1)
 
 let max_indent = ref None
 
-let set_max_indent n fs =
-  ignore fs ;
-  max_indent := Some n
+let set_max_indent n (_ : Format.formatter) = max_indent := Some n
 
 let eval fs t = t fs
 

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1658,7 +1658,13 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    $ fmt
                        ( match xbody.ast.pexp_desc with
                        | Pexp_function _ -> "@ "
-                       | _ -> "@;<1 2>" )
+                       | _ -> (
+                         (* Avoid the "double indentation" of the application
+                            and the function matching when the
+                            max-indentation is constrained. *)
+                         match c.conf.max_indent with
+                         | Some i when i <= 2 -> "@ "
+                         | _ -> "@;<1 2>" ) )
                    $ cbox 0 (fmt_expression c ?box xbody)
                    $ str ")" $ Cmts.fmt_after c pexp_loc )
                $ fmt_atrs ))

--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -1660,8 +1660,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                        | Pexp_function _ -> "@ "
                        | _ -> (
                          (* Avoid the "double indentation" of the application
-                            and the function matching when the
-                            max-indentation is constrained. *)
+                            and the function matching when the [max-indent]
+                            option is set. *)
                          match c.conf.max_indent with
                          | Some i when i <= 2 -> "@ "
                          | _ -> "@;<1 2>" ) )

--- a/test/passing/max_indent.ml
+++ b/test/passing/max_indent.ml
@@ -1,28 +1,27 @@
 let () =
   fooooo
   |> List.iter (fun x ->
-    let x = x $ y in
-    fooooooooooo x)
+         let x = x $ y in
+         fooooooooooo x)
 
 let () =
   fooooo
   |> List.iter
-    (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line
-      ->
-        let x =
-          some_really_really_really_long_name_that_doesn't_fit_on_the_line
-          $ y
-        in
-        fooooooooooo x)
+       (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line
+            ->
+         let x =
+           some_really_really_really_long_name_that_doesn't_fit_on_the_line
+           $ y
+         in
+         fooooooooooo x)
 
 let foooooooooo =
   foooooooooooooooooooooo
   |> Option.bind ~f:(function
-    | Pform.Expansion.Var (Values l) -> Some (static l)
-    | Macro (Ocaml_config, s) ->
-      Some
-        (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
-    | Macro (Env, s) -> Option.map ~f:static (expand_env t var s))
+       | Pform.Expansion.Var (Values l) -> Some (static l)
+       | Macro (Ocaml_config, s) ->
+         Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
+       | Macro (Env, s) -> Option.map ~f:static (expand_env t var s))
 
 let fooooooooooooo =
   match lbls with
@@ -37,30 +36,30 @@ let fooooooooooooo =
 let foooooooooo =
   match fooooooooooooo with
   | Pexp_construct
-    ({txt= Lident "::"; _}, Some {pexp_desc= Pexp_tuple [_; e2]; _}) ->
+      ({txt= Lident "::"; _}, Some {pexp_desc= Pexp_tuple [_; e2]; _}) ->
     if is_sugared_list e2 then Some (Semi, Non)
     else Some (ColonColon, if exp == e2 then Right else Left)
 
 let foooooooooooooooooooooooooo =
   match foooooooooooooooooooooo with
   | Pexp_apply
-    ( { pexp_desc=
-      Pexp_ident
-        {txt= Lident (("~-" | "~-." | "~+" | "~+.") as op); loc}
+      ( { pexp_desc=
+            Pexp_ident
+              {txt= Lident (("~-" | "~-." | "~+" | "~+.") as op); loc}
         ; pexp_loc
         ; pexp_attributes= []
         ; _ }
-    , [(Nolabel, e1)] ) ->
+      , [(Nolabel, e1)] ) ->
     fooooooooooooooooooooooooooooooooooooo
 
 let fooooooooooooooooooooooooooooooooooo =
   match foooooooooooooooooooooo with
   | ( Ppat_constraint
-    ( ({ppat_desc= Ppat_var _; _} as p0)
-    , {ptyp_desc= Ptyp_poly ([], t0); _} )
+        ( ({ppat_desc= Ppat_var _; _} as p0)
+        , {ptyp_desc= Ptyp_poly ([], t0); _} )
     , Pexp_constraint (e0, t1) )
     when Poly.(t0 = t1) ->
-      m.value_binding m
+    m.value_binding m
 
 let foooooooooooooooooooooooooooooooo =
   match foooooooooooooooooooooooooooo with

--- a/test/passing/max_indent.ml
+++ b/test/passing/max_indent.ml
@@ -33,3 +33,10 @@ let fooooooooooooo =
         lbl_all
     in
     fooooooo
+
+let foooooooooo =
+  match fooooooooooooo with
+  | Pexp_construct
+    ({txt= Lident "::"; _}, Some {pexp_desc= Pexp_tuple [_; e2]; _}) ->
+    if is_sugared_list e2 then Some (Semi, Non)
+    else Some (ColonColon, if exp == e2 then Right else Left)

--- a/test/passing/max_indent.ml
+++ b/test/passing/max_indent.ml
@@ -40,3 +40,33 @@ let foooooooooo =
     ({txt= Lident "::"; _}, Some {pexp_desc= Pexp_tuple [_; e2]; _}) ->
     if is_sugared_list e2 then Some (Semi, Non)
     else Some (ColonColon, if exp == e2 then Right else Left)
+
+let foooooooooooooooooooooooooo =
+  match foooooooooooooooooooooo with
+  | Pexp_apply
+    ( { pexp_desc=
+      Pexp_ident
+        {txt= Lident (("~-" | "~-." | "~+" | "~+.") as op); loc}
+        ; pexp_loc
+        ; pexp_attributes= []
+        ; _ }
+    , [(Nolabel, e1)] ) ->
+    fooooooooooooooooooooooooooooooooooooo
+
+let fooooooooooooooooooooooooooooooooooo =
+  match foooooooooooooooooooooo with
+  | ( Ppat_constraint
+    ( ({ppat_desc= Ppat_var _; _} as p0)
+    , {ptyp_desc= Ptyp_poly ([], t0); _} )
+    , Pexp_constraint (e0, t1) )
+    when Poly.(t0 = t1) ->
+      m.value_binding m
+
+let foooooooooooooooooooooooooooooooo =
+  match foooooooooooooooooooooooooooo with
+  | Tpat_variant (lab, Some omega, _) -> (
+    fun q rem ->
+      match q.pat_desc with
+      | Tpat_variant (lab', Some arg, _) when lab = lab' -> (p, arg :: rem)
+      | Tpat_any -> (p, omega :: rem)
+      | _ -> raise NoMatch )

--- a/test/passing/max_indent.ml
+++ b/test/passing/max_indent.ml
@@ -1,19 +1,18 @@
 let () =
   fooooo
   |> List.iter (fun x ->
-         let x = x $ y in
-         fooooooooooo x)
+       let x = x $ y in
+       fooooooooooo x)
 
 let () =
   fooooo
   |> List.iter
        (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line
             ->
-         let x =
-           some_really_really_really_long_name_that_doesn't_fit_on_the_line
-           $ y
-         in
-         fooooooooooo x)
+       let x =
+         some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+       in
+       fooooooooooo x)
 
 let foooooooooo =
   foooooooooooooooooooooo

--- a/test/passing/max_indent.ml
+++ b/test/passing/max_indent.ml
@@ -7,16 +7,29 @@ let () =
 let () =
   fooooo
   |> List.iter
-    (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
-      let x =
-        some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
-      in
-      fooooooooooo x)
+    (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line
+      ->
+        let x =
+          some_really_really_really_long_name_that_doesn't_fit_on_the_line
+          $ y
+        in
+        fooooooooooo x)
 
 let foooooooooo =
   foooooooooooooooooooooo
   |> Option.bind ~f:(function
     | Pform.Expansion.Var (Values l) -> Some (static l)
     | Macro (Ocaml_config, s) ->
-      Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
+      Some
+        (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
     | Macro (Env, s) -> Option.map ~f:static (expand_env t var s))
+
+let fooooooooooooo =
+  match lbls with
+  | (_, {lbl_all}, _) :: _ ->
+    let t =
+      Array.map
+        (fun lbl -> (mknoloc (Longident.Lident "?temp?"), lbl, omega))
+        lbl_all
+    in
+    fooooooo

--- a/test/passing/max_indent.ml
+++ b/test/passing/max_indent.ml
@@ -12,3 +12,11 @@ let () =
         some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
       in
       fooooooooooo x)
+
+let foooooooooo =
+  foooooooooooooooooooooo
+  |> Option.bind ~f:(function
+    | Pform.Expansion.Var (Values l) -> Some (static l)
+    | Macro (Ocaml_config, s) ->
+      Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
+    | Macro (Env, s) -> Option.map ~f:static (expand_env t var s))

--- a/vendor/ocamlformat_support/format_.ml
+++ b/vendor/ocamlformat_support/format_.ml
@@ -326,9 +326,12 @@ let break_new_line state (before, offset, after) width =
         new_indent
   in
   (* Don't indent more than pp_max_newline_offset wrt. to the last indent. *)
-  let real_indent = find_real_indent real_indent in
-  state.pp_current_indent <- real_indent;
-  state.pp_space_left <- state.pp_margin - state.pp_current_indent;
+  let artificial_indent = find_real_indent real_indent in
+  state.pp_current_indent <- artificial_indent;
+  (* we use the indent without taking pp_max_newline_offset into account,
+     otherwise too much space is available and Format starts reducing the
+     indentation and it messes with what is already computed. *)
+  state.pp_space_left <- state.pp_margin - real_indent;
   pp_output_indent state state.pp_current_indent;
   format_string state after
 

--- a/vendor/ocamlformat_support/format_.ml
+++ b/vendor/ocamlformat_support/format_.ml
@@ -283,32 +283,20 @@ let format_string state s =
 
 (* Don't indent more than pp_max_newline_offset wrt to the last indent. *)
 let rec find_real_indent state indent =
-  let debug s =
-    let debug = false in
-    if debug then
-      print_endline s
-  in
-  debug ("find " ^ Int.to_string indent);
   match Stack.top_opt state.pp_indent_stack with
   | Some (s, r) ->
       (* we only know the real indent for the suggested indent. *)
-      if indent = s then (
-        debug ("found --> " ^ Int.to_string r);
-        r
-      )
+      if indent = s then r
       (* we need to indent further. *)
       else if s < indent then (
         let new_indent = min indent (r + state.pp_max_newline_offset) in
         Stack.push (indent, new_indent) state.pp_indent_stack;
-        debug ("new: " ^ Int.to_string indent ^ " --> "
-               ^ Int.to_string new_indent);
         new_indent
       )
       (* the last indentation is too big, we may need a previous indentation
          or to create a newer but smaller one. *)
       else if indent <= r then (
         ignore (Stack.pop state.pp_indent_stack);
-        debug "too big: POP";
         find_real_indent state indent
       )
       else (* r < indent < s *) (
@@ -316,16 +304,12 @@ let rec find_real_indent state indent =
         (* this indentation already exists in the stack. *)
         if Stack.fold already_suggested false state.pp_indent_stack then (
           ignore (Stack.pop state.pp_indent_stack);
-          debug "already suggested";
           find_real_indent state indent
         )
         (* this is a new indentation and we need to indent further. *)
         else (
           let new_indent = min indent (r + state.pp_max_newline_offset) in
           Stack.push (indent, new_indent) state.pp_indent_stack;
-          debug "not suggested yet";
-          debug ("new: " ^ Int.to_string indent ^ " --> "
-                 ^ Int.to_string new_indent);
           new_indent
         )
       )

--- a/vendor/ocamlformat_support/format_.ml
+++ b/vendor/ocamlformat_support/format_.ml
@@ -300,7 +300,7 @@ let rec find_real_indent state indent =
         find_real_indent state indent
       )
       else (* r < indent < s *) (
-        let already_suggested acc (s, _) = acc || Int.equal indent s in
+        let already_suggested acc (s, _) = acc || indent = s in
         (* this indentation already exists in the stack. *)
         if Stack.fold already_suggested false state.pp_indent_stack then (
           ignore (Stack.pop state.pp_indent_stack);

--- a/vendor/ocamlformat_support/format_.mli
+++ b/vendor/ocamlformat_support/format_.mli
@@ -978,8 +978,6 @@ val formatter_of_out_functions :
   @since 4.06.0
 *)
 
-val pp_set_max_newline_offset : formatter -> int -> unit
-
 (** {2:symbolic Symbolic pretty-printing} *)
 
 (**


### PR DESCRIPTION
Improve #997 and fix #925 :

Pros:
- not involved in `Format`
- simpler implementation
- easier to maintain
- more correct since we don't have to handle "weird" cases

Cons:
- less precise than #997 
- can not achieve a minimal identation since we do not handle the "real" indentation and we let `Format` choose the indentation