### PR TITLE
Fix unstable cmt in or-pattern

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
   + Fix the indentation produced by max-indent (#1118) (Guillaume Petiot)
   + Fix break after Psig_include depending on presence of docstring (#1125) (Guillaume Petiot)
   + Remove some calls to if_newline and break_unless_newline and fix break before closing brackets (#1168) (Guillaume Petiot)
+  + Fix unstable cmt in or-pattern (#1173) (Guillaume Petiot)
 
 #### Internal
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1029,7 +1029,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
                   (* side effects of Cmts.fmt_before before [fmt_pattern] is
                      important *)
                   let loc = xpat.ast.ppat_loc in
-                  let force_break = Cmts.has_before c.cmts loc in
+                  let cmts_before = Cmts.has_before c.cmts loc in
                   let leading_cmt =
                     let pro, adj =
                       if first_grp && first then (noop, fmt "@ ")
@@ -1045,10 +1045,10 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
                           (if nested then "" else "( ")
                       $ open_box (-2)
                     else if first then
-                      Params.get_or_pattern_sep c.conf ~ctx:ctx0 ~force_break
+                      Params.get_or_pattern_sep c.conf ~ctx:ctx0 ~cmts_before
                       $ open_box (-2)
                     else
-                      Params.get_or_pattern_sep c.conf ~ctx:ctx0 ~force_break
+                      Params.get_or_pattern_sep c.conf ~ctx:ctx0 ~cmts_before
                         ~space:(space xpat.ast)
                   in
                   leading_cmt $ fmt_pattern c ~pro xpat

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -34,23 +34,22 @@ let wrap_exp (c : Conf.t) ?(disambiguate = false) ?(fits_breaks = true)
   | `Begin_end ->
       vbox 2 (wrap "begin" "end" (wrap_k (break 1 0) (break 1000 ~-2) k))
 
-let get_or_pattern_sep ?(force_break = false) ?(space = false) (c : Conf.t)
+let get_or_pattern_sep ?(cmts_before = false) ?(space = false) (c : Conf.t)
     ~ctx =
-  let nspaces = if force_break then 1000 else 1 in
-  let bar ~force_break =
-    let nspaces = if force_break then 1000 else 1 in
-    match c.indicate_nested_or_patterns with
-    | `Space ->
-        let breaks = if space then " | " else " |" in
-        cbreak ~fits:("", nspaces, "| ") ~breaks:("", 0, breaks)
-    | `Unsafe_no -> cbreak ~fits:("", nspaces, "| ") ~breaks:("", 0, "| ")
-  in
+  let nspaces = if cmts_before then 1000 else 1 in
   match ctx with
   | Ast.Exp {pexp_desc= Pexp_function _ | Pexp_match _ | Pexp_try _; _} -> (
     match c.break_cases with
     | `Nested -> break nspaces 0 $ str "| "
-    | `All -> bar ~force_break:true
-    | `Fit | `Fit_or_vertical | `Toplevel -> bar ~force_break )
+    | _ -> (
+        let nspaces =
+          match c.break_cases with `All -> 1000 | _ -> nspaces
+        in
+        match c.indicate_nested_or_patterns with
+        | `Space ->
+            cbreak ~fits:("", nspaces, "| ")
+              ~breaks:("", 0, if space then " | " else " |")
+        | `Unsafe_no -> break nspaces 0 $ str "| " ) )
   | _ -> break nspaces 0 $ str "| "
 
 type cases =

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -22,7 +22,7 @@ val wrap_exp :
   -> Fmt.t
 
 val get_or_pattern_sep :
-  ?force_break:bool -> ?space:bool -> Conf.t -> ctx:Ast.t -> Fmt.t
+  ?cmts_before:bool -> ?space:bool -> Conf.t -> ctx:Ast.t -> Fmt.t
 
 type cases =
   { leading_space: Fmt.t

--- a/test/passing/break_cases-align.ml.ref
+++ b/test/passing/break_cases-align.ml.ref
@@ -234,3 +234,26 @@ let _ =
         (* _____________________________________________________________________ *)
         | X _ | Y _ ) } ->
       ()
+
+let foooooooooooooo = function
+  | Fooo
+  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo
+  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo
+  (* foooooo foooo fooooooooooo *)
+  | Foooooooooooooo _
+  (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
+     Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
+     Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
+     foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
+     foooooooooooooo foooooo. *)
+  | Foooo foooo
+  | FooooFoooooFoooooo
+  (* fooooooo fooooo fooo foooooooooooooo *)
+  | Foooo
+  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    ->
+      Foooooooooo.Foooooo
+  | Foooo {foooo_fooo= {foooooooooo}} ->
+      Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo

--- a/test/passing/break_cases-align.ml.ref
+++ b/test/passing/break_cases-align.ml.ref
@@ -248,12 +248,21 @@ let foooooooooooooo = function
      Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
-  | Foooo foooo
+  | Foooooooooo
   | FooooFoooooFoooooo
-  (* fooooooo fooooo fooo foooooooooooooo *)
+  (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
   (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
+
+let get_nullability = function
+  | ArrayAccess
+  | OptimisticFallback
+  (* non-null is the most optimistic type *)
+  | Undef
+  (* This is a very special case, assigning non-null is a technical trick *)
+    ->
+      Nullability.Nonnull

--- a/test/passing/break_cases-all.ml.ref
+++ b/test/passing/break_cases-all.ml.ref
@@ -234,3 +234,26 @@ let _ =
         (* _____________________________________________________________________ *)
         | X _ | Y _ ) } ->
       ()
+
+let foooooooooooooo = function
+  | Fooo
+  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo
+  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo
+  (* foooooo foooo fooooooooooo *)
+  | Foooooooooooooo _
+  (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
+     Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
+     Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
+     foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
+     foooooooooooooo foooooo. *)
+  | Foooo foooo
+  | FooooFoooooFoooooo
+  (* fooooooo fooooo fooo foooooooooooooo *)
+  | Foooo
+  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    ->
+      Foooooooooo.Foooooo
+  | Foooo {foooo_fooo= {foooooooooo}} ->
+      Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo

--- a/test/passing/break_cases-all.ml.ref
+++ b/test/passing/break_cases-all.ml.ref
@@ -248,12 +248,21 @@ let foooooooooooooo = function
      Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
-  | Foooo foooo
+  | Foooooooooo
   | FooooFoooooFoooooo
-  (* fooooooo fooooo fooo foooooooooooooo *)
+  (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
   (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
+
+let get_nullability = function
+  | ArrayAccess
+  | OptimisticFallback
+  (* non-null is the most optimistic type *)
+  | Undef
+  (* This is a very special case, assigning non-null is a technical trick *)
+    ->
+      Nullability.Nonnull

--- a/test/passing/break_cases-closing_on_separate_line.ml.ref
+++ b/test/passing/break_cases-closing_on_separate_line.ml.ref
@@ -241,3 +241,26 @@ let _ =
         (* _____________________________________________________________________ *)
         | X _ | Y _ ) } ->
       ()
+
+let foooooooooooooo = function
+  | Fooo
+  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo
+  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo
+  (* foooooo foooo fooooooooooo *)
+  | Foooooooooooooo _
+  (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
+     Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
+     Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
+     foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
+     foooooooooooooo foooooo. *)
+  | Foooo foooo
+  | FooooFoooooFoooooo
+  (* fooooooo fooooo fooo foooooooooooooo *)
+  | Foooo
+  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    ->
+      Foooooooooo.Foooooo
+  | Foooo {foooo_fooo= {foooooooooo}} ->
+      Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo

--- a/test/passing/break_cases-closing_on_separate_line.ml.ref
+++ b/test/passing/break_cases-closing_on_separate_line.ml.ref
@@ -255,12 +255,21 @@ let foooooooooooooo = function
      Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
-  | Foooo foooo
+  | Foooooooooo
   | FooooFoooooFoooooo
-  (* fooooooo fooooo fooo foooooooooooooo *)
+  (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
   (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
+
+let get_nullability = function
+  | ArrayAccess
+  | OptimisticFallback
+  (* non-null is the most optimistic type *)
+  | Undef
+  (* This is a very special case, assigning non-null is a technical trick *)
+    ->
+      Nullability.Nonnull

--- a/test/passing/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref
+++ b/test/passing/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref
@@ -254,12 +254,21 @@ let foooooooooooooo = function
      Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
-  | Foooo foooo
+  | Foooooooooo
   | FooooFoooooFoooooo
-  (* fooooooo fooooo fooo foooooooooooooo *)
+  (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
   (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
+
+let get_nullability = function
+  | ArrayAccess
+  | OptimisticFallback
+  (* non-null is the most optimistic type *)
+  | Undef
+  (* This is a very special case, assigning non-null is a technical trick *)
+    ->
+      Nullability.Nonnull

--- a/test/passing/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref
+++ b/test/passing/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref
@@ -240,3 +240,26 @@ let _ =
         (* _____________________________________________________________________ *)
         | X _ | Y _ ) } ->
       ()
+
+let foooooooooooooo = function
+  | Fooo
+  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo
+  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo
+  (* foooooo foooo fooooooooooo *)
+  | Foooooooooooooo _
+  (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
+     Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
+     Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
+     foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
+     foooooooooooooo foooooo. *)
+  | Foooo foooo
+  | FooooFoooooFoooooo
+  (* fooooooo fooooo fooo foooooooooooooo *)
+  | Foooo
+  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    ->
+      Foooooooooo.Foooooo
+  | Foooo {foooo_fooo= {foooooooooo}} ->
+      Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo

--- a/test/passing/break_cases-cosl_lnmp_cmei.ml.ref
+++ b/test/passing/break_cases-cosl_lnmp_cmei.ml.ref
@@ -254,12 +254,21 @@ let foooooooooooooo = function
      Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
-  | Foooo foooo
+  | Foooooooooo
   | FooooFoooooFoooooo
-  (* fooooooo fooooo fooo foooooooooooooo *)
+  (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
   (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
+
+let get_nullability = function
+  | ArrayAccess
+  | OptimisticFallback
+  (* non-null is the most optimistic type *)
+  | Undef
+  (* This is a very special case, assigning non-null is a technical trick *)
+    ->
+      Nullability.Nonnull

--- a/test/passing/break_cases-cosl_lnmp_cmei.ml.ref
+++ b/test/passing/break_cases-cosl_lnmp_cmei.ml.ref
@@ -240,3 +240,26 @@ let _ =
         (* _____________________________________________________________________ *)
         | X _ | Y _ ) } ->
       ()
+
+let foooooooooooooo = function
+  | Fooo
+  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo
+  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo
+  (* foooooo foooo fooooooooooo *)
+  | Foooooooooooooo _
+  (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
+     Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
+     Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
+     foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
+     foooooooooooooo foooooo. *)
+  | Foooo foooo
+  | FooooFoooooFoooooo
+  (* fooooooo fooooo fooo foooooooooooooo *)
+  | Foooo
+  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    ->
+      Foooooooooo.Foooooo
+  | Foooo {foooo_fooo= {foooooooooo}} ->
+      Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo

--- a/test/passing/break_cases-fit_or_vertical.ml.ref
+++ b/test/passing/break_cases-fit_or_vertical.ml.ref
@@ -198,3 +198,25 @@ let _ =
         (* _____________________________________________________________________ *)
         | X _
         | Y _ ) } -> ()
+
+let foooooooooooooo = function
+  | Fooo
+  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo
+  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo
+  (* foooooo foooo fooooooooooo *)
+  | Foooooooooooooo _
+  (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
+     Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
+     Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
+     foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
+     foooooooooooooo foooooo. *)
+  | Foooo foooo
+  | FooooFoooooFoooooo
+  (* fooooooo fooooo fooo foooooooooooooo *)
+  | Foooo
+  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    -> Foooooooooo.Foooooo
+  | Foooo {foooo_fooo= {foooooooooo}} ->
+      Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo

--- a/test/passing/break_cases-fit_or_vertical.ml.ref
+++ b/test/passing/break_cases-fit_or_vertical.ml.ref
@@ -212,11 +212,19 @@ let foooooooooooooo = function
      Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
-  | Foooo foooo
+  | Foooooooooo
   | FooooFoooooFoooooo
-  (* fooooooo fooooo fooo foooooooooooooo *)
+  (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
   (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     -> Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
+
+let get_nullability = function
+  | ArrayAccess
+  | OptimisticFallback
+  (* non-null is the most optimistic type *)
+  | Undef
+  (* This is a very special case, assigning non-null is a technical trick *)
+    -> Nullability.Nonnull

--- a/test/passing/break_cases-nested.ml.ref
+++ b/test/passing/break_cases-nested.ml.ref
@@ -216,11 +216,19 @@ let foooooooooooooo = function
      Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
-  | Foooo foooo
-  | FooooFoooooFoooooo (* fooooooo fooooo fooo foooooooooooooo *)
+  | Foooooooooo
+  | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
   (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
+
+let get_nullability = function
+  | ArrayAccess
+  | OptimisticFallback (* non-null is the most optimistic type *)
+  | Undef
+  (* This is a very special case, assigning non-null is a technical trick *)
+    ->
+      Nullability.Nonnull

--- a/test/passing/break_cases-nested.ml.ref
+++ b/test/passing/break_cases-nested.ml.ref
@@ -205,3 +205,22 @@ let _ =
         | X _
         | Y _ ) } ->
       ()
+
+let foooooooooooooo = function
+  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo (* foooooo foooo fooooooooooo *)
+  | Foooooooooooooo _
+  (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
+     Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
+     Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
+     foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
+     foooooooooooooo foooooo. *)
+  | Foooo foooo
+  | FooooFoooooFoooooo (* fooooooo fooooo fooo foooooooooooooo *)
+  | Foooo
+  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    ->
+      Foooooooooo.Foooooo
+  | Foooo {foooo_fooo= {foooooooooo}} ->
+      Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo

--- a/test/passing/break_cases-normal_indent.ml.ref
+++ b/test/passing/break_cases-normal_indent.ml.ref
@@ -234,3 +234,26 @@ let _ =
         (* _____________________________________________________________________ *)
         | X _ | Y _ ) } ->
       ()
+
+let foooooooooooooo = function
+  | Fooo
+  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo
+  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo
+  (* foooooo foooo fooooooooooo *)
+  | Foooooooooooooo _
+  (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
+     Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
+     Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
+     foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
+     foooooooooooooo foooooo. *)
+  | Foooo foooo
+  | FooooFoooooFoooooo
+  (* fooooooo fooooo fooo foooooooooooooo *)
+  | Foooo
+  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    ->
+      Foooooooooo.Foooooo
+  | Foooo {foooo_fooo= {foooooooooo}} ->
+      Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo

--- a/test/passing/break_cases-normal_indent.ml.ref
+++ b/test/passing/break_cases-normal_indent.ml.ref
@@ -248,12 +248,21 @@ let foooooooooooooo = function
      Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
-  | Foooo foooo
+  | Foooooooooo
   | FooooFoooooFoooooo
-  (* fooooooo fooooo fooo foooooooooooooo *)
+  (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
   (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
+
+let get_nullability = function
+  | ArrayAccess
+  | OptimisticFallback
+  (* non-null is the most optimistic type *)
+  | Undef
+  (* This is a very special case, assigning non-null is a technical trick *)
+    ->
+      Nullability.Nonnull

--- a/test/passing/break_cases-toplevel.ml.opts
+++ b/test/passing/break_cases-toplevel.ml.opts
@@ -1,1 +1,2 @@
 --break-cases=toplevel
+--max-iter=4

--- a/test/passing/break_cases-toplevel.ml.ref
+++ b/test/passing/break_cases-toplevel.ml.ref
@@ -200,3 +200,20 @@ let _ =
         (* _____________________________________________________________________ *)
         | X _ | Y _ ) } ->
       ()
+
+let foooooooooooooo = function
+  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *) | Foo
+  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo (* foooooo foooo fooooooooooo *) | Foooooooooooooo _
+  (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
+     Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
+     Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
+     foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
+     foooooooooooooo foooooo. *)
+  | Foooo foooo
+  | FooooFoooooFoooooo (* fooooooo fooooo fooo foooooooooooooo *) | Foooo
+  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    ->
+      Foooooooooo.Foooooo
+  | Foooo {foooo_fooo= {foooooooooo}} ->
+      Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo

--- a/test/passing/break_cases-toplevel.ml.ref
+++ b/test/passing/break_cases-toplevel.ml.ref
@@ -210,10 +210,19 @@ let foooooooooooooo = function
      Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
-  | Foooo foooo
-  | FooooFoooooFoooooo (* fooooooo fooooo fooo foooooooooooooo *) | Foooo
+  | Foooooooooo | FooooFoooooFoooooo
+  (* fooooooooooooooooooooooooooooooooooo *)
+  | Foooo
   (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
+
+let get_nullability = function
+  | ArrayAccess | OptimisticFallback
+  (* non-null is the most optimistic type *)
+  | Undef
+  (* This is a very special case, assigning non-null is a technical trick *)
+    ->
+      Nullability.Nonnull

--- a/test/passing/break_cases.ml
+++ b/test/passing/break_cases.ml
@@ -225,9 +225,15 @@ let foooooooooooooo = function
      Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo foooooooooooooooooo foooooooo.
      Foooooooooooo fooooooooooo fooooooooooooo foooooooooooooo foooooo.
   *)
-  | Foooo foooo
-  | FooooFoooooFoooooo (* fooooooo fooooo fooo foooooooooooooo *)
+  | Foooooooooo
+  | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *) ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
+
+let get_nullability = function
+  | ArrayAccess | OptimisticFallback (* non-null is the most optimistic type *)
+  | Undef
+  (* This is a very special case, assigning non-null is a technical trick *) ->
+      Nullability.Nonnull

--- a/test/passing/break_cases.ml
+++ b/test/passing/break_cases.ml
@@ -214,3 +214,20 @@ let _ =
         ( X _ | Y _ )
     } -> ()
 ;;
+
+let foooooooooooooo = function
+  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo (* foooooo foooo fooooo fooooooo fooooooo fooooo  *)
+  | Foooooooooooooooo (* foooooo foooo fooooooooooo *)
+  | Foooooooooooooo _
+  (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
+     Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
+     Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo foooooooooooooooooo foooooooo.
+     Foooooooooooo fooooooooooo fooooooooooooo foooooooooooooo foooooo.
+  *)
+  | Foooo foooo
+  | FooooFoooooFoooooo (* fooooooo fooooo fooo foooooooooooooo *)
+  | Foooo (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *) ->
+      Foooooooooo.Foooooo
+  | Foooo {foooo_fooo= {foooooooooo}} ->
+      Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo

--- a/test/passing/break_cases.ml.opts
+++ b/test/passing/break_cases.ml.opts
@@ -1,1 +1,2 @@
 --break-cases=fit
+--max-iter=4

--- a/test/passing/break_cases.ml.ref
+++ b/test/passing/break_cases.ml.ref
@@ -177,3 +177,20 @@ let _ =
         (* _____________________________________________________________________ *)
         | X _ | Y _ ) } ->
       ()
+
+let foooooooooooooo = function
+  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *) | Foo
+  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo (* foooooo foooo fooooooooooo *) | Foooooooooooooo _
+  (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
+     Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
+     Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
+     foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
+     foooooooooooooo foooooo. *)
+  | Foooo foooo
+  | FooooFoooooFoooooo (* fooooooo fooooo fooo foooooooooooooo *) | Foooo
+  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    ->
+      Foooooooooo.Foooooo
+  | Foooo {foooo_fooo= {foooooooooo}} ->
+      Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo

--- a/test/passing/break_cases.ml.ref
+++ b/test/passing/break_cases.ml.ref
@@ -187,10 +187,19 @@ let foooooooooooooo = function
      Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
-  | Foooo foooo
-  | FooooFoooooFoooooo (* fooooooo fooooo fooo foooooooooooooo *) | Foooo
+  | Foooooooooo | FooooFoooooFoooooo
+  (* fooooooooooooooooooooooooooooooooooo *)
+  | Foooo
   (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
+
+let get_nullability = function
+  | ArrayAccess | OptimisticFallback
+  (* non-null is the most optimistic type *)
+  | Undef
+  (* This is a very special case, assigning non-null is a technical trick *)
+    ->
+      Nullability.Nonnull


### PR DESCRIPTION
The issue appeared in `test-extra/code/infer/infer/src/nullsafe/typeOrigin.ml` with `profile=conventional`.

The problem is fixed when testing locally but still appears with test_branch, comparing this branch with master. But everything is fine when comparing this branch with itself (non-stabilizing formatting should still appear if present).

So maybe there is some fixing to do in test_branch as well.