### PR TITLE
Refactor handling of non-formatting options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@
   + Testing interactions between break-infix and break-infix-before-func (#1136) (Guillaume Petiot)
   + Add dune to repositories checked for regressions (#1129) (Jules Aguillon)
   + Remove the test generator for cli tests (#1126, #1157) (Etienne Millon)
-  + Factor out a private library (#1134, #1148, #1158) (Etienne Millon, Jules Aguillon)
+  + Factor out a private library (#1134, #1148, #1161, #1162) (Etienne Millon, Jules Aguillon)
   + Remove global reference `Cmts.remove` (#1142) (Etienne Millon)
   + Remove symbol strings in `Cmts` (#1146) (Etienne Millon)
   + Allow tests to be postprocessed with ocp-indent (#1171) (Guillaume Petiot, Jules Aguillon)

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -67,9 +67,9 @@ let source_from_file = function
   | Conf.Stdin -> In_channel.input_all In_channel.stdin
   | File f -> In_channel.with_file f ~f:In_channel.input_all
 
-let print_error ?(check = false) conf opts ~input_name e =
+let print_error conf opts ~input_name e =
   Translation_unit.print_error ~debug:opts.Conf.debug ~quiet:conf.Conf.quiet
-    ~check ~input_name e
+    ~input_name e
 
 let action, opts = Conf.action ()
 
@@ -114,7 +114,7 @@ match action with
       match format ~kind ~input_name ~source conf opts with
       | Ok res -> String.equal res source
       | Error e ->
-          print_error ~check:true conf opts ~input_name e ;
+          print_error conf opts ~input_name e ;
           false
     in
     let checked = List.for_all inputs ~f in

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -48,15 +48,15 @@ Caml.at_exit (Format.pp_print_flush Format.err_formatter)
 ;;
 Caml.at_exit (Format_.pp_print_flush Format_.err_formatter)
 
-let format ?output_file ~kind ~input_name ~source (c : Conf.t) =
-  if c.disable then Ok source
+let format ?output_file ~kind ~input_name ~source conf opts =
+  if conf.Conf.disable then Ok source
   else
     let f =
       match kind with
       | `Impl -> Translation_unit.parse_and_format impl
       | `Intf -> Translation_unit.parse_and_format intf
     in
-    f ?output_file ~input_name ~source c
+    f ?output_file ~input_name ~source conf opts
 
 let to_output_file output_file data =
   match output_file with
@@ -67,8 +67,14 @@ let source_from_file = function
   | Conf.Stdin -> In_channel.input_all In_channel.stdin
   | File f -> In_channel.with_file f ~f:In_channel.input_all
 
+let print_error ?(check = false) conf opts ~input_name e =
+  Translation_unit.print_error ~debug:opts.Conf.debug ~quiet:conf.Conf.quiet
+    ~check ~input_name e
+
+let action, opts = Conf.action ()
+
 ;;
-match Conf.action () with
+match action with
 | Inplace inputs ->
     let errors =
       List.filter_map inputs
@@ -81,10 +87,10 @@ match Conf.action () with
           let source =
             In_channel.with_file input_file ~f:In_channel.input_all
           in
-          let result = format conf ~kind ~input_name ~source in
+          let result = format ~kind ~input_name ~source conf opts in
           match result with
           | Error e ->
-              Translation_unit.print_error conf ~input_name e ;
+              print_error conf opts ~input_name e ;
               Some ()
           | Ok formatted ->
               if not (String.equal formatted source) then
@@ -94,21 +100,21 @@ match Conf.action () with
     if List.is_empty errors then Caml.exit 0 else Caml.exit 1
 | In_out ({kind; file; name= input_name; conf}, output_file) -> (
     let source = source_from_file file in
-    let result = format conf ?output_file ~kind ~input_name ~source in
+    let result = format ?output_file ~kind ~input_name ~source conf opts in
     match result with
     | Ok s ->
         to_output_file output_file s ;
         Caml.exit 0
     | Error e ->
-        Translation_unit.print_error conf ~input_name e ;
+        print_error conf opts ~input_name e ;
         Caml.exit 1 )
 | Check inputs ->
     let f {Conf.kind; name= input_name; file; conf} =
       let source = source_from_file file in
-      match format conf ~kind ~input_name ~source with
+      match format ~kind ~input_name ~source conf opts with
       | Ok res -> String.equal res source
       | Error e ->
-          Translation_unit.print_error conf ~input_name e ;
+          print_error ~check:true conf opts ~input_name e ;
           false
     in
     let checked = List.for_all inputs ~f in

--- a/bin/ocamlformat_reason.ml
+++ b/bin/ocamlformat_reason.ml
@@ -79,7 +79,7 @@ match action with
         to_output_file output_file s ;
         Caml.exit 0
     | Error e ->
-        Translation_unit.print_error ~debug:opts.debug ~check:false
-          ~quiet:conf.quiet ~input_name e ;
+        Translation_unit.print_error ~debug:opts.debug ~quiet:conf.quiet
+          ~input_name e ;
         Caml.exit 1 )
 | Print_config conf -> Conf.print_config conf ; Caml.exit 0

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -28,20 +28,22 @@ open Migrate_ast
 
 type t
 
-val init_impl : Source.t -> Parsetree.structure -> Cmt.t list -> t
+val init_impl :
+  debug:bool -> Source.t -> Parsetree.structure -> Cmt.t list -> t
 (** [init_impl source structure comments] associates each comment in
     [comments] with a source location appearing in [structure]. It uses
     [Source] to help resolve ambiguities. Initializes the state used by the
     [fmt] functions. *)
 
-val init_intf : Source.t -> Parsetree.signature -> Cmt.t list -> t
+val init_intf :
+  debug:bool -> Source.t -> Parsetree.signature -> Cmt.t list -> t
 (** [init_inft source signature comments] associates each comment in
     [comments] with a source location appearing in [signature]. It uses
     [Source] to help resolve ambiguities. Initializes the state used by the
     [fmt] functions. *)
 
 val init_toplevel :
-  Source.t -> Parsetree.toplevel_phrase list -> Cmt.t list -> t
+  debug:bool -> Source.t -> Parsetree.toplevel_phrase list -> Cmt.t list -> t
 (** [init_toplevel source toplevel comments] associates each comment in
     [comments] with a source location appearing in [toplevel]. It uses
     [Source] to help resolve ambiguities. Initializes the state used by the

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -2189,13 +2189,12 @@ let validate () =
   | Error e -> `Error (false, e)
   | Ok action -> `Ok action
 
-let action () = parse info validate
+type opts = {debug: bool; margin_check: bool}
 
-let debug () = !debug
-
-and check () = !check
-
-let margin_check () = !margin_check
+let action () =
+  let action = parse info validate in
+  let opts = {debug= !debug; margin_check= !margin_check} in
+  (action, opts)
 
 open Migrate_ast.Parsetree
 

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -85,6 +85,7 @@ type t =
   ; type_decl_indent: int
   ; wrap_comments: bool  (** Wrap comments at margin. *)
   ; wrap_fun_args: bool }
+(** Formatting options *)
 
 type file = Stdin | File of string
 
@@ -100,17 +101,14 @@ type action =
       (** Check whether the input files already are formatted. *)
   | Print_config of t  (** Print the configuration and exit. *)
 
-val action : unit -> action
+type opts =
+  { debug: bool  (** Generate debugging output if true. *)
+  ; margin_check: bool
+        (** Check whether the formatted output exceeds the margin. *) }
+(** Options changing the tool's behavior *)
+
+val action : unit -> action * opts
 (** Formatting action: input type and source, and output destination. *)
-
-val debug : unit -> bool
-(** Generate debugging output if true. *)
-
-val check : unit -> bool
-(** Check whether the input files already are formatted. *)
-
-val margin_check : unit -> bool
-(** Check whether the formatted output exceeds the margin. *)
 
 val update : ?quiet:bool -> t -> Migrate_ast.Parsetree.attribute -> t
 (** [update ?quiet c a] updates configuration [c] after reading attribute

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -21,6 +21,7 @@ open Fmt
 
 type c =
   { conf: Conf.t
+  ; debug: bool
   ; source: Source.t
   ; cmts: Cmts.t
   ; fmt_code: Conf.t -> string -> (Fmt.t, unit) Result.t }
@@ -64,9 +65,9 @@ let compose_module {opn; pro; psp; bdy; cls; esp; epi} ~f =
 
 let protect =
   let first = ref true in
-  fun ast pp ->
+  fun c ast pp ->
     Fmt.protect pp ~on_error:(fun exc ->
-        if !first && Conf.debug () then (
+        if !first && c.debug then (
           let bt = Caml.Printexc.get_backtrace () in
           Caml.Format.eprintf "@\nFAIL@\n%a@\n%s@.%!" Ast.dump ast bt ;
           first := false ) ;
@@ -560,7 +561,7 @@ and fmt_attributes c ?pre ?suf ~key attrs =
     (fmt_opt pre $ hvbox_if (num > 1) 0 (list_fl attrs fmt_attr))
 
 and fmt_payload c ctx pld =
-  protect (Pld pld)
+  protect c (Pld pld)
   @@
   match pld with
   | PStr mex ->
@@ -610,7 +611,7 @@ and fmt_type_var s =
 
 and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
     ?(pro_space = true) ({ast= typ; _} as xtyp) =
-  protect (Typ typ)
+  protect c (Typ typ)
   @@
   let {ptyp_desc; ptyp_attributes; ptyp_loc; _} = typ in
   update_config_maybe_disabled c ptyp_loc ptyp_attributes
@@ -834,7 +835,7 @@ and fmt_row_field c ctx {prf_desc; prf_attributes= atrs; prf_loc}
     $ fmt_docstring_padded c doc )
 
 and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
-  protect (Pat pat)
+  protect c (Pat pat)
   @@
   let ctx = Pat pat in
   let {ppat_desc; ppat_attributes; ppat_loc; ppat_loc_stack} = pat in
@@ -1390,7 +1391,7 @@ and fmt_infix_op_args c ~parens xexp op_args =
 
 and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
     ?ext ({ast= exp; _} as xexp) =
-  protect (Exp exp)
+  protect c (Exp exp)
   @@
   let {pexp_desc; pexp_loc; pexp_attributes; pexp_loc_stack} = exp in
   update_config_maybe_disabled c pexp_loc pexp_attributes
@@ -2483,7 +2484,7 @@ and fmt_class_signature c ~ctx ~parens ?ext self_ fields =
        $ str "end" ))
 
 and fmt_class_type c ?(box = true) ({ast= typ; _} as xtyp) =
-  protect (Cty typ)
+  protect c (Cty typ)
   @@
   let {pcty_desc; pcty_loc; pcty_attributes} = typ in
   update_config_maybe_disabled c pcty_loc pcty_attributes
@@ -2530,7 +2531,7 @@ and fmt_class_type c ?(box = true) ({ast= typ; _} as xtyp) =
   $ fmt_docstring c ~pro:(fmt "@ ") doc
 
 and fmt_class_expr c ?eol ?(box = true) ({ast= exp; _} as xexp) =
-  protect (Cl exp)
+  protect c (Cl exp)
   @@
   let {pcl_desc; pcl_loc; pcl_attributes} = exp in
   update_config_maybe_disabled c pcl_loc pcl_attributes
@@ -3358,7 +3359,7 @@ and fmt_signature c ctx itms =
   hvbox 0 (list grps "\n@;<1000 0>" fmt_grp)
 
 and fmt_signature_item c ?ext {ast= si; _} =
-  protect (Sig si)
+  protect c (Sig si)
   @@
   let eol = fmt "\n@;<1000 0>" in
   let epi = eol in
@@ -3947,7 +3948,7 @@ and fmt_type c ?ext ?eq rec_flag decls ctx =
   vbox 0 (list_fl decls fmt_decl)
 
 and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
-  protect (Str si)
+  protect c (Str si)
   @@
   let skip_double_semi =
     match ctx with Pld (PStr [_]) -> true | _ -> false
@@ -4333,28 +4334,35 @@ let fmt_toplevel c ctx itms =
 
 (** Entry points *)
 
-let fmt_file ~ctx ~f ~fmt_code source cmts conf itms =
-  let c = {source; cmts; conf; fmt_code} in
+let fmt_file ~ctx ~f ~fmt_code ~debug source cmts conf itms =
+  let c = {source; cmts; conf; debug; fmt_code} in
   match itms with
   | [] -> Cmts.fmt_after ~pro:noop c Location.none
   | l -> f c ctx l
 
-let rec fmt_code conf s =
-  match
-    Parse_with_comments.parse Migrate_ast.Parse.implementation conf ~source:s
-  with
-  | {ast; comments; _} ->
-      let source = Source.create s in
-      let cmts = Cmts.init_impl source ast comments in
-      let ctx = Pld (PStr ast) in
-      Ok (fmt_file ~f:fmt_structure ~ctx source cmts conf ast ~fmt_code)
-  | exception _ -> Error ()
+let fmt_code ~debug =
+  let rec fmt_code conf s =
+    match
+      Parse_with_comments.parse Migrate_ast.Parse.implementation conf
+        ~source:s
+    with
+    | {ast; comments; _} ->
+        let source = Source.create s in
+        let cmts = Cmts.init_impl ~debug source ast comments in
+        let ctx = Pld (PStr ast) in
+        Ok
+          (fmt_file ~f:fmt_structure ~ctx ~debug source cmts conf ast
+             ~fmt_code)
+    | exception _ -> Error ()
+  in
+  fmt_code
 
-let entry_point ~f ~ctx source cmts conf l =
+let entry_point ~f ~ctx ~debug source cmts conf l =
   (* [Ast.init] should be called only once per file. In particular, we don't
      want to call it when formatting comments *)
   Ast.init conf ;
-  fmt_file ~f ~ctx ~fmt_code source cmts conf l
+  let fmt_code = fmt_code ~debug in
+  fmt_file ~f ~ctx ~fmt_code ~debug source cmts conf l
 
 let fmt_signature = entry_point ~f:fmt_signature ~ctx:Top
 

--- a/lib/Fmt_ast.mli
+++ b/lib/Fmt_ast.mli
@@ -15,12 +15,14 @@ module Format = Format_
 open Migrate_ast
 open Parsetree
 
-val fmt_signature : Source.t -> Cmts.t -> Conf.t -> signature -> Fmt.t
+val fmt_signature :
+  debug:bool -> Source.t -> Cmts.t -> Conf.t -> signature -> Fmt.t
 (** Format a signature. *)
 
-val fmt_structure : Source.t -> Cmts.t -> Conf.t -> structure -> Fmt.t
+val fmt_structure :
+  debug:bool -> Source.t -> Cmts.t -> Conf.t -> structure -> Fmt.t
 (** Format a structure. *)
 
 val fmt_toplevel :
-  Source.t -> Cmts.t -> Conf.t -> toplevel_phrase list -> Fmt.t
+  debug:bool -> Source.t -> Cmts.t -> Conf.t -> toplevel_phrase list -> Fmt.t
 (** Format a toplevel structure. *)

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -15,8 +15,8 @@ open Migrate_ast
 open Parse_with_comments
 
 type 'a t =
-  { init_cmts: Source.t -> 'a -> Cmt.t list -> Cmts.t
-  ; fmt: Source.t -> Cmts.t -> Conf.t -> 'a -> Fmt.t
+  { init_cmts: debug:bool -> Source.t -> 'a -> Cmt.t list -> Cmts.t
+  ; fmt: debug:bool -> Source.t -> Cmts.t -> Conf.t -> 'a -> Fmt.t
   ; parse: Lexing.lexbuf -> 'a
   ; equal:
          ignore_doc_comments:bool
@@ -70,8 +70,8 @@ let with_file input_name output_file suf ext f =
   Out_channel.with_file tmp ~f ;
   tmp
 
-let dump_ast ~input_name ?output_file ~suffix fmt =
-  if Conf.debug () then
+let dump_ast ~debug ~input_name ?output_file ~suffix fmt =
+  if debug then
     let ext = ".ast" in
     let file =
       with_file input_name output_file suffix ext (fun oc ->
@@ -80,9 +80,9 @@ let dump_ast ~input_name ?output_file ~suffix fmt =
     Some file
   else None
 
-let dump_formatted ~input_name ?output_file ~suffix fmted =
+let dump_formatted ~debug ~input_name ?output_file ~suffix fmted =
   let ext = Filename.extension input_name in
-  if Conf.debug () then
+  if debug then
     let file =
       with_file input_name output_file suffix ext (fun oc ->
           Out_channel.output_string oc fmted)
@@ -90,10 +90,11 @@ let dump_formatted ~input_name ?output_file ~suffix fmted =
     Some file
   else None
 
-let print_error ?(fmt = Format.err_formatter) conf ~input_name error =
+let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~check
+    ~input_name error =
   let exe = Filename.basename Caml.Sys.argv.(0) in
   match error with
-  | Invalid_source _ when conf.Conf.quiet -> ()
+  | Invalid_source _ when quiet -> ()
   | Invalid_source {exn} -> (
       let reason =
         (* NOTE: Warning 28 is suppressed due to a difference in exception
@@ -123,7 +124,7 @@ let print_error ?(fmt = Format.err_formatter) conf ~input_name error =
              %!"
       | exn -> Format.fprintf fmt "%s\n%!" (Exn.to_string exn) )
   | Unstable {iteration; prev; next} ->
-      if Conf.debug () then (
+      if debug then (
         let ext = Filename.extension input_name in
         let input_name =
           Filename.chop_extension (Filename.basename input_name)
@@ -139,7 +140,7 @@ let print_error ?(fmt = Format.err_formatter) conf ~input_name error =
         ignore (Unix.system (Printf.sprintf "diff %S %S 1>&2" p n)) ;
         Unix.unlink p ;
         Unix.unlink n ) ;
-      if not (Conf.check ()) then
+      if not check then
         if iteration <= 1 then
           Format.fprintf fmt
             "%s: %S was not already formatted. ([max-iters = 1])\n%!" exe
@@ -175,7 +176,7 @@ let print_error ?(fmt = Format.err_formatter) conf ~input_name error =
           in
           Format.fprintf fmt "  BUG: %s.\n%!" s ;
           ( match m with
-          | `Doc_comment l when not conf.Conf.quiet ->
+          | `Doc_comment l when not quiet ->
               List.iter l ~f:(function
                 | Normalize.Moved (loc_before, loc_after, msg) ->
                     if Location.compare loc_before Location.none = 0 then
@@ -208,7 +209,7 @@ let print_error ?(fmt = Format.err_formatter) conf ~input_name error =
                        --no-parse-docstrings.\n\
                        %!"
                       Location.print_loc loc (ellipsis_cmt s))
-          | `Comment_dropped l when not conf.Conf.quiet ->
+          | `Comment_dropped l when not quiet ->
               List.iter l ~f:(fun Cmt.{txt= msg; loc} ->
                   Format.fprintf fmt
                     "%!@{<loc>%a@}:@,\
@@ -216,22 +217,21 @@ let print_error ?(fmt = Format.err_formatter) conf ~input_name error =
                      %!"
                     Location.print_loc loc (ellipsis_cmt msg))
           | `Cannot_parse ((Syntaxerr.Error _ | Lexer.Error _) as exn) ->
-              if Conf.debug () then Location.report_exception fmt exn
+              if debug then Location.report_exception fmt exn
           | `Warning50 l ->
-              if Conf.debug () then
+              if debug then
                 List.iter l ~f:(fun (l, w) -> Compat.print_warning l w)
           | _ -> () ) ;
-          if Conf.debug () then
+          if debug then
             List.iter l ~f:(fun (msg, sexp) ->
                 Format.fprintf fmt "  %s: %s\n%!" msg (Sexp.to_string sexp))
       | exn ->
           Format.fprintf fmt
             "  BUG: unhandled exception. Use [--debug] for details.\n%!" ;
-          if Conf.debug () then
-            Format.fprintf fmt "%s\n%!" (Exn.to_string exn) )
+          if debug then Format.fprintf fmt "%s\n%!" (Exn.to_string exn) )
 
-let check_all_locations fmt cmts_t =
-  if Conf.debug () then
+let check_all_locations ~debug fmt cmts_t =
+  if debug then
     match Cmts.remaining_locs cmts_t with
     | [] -> ()
     | l ->
@@ -240,10 +240,10 @@ let check_all_locations fmt cmts_t =
           "Warning: Some locations have not been considered\n%!" ;
         List.iter ~f:print (List.sort l ~compare:Location.compare)
 
-let check_margin (conf : Conf.t) ~filename ~fmted =
-  if Conf.margin_check () then
+let check_margin conf opts ~filename ~fmted =
+  if opts.Conf.margin_check then
     List.iteri (String.split_lines fmted) ~f:(fun i line ->
-        if String.length line > conf.margin then
+        if String.length line > conf.Conf.margin then
           Format.fprintf Format.err_formatter
             "Warning: %s:%i exceeds the margin\n%!" filename i)
 
@@ -258,19 +258,23 @@ let with_buffer_formatter ~buffer_size k =
   if Buffer.length buffer > 0 then Format_.pp_print_newline fs () ;
   Buffer.contents buffer
 
-let format xunit ?output_file ~input_name ~source ~parsed (conf : Conf.t) =
+let format xunit ?output_file ~input_name ~source ~parsed conf opts =
   let dump_ast ~suffix ast =
-    dump_ast ~input_name ?output_file ~suffix (fun fmt ->
-        xunit.printast fmt ast)
+    dump_ast ~debug:opts.Conf.debug ~input_name ?output_file ~suffix
+      (fun fmt -> xunit.printast fmt ast)
   in
-  let dump_formatted = dump_formatted ~input_name ?output_file in
+  let dump_formatted =
+    dump_formatted ~debug:opts.debug ~input_name ?output_file
+  in
   Location.input_name := input_name ;
   (* iterate until formatting stabilizes *)
   let rec print_check ~i ~(conf : Conf.t) t ~source =
     let format ~box_debug =
       let open Fmt in
       let source_t = Source.create source in
-      let cmts_t = xunit.init_cmts source_t t.ast t.comments in
+      let cmts_t =
+        xunit.init_cmts ~debug:opts.debug source_t t.ast t.comments
+      in
       let contents =
         with_buffer_formatter ~buffer_size:(String.length source)
           ( set_margin conf.margin
@@ -279,21 +283,19 @@ let format xunit ?output_file ~input_name ~source ~parsed (conf : Conf.t) =
               (not (String.is_empty t.prefix))
               (str t.prefix $ fmt "@.")
           $ with_optional_box_debug ~box_debug
-              (xunit.fmt source_t cmts_t conf t.ast) )
+              (xunit.fmt ~debug:opts.debug source_t cmts_t conf t.ast) )
       in
       (contents, cmts_t)
     in
-    if Conf.debug () then
+    if opts.debug then
       format ~box_debug:true |> fst
       |> dump_formatted ~suffix:".boxes"
       |> (ignore : string option -> unit) ;
     let fmted, cmts_t = format ~box_debug:false in
-    let conf =
-      if Conf.debug () then conf else {conf with Conf.quiet= true}
-    in
+    let conf = if opts.debug then conf else {conf with Conf.quiet= true} in
     if String.equal source fmted then (
-      check_all_locations Format.err_formatter cmts_t ;
-      check_margin conf ~fmted
+      check_all_locations ~debug:opts.debug Format.err_formatter cmts_t ;
+      check_margin conf opts ~fmted
         ~filename:(Option.value output_file ~default:input_name) ;
       Ok fmted )
     else
@@ -337,7 +339,7 @@ let format xunit ?output_file ~input_name ~source ~parsed (conf : Conf.t) =
             | [] -> ()
             | l -> internal_error (`Comment_dropped l) [] ) ;
             let is_docstring Cmt.{txt; _} =
-              conf.Conf.parse_docstrings && Char.equal txt.[0] '*'
+              conf.parse_docstrings && Char.equal txt.[0] '*'
             in
             let old_docstrings, old_comments =
               List.partition_tf t.comments ~f:is_docstring
@@ -380,8 +382,8 @@ let format xunit ?output_file ~input_name ~source ~parsed (conf : Conf.t) =
   | Sys_error msg -> Error (User_error msg)
   | exn -> Error (Ocamlformat_bug {exn})
 
-let parse_and_format xunit ?output_file ~input_name ~source conf =
+let parse_and_format xunit ?output_file ~input_name ~source conf opts =
   Location.input_name := input_name ;
   match parse xunit.parse conf ~source with
   | exception exn -> Error (Invalid_source {exn})
-  | parsed -> format xunit conf ?output_file ~input_name ~source ~parsed
+  | parsed -> format xunit ?output_file ~input_name ~source ~parsed conf opts

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -70,25 +70,15 @@ let with_file input_name output_file suf ext f =
   Out_channel.with_file tmp ~f ;
   tmp
 
-let dump_ast ~debug ~input_name ?output_file ~suffix fmt =
-  if debug then
-    let ext = ".ast" in
-    let file =
-      with_file input_name output_file suffix ext (fun oc ->
-          fmt (Format.formatter_of_out_channel oc))
-    in
-    Some file
-  else None
+let dump_ast ~input_name ?output_file ~suffix fmt =
+  let ext = ".ast" in
+  with_file input_name output_file suffix ext (fun oc ->
+      fmt (Format.formatter_of_out_channel oc))
 
-let dump_formatted ~debug ~input_name ?output_file ~suffix fmted =
+let dump_formatted ~input_name ?output_file ~suffix fmted =
   let ext = Filename.extension input_name in
-  if debug then
-    let file =
-      with_file input_name output_file suffix ext (fun oc ->
-          Out_channel.output_string oc fmted)
-    in
-    Some file
-  else None
+  with_file input_name output_file suffix ext (fun oc ->
+      Out_channel.output_string oc fmted)
 
 let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~check
     ~input_name error =
@@ -230,22 +220,20 @@ let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~check
             "  BUG: unhandled exception. Use [--debug] for details.\n%!" ;
           if debug then Format.fprintf fmt "%s\n%!" (Exn.to_string exn) )
 
-let check_all_locations ~debug fmt cmts_t =
-  if debug then
-    match Cmts.remaining_locs cmts_t with
-    | [] -> ()
-    | l ->
-        let print l = Format.fprintf fmt "%a\n%!" Location.print_loc l in
-        Format.fprintf fmt
-          "Warning: Some locations have not been considered\n%!" ;
-        List.iter ~f:print (List.sort l ~compare:Location.compare)
+let check_all_locations fmt cmts_t =
+  match Cmts.remaining_locs cmts_t with
+  | [] -> ()
+  | l ->
+      let print l = Format.fprintf fmt "%a\n%!" Location.print_loc l in
+      Format.fprintf fmt
+        "Warning: Some locations have not been considered\n%!" ;
+      List.iter ~f:print (List.sort l ~compare:Location.compare)
 
-let check_margin conf opts ~filename ~fmted =
-  if opts.Conf.margin_check then
-    List.iteri (String.split_lines fmted) ~f:(fun i line ->
-        if String.length line > conf.Conf.margin then
-          Format.fprintf Format.err_formatter
-            "Warning: %s:%i exceeds the margin\n%!" filename i)
+let check_margin conf ~filename ~fmted =
+  List.iteri (String.split_lines fmted) ~f:(fun i line ->
+      if String.length line > conf.Conf.margin then
+        Format.fprintf Format.err_formatter
+          "Warning: %s:%i exceeds the margin\n%!" filename i)
 
 let with_optional_box_debug ~box_debug k =
   if box_debug then Fmt.with_box_debug k else k
@@ -260,11 +248,16 @@ let with_buffer_formatter ~buffer_size k =
 
 let format xunit ?output_file ~input_name ~source ~parsed conf opts =
   let dump_ast ~suffix ast =
-    dump_ast ~debug:opts.Conf.debug ~input_name ?output_file ~suffix
-      (fun fmt -> xunit.printast fmt ast)
+    if opts.Conf.debug then
+      Some
+        (dump_ast ~input_name ?output_file ~suffix (fun fmt ->
+             xunit.printast fmt ast))
+    else None
   in
-  let dump_formatted =
-    dump_formatted ~debug:opts.debug ~input_name ?output_file
+  let dump_formatted ~suffix fmted =
+    if opts.debug then
+      Some (dump_formatted ~input_name ?output_file ~suffix fmted)
+    else None
   in
   Location.input_name := input_name ;
   (* iterate until formatting stabilizes *)
@@ -294,9 +287,10 @@ let format xunit ?output_file ~input_name ~source ~parsed conf opts =
     let fmted, cmts_t = format ~box_debug:false in
     let conf = if opts.debug then conf else {conf with Conf.quiet= true} in
     if String.equal source fmted then (
-      check_all_locations ~debug:opts.debug Format.err_formatter cmts_t ;
-      check_margin conf opts ~fmted
-        ~filename:(Option.value output_file ~default:input_name) ;
+      if opts.debug then check_all_locations Format.err_formatter cmts_t ;
+      if opts.Conf.margin_check then
+        check_margin conf ~fmted
+          ~filename:(Option.value output_file ~default:input_name) ;
       Ok fmted )
     else
       let exn_args () =

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -80,8 +80,8 @@ let dump_formatted ~input_name ?output_file ~suffix fmted =
   with_file input_name output_file suffix ext (fun oc ->
       Out_channel.output_string oc fmted)
 
-let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~check
-    ~input_name error =
+let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~input_name error
+    =
   let exe = Filename.basename Caml.Sys.argv.(0) in
   match error with
   | Invalid_source _ when quiet -> ()
@@ -130,21 +130,20 @@ let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~check
         ignore (Unix.system (Printf.sprintf "diff %S %S 1>&2" p n)) ;
         Unix.unlink p ;
         Unix.unlink n ) ;
-      if not check then
-        if iteration <= 1 then
-          Format.fprintf fmt
-            "%s: %S was not already formatted. ([max-iters = 1])\n%!" exe
-            input_name
-        else (
-          Format.fprintf fmt
-            "%s: Cannot process %S.\n\
-            \  Please report this bug at \
-             https://github.com/ocaml-ppx/ocamlformat/issues.\n\
-             %!"
-            exe input_name ;
-          Format.fprintf fmt
-            "  BUG: formatting did not stabilize after %i iterations.\n%!"
-            iteration )
+      if iteration <= 1 then
+        Format.fprintf fmt
+          "%s: %S was not already formatted. ([max-iters = 1])\n%!" exe
+          input_name
+      else (
+        Format.fprintf fmt
+          "%s: Cannot process %S.\n\
+          \  Please report this bug at \
+           https://github.com/ocaml-ppx/ocamlformat/issues.\n\
+           %!"
+          exe input_name ;
+        Format.fprintf fmt
+          "  BUG: formatting did not stabilize after %i iterations.\n%!"
+          iteration )
   | User_error msg -> Format.fprintf fmt "%s: %s.\n%!" exe msg
   | Ocamlformat_bug {exn} -> (
       Format.fprintf fmt

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -12,8 +12,8 @@
 open Parse_with_comments
 
 type 'a t =
-  { init_cmts: Source.t -> 'a -> Cmt.t list -> Cmts.t
-  ; fmt: Source.t -> Cmts.t -> Conf.t -> 'a -> Fmt.t
+  { init_cmts: debug:bool -> Source.t -> 'a -> Cmt.t list -> Cmts.t
+  ; fmt: debug:bool -> Source.t -> Cmts.t -> Conf.t -> 'a -> Fmt.t
   ; parse: Lexing.lexbuf -> 'a
   ; equal:
          ignore_doc_comments:bool
@@ -39,6 +39,7 @@ val format :
   -> source:string
   -> parsed:'a with_comments
   -> Conf.t
+  -> Conf.opts
   -> (string, error) Result.t
 (** [format xunit conf ?output_file ~input_name ~source ~parsed] formats
     [parsed], using [input_name] for error messages, and referring to
@@ -51,11 +52,18 @@ val parse_and_format :
   -> input_name:string
   -> source:string
   -> Conf.t
+  -> Conf.opts
   -> (string, error) Result.t
 (** [parse_and_format xunit conf ?output_file ~input_name ~source] is similar
     to [format] but parses the source according to [xunit]. *)
 
 val print_error :
-  ?fmt:Format.formatter -> Conf.t -> input_name:string -> error -> unit
+     ?fmt:Format.formatter
+  -> debug:bool
+  -> quiet:bool
+  -> check:bool
+  -> input_name:string
+  -> error
+  -> unit
 (** [print_error conf ?fmt ~input_name e] prints the error message
     corresponding to error [e] on the [fmt] formatter (stderr by default). *)

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -61,7 +61,6 @@ val print_error :
      ?fmt:Format.formatter
   -> debug:bool
   -> quiet:bool
-  -> check:bool
   -> input_name:string
   -> error
   -> unit

--- a/test/cli/dune
+++ b/test/cli/dune
@@ -277,3 +277,23 @@
  (name runtest)
  (action
   (diff debug.expected debug.output)))
+
+(rule
+ (with-outputs-to
+  max_iter_1_ok.output
+  (run ocamlformat --max-iters=1 %{dep:sample/a.ml})))
+
+(alias
+ (name runtest)
+ (action
+  (diff max_iter_1_ok.expected max_iter_1_ok.output)))
+
+(rule
+ (with-outputs-to
+  max_iter_1_failing.output
+  (system "! %{bin:ocamlformat} --max-iters=1 %{dep:sample/b.ml}")))
+
+(alias
+ (name runtest)
+ (action
+  (diff max_iter_1_failing.expected max_iter_1_failing.output)))

--- a/test/cli/max_iter_1_failing.expected
+++ b/test/cli/max_iter_1_failing.expected
@@ -1,0 +1,1 @@
+ocamlformat: "sample/b.ml" was not already formatted. ([max-iters = 1])

--- a/test/cli/max_iter_1_ok.expected
+++ b/test/cli/max_iter_1_ok.expected
@@ -1,0 +1,1 @@
+let x = "Hello World"


### PR DESCRIPTION
~Rebased on https://github.com/ocaml-ppx/ocamlformat/pull/1161~

This PR add a new record `Conf.opts`, it should contains non-formatting options.
Currently, it's used for `debug` and `margin_check` options.

It is different from `Conf.t` because these options changes the behavior of the tool (error printing, debug).

Later, some options currently in `Conf.t` should be moved to `Conf.opts` and passed accordingly (eg. `comment_check`).
The bottom half of `Conf.ml` (defining `action`) should now be removed from `Fmt_ast.ml`'s dependencies, a little more work is needed before we can split that file.