### PR TITLE
Cmts: Remove symbol strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
   + Use an expect test for cli tests (#1126) (Etienne Millon)
   + Factor out a private library (#1134) (Etienne Millon)
   + Remove global reference `Cmts.remove` (#1142) (Etienne Millon)
+  + Remove symbol strings in `Cmts` (#1146) (Etienne Millon)
 
 #### Documentation
 

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -125,7 +125,7 @@ val has_within : t -> Location.t -> bool
 val has_after : t -> Location.t -> bool
 (** [has_after t loc] holds if [t] contains some comment after [loc]. *)
 
-val remaining_comments : t -> (Cmt.t * string * Sexp.t) list
+val remaining_comments : t -> Cmt.t list
 (** Returns comments that have not been formatted yet. *)
 
 val remaining_locs : t -> Location.t list

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -333,9 +333,7 @@ let format xunit ?output_file ~input_name ~source ~parsed (conf : Conf.t) =
           if conf.comment_check then (
             ( match Cmts.remaining_comments cmts_t with
             | [] -> ()
-            | l ->
-                let l = List.map l ~f:(fun (cmt, _, _) -> cmt) in
-                internal_error (`Comment_dropped l) [] ) ;
+            | l -> internal_error (`Comment_dropped l) [] ) ;
             let is_docstring Cmt.{txt; _} =
               conf.Conf.parse_docstrings && Char.equal txt.[0] '*'
             in


### PR DESCRIPTION
In `Cmts`, the strings `"before"`, `"after"` and `"within"` are sometimes used as symbols in debugging output. This leaks in the output type of `remaining_comments`. Since these are only used for debugging, they can be replaced by an abstract type that makes the intention clearer.