### PR TITLE
Remove some calls to if_newline and break_unless_newline and fix break before closing brackets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
   + Fix: types on named arguments were wrapped incorrectly when preceding comments (#1124) (Guillaume Petiot)
   + Fix the indentation produced by max-indent (#1118) (Guillaume Petiot)
   + Fix break after Psig_include depending on presence of docstring (#1125) (Guillaume Petiot)
+  + Remove some calls to if_newline and break_unless_newline and fix break before closing brackets (#1168) (Guillaume Petiot)
 
 #### Internal
 

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -628,18 +628,17 @@ let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
               ( close_box
               $ fmt_or_k eol_cmt (fmt_or_k adj_cmt adj eol) (fmt_opt epi) ))
 
-let fmt_before t conf ~fmt_code ?pro ?(epi = Fmt.break_unless_newline 1 0)
-    ?eol ?adj =
+let fmt_before t conf ~fmt_code ?pro ?(epi = Fmt.break 1 0) ?eol ?adj =
   fmt_cmts t conf t.cmts_before ~fmt_code ?pro ~epi ?eol ?adj
 
-let fmt_after t conf ~fmt_code ?(pro = Fmt.break_unless_newline 1 0) ?epi =
+let fmt_after t conf ~fmt_code ?(pro = Fmt.break 1 0) ?epi =
   let open Fmt in
   let within = fmt_cmts t conf t.cmts_within ~fmt_code ~pro ?epi in
   let after = fmt_cmts t conf t.cmts_after ~fmt_code ~pro ?epi ~eol:noop in
   fun loc -> within loc $ after loc
 
-let fmt_within t conf ~fmt_code ?(pro = Fmt.break_unless_newline 1 0)
-    ?(epi = Fmt.break_unless_newline 1 0) =
+let fmt_within t conf ~fmt_code ?(pro = Fmt.break 1 0) ?(epi = Fmt.break 1 0)
+    =
   fmt_cmts t conf t.cmts_within ~fmt_code ~pro ~epi ~eol:Fmt.noop
 
 let fmt t conf ~fmt_code ?pro ?epi ?eol ?adj loc =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -914,6 +914,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
              (p.box
                 ( list_fl loc_xpats fmt_pat
                 $ Cmts.fmt_before c ~pro:cmt_break ~epi:noop nil_loc
+                    ~eol:noop
                 $ Cmts.fmt_after c ~pro:(fmt "@ ") ~epi:noop nil_loc )))
     | None ->
         hvbox 0

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4324,7 +4324,9 @@ let fmt_toplevel c ctx itms =
 
 let fmt_file ~ctx ~f ~fmt_code source cmts conf itms =
   let c = {source; cmts; conf; fmt_code} in
-  match itms with [] -> Cmts.fmt_after c Location.none | l -> f c ctx l
+  match itms with
+  | [] -> Cmts.fmt_after ~pro:noop c Location.none
+  | l -> f c ctx l
 
 let rec fmt_code conf s =
   match

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3165,10 +3165,10 @@ and fmt_type_extension c ctx
            $ fmt_longident_loc c ptyext_path
            $ str " +="
            $ fmt_private_flag ptyext_private
-           $ fmt "@ "
-           $ hvbox 0
-               (if_newline "| " $ list ptyext_constructors "@ | " fmt_ctor)
-           )
+           $ list_fl ptyext_constructors (fun ~first ~last:_ x ->
+                 let bar_fits = if first then "" else "| " in
+                 cbreak ~fits:("", 1, bar_fits) ~breaks:("", 0, "| ")
+                 $ fmt_ctor x) )
        $ fmt_attributes c ~pre:(fmt "@ ") ~key:"@@" atrs )
 
 and fmt_type_exception ~pre c sep ctx

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -98,8 +98,7 @@ let get_cases (c : Conf.t) ~first ~indent ~parens_here =
       ; break_after_opening_paren= fmt "@ " }
 
 let wrap_collec c ~space_around opn cls =
-  if space_around then
-    wrap_k (str opn $ char ' ') (break_unless_newline 1 0 $ str cls)
+  if space_around then wrap_k (str opn $ char ' ') (break 1 0 $ str cls)
   else wrap_fits_breaks c opn cls
 
 let wrap_record (c : Conf.t) =

--- a/test/passing/list.ml
+++ b/test/passing/list.ml
@@ -29,12 +29,12 @@ let x = function
         "sed do eiusmod tempor incididunt ut labore et dolore"
         (* " magna aliqua. Ut enim ad minim veniam, quis nostrud "; *)
         (* "exercitation ullamco laboris nisi ut aliquip ex ea commodo " *)
-       ]
+      ]
     ; (* ", sed do eiusmod tempor incididunt ut labore et dolore"; *)
       "sed do eiusmod tempor incididunt ut labore et dolore"
       (* " magna aliqua. Ut enim ad minim veniam, quis nostrud "; *)
-      (* "exercitation ullamco laboris nisi ut aliquip ex ea commodo " *)
-     ] ->
+      (* "exercitation ullamco laboris nisi ut aliquip ex ea commodo " *) ]
+    ->
       ()
 
 [@@@ocamlformat "space-around-lists=true"]


### PR DESCRIPTION
Still on the way to remove calls to our custom `Format` functions.

Only b6208ad produces a diff.
No diff with `janestreet` profile.
Diff with `conventional` profile:
```diff
diff --git a/sledge/src/llair/frontend.ml b/sledge/src/llair/frontend.ml
index 6f0ebabff..115fa2834 100644
--- a/sledge/src/llair/frontend.ml
+++ b/sledge/src/llair/frontend.ml
@@ -932,7 +932,6 @@ let xlate_instr :
           | [
               "_ZnwmSt11align_val_t";
               (* operator new(unsigned long, std::align_val_t) *)
-              
             ] ->
               let reg = xlate_name x instr in
               let num = xlate_value x (Llvm.operand instr 0) in
@@ -942,12 +941,10 @@ let xlate_instr :
           | [
               "_ZdlPvSt11align_val_t";
               (* operator delete(void* ptr, std::align_val_t) *)
-              
             ]
           | [
               "_ZdlPvmSt11align_val_t";
               (* operator delete(void* ptr, unsigned long, std::align_val_t) *)
-              
             ]
           | [ "free" (* void free(void* ptr) *) ] ->
               let ptr = xlate_value x (Llvm.operand instr 0) in
@@ -1055,7 +1052,6 @@ let xlate_instr :
       | [
           "_ZnwmSt11align_val_t";
           (* operator new(unsigned long num, std::align_val_t) *)
-          
         ]
         when num_actuals > 0 ->
           let reg = xlate_name x instr in
```