### PR TITLE
Fix: break multiline comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 #### Bug fixes
 
+  + Fix: break multiline comments (#1122) (Guillaume Petiot)
   + Fix: types on named arguments were wrapped incorrectly when preceding comments (#1124) (Guillaume Petiot)
   + Fix the indentation produced by max-indent (#1118) (Guillaume Petiot)
   + Fix break after Psig_include depending on presence of docstring (#1125) (Guillaume Petiot)

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -500,7 +500,7 @@ let fmt_cmt t (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
     then
       let b_space = String.length s > 0 && Char.equal s.[0] ' ' in
       let e_space =
-        String.length s > 0 && Char.equal s.[String.length s - 1] ' '
+        String.length s > 1 && Char.equal s.[String.length s - 1] ' '
       in
       let fmt_line ~first ~last s =
         if String.(is_empty (strip s)) then

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -496,8 +496,8 @@ let fmt_cmt t (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
     match lines with
     | first_line :: _ :: _
       when (not begins_line) && not (String.is_empty first_line) ->
-        let b_space = String.length s > 0 && Char.equal s.[0] ' ' in
-        let e_space =
+        let begin_space = String.length s > 0 && Char.equal s.[0] ' ' in
+        let end_space =
           String.length s > 1 && Char.equal s.[String.length s - 1] ' '
         in
         let fmt_line ~first ~last s =
@@ -507,8 +507,8 @@ let fmt_cmt t (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
             else str "\n"
           else
             fmt_if (not first) "@;<1000 0>"
-            $ fmt_if b_space " " $ str stripped
-            $ fmt_if (last && e_space) " "
+            $ fmt_if begin_space " " $ str stripped
+            $ fmt_if (last && end_space) " "
         in
         vbox 0 (list_fl lines fmt_line)
     | _ -> str s

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -479,7 +479,7 @@ let split_asterisk_prefixed {Cmt.txt; loc= {Location.loc_start; _}} =
   in
   split_asterisk_prefixed_ 0
 
-let fmt_cmt (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
+let fmt_cmt t (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
   let open Fmt in
   let fmt_asterisk_prefixed_lines lines =
     vbox 1
@@ -490,10 +490,35 @@ let fmt_cmt (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
             | _, None -> str line $ fmt "*)"
             | _, Some _ -> str line $ fmt "@,*") )
   in
-  let fmt_non_code (cmt : Cmt.t) =
+  let fmt_unwrapped_cmt ({txt= s; loc} : Cmt.t) =
+    let lines = String.split_lines s in
+    let first_line_empty =
+      List.length lines > 0 && String.is_empty (List.hd_exn lines)
+    in
+    let begins_line = Source.begins_line t.source loc ~ignore_spaces:false in
+    if String.contains s '\n' && (not begins_line) && not first_line_empty
+    then
+      let b_space = String.length s > 0 && Char.equal s.[0] ' ' in
+      let e_space =
+        String.length s > 0 && Char.equal s.[String.length s - 1] ' '
+      in
+      let fmt_line ~first ~last s =
+        if String.(is_empty (strip s)) then
+          if last then if first then str s else fmt "@;<1000 -2>"
+          else str "\n"
+        else
+          fmt_if (not first) "@;<1000 0>"
+          $ fmt_if b_space " "
+          $ str (String.strip s)
+          $ fmt_if (last && e_space) " "
+      in
+      vbox 0 (list_fl lines fmt_line)
+    else str s
+  in
+  let fmt_non_code cmt =
     if not conf.wrap_comments then
       match split_asterisk_prefixed cmt with
-      | [""] | [_] | [_; ""] -> wrap "(*" "*)" (str cmt.txt)
+      | [""] | [_] | [_; ""] -> wrap "(*" "*)" (fmt_unwrapped_cmt cmt)
       | asterisk_prefixed_lines ->
           fmt_asterisk_prefixed_lines asterisk_prefixed_lines
     else
@@ -559,7 +584,7 @@ let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
             (fmt "@ ")
           $ ( match group with
             | [] -> impossible "previous match"
-            | [cmt] -> fmt_cmt conf cmt ~fmt_code $ maybe_newline ~next cmt
+            | [cmt] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt
             | group ->
                 list group "@;<1000 0>" (fun cmt ->
                     wrap "(*" "*)" (str (Cmt.txt cmt)))

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -501,13 +501,13 @@ let fmt_cmt t (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
           String.length s > 1 && Char.equal s.[String.length s - 1] ' '
         in
         let fmt_line ~first ~last s =
-          if String.(is_empty (strip s)) then
+          let stripped = String.strip s in
+          if String.is_empty stripped then
             if last then if first then str s else fmt "@;<1000 -2>"
             else str "\n"
           else
             fmt_if (not first) "@;<1000 0>"
-            $ fmt_if b_space " "
-            $ str (String.strip s)
+            $ fmt_if b_space " " $ str stripped
             $ fmt_if (last && e_space) " "
         in
         vbox 0 (list_fl lines fmt_line)

--- a/src/Cmts.ml
+++ b/src/Cmts.ml
@@ -492,28 +492,26 @@ let fmt_cmt t (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
   in
   let fmt_unwrapped_cmt ({txt= s; loc} : Cmt.t) =
     let lines = String.split_lines s in
-    let first_line_empty =
-      List.length lines > 0 && String.is_empty (List.hd_exn lines)
-    in
     let begins_line = Source.begins_line t.source loc ~ignore_spaces:false in
-    if String.contains s '\n' && (not begins_line) && not first_line_empty
-    then
-      let b_space = String.length s > 0 && Char.equal s.[0] ' ' in
-      let e_space =
-        String.length s > 1 && Char.equal s.[String.length s - 1] ' '
-      in
-      let fmt_line ~first ~last s =
-        if String.(is_empty (strip s)) then
-          if last then if first then str s else fmt "@;<1000 -2>"
-          else str "\n"
-        else
-          fmt_if (not first) "@;<1000 0>"
-          $ fmt_if b_space " "
-          $ str (String.strip s)
-          $ fmt_if (last && e_space) " "
-      in
-      vbox 0 (list_fl lines fmt_line)
-    else str s
+    match lines with
+    | first_line :: _ :: _
+      when (not begins_line) && not (String.is_empty first_line) ->
+        let b_space = String.length s > 0 && Char.equal s.[0] ' ' in
+        let e_space =
+          String.length s > 1 && Char.equal s.[String.length s - 1] ' '
+        in
+        let fmt_line ~first ~last s =
+          if String.(is_empty (strip s)) then
+            if last then if first then str s else fmt "@;<1000 -2>"
+            else str "\n"
+          else
+            fmt_if (not first) "@;<1000 0>"
+            $ fmt_if b_space " "
+            $ str (String.strip s)
+            $ fmt_if (last && e_space) " "
+        in
+        vbox 0 (list_fl lines fmt_line)
+    | _ -> str s
   in
   let fmt_non_code cmt =
     if not conf.wrap_comments then

--- a/src/Source.ml
+++ b/src/Source.ml
@@ -260,14 +260,14 @@ let char_literal t (l : Location.t) =
       Some (Literal_lexer.char (lexbuf_from_loc t loc))
   | _ -> None
 
-let begins_line t (l : Location.t) =
+let begins_line ?(ignore_spaces = true) t (l : Location.t) =
   let rec begins_line_ cnum =
     cnum = 0
     ||
     let cnum = cnum - 1 in
     match t.[cnum] with
     | '\n' | '\r' -> true
-    | c when Char.is_whitespace c -> begins_line_ cnum
+    | c when Char.is_whitespace c && ignore_spaces -> begins_line_ cnum
     | _ -> false
   in
   begins_line_ l.loc_start.pos_cnum

--- a/src/Source.mli
+++ b/src/Source.mli
@@ -60,7 +60,7 @@ val is_long_pmod_functor : t -> Parsetree.module_expr -> bool
     [Pmod_functor] expression that is expressed in long ('functor (M) ->')
     form in source. *)
 
-val begins_line : t -> Location.t -> bool
+val begins_line : ?ignore_spaces:bool -> t -> Location.t -> bool
 
 val ends_line : t -> Location.t -> bool
 

--- a/test/passing/js_source.ml
+++ b/test/passing/js_source.ml
@@ -7472,3 +7472,13 @@ let _ =
   (* __________________________________________________________________________________ *)
   := bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 ;;
+
+let g = f ~x (* this is a multiple-line-spanning
+                comment *) ~y
+
+let f =
+  very_long_function_name
+    ~x:very_long_variable_name (* this is a multiple-line-spanning
+       comment *)
+    ~y
+;;

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -9839,3 +9839,20 @@ let _ =
     (* __________________________________________________________________________________ *)
     := bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 ;;
+
+let g =
+  f
+    ~x
+      (* this is a multiple-line-spanning
+         comment *)
+    ~y
+;;
+
+let f =
+  very_long_function_name
+    ~x:
+      very_long_variable_name
+      (* this is a multiple-line-spanning
+         comment *)
+    ~y
+;;

--- a/test/passing/wrap_comments.ml
+++ b/test/passing/wrap_comments.ml
@@ -56,3 +56,40 @@ type foo =
     (* long long long long long long long long long long long long long long
      * long long long long *)
   ; another_field : string }
+
+let _ =
+  [ "a"
+  ; "b"
+  (* first line
+     second line *)
+  ; "c"
+  (* first line
+
+     second line
+  *)
+  ; "d"
+  (* first line
+
+
+     second line *)
+  ; "e"
+  (* first line
+
+     second line
+         *)
+  ; "f"
+  (* first line
+
+     second line
+
+
+         *)
+  ; "g"
+  ]
+
+let f =
+  very_long_function_name
+    ~x:very_long_variable_name (* this is a multiple-line-spanning
+       comment *)
+    ~y
+;;

--- a/test/passing/wrap_comments.ml
+++ b/test/passing/wrap_comments.ml
@@ -86,10 +86,3 @@ let _ =
          *)
   ; "g"
   ]
-
-let f =
-  very_long_function_name
-    ~x:very_long_variable_name (* this is a multiple-line-spanning
-       comment *)
-    ~y
-;;

--- a/test/passing/wrap_comments.ml.ref
+++ b/test/passing/wrap_comments.ml.ref
@@ -86,10 +86,3 @@ let _ =
 
     *)
   ; "g" ]
-
-let f =
-  very_long_function_name
-    ~x:
-      very_long_variable_name
-      (* this is a multiple-line-spanning
-         comment *) ~y

--- a/test/passing/wrap_comments.ml.ref
+++ b/test/passing/wrap_comments.ml.ref
@@ -57,3 +57,39 @@ type foo =
         (* long long long long long long long long long long long long long long
          * long long long long *)
   ; another_field: string }
+
+let _ =
+  [ "a"
+  ; "b"
+    (* first line
+       second line *)
+  ; "c"
+    (* first line
+
+       second line
+    *)
+  ; "d"
+    (* first line
+
+
+       second line *)
+  ; "e"
+    (* first line
+
+       second line
+    *)
+  ; "f"
+    (* first line
+
+       second line
+
+
+    *)
+  ; "g" ]
+
+let f =
+  very_long_function_name
+    ~x:
+      very_long_variable_name
+      (* this is a multiple-line-spanning
+         comment *) ~y


### PR DESCRIPTION
Fix #912 and #1100, something similar could be done for docstrings to tackle #1043 

The diff of test_branch.sh looks good.

This new behavior is only triggered when `wrap-comments=false` and when the first line of the comment is not empty (we don't want to indent the following lines of the comment if the first one is empty).