### PR TITLE
Fix regression with `indicate-multiline-delimiters=space`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -163,6 +163,7 @@
   + Fix dropped comments around module pack expressions (#1214) (Jules Aguillon)
   + Fix regression of comment position in list patterns (#1141) (Josh Berdine)
   + Fix: adjust definition of Location.is_single_line to reflect margin (#1102) (Josh Berdine)
+  + Fix regression with `indicate-multiline-delimiters=space` (#1169) (Josh Berdine)
 
 #### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -122,6 +122,8 @@
   + Fix parenthesizing of optional arguments rebound to non-variables, e.g. `let
     f ?a:(A) = ()` rather than the unparsable `let f ?a:A = ()` (#1305) (Craig Ferguson)
 
+  + Fix regression with `indicate-multiline-delimiters=space` (#1169) (Josh Berdine, Guillaume Petiot)
+
 ### 0.13.0 (2020-01-28)
 
 #### New features
@@ -163,7 +165,6 @@
   + Fix dropped comments around module pack expressions (#1214) (Jules Aguillon)
   + Fix regression of comment position in list patterns (#1141) (Josh Berdine)
   + Fix: adjust definition of Location.is_single_line to reflect margin (#1102) (Josh Berdine)
-  + Fix regression with `indicate-multiline-delimiters=space` (#1169) (Josh Berdine)
 
 #### Documentation
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2224,7 +2224,7 @@ end = struct
             ({pexp_desc= Pexp_ident {txt= Lident i; _}; _}, _ :: (_, e2) :: _)
           when e2 == exp && is_infix_id i
                && Option.value_map ~default:false (prec_ast ctx) ~f:(fun p ->
-                      compare_prec p Apply < 0) ->
+                      compare_prec p Apply < 0 ) ->
             true
         | Pexp_apply
             ({pexp_desc= Pexp_ident lid; _}, (_ :: (_, e2) :: _ as args))

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -267,7 +267,7 @@ let doc_atrs ?(acc = []) atrs =
           | _ ->
               ( ({txt= doc; loc}, String.equal "ocaml.text" txt) :: docs
               , rev_atrs ) )
-        | _ -> (docs, atr :: rev_atrs))
+        | _ -> (docs, atr :: rev_atrs) )
   in
   let docs = match docs with [] -> None | l -> Some (List.rev l) in
   (docs, List.rev rev_atrs)
@@ -931,11 +931,11 @@ end = struct
         =
       List.exists ptype_params ~f:fst_f
       || List.exists ptype_cstrs ~f:(fun (t1, t2, _) ->
-             typ == t1 || typ == t2)
+             typ == t1 || typ == t2 )
       || ( match ptype_kind with
          | Ptype_variant cd1N ->
              List.exists cd1N ~f:(fun {pcd_args; pcd_res; _} ->
-                 check_cstr pcd_args || Option.exists pcd_res ~f)
+                 check_cstr pcd_args || Option.exists pcd_res ~f )
          | Ptype_record ld1N ->
              List.exists ld1N ~f:(fun {pld_type; _} -> typ == pld_type)
          | _ -> false )
@@ -969,7 +969,7 @@ end = struct
               || loop e
           | Pcf_method (_, _, Cfk_concrete _) -> false
           | Pcf_constraint (t1, t2) -> t1 == typ || t2 == typ
-          | Pcf_initializer _ | Pcf_attribute _ | Pcf_extension _ -> false)
+          | Pcf_initializer _ | Pcf_attribute _ | Pcf_extension _ -> false )
     in
     let check_class_type l =
       List.exists l ~f:(fun {pci_expr= {pcty_desc; _}; pci_params; _} ->
@@ -978,7 +978,7 @@ end = struct
           match pcty_desc with
           | Pcty_constr (_, l) -> List.exists l ~f:(fun x -> x == typ)
           | Pcty_arrow (_, t, _) -> t == typ
-          | _ -> false)
+          | _ -> false )
     in
     match ctx with
     | Pld (PTyp t1) -> assert (typ == t1)
@@ -994,13 +994,13 @@ end = struct
           assert (
             List.exists r1N ~f:(function
               | {prf_desc= Rtag (_, _, t1N); _} -> List.exists t1N ~f
-              | {prf_desc= Rinherit t1; _} -> typ == t1) )
+              | {prf_desc= Rinherit t1; _} -> typ == t1 ) )
       | Ptyp_package (_, it1N) -> assert (List.exists it1N ~f:snd_f)
       | Ptyp_object (fields, _) ->
           assert (
             List.exists fields ~f:(function
               | {pof_desc= Otag (_, t1); _} -> typ == t1
-              | {pof_desc= Oinherit t1; _} -> typ == t1) )
+              | {pof_desc= Oinherit t1; _} -> typ == t1 ) )
       | Ptyp_class (_, l) -> assert (List.exists l ~f) )
     | Cty {pcty_desc; _} ->
         assert (
@@ -1018,7 +1018,7 @@ end = struct
                      | Pctf_method (_, _, _, t) -> t == typ
                      | Pctf_inherit _ -> false
                      | Pctf_attribute _ -> false
-                     | Pctf_extension _ -> false) )
+                     | Pctf_extension _ -> false ) )
     | Pat ctx -> (
       match ctx.ppat_desc with
       | Ppat_constraint (_, t1) -> assert (typ == t1)
@@ -1045,7 +1045,7 @@ end = struct
                 | {pexp_desc= Pexp_constraint (_, t); pexp_attributes= []; _}
                   ->
                     t == typ
-                | _ -> false) )
+                | _ -> false ) )
       | _ -> assert false )
     | Cl {pcl_desc; _} ->
         assert (
@@ -1066,7 +1066,7 @@ end = struct
               List.exists c1N ~f:(function
                 | Pwith_type (_, d1) | Pwith_typesubst (_, d1) ->
                     check_type d1
-                | _ -> false)
+                | _ -> false )
               || loop m.pmty_desc
           | _ -> false
         in
@@ -1112,7 +1112,7 @@ end = struct
                 ||
                 match pcl_desc with
                 | Pcl_constr (_, l) -> List.exists l ~f:(fun x -> x == typ)
-                | _ -> false) )
+                | _ -> false ) )
       | Pstr_class_type l -> assert (check_class_type l)
       | Pstr_extension ((_, PTyp t), _) -> assert (t == typ)
       | Pstr_extension (_, _) -> assert false
@@ -1133,7 +1133,7 @@ end = struct
             | Pcty_arrow (_, _, x) -> loop x
             | _ -> false
           in
-          loop pci_expr)
+          loop pci_expr )
     in
     match (ctx : t) with
     | Exp _ -> assert false
@@ -1150,7 +1150,7 @@ end = struct
                   | Pcl_constraint (_, x) -> x == cty
                   | _ -> false
                 in
-                loop pci_expr) )
+                loop pci_expr ) )
       | _ -> assert false )
     | Sig ctx -> (
       match ctx.psig_desc with
@@ -1169,7 +1169,7 @@ end = struct
                 | Pctf_method _ -> false
                 | Pctf_constraint _ -> false
                 | Pctf_attribute _ -> false
-                | Pctf_extension _ -> false) )
+                | Pctf_extension _ -> false ) )
       | Pcty_open (_, t) -> assert (t == cty)
       | Pcty_constr _ -> assert false
       | Pcty_extension _ -> assert false )
@@ -1200,7 +1200,7 @@ end = struct
       List.exists pcstr_fields ~f:(fun f ->
           match f.pcf_desc with
           | Pcf_inherit (_, x, _) -> x == cl
-          | _ -> false)
+          | _ -> false )
     in
     match (ctx : t) with
     | Exp e -> (
@@ -1222,7 +1222,7 @@ end = struct
                   | Pcl_constraint (x, _) -> loop x
                   | _ -> false
                 in
-                loop pci_expr) )
+                loop pci_expr ) )
       | _ -> assert false )
     | Sig _ -> assert false
     | Cty _ -> assert false
@@ -1260,7 +1260,7 @@ end = struct
           | Pcf_extension (_, _) -> false
           | Pcf_inherit _ -> false
           | Pcf_constraint _ -> false
-          | Pcf_attribute _ -> false)
+          | Pcf_attribute _ -> false )
     in
     let check_extensions = function PPat (p, _) -> p == pat | _ -> false in
     let check_subpat ppat =
@@ -1326,7 +1326,7 @@ end = struct
           assert (
             List.exists cases ~f:(function
               | {pc_lhs; _} when pc_lhs == pat -> true
-              | _ -> false) )
+              | _ -> false ) )
       | Pexp_for (p, _, _, _, _) | Pexp_fun (_, _, p, _) -> assert (p == pat)
       )
     | Cl ctx ->
@@ -1391,7 +1391,7 @@ end = struct
           | Pcf_extension (_, ext) -> check_extensions ext
           | Pcf_inherit _ -> false
           | Pcf_constraint _ -> false
-          | Pcf_attribute _ -> false)
+          | Pcf_attribute _ -> false )
     in
     match ctx with
     | Pld (PPat (_, Some e1)) -> assert (e1 == exp)
@@ -1424,7 +1424,7 @@ end = struct
               List.exists cases ~f:(function
                 | {pc_guard= Some g; _} when g == exp -> true
                 | {pc_rhs; _} when pc_rhs == exp -> true
-                | _ -> false) )
+                | _ -> false ) )
         | Pexp_fun (_, default, _, body) ->
             assert (Option.value_map default ~default:false ~f || body == exp)
         | Pexp_apply
@@ -1454,7 +1454,7 @@ end = struct
                        ; _ }
                        when e == exp ->
                          true
-                     | _ -> e == e) )
+                     | _ -> e == e ) )
         | Pexp_assert e
          |Pexp_constraint (e, _)
          |Pexp_coerce (e, _, _)
@@ -1562,7 +1562,7 @@ end = struct
           List.exists cd1N ~f:(function
             | {pcd_args= Pcstr_tuple t1N; _} ->
                 List.exists t1N ~f:(phys_equal ty)
-            | _ -> false)
+            | _ -> false )
       | _ -> false
     in
     let is_tuple_lvl1_in_ext_constructor ty = function
@@ -1841,8 +1841,8 @@ end = struct
                    List.exists l ~f:(fun c ->
                        match c.pcd_args with
                        | Pcstr_tuple l -> List.exists l ~f:(phys_equal typ)
-                       | _ -> false)
-               | _ -> false) ->
+                       | _ -> false )
+               | _ -> false ) ->
         true
     | { ast= {ptyp_desc= Ptyp_alias _; _}
       ; ctx=
@@ -1999,7 +1999,7 @@ end = struct
         List.exists bindings ~f:(function
           | {pvb_pat; pvb_expr= {pexp_desc= Pexp_constraint _; _}; _} ->
               pvb_pat == pat
-          | _ -> false)
+          | _ -> false )
     | Pld _, Ppat_constraint _ -> true
     | _ -> false
 
@@ -2187,12 +2187,12 @@ end = struct
         | Pexp_function cases | Pexp_match (_, cases) | Pexp_try (_, cases)
           ->
             List.iter cases ~f:(fun case ->
-                mark_parenzed_inner_nested_match case.pc_rhs) ;
+                mark_parenzed_inner_nested_match case.pc_rhs ) ;
             true
         | _ -> continue e )
       | Pexp_function cases | Pexp_match (_, cases) | Pexp_try (_, cases) ->
           List.iter cases ~f:(fun case ->
-              mark_parenzed_inner_nested_match case.pc_rhs) ;
+              mark_parenzed_inner_nested_match case.pc_rhs ) ;
           true
       | Pexp_apply ({pexp_desc= Pexp_ident ident; _}, args)
         when Option.is_some (Indexing_op.get_sugar ident args) -> (
@@ -2333,7 +2333,7 @@ end = struct
        |Pexp_try (_, cases) ->
           if !leading_nested_match_parens then
             List.iter cases ~f:(fun {pc_rhs; _} ->
-                mark_parenzed_inner_nested_match pc_rhs) ;
+                mark_parenzed_inner_nested_match pc_rhs ) ;
           List.exists cases ~f:(fun {pc_rhs; _} -> pc_rhs == exp)
           && exposed_right_exp Match exp
       | Pexp_ifthenelse (cnd, _, _) when cnd == exp -> false
@@ -2363,7 +2363,7 @@ end = struct
                  | {pexp_desc= Pexp_constraint (e, _); pexp_attributes= []; _}
                    when e == exp ->
                      true
-                 | _ -> e0 == exp) ->
+                 | _ -> e0 == exp ) ->
           exposed_right_exp Non_apply exp
           (* Non_apply is perhaps pessimistic *)
       | Pexp_record (_, Some ({pexp_desc= Pexp_apply (ident, [_]); _} as e0))

--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -40,7 +40,7 @@ let split_asterisk_prefixed {txt; loc= {Location.loc_start; _}} =
       (String.init len ~f:(function
         | 0 -> '\n'
         | n when n < len - 1 -> ' '
-        | _ -> '*'))
+        | _ -> '*' ))
   in
   let rec split_asterisk_prefixed_ pos =
     match String.Search_pattern.index pat ~pos ~in_:txt with
@@ -73,7 +73,7 @@ let unindent_lines ~opn_pos first_line tl_lines =
   let min_indent =
     List.fold_left ~init:fl_indent
       ~f:(fun acc s ->
-        Option.value_map ~default:acc ~f:(min acc) (indent_of_line s))
+        Option.value_map ~default:acc ~f:(min acc) (indent_of_line s) )
       tl_lines
   in
   (* Completely trim the first line *)
@@ -102,7 +102,7 @@ let fmt cmt src ~wrap:wrap_comments ~fmt_code =
             match (line, next) with
             | "", None -> fmt ")"
             | _, None -> str line $ fmt "*)"
-            | _, Some _ -> str line $ fmt "@,*") )
+            | _, Some _ -> str line $ fmt "@,*" ) )
   in
   let fmt_unwrapped_cmt {txt= s; loc} =
     let begins_line = Source.begins_line src loc ~ignore_spaces:false in

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -317,7 +317,7 @@ let init map_ast ~debug source asts comments_n_docstrings =
     if debug then
       List.iter locs ~f:(fun loc ->
           if not (Location.compare loc Location.none = 0) then
-            update_remaining t ~f:(Location.Set.add loc)) ;
+            update_remaining t ~f:(Location.Set.add loc) ) ;
     if debug then (
       let dump fs lt = Fmt.eval fs (Loc_tree.dump lt) in
       Format.eprintf "\nLoc_tree:\n%!" ;

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -127,7 +127,7 @@ end = struct
   let of_list cmts =
     List.fold cmts ~init:empty ~f:(fun map cmt ->
         let pos = cmt.Cmt.loc.loc_start in
-        Map.add_multi map ~key:pos ~data:cmt)
+        Map.add_multi map ~key:pos ~data:cmt )
 
   let to_list map = List.concat (Map.data map)
 
@@ -160,7 +160,7 @@ let is_adjacent t (l1 : Location.t) (l2 : Location.t) =
       | "|" ->
           Source.begins_line t.source l1
           && Position.column l1.loc_start < Position.column l2.loc_start
-      | _ -> false)
+      | _ -> false )
 
 (** Whether the symbol preceding location [loc] is an infix symbol or a
     semicolon. If it is the case, comments attached to the following item
@@ -183,7 +183,7 @@ let partition_after_prev_or_before_next t ~prev cmts ~next =
   | {loc; _} :: _ as cmtl when is_adjacent t prev loc -> (
     match
       List.group cmtl ~break:(fun l1 l2 ->
-          not (is_adjacent t (Cmt.loc l1) (Cmt.loc l2)))
+          not (is_adjacent t (Cmt.loc l1) (Cmt.loc l2)) )
     with
     | [cmtl] when is_adjacent t (List.last_exn cmtl).loc next ->
         let open Location in
@@ -199,7 +199,7 @@ let partition_after_prev_or_before_next t ~prev cmts ~next =
               List.partition_tf cmtl ~f:(fun {Cmt.loc= l1; _} ->
                   same_line_as_next l1
                   || (same_line_as_prev l1 && infix_symbol_before t prev)
-                  || not (same_line_as_prev l1))
+                  || not (same_line_as_prev l1) )
             in
             (prev, next)
           else ([], cmtl)
@@ -236,9 +236,9 @@ let add_cmts t ?prev ?next position loc cmts =
           Format.eprintf "add %s %a: %a \"%s\" %s \"%s\"@\n%!"
             (position_to_string position)
             Location.fmt loc Location.fmt cmt_loc (String.escaped btw_prev)
-            cmt_txt (String.escaped btw_next)) ;
-    update_cmts t position ~f:(fun v ->
-        Location.Multimap.add_list v loc cmtl) )
+            cmt_txt (String.escaped btw_next) ) ;
+    update_cmts t position ~f:(fun v -> Location.Multimap.add_list v loc cmtl)
+    )
 
 (** Traverse the location tree from locs, find the deepest location that
     contains each comment, intersperse comments between that location's
@@ -271,7 +271,7 @@ let rec place t loc_tree ?prev_loc locs cmts =
     | None ->
         if t.debug then
           List.iter (CmtSet.to_list cmts) ~f:(fun {Cmt.txt; _} ->
-              Format.eprintf "lost: %s@\n%!" txt) )
+              Format.eprintf "lost: %s@\n%!" txt ) )
 
 (** Relocate comments, for Ast transformations such as sugaring. *)
 let relocate (t : t) ~src ~before ~after =
@@ -293,7 +293,7 @@ let relocate (t : t) ~src ~before ~after =
     if t.debug then
       update_remaining t ~f:(fun r ->
           r |> Location.Set.remove src |> Location.Set.add after
-          |> Location.Set.add before) )
+          |> Location.Set.add before ) )
 
 (** Initialize global state and place comments. *)
 let init map_ast ~debug source asts comments_n_docstrings =
@@ -311,7 +311,7 @@ let init map_ast ~debug source asts comments_n_docstrings =
     Format.eprintf "\nComments:\n%!" ;
     List.iter comments ~f:(fun {Cmt.txt; loc} ->
         Format.eprintf "%a %s %s@\n%!" Location.fmt loc txt
-          (if Source.ends_line source loc then "eol" else "")) ) ;
+          (if Source.ends_line source loc then "eol" else "") ) ) ;
   if not (List.is_empty comments) then (
     let loc_tree, locs = Loc_tree.of_ast map_ast asts source in
     if debug then
@@ -425,11 +425,11 @@ let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
                 $ maybe_newline ~next cmt
             | group ->
                 list group "@;<1000 0>" (fun cmt ->
-                    wrap "(*" "*)" (str (Cmt.txt cmt)))
+                    wrap "(*" "*)" (str (Cmt.txt cmt)) )
                 $ maybe_newline ~next (List.last_exn group) )
           $ fmt_if_k (Option.is_none next)
               ( close_box
-              $ fmt_or_k eol_cmt (fmt_or_k adj_cmt adj eol) (fmt_opt epi) ))
+              $ fmt_or_k eol_cmt (fmt_or_k adj_cmt adj eol) (fmt_opt epi) ) )
 
 let fmt_before t conf ~fmt_code ?pro ?(epi = Fmt.break 1 0) ?eol ?adj loc =
   fmt_cmts t conf (find_cmts t `Before loc) ~fmt_code ?pro ~epi ?eol ?adj loc
@@ -457,7 +457,7 @@ let drop_inside t loc =
     update_cmts t pos
       ~f:
         (Location.Multimap.filter ~f:(fun {Cmt.loc= cmt_loc; _} ->
-             not (Location.contains loc cmt_loc)))
+             not (Location.contains loc cmt_loc) ))
   in
   clear `Before ;
   clear `Within ;

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -91,7 +91,7 @@ end = struct
       ( match p.ppat_desc with
       | Ppat_record (flds, Open) ->
           Option.iter (Source.loc_of_underscore src flds p.ppat_loc)
-            ~f:(fun loc -> locs := loc :: !locs )
+            ~f:(fun loc -> locs := loc :: !locs)
       | _ -> () ) ;
       Ast_mapper.default_mapper.pat m p
     in
@@ -237,8 +237,8 @@ let add_cmts t ?prev ?next position loc cmts =
             (position_to_string position)
             Location.fmt loc Location.fmt cmt_loc (String.escaped btw_prev)
             cmt_txt (String.escaped btw_next) ) ;
-    update_cmts t position ~f:(fun v -> Location.Multimap.add_list v loc cmtl)
-    )
+    update_cmts t position ~f:(fun v ->
+        Location.Multimap.add_list v loc cmtl ) )
 
 (** Traverse the location tree from locs, find the deepest location that
     contains each comment, intersperse comments between that location's

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -91,7 +91,7 @@ end = struct
       ( match p.ppat_desc with
       | Ppat_record (flds, Open) ->
           Option.iter (Source.loc_of_underscore src flds p.ppat_loc)
-            ~f:(fun loc -> locs := loc :: !locs)
+            ~f:(fun loc -> locs := loc :: !locs )
       | _ -> () ) ;
       Ast_mapper.default_mapper.pat m p
     in

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -115,7 +115,7 @@ let warn ?filename ?lnum fmt =
         | Some file, None -> Format.asprintf "File %a@\n" Fpath.pp file
         | None, _ -> ""
       in
-      warn_raw (Format.asprintf "%sWarning: %s@\n" loc s))
+      warn_raw (Format.asprintf "%sWarning: %s@\n" loc s) )
     fmt
 
 module C = Config_option.Make (struct
@@ -1206,7 +1206,7 @@ let enable_outside_detected_project =
   let witness =
     String.concat ~sep:" or "
       (List.map project_root_witness ~f:(fun name ->
-           Format.sprintf "$(b,%s)" name))
+           Format.sprintf "$(b,%s)" name ))
   in
   let doc =
     Format.sprintf
@@ -1763,7 +1763,7 @@ let (_profile : t option C.t) =
       selected_profile_ref := p ;
       let new_conf = Option.value p ~default:conf in
       (* The quiet option is cummulative *)
-      {new_conf with quiet= new_conf.quiet || conf.quiet})
+      {new_conf with quiet= new_conf.quiet || conf.quiet} )
     (fun _ -> !selected_profile_ref)
 
 let ocp_indent_normal_profile =
@@ -1878,7 +1878,7 @@ let parse_line config ~from s =
         Result.( >>= )
           (update ~config ~from ~name:"profile" ~value:"janestreet")
           (fun config ->
-            update_many ~config ~from ocp_indent_janestreet_profile)
+            update_many ~config ~from ocp_indent_janestreet_profile )
     | name -> update ~config ~from ~name ~value:"true" )
   | _ -> Error (`Malformed s)
 
@@ -1887,7 +1887,7 @@ let is_project_root ~root dir =
   | Some root -> Fpath.equal dir root
   | None ->
       List.exists project_root_witness ~f:(fun name ->
-          Fpath.(exists (dir / name)))
+          Fpath.(exists (dir / name)) )
 
 let dot_ocp_indent = ".ocp-indent"
 
@@ -1954,7 +1954,7 @@ let read_config_file conf filename_kind =
                     warn ~filename ~lnum:num "ignoring invalid options %S"
                       line ;
                     (conf, errors, Int.succ num)
-                | Error e -> (conf, e :: errors, Int.succ num))
+                | Error e -> (conf, e :: errors, Int.succ num) )
           in
           match List.rev errors with
           | [] -> c
@@ -2027,10 +2027,10 @@ let is_in_listing_file ~listings ~filename =
                         None )
                 | Error (`Msg msg) ->
                     warn ~filename:listing_file ~lnum:lno "%s" msg ;
-                    None))
+                    None ) )
       with Sys_error err ->
         warn "ignoring %a, %s" Fpath.pp listing_file err ;
-        None)
+        None )
 
 let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
   let vfile = Fpath.v file in
@@ -2071,7 +2071,7 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
      warn ~filename:vfile
        "Ocamlformat disabled because [--enable-outside-detected-project] is \
         not set and %s"
-       why) ;
+       why ) ;
     {conf with disable= true} )
   else
     let listings = if conf.disable then enables else ignores in
@@ -2087,7 +2087,8 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
 let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
   let conf, warn_now =
     collect_warnings (fun () ->
-        build_config ~enable_outside_detected_project ~root ~file ~is_stdin)
+        build_config ~enable_outside_detected_project ~root ~file ~is_stdin
+      )
   in
   if not conf.quiet then warn_now () ;
   conf
@@ -2130,7 +2131,7 @@ let validate_inputs () =
         | Stdin -> Error "Cannot specify stdin together with other inputs"
         | File f ->
             let kind = Option.value ~default:`Impl (kind_of_ext f) in
-            Ok (kind, f))
+            Ok (kind, f) )
       |> Result.all
       |> Result.map ~f:(fun files -> `Several_files files)
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -2087,8 +2087,7 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
 let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
   let conf, warn_now =
     collect_warnings (fun () ->
-        build_config ~enable_outside_detected_project ~root ~file ~is_stdin
-      )
+        build_config ~enable_outside_detected_project ~root ~file ~is_stdin )
   in
   if not conf.quiet then warn_now () ;
   conf

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1964,7 +1964,7 @@ let read_config_file conf filename_kind =
                 | `Ocp_indent _ -> dot_ocp_indent
                 | `Ocamlformat _ -> dot_ocamlformat
               in
-              failwith_user_errors ~kind l)
+              failwith_user_errors ~kind l )
     with Sys_error _ -> conf )
 
 let update_using_env conf =

--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -98,7 +98,7 @@ module Make (C : CONFIG) = struct
     let open Cmdliner in
     let invert_names =
       List.filter_map names ~f:(fun n ->
-          if String.length n = 1 then None else Some ("no-" ^ n))
+          if String.length n = 1 then None else Some ("no-" ^ n) )
     in
     let doc =
       generated_flag_doc ~allow_inline ~doc ~section ~default ~deprecated
@@ -242,7 +242,7 @@ module Make (C : CONFIG) = struct
                 update_from config name from ;
                 Some (Ok config)
             | Error (`Msg error) -> Some (Error (`Bad_value (name, error)))
-        else None)
+        else None )
     |> Option.value ~default:(Error (`Unknown (name, value)))
 
   let default {default; _} = default

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -79,7 +79,7 @@ let list_pn x1N pp fs =
 let list_fl xs pp fs =
   list_pn xs
     (fun ~prev x ~next fs ->
-      pp ~first:(Option.is_none prev) ~last:(Option.is_none next) x fs)
+      pp ~first:(Option.is_none prev) ~last:(Option.is_none next) x fs )
     fs
 
 let list xs sep pp fs =
@@ -271,6 +271,6 @@ let fill_text ?epi text =
                   | Some str when String.for_all str ~f:Char.is_whitespace ->
                       close_box $ fmt "\n@," $ open_hovbox 0
                   | Some _ when not (String.is_empty curr) -> fmt "@ "
-                  | _ -> noop)))
+                  | _ -> noop )))
       $ fmt_if (Char.is_whitespace text.[String.length text - 1]) " "
       $ opt epi Fn.id )

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -81,7 +81,7 @@ let protect =
           let bt = Caml.Printexc.get_backtrace () in
           Caml.Format.eprintf "@\nFAIL@\n%a@\n%s@.%!" Ast.dump ast bt ;
           first := false ) ;
-        raise exc)
+        raise exc )
 
 let update_config ?quiet c l =
   {c with conf= List.fold ~init:c.conf l ~f:(Conf.update ?quiet)}
@@ -155,7 +155,7 @@ let maybe_disabled_k c (loc : Location.t) (l : attributes) f k =
           if i = 0 then s
           else
             drop_while s ~f:(fun i c ->
-                Char.is_whitespace c && i < indent_of_first_line))
+                Char.is_whitespace c && i < indent_of_first_line ) )
     in
     k (Cmts.fmt c loc (list l "@\n" str))
 
@@ -190,7 +190,7 @@ let fmt_groups c ctx grps fmt_grp =
       fmt_if (break_struct && not first) "\n@;<1000 0>"
       $ fmt_if ((not break_struct) && not first) "@;<1000 0>"
       $ fmt_grp ~first ~last grp
-      $ fits_breaks_if ((not break_struct) && not last) "" "\n")
+      $ fits_breaks_if ((not break_struct) && not last) "" "\n" )
 
 let value_binding_op_rec first rec_flag =
   match (first, rec_flag) with
@@ -206,7 +206,7 @@ let fmt_recmodule c ctx items f ast =
     list_fl itms (fun ~first ~last:_ (itm, c) ->
         fmt_if_k (not first) (fmt_or break_struct "@;<1000 0>" "@ ")
         $ maybe_disabled c (Ast.location (ast itm)) []
-          @@ fun c -> f c ctx ~rec_flag:true ~first:(first && first_grp) itm)
+          @@ fun c -> f c ctx ~rec_flag:true ~first:(first && first_grp) itm )
   in
   hvbox 0 (fmt_groups c ctx grps fmt_grp)
 
@@ -430,7 +430,7 @@ let fmt_docstring c ?standalone ?pro ?epi doc =
   list_pn (Option.value ~default:[] doc)
     (fun ~prev:_ ({txt; loc}, floating) ~next ->
       let epi = docstring_epi ?standalone ?next ?epi ~floating in
-      fmt_parsed_docstring c ~loc ?pro ~epi txt (parse_docstring ~loc txt))
+      fmt_parsed_docstring c ~loc ?pro ~epi txt (parse_docstring ~loc txt) )
 
 let fmt_docstring_around_item' ?(is_val = false) ?(force_before = false)
     ?(fit = false) c doc1 doc2 =
@@ -443,18 +443,18 @@ let fmt_docstring_around_item' ?(is_val = false) ?(force_before = false)
       let is_tag_only =
         List.for_all ~f:(function
           | Ok es, _ -> Fmt_odoc.is_tag_only es
-          | _ -> false)
+          | _ -> false )
       in
       let fmt_doc ?epi ?pro doc =
         list_pn doc (fun ~prev:_ (parsed, ({txt; loc}, floating)) ~next ->
             let next = Option.map next ~f:snd in
             let epi = docstring_epi ?standalone:None ?next ?epi ~floating in
-            fmt_parsed_docstring c ~loc ~epi ?pro txt parsed)
+            fmt_parsed_docstring c ~loc ~epi ?pro txt parsed )
       in
       let floating_doc, doc =
         doc
         |> List.map ~f:(fun (({txt; loc}, _) as doc) ->
-               (parse_docstring ~loc txt, doc))
+               (parse_docstring ~loc txt, doc) )
         |> List.partition_tf ~f:(fun (_, (_, floating)) -> floating)
       in
       let placement =
@@ -1092,7 +1092,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
                         ~space:(space xpat.ast)
                   in
                   leading_cmt $ fmt_pattern c ~pro xpat
-                  $ fmt_if_k last close_box))
+                  $ fmt_if_k last close_box ) )
         $ fmt_or_k nested
             (fits_breaks (if parens then ")" else "") "")
             (fits_breaks (if parens then ")" else "") ~hint:(1, 2) ")") )
@@ -1429,7 +1429,7 @@ and fmt_infix_op_args c ~parens xexp op_args =
                $ cmts_after
                $ hovbox_if (not very_last) 2
                    (list_fl xargs (fmt_arg very_last)) )
-           $ fmt_if_k (not last) (break 1 0)))
+           $ fmt_if_k (not last) (break 1 0) ))
     $ fmt_if_k (not last_grp) (break 1 0)
   in
   let opn, hint, cls =
@@ -1694,7 +1694,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       match List.rev e1N1 with
       | (lbl, ({pexp_desc= Pexp_fun _; pexp_loc; _} as eN1)) :: rev_e1N
         when List.for_all rev_e1N ~f:(fun (_, eI) ->
-                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI)) ->
+                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI) ) ->
           let e1N = List.rev rev_e1N in
           (* side effects of Cmts.fmt c.cmts before Sugar.fun_ is important *)
           let cmts_before = Cmts.fmt_before c pexp_loc in
@@ -1737,7 +1737,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             ; _ } as eN ) )
         :: rev_e1N
         when List.for_all rev_e1N ~f:(fun (_, eI) ->
-                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI)) ->
+                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI) ) ->
           let e1N = List.rev rev_e1N in
           let ctx = Exp eN in
           (* side effects of Cmts.fmt_before before [fmt_pattern] is
@@ -1766,7 +1766,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                $ fmt_atrs ))
       | (lbl, ({pexp_desc= Pexp_function cs; pexp_loc; _} as eN)) :: rev_e1N
         when List.for_all rev_e1N ~f:(fun (_, eI) ->
-                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI)) ->
+                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI) ) ->
           let e1N = List.rev rev_e1N in
           let ctx'' = Exp eN in
           let default_indent = if c.conf.wrap_fun_args then 2 else 4 in
@@ -1856,7 +1856,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                          ( opn_paren $ str "module " $ m $ fmt "@ : "
                          $ fmt_longident_loc c id )
                      $ fmt_package_type c ctx cnstrs
-                     $ cls_paren $ fmt_atrs )))))
+                     $ cls_paren $ fmt_atrs ) ) ) ) )
   | Pexp_constraint (e, t) ->
       hvbox 2
         ( wrap_fits_breaks ~space:false c.conf "(" ")"
@@ -1891,7 +1891,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                  ( fmt_expressions c (expression_width c) snd loc_xes
                      (fun (locs, xexp) ->
                        Cmts.fmt_list c ~eol:cmt_break locs
-                       @@ fmt_expression c xexp)
+                       @@ fmt_expression c xexp )
                      p
                  $ Cmts.fmt_before c ~pro:cmt_break ~epi:noop ~eol:noop
                      nil_loc
@@ -1910,7 +1910,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    ( has_cmts
                    , fmt_before_cmts
                    , fmt_after_cmts
-                   , (fmt_op, [(Nolabel, arg)]) )))
+                   , (fmt_op, [(Nolabel, arg)]) ) ))
           $ fmt_atrs ) )
   | Pexp_construct (({txt= Lident "::"; loc= _} as lid), Some arg) ->
       let opn, cls =
@@ -2013,7 +2013,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                           ( fmt_expression c ~box:false ~parens:false
                               ?pro:p.expr_pro ?eol:p.expr_eol xbch
                           $ p.break_end_branch ) ) )
-                $ fmt_if_k (not last) p.space_between_branches)))
+                $ fmt_if_k (not last) p.space_between_branches )))
   | Pexp_let (rec_flag, bindings, body) ->
       let indent_after_in =
         match body.pexp_desc with
@@ -2210,7 +2210,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                                (sub_pat ~ctx pc_lhs)
                            $ opt pc_guard (fun g ->
                                  fmt "@ when "
-                                 $ fmt_expression c (sub_exp ~ctx g))
+                                 $ fmt_expression c (sub_exp ~ctx g) )
                            $ fmt "@ ->" $ fmt_if parens_here " (" ) )
                    $ fmt "@;<1 2>"
                    $ cbox 0 (fmt_expression c ?parens:parens_for_exp xpc_rhs)
@@ -2474,7 +2474,7 @@ and fmt_class_structure c ~ctx ?ext self_ fields =
           | Pcf_attribute atr -> update_config c [atr]
           | _ -> c
         in
-        (c, (i, c)))
+        (c, (i, c)) )
   in
   let cmts_after_self = Cmts.fmt_after c self_.ppat_loc in
   let self_ =
@@ -2490,7 +2490,7 @@ and fmt_class_structure c ~ctx ?ext self_ fields =
         ( str "object"
         $ fmt_extension_suffix c ext
         $ opt self_ (fun self_ ->
-              fmt "@;" $ wrap "(" ")" (fmt_pattern c (sub_pat ~ctx self_)))
+              fmt "@;" $ wrap "(" ")" (fmt_pattern c (sub_pat ~ctx self_)) )
         )
     $ cmts_after_self
     $ ( match fields with
@@ -2511,7 +2511,7 @@ and fmt_class_signature c ~ctx ~parens ?ext self_ fields =
           | Pctf_attribute atr -> update_config c [atr]
           | _ -> c
         in
-        (c, (i, c)))
+        (c, (i, c)) )
   in
   let cmts_after_self = Cmts.fmt_after c self_.ptyp_loc in
   let self_ =
@@ -2530,7 +2530,7 @@ and fmt_class_signature c ~ctx ~parens ?ext self_ fields =
                $ fmt_extension_suffix c ext
                $ opt self_ (fun self_ ->
                      fmt "@;"
-                     $ wrap "(" ")" (fmt_core_type c (sub_typ ~ctx self_)))
+                     $ wrap "(" ")" (fmt_core_type c (sub_typ ~ctx self_)) )
                )
            $ cmts_after_self
            $ ( match fields with
@@ -2853,7 +2853,7 @@ and fmt_cases c ctx cs =
       ~f:(fun acc case ->
         match pattern_len case with
         | Some l -> Continue (f acc l)
-        | None -> Stop None)
+        | None -> Stop None )
       ~finish:(fun acc -> Some acc)
   in
   let max_len = fold_pattern_len ~f:max cs in
@@ -2877,7 +2877,7 @@ and fmt_cases c ctx cs =
           | _ -> None )
         | _ -> None
       in
-      fmt_case c ctx ~first ~last ~padding case)
+      fmt_case c ctx ~first ~last ~padding case )
 
 and fmt_case c ctx ~first ~last ~padding case =
   let {pc_lhs; pc_guard; pc_rhs} = case in
@@ -2922,7 +2922,7 @@ and fmt_case c ctx ~first ~last ~padding case =
               ( fmt_pattern c ~pro:p.bar ~parens:paren_lhs xlhs
               $ fmt_opt padding
               $ opt pc_guard (fun g ->
-                    fmt "@;<1 2>when " $ fmt_expression c (sub_exp ~ctx g))
+                    fmt "@;<1 2>when " $ fmt_expression c (sub_exp ~ctx g) )
               )
           $ p.break_before_arrow $ str "->" $ p.break_after_arrow
           $ fmt_if parens_here " (" )
@@ -2972,7 +2972,7 @@ and fmt_tydcl_params c ctx params =
         (List.length params > 1)
         "(" ")"
         (list params (Params.comma_sep c.conf) (fun (ty, vc) ->
-             fmt_variance vc $ fmt_core_type c (sub_typ ~ctx ty)))
+             fmt_variance vc $ fmt_core_type c (sub_typ ~ctx ty) ))
     $ fmt "@ " )
 
 and fmt_class_params c ctx params =
@@ -3242,7 +3242,7 @@ and fmt_type_extension c ctx
            $ list_fl ptyext_constructors (fun ~first ~last:_ x ->
                  let bar_fits = if first then "" else "| " in
                  cbreak ~fits:("", 1, bar_fits) ~breaks:("", 0, "| ")
-                 $ fmt_ctor x) )
+                 $ fmt_ctor x ) )
        $ fmt_attributes c ~pre:(fmt "@ ") ~key:"@@" atrs )
 
 and fmt_type_exception ~pre c sep ctx
@@ -3362,7 +3362,7 @@ and fmt_module_type c ({ast= mty; _} as xmty) =
       { empty with
         pro=
           Option.map pro ~f:(fun pro ->
-              open_hvbox 0 $ fmt_if parens "(" $ pro)
+              open_hvbox 0 $ fmt_if parens "(" $ pro )
       ; psp
       ; bdy=
           fmt_if_k (Option.is_none pro) (open_hvbox 2 $ fmt_if parens "(")
@@ -3487,8 +3487,7 @@ and fmt_signature_item c ?ext {ast= si; _} =
   | Psig_modsubst ms -> hvbox 0 (fmt_module_substitution c ctx ms)
   | Psig_open od -> fmt_open_description c ~kw_attributes:[] od
   | Psig_recmodule mds ->
-      fmt_recmodule c ctx mds fmt_module_declaration (fun x ->
-          Mty x.pmd_type)
+      fmt_recmodule c ctx mds fmt_module_declaration (fun x -> Mty x.pmd_type)
   | Psig_type (rec_flag, decls) -> fmt_type c ?ext rec_flag decls ctx
   | Psig_typext te -> fmt_type_extension c ctx te
   | Psig_value vd -> fmt_value_description c ctx vd
@@ -3518,7 +3517,7 @@ and fmt_class_types c ctx ~pre ~sep (cls : class_type class_infos list) =
       in
       fmt_if (not first) "\n@\n"
       $ hovbox 0
-        @@ Cmts.fmt c cl.pci_loc (doc_before $ class_types $ doc_after))
+        @@ Cmts.fmt c cl.pci_loc (doc_before $ class_types $ doc_after) )
 
 and fmt_class_exprs c ctx (cls : class_expr class_infos list) =
   list_fl cls (fun ~first ~last:_ cl ->
@@ -3553,14 +3552,14 @@ and fmt_class_exprs c ctx (cls : class_expr class_infos list) =
                   $ fmt_if (not (List.is_empty xargs)) "@ "
                   $ wrap_fun_decl_args c (fmt_fun_args c xargs) )
               $ opt ty (fun t ->
-                    fmt " :@ " $ fmt_class_type c (sub_cty ~ctx t))
+                    fmt " :@ " $ fmt_class_type c (sub_cty ~ctx t) )
               $ fmt "@ =" )
           $ fmt "@;" $ fmt_class_expr c e )
         $ fmt_attributes c ~pre:(fmt "@;") ~key:"@@" atrs
       in
       fmt_if (not first) "\n@\n"
       $ hovbox 0
-        @@ Cmts.fmt c cl.pci_loc (doc_before $ class_exprs $ doc_after))
+        @@ Cmts.fmt c cl.pci_loc (doc_before $ class_exprs $ doc_after) )
 
 and fmt_module c ?epi ?(can_sparse = false) keyword ?(eqty = "=") name xargs
     xbody xmty attributes =
@@ -3579,7 +3578,7 @@ and fmt_module c ?epi ?(can_sparse = false) keyword ?(eqty = "=") name xargs
         { blk with
           pro=
             Some (str " " $ str eqty $ opt blk.pro (fun pro -> str " " $ pro))
-        ; psp= fmt_if (Option.is_none blk.pro) "@;<1 2>" $ blk.psp })
+        ; psp= fmt_if (Option.is_none blk.pro) "@;<1 2>" $ blk.psp } )
   in
   let blk_b = Option.value_map xbody ~default:empty ~f:(fmt_module_expr c) in
   let box_t = wrap_k blk_t.opn blk_t.cls in
@@ -3655,7 +3654,7 @@ and fmt_module c ?epi ?(can_sparse = false) keyword ?(eqty = "=") name xargs
                (Option.is_some blk_b.epi && not c.conf.ocp_indent_compat)
                " " "@ ")
             (fmt "@;<1 -2>")
-          $ epi) )
+          $ epi ) )
 
 and fmt_module_declaration c ctx ~rec_flag ~first pmd =
   let {pmd_name; pmd_type; pmd_attributes; pmd_loc} = pmd in
@@ -4002,7 +4001,7 @@ and fmt_structure c ctx itms =
         let last = last && last_grp in
         fmt_if_k (not first) (fmt_or break_struct "@\n" "@ ")
         $ maybe_disabled c itm.pstr_loc []
-          @@ fun c -> fmt_structure_item c ~last (sub_str ~ctx itm))
+          @@ fun c -> fmt_structure_item c ~last (sub_str ~ctx itm) )
   in
   hvbox 0 (fmt_groups c ctx grps fmt_grp)
 
@@ -4037,7 +4036,8 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
   let pro = fmt_or maybe_box "@ " "\n@;<1000 0>" in
   let fmt_cmts_after = Cmts.fmt_after ~pro c si.pstr_loc in
   (fun k ->
-    fmt_cmts_before $ hvbox_if maybe_box 0 ~name:"stri" (k $ fmt_cmts_after))
+    fmt_cmts_before $ hvbox_if maybe_box 0 ~name:"stri" (k $ fmt_cmts_after)
+    )
   @@
   match si.pstr_desc with
   | Pstr_attribute atr ->
@@ -4073,7 +4073,7 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
   | Pstr_primitive vd -> fmt_value_description c ctx vd
   | Pstr_recmodule bindings ->
       fmt_recmodule c ctx bindings fmt_module_binding (fun x ->
-          Mod x.pmb_expr)
+          Mod x.pmb_expr )
   | Pstr_type (rec_flag, decls) -> fmt_type c ?ext rec_flag decls ctx
   | Pstr_typext te -> fmt_type_extension c ctx te
   | Pstr_value (rec_flag, bindings) ->
@@ -4113,11 +4113,11 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
             fmt_if (not first) "@;<1000 0>"
             $ fmt_value_binding c op ~rec_flag
                 ?ext:(if first && first_grp then ext else None)
-                ctx ?epi ~attributes ~loc pvb_pat pvb_expr)
+                ctx ?epi ~attributes ~loc pvb_pat pvb_expr )
       in
       hvbox 0 ~name:"value"
         (list_fl grps (fun ~first ~last grp ->
-             fmt_grp ~first ~last grp $ fmt_if (not last) "\n@;<1000 0>"))
+             fmt_grp ~first ~last grp $ fmt_if (not last) "\n@;<1000 0>" ))
   | Pstr_modtype mtd -> fmt_module_type_declaration c ctx mtd
   | Pstr_extension (ext, atrs) ->
       let doc_before, doc_after, atrs = fmt_docstring_around_item c atrs in
@@ -4380,7 +4380,7 @@ let fmt_toplevel_directive c dir =
 let flatten_ptop =
   List.concat_map ~f:(function
     | Ptop_def items -> List.map items ~f:(fun i -> `Item i)
-    | Ptop_dir d -> [`Directive d])
+    | Ptop_dir d -> [`Directive d] )
 
 let fmt_toplevel c ctx itms =
   let itms = flatten_ptop itms in
@@ -4400,7 +4400,7 @@ let fmt_toplevel c ctx itms =
     list_fl itms (fun ~first ~last (itm, c) ->
         let last = last && last_grp in
         fmt_if_k (not first) (fmt_or break_struct "@\n" "@ ")
-        $ fmt_item c ~last itm)
+        $ fmt_item c ~last itm )
   in
   hvbox 0 (fmt_groups c ctx grps fmt_grp)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -47,7 +47,7 @@ module Cmts = struct
 
   let fmt_list ?pro ?epi ?eol c locs init =
     List.fold locs ~init ~f:(fun k loc ->
-        fmt ?pro ?epi ?eol ?adj:None c loc k)
+        fmt ?pro ?epi ?eol ?adj:None c loc k )
 end
 
 type block =
@@ -947,7 +947,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
         let pat =
           fmt_elements_collection p
             (fun (locs, xpat) ->
-              Cmts.fmt_list c ~eol:cmt_break locs (fmt_pattern c xpat))
+              Cmts.fmt_list c ~eol:cmt_break locs (fmt_pattern c xpat) )
             loc_xpats
         in
         hvbox 0
@@ -1280,7 +1280,7 @@ and fmt_index_op c ctx ~fmt_atrs ~has_attr ~parens op =
            $ Cmts.fmt_before c op.loc $ str "." $ fmt_op
            $ wrap_brackets brackets (Cmts.fmt_after c op.loc $ fmt_args)
            $ opt op.rhs (fun e ->
-                 fmt_assign_arrow c $ fmt_expression c (sub_exp ~ctx e)) )
+                 fmt_assign_arrow c $ fmt_expression c (sub_exp ~ctx e) ) )
        $ fmt_atrs ))
 
 and fmt_label_arg ?(box = true) ?epi ?parens ?eol c
@@ -1673,11 +1673,11 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                 let fmt_after_cmts =
                   Cmts.fmt_after c pexp_loc
                   $ opt (List.hd args) (fun (_, {ast= e; _}) ->
-                        Cmts.fmt_before ~adj c e.pexp_loc)
+                        Cmts.fmt_before ~adj c e.pexp_loc )
                 in
                 let fmt_op = fmt_expression c op in
                 (has_cmts, fmt_before_cmts, fmt_after_cmts, (fmt_op, args))
-            | None -> (false, noop, noop, (noop, args)))
+            | None -> (false, noop, noop, (noop, args)) )
       in
       hvbox_if outer_wrap 0
         (wrap_if outer_wrap "(" ")"
@@ -2268,7 +2268,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         ( p1.box
             ( opt default (fun d ->
                   hvbox 2 (fmt_expression c (sub_exp ~ctx d) $ fmt "@;<1 -2>")
-                  $ str "with" $ p2.break_after_with)
+                  $ str "with" $ p2.break_after_with )
             $ fmt_fields )
         $ fmt_atrs )
   | Pexp_extension
@@ -3575,7 +3575,7 @@ and fmt_module c ?epi ?(can_sparse = false) keyword ?(eqty = "=") name xargs
           | Sugar.Unit -> `Unit
           | Sugar.Named (name, x) -> `Named (name, fmt_module_type c x)
         in
-        {loc; txt})
+        {loc; txt} )
   in
   let blk_t =
     Option.value_map xmty ~default:empty ~f:(fun xmty ->

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1704,16 +1704,6 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             | Pexp_fun _ | Pexp_function _ -> Some false
             | _ -> None
           in
-          let break_after_arrow =
-            match xbody.ast.pexp_desc with
-            | Pexp_function _ -> break 1 0
-            | _ -> (
-              (* Avoid the "double indentation" of the application and the
-                 function matching when the [max-indent] option is set. *)
-              match c.conf.max_indent with
-              | Some i when i <= 2 -> break 1 0
-              | _ -> break 1 2 )
-          in
           hvbox 0
             (wrap_if parens "(" ")"
                ( hovbox 2
@@ -1725,7 +1715,16 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                            $ fmt_attributes c ~key:"@" eN1.pexp_attributes
                                ~suf:(str " ")
                            $ hvbox 0 (fmt_fun_args c xargs $ fmt "@ ->") ) )
-                   $ break_after_arrow
+                   $ fmt
+                       ( match xbody.ast.pexp_desc with
+                       | Pexp_function _ -> "@ "
+                       | _ -> (
+                         (* Avoid the "double indentation" of the application
+                            and the function matching when the [max-indent]
+                            option is set. *)
+                         match c.conf.max_indent with
+                         | Some i when i <= 2 -> "@ "
+                         | _ -> "@;<1 2>" ) )
                    $ cbox 0 (fmt_expression c ?box xbody)
                    $ fmt_or_k
                        Poly.(c.conf.indicate_multiline_delimiters = `Space)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1704,7 +1704,6 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             | Pexp_fun _ | Pexp_function _ -> Some false
             | _ -> None
           in
-          let fit = Location.is_single_line pexp_loc c.conf.margin in
           hvbox 0
             (wrap_if parens "(" ")"
                ( hovbox 2
@@ -1729,9 +1728,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    $ cbox 0 (fmt_expression c ?box xbody)
                    $ fmt_or_k
                        Poly.(c.conf.indicate_multiline_delimiters = `Space)
-                       (fmt_or_k fit (str ")")
-                          (fits_breaks ~force_fit_if:fit ")" ~hint:(1, 0) ")"))
-                       (str ")")
+                       (fits_breaks ")" " )") (str ")")
                    $ Cmts.fmt_after c pexp_loc )
                $ fmt_atrs ))
       | ( lbl

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -713,7 +713,7 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
               | None -> fmt_core_type c xtI
               | Some f -> hovbox 2 (f $ fmt_core_type c xtI)
             in
-            hvbox 0 (Cmts.fmt_before c locI $ arg))
+            hvbox 0 (Cmts.fmt_before c locI $ arg) )
   | Ptyp_constr (lid, []) -> fmt_longident_loc c lid
   | Ptyp_constr (lid, [t1]) ->
       fmt_core_type c (sub_typ ~ctx t1) $ fmt "@ " $ fmt_longident_loc c lid

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1014,7 +1014,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
       let fmt_underscore =
         if is_open closed_flag then
           opt (Source.loc_of_underscore c.source flds ppat_loc) (fun loc ->
-              Cmts.fmt c loc p2.wildcard)
+              Cmts.fmt c loc p2.wildcard )
         else noop
       in
       hvbox_if parens 0

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1731,7 +1731,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                        Poly.(c.conf.indicate_multiline_delimiters = `Space)
                        (fmt_or_k fit (str ")")
                           (fits_breaks ~force_fit_if:fit ")" ~hint:(1, 0) ")"))
-                       (fits_breaks ~force_fit_if:fit ")" ~hint:(0, 0) ")")
+                       (str ")")
                    $ Cmts.fmt_after c pexp_loc )
                $ fmt_atrs ))
       | ( lbl

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2231,7 +2231,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
               (str "module " $ m)
           $ fmt_atrs )
       in
-      hovbox 0
+      hvbox 0
         (compose_module (fmt_module_expr c (sub_mod ~ctx me)) ~f:fmt_mod)
   | Pexp_record (flds, default) ->
       let fmt_field (lid1, f) =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1704,6 +1704,16 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             | Pexp_fun _ | Pexp_function _ -> Some false
             | _ -> None
           in
+          let break_after_arrow =
+            match xbody.ast.pexp_desc with
+            | Pexp_function _ -> break 1 0
+            | _ -> (
+              (* Avoid the "double indentation" of the application and the
+                 function matching when the [max-indent] option is set. *)
+              match c.conf.max_indent with
+              | Some i when i <= 2 -> break 1 0
+              | _ -> break 1 2 )
+          in
           hvbox 0
             (wrap_if parens "(" ")"
                ( hovbox 2
@@ -1715,16 +1725,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                            $ fmt_attributes c ~key:"@" eN1.pexp_attributes
                                ~suf:(str " ")
                            $ hvbox 0 (fmt_fun_args c xargs $ fmt "@ ->") ) )
-                   $ fmt
-                       ( match xbody.ast.pexp_desc with
-                       | Pexp_function _ -> "@ "
-                       | _ -> (
-                         (* Avoid the "double indentation" of the application
-                            and the function matching when the [max-indent]
-                            option is set. *)
-                         match c.conf.max_indent with
-                         | Some i when i <= 2 -> "@ "
-                         | _ -> "@;<1 2>" ) )
+                   $ break_after_arrow
                    $ cbox 0 (fmt_expression c ?box xbody)
                    $ fmt_or_k
                        Poly.(c.conf.indicate_multiline_delimiters = `Space)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1860,7 +1860,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                          ( opn_paren $ str "module " $ m $ fmt "@ : "
                          $ fmt_longident_loc c id )
                      $ fmt_package_type c ctx cnstrs
-                     $ cls_paren $ fmt_atrs ) ) ) ) )
+                     $ cls_paren $ fmt_atrs ))) ))
   | Pexp_constraint (e, t) ->
       hvbox 2
         ( wrap_fits_breaks ~space:false c.conf "(" ")"

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -116,7 +116,7 @@ let list_block_elem elems f =
         | Some _ -> fmt "@\n"
         | None -> fmt ""
       in
-      f elem $ break)
+      f elem $ break )
 
 let space_elt : inline_element with_location =
   Location_.(at (span []) (`Space ""))
@@ -267,4 +267,4 @@ let diff c x y =
 let is_tag_only =
   List.for_all ~f:(function
     | {Location_.value= `Tag _; _} -> true
-    | _ -> false)
+    | _ -> false )

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -234,7 +234,7 @@ module Location = struct
       Option.fold (Map.find map src) ~init:(Map.remove map src)
         ~f:(fun new_map src_data ->
           Map.update new_map dst ~f:(fun dst_data ->
-              Option.fold dst_data ~init:src_data ~f))
+              Option.fold dst_data ~init:src_data ~f ) )
 
     let empty =
       Map.empty

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -63,7 +63,7 @@ module Mapper = struct
               { pdir_name=
                   {pdir_name with loc= mapper.location mapper pdir_name.loc}
               ; pdir_arg
-              ; pdir_loc= mapper.location mapper pdir_loc })
+              ; pdir_loc= mapper.location mapper pdir_loc } )
 end
 
 module Parse = struct
@@ -78,7 +78,7 @@ module Parse = struct
       ~f:(fun (p : Parsetree.toplevel_phrase) ->
         match p with
         | Ptop_def [] -> false
-        | Ptop_def (_ :: _) | Ptop_dir _ -> true)
+        | Ptop_def (_ :: _) | Ptop_dir _ -> true )
 end
 
 let to_current =
@@ -106,7 +106,7 @@ module Printast = struct
 
   let use_file f (x : Parsetree.toplevel_phrase list) =
     List.iter x ~f:(fun (p : Parsetree.toplevel_phrase) ->
-        top_phrase f (to_current.copy_toplevel_phrase p))
+        top_phrase f (to_current.copy_toplevel_phrase p) )
 end
 
 module Pprintast = struct

--- a/lib/Non_overlapping_interval_tree.ml
+++ b/lib/Non_overlapping_interval_tree.ml
@@ -58,7 +58,7 @@ module Make (Itv : IN) = struct
              | Some children -> parents map children ~ancestors elt
              | None -> ancestors )
              |> Option.some
-           else None))
+           else None ))
 
   let add_root t root = {t with roots= root :: t.roots}
 
@@ -105,7 +105,7 @@ module Make (Itv : IN) = struct
                ( str (Sexp.to_string_hum (Itv.comparator.sexp_of_t root))
                $ wrap_if
                    (not (List.is_empty children))
-                   "@,{" " }" (dump_ tree children) )))
+                   "@,{" " }" (dump_ tree children) ) ))
     in
     set_margin 100000000 $ dump_ tree tree.roots
 end

--- a/lib/Normalize.ml
+++ b/lib/Normalize.ml
@@ -108,9 +108,9 @@ let rec odoc_nestable_block_element c fmt = function
           let comments = dedup_cmts Mapper.structure ast comments in
           let print_comments fmt (l : Cmt.t list) =
             List.sort l ~compare:(fun {Cmt.loc= a; _} {Cmt.loc= b; _} ->
-                Location.compare a b)
+                Location.compare a b )
             |> List.iter ~f:(fun {Cmt.txt; _} ->
-                   Caml.Format.fprintf fmt "%s," txt)
+                   Caml.Format.fprintf fmt "%s," txt )
           in
           let ast = c.normalize_code ast in
           Caml.Format.asprintf "AST,%a,COMMENTS,[%a]" Printast.implementation
@@ -303,7 +303,7 @@ let make_mapper conf ~ignore_doc_comment =
         List.filter si ~f:(fun si ->
             match si.pstr_desc with
             | Pstr_attribute a -> not (doc_attribute a)
-            | _ -> true)
+            | _ -> true )
       else si
     in
     Ast_mapper.default_mapper.structure m si
@@ -314,7 +314,7 @@ let make_mapper conf ~ignore_doc_comment =
         List.filter si ~f:(fun si ->
             match si.psig_desc with
             | Psig_attribute a -> not (doc_attribute a)
-            | _ -> true)
+            | _ -> true )
       else si
     in
     Ast_mapper.default_mapper.signature m si
@@ -326,7 +326,7 @@ let make_mapper conf ~ignore_doc_comment =
           List.filter si.pcsig_fields ~f:(fun si ->
               match si.pctf_desc with
               | Pctf_attribute a -> not (doc_attribute a)
-              | _ -> true)
+              | _ -> true )
         in
         {si with pcsig_fields}
       else si
@@ -340,7 +340,7 @@ let make_mapper conf ~ignore_doc_comment =
           List.filter si.pcstr_fields ~f:(fun si ->
               match si.pcf_desc with
               | Pcf_attribute a -> not (doc_attribute a)
-              | _ -> true)
+              | _ -> true )
         in
         {si with pcstr_fields}
       else si
@@ -489,7 +489,7 @@ let moved_docstrings c get_docstrings s1 s2 =
         List.partition_map l1 ~f:(fun x ->
             match List.find l2 ~f:(equal x) with
             | Some (l, s) -> `Fst (Moved (fst x, l, s))
-            | None -> `Snd x)
+            | None -> `Snd x )
       in
       let l2 = List.filter l2 ~f:(fun x -> not (List.mem ~equal l1 x)) in
       let l1 = List.map ~f:unstable l1 in

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -30,7 +30,11 @@ let wrap_exp (c : Conf.t) ?(disambiguate = false) ?(fits_breaks = true)
       wrap_if_fits_or parens "(" ")" k
   | (`Parens | `Begin_end) when not parens -> k
   | `Parens when fits_breaks -> wrap_fits_breaks ~space:false c "(" ")" k
-  | `Parens -> wrap "(" ")" k
+  | `Parens -> (
+    match c.Conf.indicate_multiline_delimiters with
+    | `Space ->
+        Fmt.fits_breaks "(" "(" $ k $ Fmt.fits_breaks ")" ~hint:(1, 0) ")"
+    | _ -> wrap "(" ")" k )
   | `Begin_end ->
       vbox 2 (wrap "begin" "end" (wrap_k (break 1 0) (break 1000 ~-2) k))
 

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -196,7 +196,7 @@ let collection_expr (c : Conf.t) ~space_around opn cls =
                 (wrap_k (str opn) (str cls)
                    ( break space (String.length opn + 1)
                    $ box_collec c 0 k $ break space 0 ))
-            else box_collec c 0 (wrap_collec c ~space_around opn cls k))
+            else box_collec c 0 (wrap_collec c ~space_around opn cls k) )
       ; sep_before= break 0 offset $ str "; "
       ; sep_after_non_final= noop
       ; sep_after_final= noop }
@@ -207,7 +207,7 @@ let collection_expr (c : Conf.t) ~space_around opn cls =
               hvbox 0
                 (wrap_k (str opn) (str cls)
                    (break space 2 $ box_collec c 0 k $ break space 0))
-            else box_collec c 0 (wrap_collec c ~space_around opn cls k))
+            else box_collec c 0 (wrap_collec c ~space_around opn cls k) )
       ; sep_before= noop
       ; sep_after_non_final=
           fmt_or_k dock (fmt ";@;<1 0>")
@@ -371,10 +371,9 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
                     (str "if" $ fmt_extension_suffix)
                     (str "else if")
                 $ fmt_attributes $ str " " $ fmt_cond xcnd )
-              $ fmt "@ ")
+              $ fmt "@ " )
       ; box_keyword_and_expr=
-          (fun k ->
-            hvbox 2 (fmt_or (Option.is_some xcond) "then" "else" $ k))
+          (fun k -> hvbox 2 (fmt_or (Option.is_some xcond) "then" "else" $ k))
       ; branch_pro= fmt_or parens_bch " " "@ "
       ; wrap_parens=
           wrap_parens

--- a/lib/Parse_with_comments.ml
+++ b/lib/Parse_with_comments.ml
@@ -47,7 +47,7 @@ let parse parse_ast (conf : Conf.t) ~source =
         | Warnings.Bad_docstring _ when conf.comment_check ->
             w50 := (loc, warn) :: !w50 ;
             false
-        | _ -> not conf.quiet)
+        | _ -> not conf.quiet )
       ~f:(fun () ->
         let ast = parse_ast lexbuf in
         Warnings.check_fatal () ;
@@ -56,6 +56,6 @@ let parse parse_ast (conf : Conf.t) ~source =
             ~f:(fun (txt, loc) -> Cmt.create txt loc)
             (Lexer.comments ())
         in
-        {ast; comments; prefix= hash_bang})
+        {ast; comments; prefix= hash_bang} )
   in
   match List.rev !w50 with [] -> t | w50 -> raise (Warning50 w50)

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -324,7 +324,7 @@ let locs_of_interval source loc =
   let toks =
     tokens_at source loc ~filter:(function
       | CHAR _ | DOTDOT | INT _ | STRING _ | FLOAT _ -> true
-      | _ -> false)
+      | _ -> false )
   in
   match toks with
   | [ ((CHAR _ | INT _ | STRING _ | FLOAT _), loc1)

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -122,7 +122,7 @@ let find_after t f (loc : Location.t) =
         Bytes.From_string.blit ~src:t ~src_pos:!pos ~dst:bytes ~dst_pos:0
           ~len:to_write ;
         pos := !pos + to_write ;
-        to_write)
+        to_write )
   in
   lexbuf_set_pos lexbuf pos_start ;
   let rec loop () =
@@ -136,13 +136,13 @@ let extend_loc_to_include_attributes t (loc : Location.t)
     (l : Parsetree.attributes) =
   if
     List.for_all l ~f:(fun ({attr_loc; _} : Parsetree.attribute) ->
-        Location.compare Location.none attr_loc <> 0)
+        Location.compare Location.none attr_loc <> 0 )
   then
     (* Starting with OCaml 4.08, attributes have locations *)
     let loc_end =
       List.fold l ~init:loc
         ~f:(fun acc ({attr_loc; _} : Parsetree.attribute) ->
-          if Location.compare_end attr_loc acc <= 0 then acc else attr_loc)
+          if Location.compare_end attr_loc acc <= 0 then acc else attr_loc )
     in
     if phys_equal loc_end loc then loc
     else
@@ -168,7 +168,7 @@ let extend_loc_to_include_attributes t (loc : Location.t)
               | PPat (p, None) -> p.ppat_loc
               | PPat (_, Some e) -> e.pexp_loc
             in
-            if Location.compare_end loc acc <= 0 then acc else loc)
+            if Location.compare_end loc acc <= 0 then acc else loc )
     in
     if phys_equal last_loc loc then loc
     else
@@ -188,7 +188,7 @@ let extend_loc_to_include_attributes t (loc : Location.t)
              |LBRACKETPERCENT | LBRACKETPERCENTPERCENT | LBRACKETAT
              |LBRACKETATAT | LBRACKETATATAT ->
                 Int.incr count ; false
-            | _ -> false)
+            | _ -> false )
           loc
       in
       match l with
@@ -233,7 +233,7 @@ let string_literal t mode (l : Location.t) =
         | Parser.STRING (_, None) -> true
         | Parser.LBRACKETAT | Parser.LBRACKETATAT | Parser.LBRACKETATATAT ->
             true
-        | _ -> false)
+        | _ -> false )
       l
   in
   match toks with
@@ -256,7 +256,7 @@ let char_literal t (l : Location.t) =
         | Parser.CHAR _ -> true
         | Parser.LBRACKETAT | Parser.LBRACKETATAT | Parser.LBRACKETATATAT ->
             true
-        | _ -> false)
+        | _ -> false )
       l
   in
   match toks with

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -323,7 +323,7 @@ let format xunit ?output_file ~input_name ~source ~parsed conf opts =
           ; ("old ast", old_ast)
           ; ("new ast", new_ast) ]
           |> List.filter_map ~f:(fun (s, f_opt) ->
-                 Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)))
+                 Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)) )
         in
         if xunit.equal ~ignore_doc_comments:true conf t t_new then
           let docstrings = xunit.moved_docstrings conf t t_new in
@@ -366,7 +366,7 @@ let format xunit ?output_file ~input_name ~source ~parsed conf opts =
             ; ("old ast", Option.map old_ast ~f:String.sexp_of_t)
             ; ("new ast", Option.map new_ast ~f:String.sexp_of_t) ]
             |> List.filter_map ~f:(fun (s, f_opt) ->
-                   Option.map f_opt ~f:(fun f -> (s, f)))
+                   Option.map f_opt ~f:(fun f -> (s, f)) )
           in
           internal_error `Comment args ) ;
       (* Too many iteration ? *)

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -210,8 +210,7 @@ let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~input_name error
           | _ -> () ) ;
           if debug then
             List.iter l ~f:(fun (msg, sexp) ->
-                Format.fprintf fmt "  %s: %s\n%!" msg (Sexp.to_string sexp)
-              )
+                Format.fprintf fmt "  %s: %s\n%!" msg (Sexp.to_string sexp) )
       | exn ->
           Format.fprintf fmt
             "  BUG: unhandled exception. Use [--debug] for details.\n%!" ;

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -201,7 +201,7 @@ let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~input_name error
                     "%!@{<loc>%a@}:@,\
                      @{<error>Error@}: Comment (* %s *) dropped.\n\
                      %!"
-                    Location.print_loc loc (ellipsis_cmt msg))
+                    Location.print_loc loc (ellipsis_cmt msg) )
           | `Cannot_parse ((Syntaxerr.Error _ | Lexer.Error _) as exn) ->
               if debug then Location.report_exception fmt exn
           | `Warning50 l ->
@@ -210,7 +210,8 @@ let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~input_name error
           | _ -> () ) ;
           if debug then
             List.iter l ~f:(fun (msg, sexp) ->
-                Format.fprintf fmt "  %s: %s\n%!" msg (Sexp.to_string sexp))
+                Format.fprintf fmt "  %s: %s\n%!" msg (Sexp.to_string sexp)
+              )
       | exn ->
           Format.fprintf fmt
             "  BUG: unhandled exception. Use [--debug] for details.\n%!" ;
@@ -293,7 +294,7 @@ let format xunit ?output_file ~input_name ~source ~parsed conf opts =
       let exn_args () =
         [("output file", dump_formatted ~suffix:".invalid-ast" fmted)]
         |> List.filter_map ~f:(fun (s, f_opt) ->
-               Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)))
+               Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)) )
       in
       ( match parse xunit.parse conf ~source:fmted with
       | exception Sys_error msg -> Error (User_error msg)

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -74,12 +74,12 @@ let with_file input_name output_file suf ext f =
 let dump_ast ~input_name ?output_file ~suffix fmt =
   let ext = ".ast" in
   with_file input_name output_file suffix ext (fun oc ->
-      fmt (Format.formatter_of_out_channel oc))
+      fmt (Format.formatter_of_out_channel oc) )
 
 let dump_formatted ~input_name ?output_file ~suffix fmted =
   let ext = Filename.extension input_name in
   with_file input_name output_file suffix ext (fun oc ->
-      Out_channel.output_string oc fmted)
+      Out_channel.output_string oc fmted )
 
 let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~input_name error
     =
@@ -194,7 +194,7 @@ let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~input_name error
                        source or disable the formatting using the option \
                        --no-parse-docstrings.\n\
                        %!"
-                      Location.print_loc loc (ellipsis_cmt s))
+                      Location.print_loc loc (ellipsis_cmt s) )
           | `Comment_dropped l when not quiet ->
               List.iter l ~f:(fun Cmt.{txt= msg; loc} ->
                   Format.fprintf fmt
@@ -229,7 +229,7 @@ let check_margin conf ~filename ~fmted =
   List.iteri (String.split_lines fmted) ~f:(fun i line ->
       if String.length line > conf.Conf.margin then
         Format.fprintf Format.err_formatter
-          "Warning: %s:%i exceeds the margin\n%!" filename i)
+          "Warning: %s:%i exceeds the margin\n%!" filename i )
 
 let with_optional_box_debug ~box_debug k =
   if box_debug then Fmt.with_box_debug k else k
@@ -248,7 +248,7 @@ let format xunit ?output_file ~input_name ~source ~parsed conf opts =
     if opts.Conf.debug then
       Some
         (dump_ast ~input_name ?output_file ~suffix (fun fmt ->
-             xunit.printast fmt ast))
+             xunit.printast fmt ast ))
     else None
   in
   let dump_formatted ~suffix fmted =

--- a/test/passing/apply.ml
+++ b/test/passing/apply.ml
@@ -37,13 +37,13 @@ let whatever a_function_name long_list_one some_other_thing =
   List.map
     (fun long_list_one_elt ->
       do_something_with_a_function_and_some_things a_function_name
-        long_list_one_elt some_other_thing)
+        long_list_one_elt some_other_thing )
     long_list_one
 
 let whatever_labelled a_function_name long_list_one some_other_thing =
   ListLabels.map long_list_one ~f:(fun long_list_one_elt ->
       do_something_with_a_function_and_some_things a_function_name
-        long_list_one_elt some_other_thing)
+        long_list_one_elt some_other_thing )
 
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -287,7 +287,7 @@ let _ =
       (* do nothing *) )
 
 let _ = try_with (fun () -> (* comment before *)
-                            a ; b (* after b *))
+                            a ; b (* after b *) )
 
 let _ =
   match x with

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -284,7 +284,7 @@ let _ =
   try_with (fun () ->
       (* comment before *)
       match get () with None -> do_something () | Some _ -> ()
-      (* do nothing *))
+      (* do nothing *) )
 
 let _ = try_with (fun () -> (* comment before *)
                             a ; b (* after b *))

--- a/test/passing/doc_comments.mli.ref
+++ b/test/passing/doc_comments.mli.ref
@@ -357,7 +357,7 @@ end
 (** {[
       List.iter all_fields ~f:(fun (name, type_) ->
           printf "\nexternal get_%s\n: unit -> %s = \"get_%s\"" name type_
-            name)
+            name )
     ]} *)
 
 (** {[

--- a/test/passing/exp_grouping-parens.ml.ref
+++ b/test/passing/exp_grouping-parens.ml.ref
@@ -3,14 +3,14 @@ let () =
     (let a = "a" in
      let b = "b" in
      let c = "c" in
-     Lwt.return "test")
+     Lwt.return "test" )
 
 let () =
   Lwt_main.run
     (let a = "a" in
      let b = "b" in
      let c = "c" in
-     Lwt.return "test")
+     Lwt.return "test" )
 
 let () =
   List.iter
@@ -19,7 +19,7 @@ let () =
       let a = "a" in
       let b = "b" in
       let c = "c" in
-      ())
+      () )
     values
 
 let () =
@@ -29,7 +29,7 @@ let () =
       let a = "a" in
       let b = "b" in
       let c = "c" in
-      ())
+      () )
     values
 
 let () =
@@ -90,7 +90,7 @@ let _ =
 
 let _ =
   (let a = b in
-   c)
+   c )
   |> d
 
 let _ =
@@ -100,7 +100,7 @@ let _ =
 
 let _ =
   (let a = b in
-   c)
+   c )
   := d
 
 let _ =
@@ -111,47 +111,47 @@ let _ =
 
 let _ =
   (let a = b in
-   c)
+   c )
   + d
 
 let _ =
   f
     (let a = b in
-     c)
+     c )
 
 let _ =
   (let a = b in
-   c)
+   c )
     d
 
 let _ =
   a#f
     (let a = b in
-     c)
+     c )
 
 let _ =
   (let a = b in
-   c)
+   c )
     #f
 
 let _ =
   A
     (let a = b in
-     c)
+     c )
 
 let _ =
   `A
     (let a = b in
-     c)
+     c )
 
 let _ =
   { x=
       (let a = b in
-       c) }
+       c ) }
 
 let _ =
   { (let a = b in
-     c)
+     c )
     with
     a= b }
 
@@ -162,21 +162,21 @@ let _ =
 let _ =
   x <-
     (let a = b in
-     c)
+     c )
 
 let _ =
   (let a = b in
-   c)
+   c )
     .x
 
 let _ =
   (let a = b in
-   c).x <-
+   c ).x <-
     d
 
 let _ =
   ( (let a = b in
-     c)
+     c )
   , d )
 
 let _ =
@@ -192,15 +192,15 @@ let _ =
   a
   ::
   (let a = b in
-   c)
+   c )
 
 let _ =
   [ (let a = b in
-     c) ]
+     c ) ]
 
 let _ =
   [| (let a = b in
-      c) |]
+      c ) |]
 
 [@@@ocamlformat "if-then-else=compact"]
 

--- a/test/passing/exp_grouping.ml.ref
+++ b/test/passing/exp_grouping.ml.ref
@@ -12,7 +12,7 @@ let () =
     (let a = "a" in
      let b = "b" in
      let c = "c" in
-     Lwt.return "test")
+     Lwt.return "test" )
 
 let () =
   List.iter
@@ -33,7 +33,7 @@ let () =
       let a = "a" in
       let b = "b" in
       let c = "c" in
-      ())
+      () )
     values
 
 let () =
@@ -101,7 +101,7 @@ let _ =
 
 let _ =
   (let a = b in
-   c)
+   c )
   |> d
 
 let _ =
@@ -111,7 +111,7 @@ let _ =
 
 let _ =
   (let a = b in
-   c)
+   c )
   := d
 
 let _ =
@@ -122,47 +122,47 @@ let _ =
 
 let _ =
   (let a = b in
-   c)
+   c )
   + d
 
 let _ =
   f
     (let a = b in
-     c)
+     c )
 
 let _ =
   (let a = b in
-   c)
+   c )
     d
 
 let _ =
   a#f
     (let a = b in
-     c)
+     c )
 
 let _ =
   (let a = b in
-   c)
+   c )
     #f
 
 let _ =
   A
     (let a = b in
-     c)
+     c )
 
 let _ =
   `A
     (let a = b in
-     c)
+     c )
 
 let _ =
   { x=
       (let a = b in
-       c) }
+       c ) }
 
 let _ =
   { (let a = b in
-     c)
+     c )
     with
     a= b }
 
@@ -173,21 +173,21 @@ let _ =
 let _ =
   x <-
     (let a = b in
-     c)
+     c )
 
 let _ =
   (let a = b in
-   c)
+   c )
     .x
 
 let _ =
   (let a = b in
-   c).x <-
+   c ).x <-
     d
 
 let _ =
   ( (let a = b in
-     c)
+     c )
   , d )
 
 let _ =
@@ -203,15 +203,15 @@ let _ =
   a
   ::
   (let a = b in
-   c)
+   c )
 
 let _ =
   [ (let a = b in
-     c) ]
+     c ) ]
 
 let _ =
   [| (let a = b in
-      c) |]
+      c ) |]
 
 [@@@ocamlformat "if-then-else=compact"]
 

--- a/test/passing/extensions-indent.ml.ref
+++ b/test/passing/extensions-indent.ml.ref
@@ -13,7 +13,7 @@ val f : compare:[%compare: 'a] -> sexp_of:[%sexp_of: 'a] -> t
 
 let invariant t =
   Invariant.invariant [%here] t [%sexp_of: t] (fun () ->
-      assert (check_t_invariant t))
+      assert (check_t_invariant t) )
 
 ;;
 [%e?
@@ -36,12 +36,12 @@ let invariant t =
        let f = () and g () = () in
        e]
   (let%ext f = () and g () = () in
-   e)
+   e )
   [%ext
        let rec f = () and g () = () in
        e]
   (let%ext rec f = () and g () = () in
-   e)
+   e )
 
 let _ = ([%ext? (x : x)] : [%ext? (x : x)])
 

--- a/test/passing/extensions-sugar_always.ml.ref
+++ b/test/passing/extensions-sugar_always.ml.ref
@@ -14,7 +14,7 @@ val f : compare:[%compare: 'a] -> sexp_of:[%sexp_of: 'a] -> t
 
 let invariant t =
   Invariant.invariant [%here] t [%sexp_of: t] (fun () ->
-      assert (check_t_invariant t))
+      assert (check_t_invariant t) )
 
 ;;
 [%e?
@@ -34,13 +34,13 @@ let invariant t =
   , xxxxxxxxxxx
   , xxxxxxxxxxxxxxxxxxxx ) when a < b]
   (let%ext f = () and g () = () in
-   e)
+   e )
   (let%ext f = () and g () = () in
-   e)
+   e )
   (let%ext rec f = () and g () = () in
-   e)
+   e )
   (let%ext rec f = () and g () = () in
-   e)
+   e )
 
 let _ = ([%ext? (x : x)] : [%ext? (x : x)])
 

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -13,7 +13,7 @@ val f : compare:[%compare: 'a] -> sexp_of:[%sexp_of: 'a] -> t
 
 let invariant t =
   Invariant.invariant [%here] t [%sexp_of: t] (fun () ->
-      assert (check_t_invariant t))
+      assert (check_t_invariant t) )
 
 ;;
 [%e?
@@ -36,12 +36,12 @@ let invariant t =
     let f = () and g () = () in
     e]
   (let%ext f = () and g () = () in
-   e)
+   e )
   [%ext
     let rec f = () and g () = () in
     e]
   (let%ext rec f = () and g () = () in
-   e)
+   e )
 
 let _ = ([%ext? (x : x)] : [%ext? (x : x)])
 

--- a/test/passing/first_class_module.ml
+++ b/test/passing/first_class_module.ml
@@ -97,3 +97,11 @@ let _ =
 module M = (val x : S (* a *))
 
 module M = (val x (* b *))
+
+[@@@ocamlformat "break-struct=natural"]
+
+let _ =
+  ( module struct
+    let x = 0
+
+    let y = 1 end )

--- a/test/passing/first_class_module.ml
+++ b/test/passing/first_class_module.ml
@@ -104,4 +104,5 @@ let _ =
   ( module struct
     let x = 0
 
-    let y = 1 end )
+    let y = 1
+  end )

--- a/test/passing/fun_decl.ml
+++ b/test/passing/fun_decl.ml
@@ -53,4 +53,4 @@ let f ssssssssss =
     function
     | '0' -> g accuuuuuuuuuum
     | '1' -> h accuuuuuuuuuum
-    | _ -> i accuuuuuuuuuum)
+    | _ -> i accuuuuuuuuuum )

--- a/test/passing/function_indent-never.ml.ref
+++ b/test/passing/function_indent-never.ml.ref
@@ -8,7 +8,7 @@ let foooooooo = function
 let foo =
   fooooooooo foooooooo ~foooooooo:(function
     | fooooooooooooooooooooooo -> foooooooooooooooooooooooooo
-    | fooooooooooooooooooooooo -> foooooooooooooooooooooooooo)
+    | fooooooooooooooooooooooo -> foooooooooooooooooooooooooo )
 
 let foooooooo =
   if fooooooooooo then function

--- a/test/passing/function_indent.ml.ref
+++ b/test/passing/function_indent.ml.ref
@@ -8,7 +8,7 @@ let foooooooo = function
 let foo =
   fooooooooo foooooooo ~foooooooo:(function
       | fooooooooooooooooooooooo -> foooooooooooooooooooooooooo
-      | fooooooooooooooooooooooo -> foooooooooooooooooooooooooo)
+      | fooooooooooooooooooooooo -> foooooooooooooooooooooooooo )
 
 let foooooooo =
   if fooooooooooo then function

--- a/test/passing/infix_arg_grouping.ml
+++ b/test/passing/infix_arg_grouping.ml
@@ -28,7 +28,7 @@ hvbox 1
               fmt "\\n"
               $ fmt_if_k
                   (not (String.is_empty next))
-                  (str spc $ pre_break 0 "\\" 0)))
+                  (str spc $ pre_break 0 "\\" 0) ) )
   $ str "\"" $ Option.call ~f:epi )
 
 ;;
@@ -47,7 +47,7 @@ hvbox 0
                       $ fmt_core_type c (sub_typ ~ctx typ) )
                   $ fmt_docstring c ~pro:(fmt "@;<2 0>") doc
                   $ fmt_attributes c (fmt " ") ~key:"@" atrs (fmt "") )
-         | Oinherit typ -> fmt_core_type c (sub_typ ~ctx typ))
+         | Oinherit typ -> fmt_core_type c (sub_typ ~ctx typ) )
      $ fmt_if
          Poly.(closedness = Open)
          (match fields with [] -> "@ .. " | _ -> "@ ; .. ") ))
@@ -59,7 +59,7 @@ hvbox 0
       ( str txt
       $ opt mt (fun _ ->
             fmt "@ : " $ Option.call ~f:pro_t $ psp_t $ fmt "@;<1 2>" $ bdy_t
-            $ esp_t $ Option.call ~f:epi_t) )
+            $ esp_t $ Option.call ~f:epi_t ) )
   $ fmt " ->@ " $ Option.call ~f:pro_e $ psp_e $ bdy_e $ esp_e
   $ Option.call ~f:epi_e )
 

--- a/test/passing/issue289.ml
+++ b/test/passing/issue289.ml
@@ -33,31 +33,31 @@ let foo =
       ~doc:"Toy ID."
       ~args:[]
       ~typ:(non_null guid)
-      ~resolve:(fun _ctx x -> x.id )
+      ~resolve:(fun _ctx x -> x.id)
   ; field
       "name"
       ~doc:"Toy name."
       ~args:[]
       ~typ:(non_null string)
-      ~resolve:(fun _ctx x -> x.name )
+      ~resolve:(fun _ctx x -> x.name)
   ; field
       "description"
       ~doc:"Toy description."
       ~args:[]
       ~typ:string
-      ~resolve:(fun _ctx x -> x.description |> Util.option_of_string )
+      ~resolve:(fun _ctx x -> x.description |> Util.option_of_string)
   ; field
       "type"
       ~doc:"Toy type. Possible values are: car, animal, train."
       ~args:[]
       ~typ:(non_null toy_type_enum)
-      ~resolve:(fun _ctx x -> x.toy_type )
+      ~resolve:(fun _ctx x -> x.toy_type)
   ; field
       "createdAt"
       ~doc:"Date created."
       ~args:[]
       ~typ:(non_null Scalar.date_time)
-      ~resolve:(fun _ctx x -> x.created_at ) ]
+      ~resolve:(fun _ctx x -> x.created_at) ]
 
 [@@@ocamlformat "wrap-fun-args=true"]
 
@@ -82,14 +82,14 @@ let foo =
       | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
       | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
   ; field "id" ~doc:"Toy ID." ~args:[] ~typ:(non_null guid)
-      ~resolve:(fun _ctx x -> x.id )
+      ~resolve:(fun _ctx x -> x.id)
   ; field "name" ~doc:"Toy name." ~args:[] ~typ:(non_null string)
-      ~resolve:(fun _ctx x -> x.name )
+      ~resolve:(fun _ctx x -> x.name)
   ; field "description" ~doc:"Toy description." ~args:[] ~typ:string
-      ~resolve:(fun _ctx x -> x.description |> Util.option_of_string )
+      ~resolve:(fun _ctx x -> x.description |> Util.option_of_string)
   ; field "type" ~doc:"Toy type. Possible values are: car, animal, train."
       ~args:[] ~typ:(non_null toy_type_enum) ~resolve:(fun _ctx x ->
         x.toy_type )
   ; field "createdAt" ~doc:"Date created." ~args:[]
-      ~typ:(non_null Scalar.date_time) ~resolve:(fun _ctx x -> x.created_at )
+      ~typ:(non_null Scalar.date_time) ~resolve:(fun _ctx x -> x.created_at)
   ]

--- a/test/passing/issue289.ml
+++ b/test/passing/issue289.ml
@@ -3,9 +3,9 @@
 let foo =
   let open Gql in
   [ field "id" ~doc:"Toy ID." ~args:[] ~typ:(non_null guid) ~resolve:(function
-        | _ctx -> x.id)
+        | _ctx -> x.id )
   ; field "id" ~doc:"Toy ID." ~args:[] ~typppp ~resolve:(function _ctx ->
-        x.id)
+        x.id )
   ; field
       "id"
       ~doc:"Toy ID."
@@ -13,10 +13,10 @@ let foo =
       ~typ:(non_null guid)
       ~resolve:(function
         | A -> x.id
-        | B -> c)
+        | B -> c )
   ; field "id" ~doc:"Toy ID." ~args:[] ~resolve:(function
         | A -> x.id
-        | B -> c)
+        | B -> c )
   ; field
       "id"
       ~doc:"Toy ID."
@@ -24,10 +24,10 @@ let foo =
       ~typppppppppppppppppppp
       ~resolve:(function
         | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
-        | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc)
+        | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
   ; field "id" ~doc:"Toy ID." ~args:[] ~resolve:(function
         | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
-        | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc)
+        | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
   ; field
       "id"
       ~doc:"Toy ID."
@@ -64,23 +64,23 @@ let foo =
 let foo =
   let open Gql in
   [ field "id" ~doc:"Toy ID." ~args:[] ~typ:(non_null guid)
-        ~resolve:(function _ctx -> x.id)
+        ~resolve:(function _ctx -> x.id )
   ; field "id" ~doc:"Toy ID." ~args:[] ~typppp ~resolve:(function _ctx ->
-        x.id)
+        x.id )
   ; field "id" ~doc:"Toy ID." ~args:[] ~typ:(non_null guid)
       ~resolve:(function
       | A -> x.id
-      | B -> c)
+      | B -> c )
   ; field "id" ~doc:"Toy ID." ~args:[] ~resolve:(function
       | A -> x.id
-      | B -> c)
+      | B -> c )
   ; field "id" ~doc:"Toy ID." ~args:[] ~typppppppppppppppppppp
       ~resolve:(function
       | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
-      | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc)
+      | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
   ; field "id" ~doc:"Toy ID." ~args:[] ~resolve:(function
       | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
-      | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc)
+      | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
   ; field "id" ~doc:"Toy ID." ~args:[] ~typ:(non_null guid)
       ~resolve:(fun _ctx x -> x.id)
   ; field "name" ~doc:"Toy name." ~args:[] ~typ:(non_null string)
@@ -89,7 +89,7 @@ let foo =
       ~resolve:(fun _ctx x -> x.description |> Util.option_of_string)
   ; field "type" ~doc:"Toy type. Possible values are: car, animal, train."
       ~args:[] ~typ:(non_null toy_type_enum) ~resolve:(fun _ctx x ->
-        x.toy_type)
+        x.toy_type )
   ; field "createdAt" ~doc:"Date created." ~args:[]
       ~typ:(non_null Scalar.date_time) ~resolve:(fun _ctx x -> x.created_at)
   ]

--- a/test/passing/issue289.ml
+++ b/test/passing/issue289.ml
@@ -33,31 +33,31 @@ let foo =
       ~doc:"Toy ID."
       ~args:[]
       ~typ:(non_null guid)
-      ~resolve:(fun _ctx x -> x.id)
+      ~resolve:(fun _ctx x -> x.id )
   ; field
       "name"
       ~doc:"Toy name."
       ~args:[]
       ~typ:(non_null string)
-      ~resolve:(fun _ctx x -> x.name)
+      ~resolve:(fun _ctx x -> x.name )
   ; field
       "description"
       ~doc:"Toy description."
       ~args:[]
       ~typ:string
-      ~resolve:(fun _ctx x -> x.description |> Util.option_of_string)
+      ~resolve:(fun _ctx x -> x.description |> Util.option_of_string )
   ; field
       "type"
       ~doc:"Toy type. Possible values are: car, animal, train."
       ~args:[]
       ~typ:(non_null toy_type_enum)
-      ~resolve:(fun _ctx x -> x.toy_type)
+      ~resolve:(fun _ctx x -> x.toy_type )
   ; field
       "createdAt"
       ~doc:"Date created."
       ~args:[]
       ~typ:(non_null Scalar.date_time)
-      ~resolve:(fun _ctx x -> x.created_at) ]
+      ~resolve:(fun _ctx x -> x.created_at ) ]
 
 [@@@ocamlformat "wrap-fun-args=true"]
 
@@ -82,14 +82,14 @@ let foo =
       | AAAAAAAAAAAAAAAAAAAa -> x.idddddddddddddddddddddddddd
       | BBBBBBBBBBBBBBBB -> ccccccccccccccccccccccc )
   ; field "id" ~doc:"Toy ID." ~args:[] ~typ:(non_null guid)
-      ~resolve:(fun _ctx x -> x.id)
+      ~resolve:(fun _ctx x -> x.id )
   ; field "name" ~doc:"Toy name." ~args:[] ~typ:(non_null string)
-      ~resolve:(fun _ctx x -> x.name)
+      ~resolve:(fun _ctx x -> x.name )
   ; field "description" ~doc:"Toy description." ~args:[] ~typ:string
-      ~resolve:(fun _ctx x -> x.description |> Util.option_of_string)
+      ~resolve:(fun _ctx x -> x.description |> Util.option_of_string )
   ; field "type" ~doc:"Toy type. Possible values are: car, animal, train."
       ~args:[] ~typ:(non_null toy_type_enum) ~resolve:(fun _ctx x ->
         x.toy_type )
   ; field "createdAt" ~doc:"Date created." ~args:[]
-      ~typ:(non_null Scalar.date_time) ~resolve:(fun _ctx x -> x.created_at)
+      ~typ:(non_null Scalar.date_time) ~resolve:(fun _ctx x -> x.created_at )
   ]

--- a/test/passing/ite-compact.ml.ref
+++ b/test/passing/ite-compact.ml.ref
@@ -82,19 +82,19 @@ let foo =
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo) )
+        fooooooooooooo ) )
   else if cond2 then (
     arm2 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo) )
+        fooooooooooooo ) )
   else (
     arm3 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo) )
+        fooooooooooooo ) )
 
 let foo =
   if some condition then

--- a/test/passing/ite-fit_or_vertical.ml.ref
+++ b/test/passing/ite-fit_or_vertical.ml.ref
@@ -102,19 +102,19 @@ let foo =
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo) )
+        fooooooooooooo ) )
   else if cond2 then (
     arm2 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo) )
+        fooooooooooooo ) )
   else (
     arm3 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo) )
+        fooooooooooooo ) )
 
 let foo =
   if some condition then

--- a/test/passing/ite-kr.ml.ref
+++ b/test/passing/ite-kr.ml.ref
@@ -124,19 +124,19 @@ let foo =
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo)
+        fooooooooooooo )
   ) else if cond2 then (
     arm2 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo)
+        fooooooooooooo )
   ) else (
     arm3 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo)
+        fooooooooooooo )
   )
 
 let foo =

--- a/test/passing/ite-kw_first.ml.ref
+++ b/test/passing/ite-kw_first.ml.ref
@@ -96,20 +96,20 @@ let foo =
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo) )
+        fooooooooooooo ) )
   else if cond2
   then (
     arm2 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo) )
+        fooooooooooooo ) )
   else (
     arm3 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo) )
+        fooooooooooooo ) )
 
 let foo =
   if some condition

--- a/test/passing/ite.ml.ref
+++ b/test/passing/ite.ml.ref
@@ -82,19 +82,19 @@ let foo =
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo) )
+        fooooooooooooo ) )
   else if cond2 then (
     arm2 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo) )
+        fooooooooooooo ) )
   else (
     arm3 ;
     foooooooooooooo ;
     fooooooooooooooooooo fooooooooooooooo foooooooooooo ;
     List.foo ~fooooooo:foooooooooooooooo ~foo:(fun fooooooooo ->
-        fooooooooooooo) )
+        fooooooooooooo ) )
 
 let foo =
   if some condition then

--- a/test/passing/max_indent.ml
+++ b/test/passing/max_indent.ml
@@ -2,7 +2,7 @@ let () =
   fooooo
   |> List.iter (fun x ->
        let x = x $ y in
-       fooooooooooo x)
+       fooooooooooo x )
 
 let () =
   fooooo
@@ -12,7 +12,7 @@ let () =
        let x =
          some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
        in
-       fooooooooooo x)
+       fooooooooooo x )
 
 let foooooooooo =
   foooooooooooooooooooooo
@@ -20,7 +20,7 @@ let foooooooooo =
        | Pform.Expansion.Var (Values l) -> Some (static l)
        | Macro (Ocaml_config, s) ->
          Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
-       | Macro (Env, s) -> Option.map ~f:static (expand_env t var s))
+       | Macro (Env, s) -> Option.map ~f:static (expand_env t var s) )
 
 let fooooooooooooo =
   match lbls with

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -1004,7 +1004,7 @@ let id x = x
 let idb1 =
   (fun id ->
     let _ = id true in
-    id)
+    id )
     id
 
 let idb2 : bool -> bool = id
@@ -1100,7 +1100,7 @@ let rec variantize : type t. t ty -> t -> variant =
       VRecord
         (List.map
            (fun (Field {field_type; label; get}) ->
-             (label, variantize field_type (get x)))
+             (label, variantize field_type (get x)) )
            fields)
 
 (* Extraction *)
@@ -1141,7 +1141,7 @@ let rec devariantize : type t. t ty -> variant -> t =
       List.iter2
         (fun (Field {label; field_type; set}) (lab, v) ->
           if label <> lab then raise VariantMismatch ;
-          set builder (devariantize field_type v))
+          set builder (devariantize field_type v) )
         fields fl ;
       of_builder builder
   | _ -> raise VariantMismatch
@@ -1353,12 +1353,12 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
        { sum_proj=
            (function
            | `Nil -> ("Nil", None)
-           | `Cons p -> ("Cons", Some (Tdyn (tcons, p))))
+           | `Cons p -> ("Cons", Some (Tdyn (tcons, p))) )
        ; sum_cases= [("Nil", TCnoarg Thd); ("Cons", TCarg (Ttl Thd, tcons))]
        ; sum_inj=
            (fun (type c) ->
              ( function Thd, Noarg -> `Nil | Ttl Thd, v -> `Cons v
-               : (noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist ))
+               : (noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist ) )
            (* One can also write the type annotation directly *) })
 
 let v = variantize Enil (ty_list Int) (`Cons (1, `Cons (2, `Nil)))
@@ -1387,7 +1387,7 @@ let ty_abc : ([`A of int | `B of string | `C], 'e) ty =
     ( (function
       | `A n -> ("A", Some (Tdyn (Int, n)))
       | `B s -> ("B", Some (Tdyn (String, s)))
-      | `C -> ("C", None))
+      | `C -> ("C", None) )
     , function
       | "A", Some (Tdyn (Int, n)) -> `A n
       | "B", Some (Tdyn (String, s)) -> `B s
@@ -1401,7 +1401,8 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
   Rec
     (Sum
        ( (function
-         | `Nil -> ("Nil", None) | `Cons p -> ("Cons", Some (Tdyn (targ, p))))
+         | `Nil -> ("Nil", None) | `Cons p -> ("Cons", Some (Tdyn (targ, p)))
+         )
        , function
          | "Nil", None -> `Nil
          | "Cons", Some (Tdyn (Pair (_, Var), (p : a * a vlist))) -> `Cons p
@@ -2800,7 +2801,7 @@ let rec check : type n. n succ fin -> n succ term -> n term option =
   | Leaf -> Some Leaf
   | Fork (t1, t2) ->
       bind (check x t1) (fun t1 ->
-          bind (check x t2) (fun t2 -> Some (Fork (t1, t2))))
+          bind (check x t2) (fun t2 -> Some (Fork (t1, t2))) )
 
 let subst_var x t' y = match thick x y with None -> t' | Some y' -> Var y'
 
@@ -3510,7 +3511,7 @@ let subst_lambda ~subst_rec ~free ~subst : _ lambda -> _ = function
       let used = free t in
       let used_expr =
         Subst.fold subst ~init:[] ~f:(fun ~key ~data acc ->
-            if Names.mem s used then data :: acc else acc)
+            if Names.mem s used then data :: acc else acc )
       in
       if List.exists used_expr ~f:(fun t -> Names.mem s (free t)) then
         let name = s ^ string_of_int (next_id ()) in
@@ -3724,7 +3725,7 @@ class ['a] lambda_ops (ops : ('a, 'a) #ops Lazy.t) =
           let used = !!free t in
           let used_expr =
             Subst.fold sub ~init:[] ~f:(fun ~key ~data acc ->
-                if Names.mem s used then data :: acc else acc)
+                if Names.mem s used then data :: acc else acc )
           in
           if List.exists used_expr ~f:(fun t -> Names.mem s (!!free t)) then
             let name = s ^ string_of_int (next_id ()) in
@@ -3936,7 +3937,7 @@ let lambda_ops (ops : ('a, 'a) #ops Lazy.t) =
           let used = !!free t in
           let used_expr =
             Subst.fold sub ~init:[] ~f:(fun ~key ~data acc ->
-                if Names.mem s used then data :: acc else acc)
+                if Names.mem s used then data :: acc else acc )
           in
           if List.exists used_expr ~f:(fun t -> Names.mem s (!!free t)) then
             let name = s ^ string_of_int (next_id ()) in

--- a/test/passing/wrap_comments_break.ml
+++ b/test/passing/wrap_comments_break.ml
@@ -3,6 +3,6 @@ let _ =
     fffffffffff
       aaaaaaaaaaaaaaaaaaaaaaaaaaaa
       bbbbbbbbbbbbbbbbbbbbbbbbbb
-      ~f:(fun x -> return xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx )
+      ~f:(fun x -> return xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
   in
   2

--- a/test/passing/wrap_comments_break.ml
+++ b/test/passing/wrap_comments_break.ml
@@ -3,6 +3,6 @@ let _ =
     fffffffffff
       aaaaaaaaaaaaaaaaaaaaaaaaaaaa
       bbbbbbbbbbbbbbbbbbbbbbbbbb
-      ~f:(fun x -> return xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
+      ~f:(fun x -> return xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx )
   in
   2

--- a/vendor/parse-wyc/lib/merlin_recovery.ml
+++ b/vendor/parse-wyc/lib/merlin_recovery.ml
@@ -229,7 +229,7 @@ struct
     let shifted, final, candidates = generate env in
     let candidates =
       rev_filter candidates ~f:(fun t ->
-          not (Parser.env_has_default_reduction t.env))
+          not (Parser.env_has_default_reduction t.env) )
     in
     { shifted; final; candidates = candidate env :: candidates }
 end

--- a/vendor/parse-wyc/lib/migrate_ast.ml
+++ b/vendor/parse-wyc/lib/migrate_ast.ml
@@ -32,7 +32,7 @@ module Mapper = struct
                   { pdir_name with loc = mapper.location mapper pdir_name.loc };
                 pdir_arg;
                 pdir_loc = mapper.location mapper pdir_loc;
-              })
+              } )
       use_file
 end
 
@@ -70,7 +70,7 @@ module Parse = struct
       (fun (p : Parsetree.toplevel_phrase) ->
         match p with
         | Ptop_def [] -> false
-        | Ptop_def (_ :: _) | Ptop_dir _ -> true)
+        | Ptop_def (_ :: _) | Ptop_dir _ -> true )
       (Parse.use_file selected_version lexbuf)
 end
 
@@ -99,7 +99,7 @@ module Printast = struct
   let use_file f (x : Parsetree.toplevel_phrase list) =
     List.iter
       (fun (p : Parsetree.toplevel_phrase) ->
-        top_phrase f (to_current.copy_toplevel_phrase p))
+        top_phrase f (to_current.copy_toplevel_phrase p) )
       x
 end
 

--- a/vendor/parse-wyc/lib/parse_wyc.ml
+++ b/vendor/parse-wyc/lib/parse_wyc.ml
@@ -123,7 +123,7 @@ let merge_adj merge l =
       match acc with
       | h :: t -> (
           match merge h x with Some m -> m :: t | None -> x :: h :: t )
-      | [] -> x :: acc)
+      | [] -> x :: acc )
     [] l
   |> List.rev
 
@@ -215,7 +215,7 @@ let mk_parsable p m source =
                   t )
                 else
                   failwith
-                    "either no location left or the next locaction is after")
+                    "either no location left or the next locaction is after" )
       in
       match remaining_locs with
       | [] -> Buffer.contents buffer

--- a/vendor/parse-wyc/menhir-recover/attributes.ml
+++ b/vendor/parse-wyc/menhir-recover/attributes.ml
@@ -225,8 +225,8 @@ module Recover_attributes (G : GRAMMAR) : ATTRIBUTES with module G = G = struct
           "production attributes" (Production.attributes p);
         Array.iter
           (fun (_, _, attrs) ->
-            validate_attributes [ "recover.cost" ] "item attributes" attrs)
-          (Production.rhs p))
+            validate_attributes [ "recover.cost" ] "item attributes" attrs )
+          (Production.rhs p) )
 
   let cost_of_attributes prj attrs =
     Cost.of_int
@@ -234,7 +234,7 @@ module Recover_attributes (G : GRAMMAR) : ATTRIBUTES with module G = G = struct
          (fun total attr ->
            if Attribute.has_label "recover.cost" attr then
              total + int_of_string (Attribute.payload attr)
-           else total)
+           else total )
          0 (prj attrs))
 
   let cost_of_symbol =
@@ -247,7 +247,7 @@ module Recover_attributes (G : GRAMMAR) : ATTRIBUTES with module G = G = struct
     in
     let ft =
       Terminal.tabulate (fun t ->
-          measure ~has_default:(Terminal.typ t = None) Terminal.attributes t)
+          measure ~has_default:(Terminal.typ t = None) Terminal.attributes t )
     in
     let fn =
       Nonterminal.tabulate (measure ~has_default:false Nonterminal.attributes)
@@ -273,7 +273,7 @@ module Recover_attributes (G : GRAMMAR) : ATTRIBUTES with module G = G = struct
     List.iter
       (fun a ->
         if Attribute.has_label "recover.prelude" a then
-          Format.fprintf ppf "%s\n" (Attribute.payload a))
+          Format.fprintf ppf "%s\n" (Attribute.payload a) )
       Grammar.attributes
 
   let default_expr ?(fallback = "raise Not_found") attrs =

--- a/vendor/parse-wyc/menhir-recover/emitter.ml
+++ b/vendor/parse-wyc/menhir-recover/emitter.ml
@@ -71,7 +71,7 @@ end = struct
        | Abort | Reduce _ | Shift _ -> ()
        | Seq xs -> iter_list xs
      in
-     List.iter iter_list actions);
+     List.iter iter_list actions );
     let bindings =
       let register actions (occurrences, index) to_share =
         if !occurrences > 1 then (!index, actions) :: to_share else to_share
@@ -149,14 +149,14 @@ end = struct
         | None -> ()
         | Some str ->
             fprintf ppf "    | %s.T %s.T_%s -> %s\n" menhir menhir
-              (Terminal.name t) str);
+              (Terminal.name t) str );
     Nonterminal.iter (fun n ->
         match A.default_nonterminal n with
         | None -> ()
         | Some str ->
             fprintf ppf "    | %s.N %s.N_%s -> %s\n" menhir menhir
               (Nonterminal.mangled_name n)
-              str);
+              str );
     (*fprintf ppf "    | _ -> raise Not_found\n"; should be exhaustive*)
     fprintf ppf "end\n\n";
     fprintf ppf "let default_value = Default.value\n\n"
@@ -182,14 +182,14 @@ end = struct
         let items = G.Lr0.items (G.Lr1.lr0 st) in
         let positions = List.map snd items in
         let depth = List.fold_left max 0 positions in
-        fprintf ppf "%d;" depth);
+        fprintf ppf "%d;" depth );
     fprintf ppf "|]\n\n"
 
   let emit_can_pop ppf =
     Format.fprintf ppf "let can_pop (type a) : a terminal -> bool = function\n";
     G.Terminal.iter (fun t ->
         if G.Terminal.kind t = `REGULAR && G.Terminal.typ t = None then
-          Format.fprintf ppf "  | T_%s -> true\n" (G.Terminal.name t));
+          Format.fprintf ppf "  | T_%s -> true\n" (G.Terminal.name t) );
     Format.fprintf ppf "  | _ -> false\n\n"
 
   module C = Codesharing (G) (S) (R)
@@ -204,7 +204,7 @@ end = struct
               List.map
                 (fun (st', items) ->
                   ( list_last items,
-                    match st' with None -> -1 | Some st' -> Lr1.to_int st' ))
+                    match st' with None -> -1 | Some st' -> Lr1.to_int st' ) )
                 cases
             in
             let cases =
@@ -214,7 +214,7 @@ end = struct
               | xs -> `Select xs
             in
             (cases, Lr1.to_int st) :: acc
-          with _ -> acc)
+          with _ -> acc )
         []
     in
     let all_cases = group_assoc all_cases in
@@ -259,7 +259,7 @@ end = struct
                 (fun (item, cases) ->
                   fprintf ppf "    ";
                   List.iter (fprintf ppf "| %d ") cases;
-                  fprintf ppf "-> %a\n" emit_item item)
+                  fprintf ppf "-> %a\n" emit_item item )
                 xs;
               fprintf ppf "    | _ -> raise Not_found)\n" )
             else
@@ -273,10 +273,10 @@ end = struct
                     (fun (item, cases) ->
                       fprintf ppf "    ";
                       List.iter (fprintf ppf "| %d ") cases;
-                      fprintf ppf "-> %a\n" emit_item item)
+                      fprintf ppf "-> %a\n" emit_item item )
                     xs;
                   fprintf ppf "    | _ -> %a)\n" emit_item item
-              | [] -> assert false ))
+              | [] -> assert false ) )
       all_cases;
 
     fprintf ppf "  | _ -> raise Not_found\n"

--- a/vendor/parse-wyc/menhir-recover/main.ml
+++ b/vendor/parse-wyc/menhir-recover/main.ml
@@ -35,7 +35,7 @@ let () =
         fprintf ppf "Transitions:\n";
         List.iter
           (fun (sym, (st' : lr1)) ->
-            fprintf ppf " - on %a, goto #%d\n" Print.symbol sym (st' :> int))
+            fprintf ppf " - on %a, goto #%d\n" Print.symbol sym (st' :> int) )
           (Lr1.transitions st);
         fprintf ppf "Reductions:\n";
         List.iter
@@ -43,10 +43,10 @@ let () =
             let p : production = List.hd ps in
             fprintf ppf " - on %a, reduce %d:\n  %a\n" Print.terminal t
               (p :> int)
-              Print.production p)
-          (Lr1.reductions st));
+              Print.production p )
+          (Lr1.reductions st) );
     Production.iter (fun (p : production) ->
-        fprintf ppf "\n# Production p%d\n%a" (p :> int) Print.production p) )
+        fprintf ppf "\n# Production p%d\n%a" (p :> int) Print.production p ) )
 
 module S = Synthesis.Synthesizer (G) (A)
 

--- a/vendor/parse-wyc/menhir-recover/recovery_custom.ml
+++ b/vendor/parse-wyc/menhir-recover/recovery_custom.ml
@@ -102,9 +102,9 @@ module Recover (G : GRAMMAR) (S : SYNTHESIZER with module G := G) :
             if pos = 0 then acc
             else
               let cost, _actions = S.solve (S.Tail (st, prod, pos)) in
-              add_item cost (st, prod, pos) acc)
+              add_item cost (st, prod, pos) acc )
           []
-          (Lr0.items (Lr1.lr0 st)))
+          (Lr0.items (Lr1.lr0 st)) )
 
   let step st ntss =
     let seen = ref Bytes.empty in
@@ -150,7 +150,7 @@ module Recover (G : GRAMMAR) (S : SYNTHESIZER with module G := G) :
       tbl1.(Lr1.to_int s2) <- s1 :: tbl1.(Lr1.to_int s2)
     in
     Lr1.iter (fun lr1 ->
-        List.iter (revert_transition lr1) (Lr1.transitions lr1));
+        List.iter (revert_transition lr1) (Lr1.transitions lr1) );
     fun lr1 -> tbl1.(Lr1.to_int lr1)
 
   let expand stuck_states ((st, sts), nts) =
@@ -158,7 +158,7 @@ module Recover (G : GRAMMAR) (S : SYNTHESIZER with module G := G) :
       (fun st' ->
         let nts' = step st' nts in
         if nts' = [] then stuck_states := st' :: !stuck_states;
-        ((st', st' :: sts), nts'))
+        ((st', st' :: sts), nts') )
       (pred st)
 
   let all_stuck_states : (Lr1.t, int ref) Hashtbl.t = Hashtbl.create 7
@@ -205,7 +205,7 @@ module Recover (G : GRAMMAR) (S : SYNTHESIZER with module G := G) :
                         Hashtbl.add all_stuck_states st r;
                         r
                     in
-                    incr r)
+                    incr r )
                   !stuck_states;
                 stuck := true;
                 stuck_states := [];
@@ -232,8 +232,8 @@ module Recover (G : GRAMMAR) (S : SYNTHESIZER with module G := G) :
                (fun (st, tr') acc ->
                  match tr' with
                  | Some { items; _ } -> (st, items) :: acc
-                 | None -> acc)
-               (process_trace trace) [])
+                 | None -> acc )
+               (process_trace trace) [] )
            traces
     in
     if !stuck then
@@ -256,7 +256,7 @@ module Recover (G : GRAMMAR) (S : SYNTHESIZER with module G := G) :
         Format.eprintf
           "# State %d is preventing recovery from %d states:\n%a\n\n%!"
           (Lr1.to_int st) count Print.itemset
-          (Lr0.items (Lr1.lr0 st)))
+          (Lr0.items (Lr1.lr0 st)) )
       all_stuck_states
 
   let report _ppf = ()

--- a/vendor/parse-wyc/menhir-recover/synthesis.ml
+++ b/vendor/parse-wyc/menhir-recover/synthesis.ml
@@ -171,7 +171,7 @@ module Synthesizer (G : GRAMMAR) (A : ATTRIBUTES with module G = G) :
     let table = Array.make Nonterminal.count [] in
     Production.iter (fun p ->
         let nt = Nonterminal.to_int (Production.lhs p) in
-        table.(nt) <- p :: table.(nt));
+        table.(nt) <- p :: table.(nt) );
     fun nt -> table.(Nonterminal.to_int nt)
 
   let cost_of = function
@@ -271,14 +271,14 @@ module Synthesizer (G : GRAMMAR) (A : ATTRIBUTES with module G = G) :
               (fun (item, ((cost, _) as solution)) (prod, pos) ->
                 let ((cost', _) as solution') = solve (Tail (st, prod, pos)) in
                 if cost' < cost then (Some (prod, pos), solution')
-                else (item, solution))
+                else (item, solution) )
               (None, bottom)
               (Lr0.items (Lr1.lr0 st))
           with
           | None, _ ->
               fprintf ppf "no synthesis from %d\n" (Lr1.to_int st);
               acc
-          | Some item, cost -> (item, (cost, st)) :: acc)
+          | Some item, cost -> (item, (cost, st)) :: acc )
         []
     in
     let fprintf = Format.fprintf in
@@ -298,7 +298,7 @@ module Synthesizer (G : GRAMMAR) (A : ATTRIBUTES with module G = G) :
             fprintf ppf "at cost %d from states %a:\n%a\n\n"
               (cost : Cost.t :> int)
               (Utils.pp_list (fun ppf st -> fprintf ppf "#%d" (Lr1.to_int st)))
-              states print_actions actions)
-          (group_assoc states))
+              states print_actions actions )
+          (group_assoc states) )
       (group_assoc solutions)
 end

--- a/vendor/parse-wyc/test/unit/test_unit.ml
+++ b/vendor/parse-wyc/test/unit/test_unit.ml
@@ -320,7 +320,7 @@ module M : sig
 let check_tests checker tests =
   List.map
     (fun (name, input, locs) ->
-      (name, `Quick, fun () -> checker ~name ~input ~locs))
+      (name, `Quick, fun () -> checker ~name ~input ~locs) )
     tests
 
 let tests =


### PR DESCRIPTION
This commit is from https://github.com/ocaml-ppx/ocamlformat/pull/1104

> Various commits have removed some, but not all, of the spaces before
closing parens when indicate_multiline_delimiters = Space. The result
is that the output is very inconsistent about when a closing paren
that matches one on a different line is preceded by a space or
not.

@gpetiot @jberdine 