### PR TITLE
Remove global ref `Cmts.remove`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
   + Add dune to repositories checked for regressions (#1129) (Jules Aguillon)
   + Use an expect test for cli tests (#1126) (Etienne Millon)
   + Factor out a private library (#1134) (Etienne Millon)
+  + Remove global reference `Cmts.remove` (#1142) (Etienne Millon)
 
 #### Documentation
 

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -137,6 +137,6 @@ val diff :
   Conf.t -> Cmt.t list -> Cmt.t list -> (string, string) Either.t Sequence.t
 (** Difference between two lists of comments. *)
 
-val preserve : ('a -> Fmt.t) -> 'a -> string
+val preserve : (t -> Fmt.t) -> t -> string
 (** [preserve fmt_x x] formats like [fmt_x x] but returns a string and does
     not consume comments from the internal state. *)


### PR DESCRIPTION
This replaces a global reference by a new field in `Cmts.t`. It controls whether to remove from `remaining` or not.

This mechanism is only used in `preserve`, which did not have access to `Cmts.t` (as it was referring to the global). So the interface changes a bit so that the correct value is passed.