### PR TITLE
Remove some polymorphic comparisons

### DIFF
--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -89,6 +89,8 @@ type t =
   | Tli of toplevel_item
   | Top
 
+val is_top : t -> bool
+
 val break_between :
      Source.t
   -> cmts:'a
@@ -128,6 +130,8 @@ type prec =
   | Dot  (** [x.y] and [x#y] *)
   | High
   | Atomic
+
+val equal_prec : prec -> prec -> bool
 
 (** Associativities of Ast terms *)
 type assoc = Left | Non | Right

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -12,10 +12,33 @@
 let selected_version = Migrate_parsetree.Versions.ocaml_408
 
 module Selected_version = Ast_408
-module Parsetree = Selected_version.Parsetree
 module Ast_mapper = Selected_version.Ast_mapper
 module Ast_helper = Selected_version.Ast_helper
-module Asttypes = Selected_version.Asttypes
+
+module Parsetree = struct
+  include Selected_version.Parsetree
+
+  let equal_core_type : core_type -> core_type -> bool = Poly.equal
+
+  let equal_structure : structure -> structure -> bool = Poly.equal
+
+  let equal_signature : signature -> signature -> bool = Poly.equal
+
+  let equal_toplevel_phrase : toplevel_phrase -> toplevel_phrase -> bool =
+    Poly.equal
+end
+
+module Asttypes = struct
+  include Selected_version.Asttypes
+
+  let is_private = function Private -> true | Public -> false
+
+  let is_open = function Open -> true | Closed -> false
+
+  let is_override = function Override -> true | Fresh -> false
+
+  let is_mutable = function Mutable -> true | Immutable -> false
+end
 
 module Mapper = struct
   let structure = Selected_version.map_structure

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -3,10 +3,32 @@ val selected_version :
   Migrate_parsetree.Versions.ocaml_version
 
 module Selected_version = Ast_408
-module Parsetree = Selected_version.Parsetree
 module Ast_mapper = Selected_version.Ast_mapper
 module Ast_helper = Selected_version.Ast_helper
-module Asttypes = Selected_version.Asttypes
+
+module Parsetree : sig
+  include module type of Selected_version.Parsetree
+
+  val equal_core_type : core_type -> core_type -> bool
+
+  val equal_structure : structure -> structure -> bool
+
+  val equal_signature : signature -> signature -> bool
+
+  val equal_toplevel_phrase : toplevel_phrase -> toplevel_phrase -> bool
+end
+
+module Asttypes : sig
+  include module type of Selected_version.Asttypes
+
+  val is_private : private_flag -> bool
+
+  val is_open : closed_flag -> bool
+
+  val is_override : override_flag -> bool
+
+  val is_mutable : mutable_flag -> bool
+end
 
 module Position : sig
   val column : Lexing.position -> int

--- a/lib/Normalize.ml
+++ b/lib/Normalize.ml
@@ -277,7 +277,7 @@ let make_mapper conf ~ignore_doc_comment =
           ( ({ppat_desc= Ppat_var _; _} as p0)
           , {ptyp_desc= Ptyp_poly ([], t0); _} )
       , Pexp_constraint (e0, t1) )
-      when Poly.(t0 = t1) ->
+      when equal_core_type t0 t1 ->
         m.value_binding m
           (Vb.mk ~loc:pvb_loc ~attrs:pvb_attributes p0
              (Exp.constraint_ ~loc:ppat_loc ~attrs:ppat_attributes e0 t0))
@@ -377,7 +377,7 @@ let equal_impl ~ignore_doc_comments c ast1 ast2 =
       Mapper.structure (mapper_ignore_doc_comment c)
     else Mapper.structure (mapper c)
   in
-  Poly.(map ast1 = map ast2)
+  equal_structure (map ast1) (map ast2)
 
 let equal_intf ~ignore_doc_comments c ast1 ast2 =
   let map =
@@ -385,14 +385,14 @@ let equal_intf ~ignore_doc_comments c ast1 ast2 =
       Mapper.signature (mapper_ignore_doc_comment c)
     else Mapper.signature (mapper c)
   in
-  Poly.(map ast1 = map ast2)
+  equal_signature (map ast1) (map ast2)
 
 let equal_toplevel ~ignore_doc_comments c ast1 ast2 =
   let map =
     if ignore_doc_comments then Mapper.use_file (mapper_ignore_doc_comment c)
     else Mapper.use_file (mapper c)
   in
-  Poly.(map ast1 = map ast2)
+  List.equal equal_toplevel_phrase (map ast1) (map ast2)
 
 let make_docstring_mapper c docstrings =
   let doc_attribute = function

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -125,7 +125,7 @@ let infix cmts prec xexp =
     let ctx = Exp exp in
     match (assoc, exp) with
     | Left, {pexp_desc= Pexp_apply (e0, [(l1, e1); (l2, e2)]); pexp_loc; _}
-      when Poly.(prec = prec_ast (Exp exp)) ->
+      when Option.equal equal_prec prec (prec_ast (Exp exp)) ->
         let op_args1 = infix_ None (l1, sub_exp ~ctx e1) in
         let src = pexp_loc in
         let after = e2.pexp_loc in
@@ -138,7 +138,7 @@ let infix cmts prec xexp =
               Cmts.relocate cmts ~src ~before:e0.pexp_loc ~after ) ;
         op_args1 @ [(Some (sub_exp ~ctx e0), [(l2, sub_exp ~ctx e2)])]
     | Right, {pexp_desc= Pexp_apply (e0, [(l1, e1); (l2, e2)]); pexp_loc; _}
-      when Poly.(prec = prec_ast (Exp exp)) ->
+      when Option.equal equal_prec prec (prec_ast (Exp exp)) ->
         let op_args2 =
           infix_ (Some (sub_exp ~ctx e0)) (l2, sub_exp ~ctx e2)
         in


### PR DESCRIPTION
These can be tricky to remove later on so it is better to isolate them so that the polymorphic comparison is defined only in one place.

I tried to avoid exposing `is_*` function in the spirit of [tell-dont-ask](https://martinfowler.com/bliki/TellDontAsk.html) and preferring pattern matching like in `fmt_direction_flag`, but in some cases it was not possible.

Let me know what you think.