### PR TITLE
Fix --debug not working and propagate options functionally

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,7 +23,7 @@
   + Testing interactions between break-infix and break-infix-before-func (#1136) (Guillaume Petiot)
   + Add dune to repositories checked for regressions (#1129) (Jules Aguillon)
   + Use an expect test for cli tests (#1126) (Etienne Millon)
-  + Factor out a private library (#1134, #1148) (Etienne Millon)
+  + Factor out a private library (#1134, #1148, #1158) (Etienne Millon, Jules Aguillon)
   + Remove global reference `Cmts.remove` (#1142) (Etienne Millon)
   + Remove symbol strings in `Cmts` (#1146) (Etienne Millon)
 

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -56,7 +56,7 @@ let format ?output_file ~kind ~input_name ~source conf opts =
       | `Impl -> Translation_unit.parse_and_format impl
       | `Intf -> Translation_unit.parse_and_format intf
     in
-    f ?output_file ~input_name ~source (conf, opts)
+    f ?output_file ~input_name ~source conf opts
 
 let to_output_file output_file data =
   match output_file with

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -48,15 +48,15 @@ Caml.at_exit (Format.pp_print_flush Format.err_formatter)
 ;;
 Caml.at_exit (Format_.pp_print_flush Format_.err_formatter)
 
-let format ?output_file ~kind ~input_name ~source (c : Conf.t) =
-  if c.disable then Ok source
+let format ?output_file ~kind ~input_name ~source conf opts =
+  if conf.Conf.disable then Ok source
   else
     let f =
       match kind with
       | `Impl -> Translation_unit.parse_and_format impl
       | `Intf -> Translation_unit.parse_and_format intf
     in
-    f ?output_file ~input_name ~source c
+    f ?output_file ~input_name ~source (conf, opts)
 
 let to_output_file output_file data =
   match output_file with
@@ -67,8 +67,14 @@ let source_from_file = function
   | Conf.Stdin -> In_channel.input_all In_channel.stdin
   | File f -> In_channel.with_file f ~f:In_channel.input_all
 
+let print_error ?(check = false) conf opts ~input_name e =
+  Translation_unit.print_error ~debug:opts.Conf.debug ~quiet:conf.Conf.quiet
+    ~check ~input_name e
+
+let action, opts = Conf.action ()
+
 ;;
-match Conf.action () with
+match action with
 | Inplace inputs ->
     let errors =
       List.filter_map inputs
@@ -81,10 +87,10 @@ match Conf.action () with
           let source =
             In_channel.with_file input_file ~f:In_channel.input_all
           in
-          let result = format conf ~kind ~input_name ~source in
+          let result = format ~kind ~input_name ~source conf opts in
           match result with
           | Error e ->
-              Translation_unit.print_error conf ~input_name e ;
+              print_error conf opts ~input_name e ;
               Some ()
           | Ok formatted ->
               if not (String.equal formatted source) then
@@ -94,21 +100,21 @@ match Conf.action () with
     if List.is_empty errors then Caml.exit 0 else Caml.exit 1
 | In_out ({kind; file; name= input_name; conf}, output_file) -> (
     let source = source_from_file file in
-    let result = format conf ?output_file ~kind ~input_name ~source in
+    let result = format ?output_file ~kind ~input_name ~source conf opts in
     match result with
     | Ok s ->
         to_output_file output_file s ;
         Caml.exit 0
     | Error e ->
-        Translation_unit.print_error conf ~input_name e ;
+        print_error conf opts ~input_name e ;
         Caml.exit 1 )
 | Check inputs ->
     let f {Conf.kind; name= input_name; file; conf} =
       let source = source_from_file file in
-      match format conf ~kind ~input_name ~source with
+      match format ~kind ~input_name ~source conf opts with
       | Ok res -> String.equal res source
       | Error e ->
-          Translation_unit.print_error conf ~input_name e ;
+          print_error ~check:true conf opts ~input_name e ;
           false
     in
     let checked = List.for_all inputs ~f in

--- a/bin/ocamlformat_reason.ml
+++ b/bin/ocamlformat_reason.ml
@@ -49,8 +49,8 @@ let format xunit ?output_file ~input_name ~source ~parsed conf opts =
   Location.input_name := input_name ;
   if conf.Conf.disable then Ok source
   else
-    Translation_unit.format xunit (conf, opts) ?output_file ~input_name
-      ~source ~parsed
+    Translation_unit.format xunit ?output_file ~input_name ~source ~parsed
+      conf opts
 
 let to_output_file output_file data =
   match output_file with

--- a/bin/ocamlformat_reason.ml
+++ b/bin/ocamlformat_reason.ml
@@ -45,19 +45,22 @@ let pack_of_kind = function
   | `Impl -> Pack {parse= Reason.input_bin_impl; xunit= impl}
   | `Intf -> Pack {parse= Reason.input_bin_intf; xunit= intf}
 
-let format xunit (c : Conf.t) ?output_file ~input_name ~source ~parsed =
+let format xunit ?output_file ~input_name ~source ~parsed conf opts =
   Location.input_name := input_name ;
-  if c.disable then Ok source
+  if conf.Conf.disable then Ok source
   else
-    Translation_unit.format xunit c ?output_file ~input_name ~source ~parsed
+    Translation_unit.format xunit (conf, opts) ?output_file ~input_name
+      ~source ~parsed
 
 let to_output_file output_file data =
   match output_file with
   | None -> Out_channel.output_string Out_channel.stdout data
   | Some output_file -> Out_channel.write_all output_file ~data
 
+let action, opts = Conf.action ()
+
 ;;
-match Conf.action () with
+match action with
 | Inplace _ -> user_error "Cannot convert Reason code with --inplace" []
 | Check _ -> user_error "Cannot check Reason code with --check" []
 | In_out ({kind; file; name= input_name; conf}, output_file) -> (
@@ -69,11 +72,14 @@ match Conf.action () with
     in
     let source = try_read_original_source t.origin_filename in
     let parsed = t.ast_and_comment in
-    match format xunit conf ?output_file ~input_name ~source ~parsed with
+    match
+      format xunit ?output_file ~input_name ~source ~parsed conf opts
+    with
     | Ok s ->
         to_output_file output_file s ;
         Caml.exit 0
     | Error e ->
-        Translation_unit.print_error conf ~input_name e ;
+        Translation_unit.print_error ~debug:opts.debug ~check:false
+          ~quiet:conf.quiet ~input_name e ;
         Caml.exit 1 )
 | Print_config conf -> Conf.print_config conf ; Caml.exit 0

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -876,15 +876,19 @@ end = struct
 
   let ( == ) = Base.phys_equal
 
-  let dump fs ctx ast =
+  let dump ctx ast fs =
     Format.fprintf fs "ast: %a@\nctx: %a@\n" T.dump ast T.dump ctx
 
-  let fail ctx ast exc =
-    if Conf.debug then (
-      let bt = Caml.Printexc.get_backtrace () in
-      dump Format.err_formatter ctx ast ;
-      Format.eprintf "%s%!" bt ) ;
-    raise exc
+  let assert_no_raise ~f ~dump x =
+    assert (
+      try
+        ignore (f x) ;
+        true
+      with exc ->
+        let bt = Caml.Printexc.get_backtrace () in
+        dump x Format.err_formatter ;
+        Format.eprintf "%s%!" bt ;
+        raise exc )
 
   (** Predicates to check the claimed sub-term relation. *)
 
@@ -1101,8 +1105,9 @@ end = struct
       | _ -> assert false )
     | Top | Tli _ -> assert false
 
-  let check_typ ({ctx; ast= typ} as xtyp) =
-    try check_typ xtyp with exc -> fail ctx (Typ typ) exc
+  let assert_check_typ xtyp =
+    let dump {ctx; ast= typ} = dump ctx (Typ typ) in
+    assert_no_raise ~f:check_typ ~dump xtyp
 
   let check_cty {ctx; ast= cty} =
     let check_class_type l =
@@ -1172,8 +1177,9 @@ end = struct
     | Mty _ -> assert false
     | Mod _ -> assert false
 
-  let check_cty ({ctx; ast= cty} as xcty) =
-    try check_cty xcty with exc -> fail ctx (Cty cty) exc
+  let assert_check_cty xcty =
+    let dump {ctx; ast= cty} = dump ctx (Cty cty) in
+    assert_no_raise ~f:check_cty ~dump xcty
 
   let check_cl {ctx; ast= cl} =
     let check_pcstr_fields pcstr_fields =
@@ -1225,8 +1231,9 @@ end = struct
     | Mty _ -> assert false
     | Mod _ -> assert false
 
-  let check_cl ({ctx; ast= cl} as xcl) =
-    try check_cl xcl with exc -> fail ctx (Cl cl) exc
+  let assert_check_cl xcl =
+    let dump {ctx; ast= cl} = dump ctx (Cl cl) in
+    assert_no_raise ~f:check_cl ~dump xcl
 
   let check_pat {ctx; ast= pat} =
     let check_pcstr_fields pcstr_fields =
@@ -1329,8 +1336,9 @@ end = struct
       | _ -> assert false )
     | Top | Tli _ -> assert false
 
-  let check_pat ({ctx; ast= pat} as xpat) =
-    try check_pat xpat with exc -> fail ctx (Pat pat) exc
+  let assert_check_pat xpat =
+    let dump {ctx; ast= pat} = dump ctx (Pat pat) in
+    assert_no_raise ~f:check_pat ~dump xpat
 
   let check_exp {ctx; ast= exp} =
     let check_extensions = function
@@ -1499,8 +1507,9 @@ end = struct
     | Cty _ -> assert false
     | Mod _ | Top | Tli _ | Typ _ | Pat _ | Mty _ | Sig _ -> assert false
 
-  let check_exp ({ctx; ast= exp} as xexp) =
-    try check_exp xexp with exc -> fail ctx (Exp exp) exc
+  let assert_check_exp xexp =
+    let dump {ctx; ast= exp} = dump ctx (Exp exp) in
+    assert_no_raise ~f:check_exp ~dump xexp
 
   let rec is_simple (c : Conf.t) width ({ast= exp; _} as xexp) =
     let ctx = Exp exp in
@@ -1804,7 +1813,7 @@ end = struct
   (** [parenze_typ {ctx; ast}] holds when type [ast] should be parenthesized
       in context [ctx]. *)
   let parenze_typ ({ctx; ast= typ} as xtyp) =
-    assert (check_typ xtyp ; true) ;
+    assert_check_typ xtyp ;
     match xtyp with
     | {ast= {ptyp_desc= Ptyp_package _; _}; _} -> true
     | {ast= {ptyp_desc= Ptyp_alias _; _}; ctx= Typ _} -> true
@@ -1853,7 +1862,7 @@ end = struct
   (** [parenze_cty {ctx; ast}] holds when class type [ast] should be
       parenthesized in context [ctx]. *)
   let parenze_cty ({ctx; ast= cty} as xcty) =
-    assert (check_cty xcty ; true) ;
+    assert_check_cty xcty ;
     match ambig_prec (sub_ast ~ctx (Cty cty)) with
     | Some (Some true) -> true
     | _ -> false
@@ -1880,7 +1889,7 @@ end = struct
   (** [parenze_pat {ctx; ast}] holds when pattern [ast] should be
       parenthesized in context [ctx]. *)
   let parenze_pat ({ctx; ast= pat} as xpat) =
-    assert (check_pat xpat ; true) ;
+    assert_check_pat xpat ;
     has_trailing_attributes_pat pat
     ||
     match (ctx, pat.ppat_desc) with
@@ -2242,7 +2251,7 @@ end = struct
       | Pexp_let _ | Pexp_match _ | Pexp_try _ -> true
       | _ -> false
     in
-    assert (check_exp xexp ; true) ;
+    assert_check_exp xexp ;
     is_displaced_prefix_op xexp
     || is_displaced_infix_op xexp
     || has_trailing_attributes_exp exp
@@ -2363,7 +2372,7 @@ end = struct
   (** [parenze_cl {ctx; ast}] holds when class expr [ast] should be
       parenthesized in context [ctx]. *)
   and parenze_cl ({ctx; ast= cl} as xcl) =
-    assert (check_cl xcl ; true) ;
+    assert_check_cl xcl ;
     match ambig_prec (sub_ast ~ctx (Cl cl)) with
     | None -> false
     | Some (Some true) -> true

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -28,20 +28,26 @@ open Migrate_ast
 
 type t
 
-val init_impl : Source.t -> Parsetree.structure -> Cmt.t list -> t
+val init_impl :
+  ?debug:bool -> Source.t -> Parsetree.structure -> Cmt.t list -> t
 (** [init_impl source structure comments] associates each comment in
     [comments] with a source location appearing in [structure]. It uses
     [Source] to help resolve ambiguities. Initializes the state used by the
     [fmt] functions. *)
 
-val init_intf : Source.t -> Parsetree.signature -> Cmt.t list -> t
+val init_intf :
+  ?debug:bool -> Source.t -> Parsetree.signature -> Cmt.t list -> t
 (** [init_inft source signature comments] associates each comment in
     [comments] with a source location appearing in [signature]. It uses
     [Source] to help resolve ambiguities. Initializes the state used by the
     [fmt] functions. *)
 
 val init_toplevel :
-  Source.t -> Parsetree.toplevel_phrase list -> Cmt.t list -> t
+     ?debug:bool
+  -> Source.t
+  -> Parsetree.toplevel_phrase list
+  -> Cmt.t list
+  -> t
 (** [init_toplevel source toplevel comments] associates each comment in
     [comments] with a source location appearing in [toplevel]. It uses
     [Source] to help resolve ambiguities. Initializes the state used by the

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -2189,11 +2189,11 @@ let validate () =
   | Error e -> `Error (false, e)
   | Ok action -> `Ok action
 
-type opts = {debug: bool; check: bool; margin_check: bool}
+type opts = {debug: bool; margin_check: bool}
 
 let action () =
   let action = parse info validate in
-  let opts = {debug= !debug; check= !check; margin_check= !margin_check} in
+  let opts = {debug= !debug; margin_check= !margin_check} in
   (action, opts)
 
 open Migrate_ast.Parsetree

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -2189,13 +2189,12 @@ let validate () =
   | Error e -> `Error (false, e)
   | Ok action -> `Ok action
 
-let action () = parse info validate
+type opts = {debug: bool; check: bool; margin_check: bool}
 
-let debug = !debug
-
-and check = !check
-
-let margin_check = !margin_check
+let action () =
+  let action = parse info validate in
+  let opts = {debug= !debug; check= !check; margin_check= !margin_check} in
+  (action, opts)
 
 open Migrate_ast.Parsetree
 

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -85,6 +85,7 @@ type t =
   ; type_decl_indent: int
   ; wrap_comments: bool  (** Wrap comments at margin. *)
   ; wrap_fun_args: bool }
+(** Formatting options *)
 
 type file = Stdin | File of string
 
@@ -100,17 +101,15 @@ type action =
       (** Check whether the input files already are formatted. *)
   | Print_config of t  (** Print the configuration and exit. *)
 
-val action : unit -> action
+type opts =
+  { debug: bool  (** Generate debugging output if true. *)
+  ; check: bool  (** Check whether the input files already are formatted. *)
+  ; margin_check: bool
+        (** Check whether the formatted output exceeds the margin. *) }
+(** Options changing the tool's behavior *)
+
+val action : unit -> action * opts
 (** Formatting action: input type and source, and output destination. *)
-
-val debug : bool
-(** Generate debugging output if true. *)
-
-val check : bool
-(** Check whether the input files already are formatted. *)
-
-val margin_check : bool
-(** Check whether the formatted output exceeds the margin. *)
 
 val update : ?quiet:bool -> t -> Migrate_ast.Parsetree.attribute -> t
 (** [update ?quiet c a] updates configuration [c] after reading attribute

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -103,7 +103,6 @@ type action =
 
 type opts =
   { debug: bool  (** Generate debugging output if true. *)
-  ; check: bool  (** Check whether the input files already are formatted. *)
   ; margin_check: bool
         (** Check whether the formatted output exceeds the margin. *) }
 (** Options changing the tool's behavior *)

--- a/lib/Fmt_ast.mli
+++ b/lib/Fmt_ast.mli
@@ -15,12 +15,14 @@ module Format = Format_
 open Migrate_ast
 open Parsetree
 
-val fmt_signature : Source.t -> Cmts.t -> Conf.t -> signature -> Fmt.t
+val fmt_signature :
+  Source.t -> Cmts.t -> Conf.t * Conf.opts -> signature -> Fmt.t
 (** Format a signature. *)
 
-val fmt_structure : Source.t -> Cmts.t -> Conf.t -> structure -> Fmt.t
+val fmt_structure :
+  Source.t -> Cmts.t -> Conf.t * Conf.opts -> structure -> Fmt.t
 (** Format a structure. *)
 
 val fmt_toplevel :
-  Source.t -> Cmts.t -> Conf.t -> toplevel_phrase list -> Fmt.t
+  Source.t -> Cmts.t -> Conf.t * Conf.opts -> toplevel_phrase list -> Fmt.t
 (** Format a toplevel structure. *)

--- a/lib/Fmt_ast.mli
+++ b/lib/Fmt_ast.mli
@@ -16,13 +16,13 @@ open Migrate_ast
 open Parsetree
 
 val fmt_signature :
-  Source.t -> Cmts.t -> Conf.t * Conf.opts -> signature -> Fmt.t
+  debug:bool -> Source.t -> Cmts.t -> Conf.t -> signature -> Fmt.t
 (** Format a signature. *)
 
 val fmt_structure :
-  Source.t -> Cmts.t -> Conf.t * Conf.opts -> structure -> Fmt.t
+  debug:bool -> Source.t -> Cmts.t -> Conf.t -> structure -> Fmt.t
 (** Format a structure. *)
 
 val fmt_toplevel :
-  Source.t -> Cmts.t -> Conf.t * Conf.opts -> toplevel_phrase list -> Fmt.t
+  debug:bool -> Source.t -> Cmts.t -> Conf.t -> toplevel_phrase list -> Fmt.t
 (** Format a toplevel structure. *)

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -13,7 +13,7 @@ open Parse_with_comments
 
 type 'a t =
   { init_cmts: Source.t -> 'a -> Cmt.t list -> Cmts.t
-  ; fmt: Source.t -> Cmts.t -> Conf.t * Conf.opts -> 'a -> Fmt.t
+  ; fmt: debug:bool -> Source.t -> Cmts.t -> Conf.t -> 'a -> Fmt.t
   ; parse: Lexing.lexbuf -> 'a
   ; equal:
          ignore_doc_comments:bool
@@ -38,7 +38,8 @@ val format :
   -> input_name:string
   -> source:string
   -> parsed:'a with_comments
-  -> Conf.t * Conf.opts
+  -> Conf.t
+  -> Conf.opts
   -> (string, error) Result.t
 (** [format xunit conf ?output_file ~input_name ~source ~parsed] formats
     [parsed], using [input_name] for error messages, and referring to
@@ -50,7 +51,8 @@ val parse_and_format :
   -> ?output_file:string
   -> input_name:string
   -> source:string
-  -> Conf.t * Conf.opts
+  -> Conf.t
+  -> Conf.opts
   -> (string, error) Result.t
 (** [parse_and_format xunit conf ?output_file ~input_name ~source] is similar
     to [format] but parses the source according to [xunit]. *)

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -13,7 +13,7 @@ open Parse_with_comments
 
 type 'a t =
   { init_cmts: Source.t -> 'a -> Cmt.t list -> Cmts.t
-  ; fmt: Source.t -> Cmts.t -> Conf.t -> 'a -> Fmt.t
+  ; fmt: Source.t -> Cmts.t -> Conf.t * Conf.opts -> 'a -> Fmt.t
   ; parse: Lexing.lexbuf -> 'a
   ; equal:
          ignore_doc_comments:bool
@@ -38,7 +38,7 @@ val format :
   -> input_name:string
   -> source:string
   -> parsed:'a with_comments
-  -> Conf.t
+  -> Conf.t * Conf.opts
   -> (string, error) Result.t
 (** [format xunit conf ?output_file ~input_name ~source ~parsed] formats
     [parsed], using [input_name] for error messages, and referring to
@@ -50,12 +50,18 @@ val parse_and_format :
   -> ?output_file:string
   -> input_name:string
   -> source:string
-  -> Conf.t
+  -> Conf.t * Conf.opts
   -> (string, error) Result.t
 (** [parse_and_format xunit conf ?output_file ~input_name ~source] is similar
     to [format] but parses the source according to [xunit]. *)
 
 val print_error :
-  ?fmt:Format.formatter -> Conf.t -> input_name:string -> error -> unit
+     ?fmt:Format.formatter
+  -> debug:bool
+  -> quiet:bool
+  -> check:bool
+  -> input_name:string
+  -> error
+  -> unit
 (** [print_error conf ?fmt ~input_name e] prints the error message
     corresponding to error [e] on the [fmt] formatter (stderr by default). *)


### PR DESCRIPTION
`--debug` is broken since https://github.com/ocaml-ppx/ocamlformat/pull/1148
because the parsing of options is done after `debug`, `margin_check` and
`check` are accessed.

This PR fix that by adding a new record `Conf.opts` and passing it
through to formatting functions.
It contains non-formatting options and shouldn't be used by `Fmt_ast`.

Later:
- Move `comment_check`, `max_iters` and `quiet` out of `Conf.t`
  `disable` should stay there
  `margin` and `max_indent` may be moved as well
- Move that part of `Conf.ml` into an other module