### PR TITLE
Remove load-time argv parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@
   + Testing interactions between break-infix and break-infix-before-func (#1136) (Guillaume Petiot)
   + Add dune to repositories checked for regressions (#1129) (Jules Aguillon)
   + Use an expect test for cli tests (#1126) (Etienne Millon)
-  + Factor out a private library (#1134) (Etienne Millon)
+  + Factor out a private library (#1134, #1148) (Etienne Millon)
   + Remove global reference `Cmts.remove` (#1142) (Etienne Millon)
 
 #### Documentation

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -68,7 +68,7 @@ let source_from_file = function
   | File f -> In_channel.with_file f ~f:In_channel.input_all
 
 ;;
-match Conf.action with
+match Conf.action () with
 | Inplace inputs ->
     let errors =
       List.filter_map inputs

--- a/bin/ocamlformat_reason.ml
+++ b/bin/ocamlformat_reason.ml
@@ -57,7 +57,7 @@ let to_output_file output_file data =
   | Some output_file -> Out_channel.write_all output_file ~data
 
 ;;
-match Conf.action with
+match Conf.action () with
 | Inplace _ -> user_error "Cannot convert Reason code with --inplace" []
 | Check _ -> user_error "Cannot check Reason code with --check" []
 | In_out ({kind; file; name= input_name; conf}, output_file) -> (

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -2172,7 +2172,7 @@ let validate () =
   | Error e -> `Error (false, e)
   | Ok action -> `Ok action
 
-let action = parse info validate
+let action () = parse info validate
 
 let debug = !debug
 

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -100,7 +100,7 @@ type action =
       (** Check whether the input files already are formatted. *)
   | Print_config of t  (** Print the configuration and exit. *)
 
-val action : action
+val action : unit -> action
 (** Formatting action: input type and source, and output destination. *)
 
 val debug : bool


### PR DESCRIPTION
`Conf.action` had side effects as it immediately parsed `Sys.argv` at load time. This has to be delayed so that we can link the lib in a test suite for example.