### PR TITLE
Fix break after Psig_include depending on presence of docstring

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -3386,12 +3386,13 @@ and fmt_signature_item c ?ext {ast= si; _} =
       let box = wrap_k opn cls in
       hvbox 0
         ( doc_before
-        $ ( box
-              ( hvbox 2 (keyword $ opt pro (fun pro -> str " " $ pro))
-              $ fmt_or_k (Option.is_some pro) psp (fmt "@;<1 2>")
-              $ bdy )
-          $ esp $ fmt_opt epi
-          $ fmt_attributes c ~pre:(fmt "@ ") ~key:"@@" atrs )
+        $ hvbox 0
+            ( box
+                ( hvbox 2 (keyword $ opt pro (fun pro -> str " " $ pro))
+                $ fmt_or_k (Option.is_some pro) psp (fmt "@;<1 2>")
+                $ bdy )
+            $ esp $ fmt_opt epi
+            $ fmt_attributes c ~pre:(fmt "@ ") ~key:"@@" atrs )
         $ doc_after )
   | Psig_modtype mtd -> fmt_module_type_declaration c ctx mtd
   | Psig_module md ->

--- a/test/passing/doc_comments.mli
+++ b/test/passing/doc_comments.mli
@@ -8,6 +8,9 @@ type block =
   | `Noblank
   | `Blocks of block list ]
 
+include M with type t := t
+(** Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod *)
+
 val escape : string -> string
 (** [escape s] escapes [s] from the doc language. *)
 

--- a/test/passing/doc_comments.mli.ref
+++ b/test/passing/doc_comments.mli.ref
@@ -8,6 +8,9 @@ type block =
   | `Noblank
   | `Blocks of block list ]
 
+include M with type t := t
+(** Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod *)
+
 val escape : string -> string
 (** [escape s] escapes [s] from the doc language. *)
 


### PR DESCRIPTION
Fix #1114 

diff with test_branch.sh:
```diff
diff --git a/infer/src/concurrency/ExplicitTrace.mli b/infer/src/concurrency/ExplicitTrace.mli
index 1a7b85dd9..c7ce25521 100644
--- a/infer/src/concurrency/ExplicitTrace.mli
+++ b/infer/src/concurrency/ExplicitTrace.mli
@@ -33,8 +33,7 @@ module type TraceElem = sig
   type t = private {elem: elem_t; loc: Location.t; trace: CallSite.t list}
   (** An [elem] which occured at [loc], after the chain of steps (usually calls) in [trace]. *)
 
-  include
-    Element with type t := t
+  include Element with type t := t
   (** Both [pp] and [describe] simply call the same function on the trace element. *)
 ```