### PR TITLE
Extract, test and refactor Non_overlapping_interval_tree

### DIFF
--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -171,8 +171,6 @@ module Location = struct
 
   include Location_comparator
 
-  let hash = Hashtbl.hash
-
   let compare_start x y = Position.compare x.loc_start y.loc_start
 
   let compare_start_col x y = Position.compare_col x.loc_start y.loc_start
@@ -185,13 +183,10 @@ module Location = struct
 
   let width x = Position.distance x.loc_start x.loc_end
 
-  let compare_width_decreasing l1 l2 =
-    match Position.compare l1.loc_start l2.loc_start with
-    | 0 -> (
-      match Position.compare l2.loc_end l1.loc_end with
-      | 0 -> compare l1 l2
-      | n -> n )
-    | n -> n
+  let descending cmp a b = -cmp a b
+
+  let compare_width_decreasing =
+    Comparable.lexicographic [compare_start; descending compare_end; compare]
 
   let is_single_line x margin =
     width x <= margin && x.loc_start.pos_lnum = x.loc_end.pos_lnum

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -45,13 +45,18 @@ module Location : sig
 
   val comparator : (t, comparator_witness) Comparator.t
 
-  val hash : t -> int
-
   val contains : t -> t -> bool
 
   val sexp_of_t : t -> Sexp.t
 
   val compare_width_decreasing : t -> t -> int
+  (** Compare, in order:
+
+      - start
+      - end (in reverse order)
+      - ghostness
+
+      Locs (start and end) are compared using [Position.compare]. *)
 
   val compare : t -> t -> int
 

--- a/lib/Non_overlapping_interval_tree.ml
+++ b/lib/Non_overlapping_interval_tree.ml
@@ -1,0 +1,100 @@
+module type IN = sig
+  include Comparator.S
+
+  val contains : t -> t -> bool
+
+  val compare_width_decreasing : t -> t -> int
+end
+
+module type S = sig
+  type itv
+
+  type t
+
+  val of_list : itv list -> t
+  (** If there are duplicates in the input list, earlier elements will be
+      ancestors of later elements. *)
+
+  val roots : t -> itv list
+
+  val children : t -> itv -> itv list
+
+  val dump : t -> Fmt.t
+  (** Debug: dump debug representation of tree. *)
+end
+
+module Make (Itv : IN) = struct
+  (* simple but (asymptotically) suboptimal implementation *)
+
+  type itv = Itv.t
+
+  type t = {roots: Itv.t list; map: Itv.t list Map.M(Itv).t}
+
+  let empty = {roots= []; map= Map.empty (module Itv)}
+
+  let roots t = t.roots
+
+  let map_add_multi map ~key ~data =
+    Map.update map key ~f:(function None -> [data] | Some l -> data :: l)
+
+  (** Descend tree from roots, find deepest node that contains elt. *)
+  let rec parents map roots ~ancestors elt =
+    Option.value ~default:ancestors
+      (List.find_map roots ~f:(fun root ->
+           if Itv.contains root elt then
+             let ancestors = root :: ancestors in
+             ( match Map.find map root with
+             | Some children -> parents map children ~ancestors elt
+             | None -> ancestors )
+             |> Option.some
+           else None))
+
+  let add_root t root = {t with roots= root :: t.roots}
+
+  let add_child t ~parent ~child =
+    {t with map= map_add_multi t.map ~key:parent ~data:child}
+
+  let map_lists ~f {roots; map} = {roots= f roots; map= Map.map map ~f}
+
+  let rec find_in_previous t elt = function
+    | [] -> parents t.map t.roots elt ~ancestors:[]
+    | p :: ancestors when Itv.contains p elt ->
+        parents t.map [p] elt ~ancestors
+    | _ :: px -> find_in_previous t elt px
+
+  (** Add elements in decreasing width order to construct tree from roots to
+      leaves. That is, when adding an interval to a partially constructed
+      tree, it will already contain all wider intervals, so the new
+      interval's parent will already be in the tree. *)
+  let of_list elts =
+    let add (prev_ancestor, t) elt =
+      let ancestors = find_in_previous t elt prev_ancestor in
+      let t =
+        match ancestors with
+        | parent :: _ -> add_child t ~parent ~child:elt
+        | [] -> add_root t elt
+      in
+      (ancestors, t)
+    in
+    elts
+    |> List.dedup_and_sort ~compare:Itv.compare_width_decreasing
+    |> List.fold ~init:([], empty) ~f:add
+    |> snd
+    |> map_lists ~f:(List.sort ~compare:Itv.compare_width_decreasing)
+
+  let children {map; _} elt = Option.value ~default:[] (Map.find map elt)
+
+  let dump tree =
+    let open Fmt in
+    let rec dump_ tree roots =
+      vbox 0
+        (list roots "@," (fun root ->
+             let children = children tree root in
+             vbox 1
+               ( str (Sexp.to_string_hum (Itv.comparator.sexp_of_t root))
+               $ wrap_if
+                   (not (List.is_empty children))
+                   "@,{" " }" (dump_ tree children) )))
+    in
+    set_margin 100000000 $ dump_ tree tree.roots
+end

--- a/lib/Non_overlapping_interval_tree.mli
+++ b/lib/Non_overlapping_interval_tree.mli
@@ -1,0 +1,30 @@
+(** A tree of non-overlapping intervals. Intervals are non-overlapping if
+    whenever 2 intervals share more than an end-point, then one contains the
+    other. *)
+
+module type IN = sig
+  include Comparator.S
+
+  val contains : t -> t -> bool
+
+  val compare_width_decreasing : t -> t -> int
+end
+
+module type S = sig
+  type itv
+
+  type t
+
+  val of_list : itv list -> t
+  (** If there are duplicates in the input list, earlier elements will be
+      ancestors of later elements. *)
+
+  val roots : t -> itv list
+
+  val children : t -> itv -> itv list
+
+  val dump : t -> Fmt.t
+  (** Debug: dump debug representation of tree. *)
+end
+
+module Make (Itv : IN) : S with type itv = Itv.t

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -23,6 +23,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06"}
+  "alcotest" {with-test}
   "base" {>= "v0.11.0"}
   "base-unix"
   "cmdliner"

--- a/test/unit/dune
+++ b/test/unit/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_unit)
+ (libraries alcotest base ocamlformat_lib))

--- a/test/unit/test_unit.ml
+++ b/test/unit/test_unit.ml
@@ -1,0 +1,116 @@
+open Base
+open Ocamlformat_lib
+
+module Test_location = struct
+  let test_compare_width_decreasing =
+    let open Migrate_ast in
+    let test name a b expected =
+      let test_name = "compare_width_decreasing: " ^ name in
+      ( test_name
+      , `Quick
+      , fun () ->
+          let got = Location.compare_width_decreasing a b in
+          Alcotest.check Alcotest.int test_name expected got )
+    in
+    let make_pos pos_cnum =
+      {Lexing.pos_fname= "fname"; pos_lnum= 0; pos_bol= 0; pos_cnum}
+    in
+    let make_loc s e loc_ghost =
+      {Location.loc_start= make_pos s; loc_end= make_pos e; loc_ghost}
+    in
+    [ test "equal" (make_loc 0 0 false) (make_loc 0 0 false) 0
+    ; test "different start" (make_loc 0 0 false) (make_loc 1 0 false) (-1)
+    ; test "same start" (make_loc 0 0 false) (make_loc 0 1 false) 1
+    ; test "same start, same end" (make_loc 0 0 true) (make_loc 0 0 false) 1 ]
+
+  let tests = test_compare_width_decreasing
+end
+
+module Test_noit = struct
+  module Itv = struct
+    module T = struct
+      type t = int * int
+
+      let sexp_of_t (s, e) =
+        Base.Sexp.List [Base.Int.sexp_of_t s; Base.Int.sexp_of_t e]
+
+      let compare = Poly.compare
+    end
+
+    include T
+    include Comparator.Make (T)
+
+    let contains (sa, ea) (sb, eb) = sa <= sb && eb <= ea
+
+    let compare_width_decreasing (sa, ea) (sb, eb) =
+      Poly.compare (sa, -ea) (sb, -eb)
+
+    let pp ppf (s, e) = Caml.Format.fprintf ppf "(%d, %d)" s e
+
+    let equal = Poly.equal
+  end
+
+  module T = Non_overlapping_interval_tree.Make (Itv)
+
+  let itv_list = Alcotest.list (module Itv)
+
+  let test_dump =
+    let to_string t = Format_.asprintf "%a" Fmt.eval (T.dump t) in
+    let test name l expected =
+      let test_name = "dump: " ^ name in
+      ( test_name
+      , `Quick
+      , fun () ->
+          let t = T.of_list l in
+          let got = to_string t in
+          Alcotest.check Alcotest.string test_name expected got )
+    in
+    [ test "empty" [] ""
+    ; test "singleton" [(1, 2)] "(1 2)"
+    ; test "disjoint" [(1, 2); (3, 5)] "(1 2)\n(3 5)"
+    ; test "same start" [(1, 2); (1, 3)] "(1 3)\n {(1 2) }"
+    ; test "same end" [(2, 3); (1, 3)] "(1 3)\n {(2 3) }"
+    ; test "inclusion"
+        [(1, 8); (2, 7); (3, 6); (4, 5)]
+        "(1 8)\n {(2 7)\n   {(3 6)\n     {(4 5) } } }" ]
+
+  let test_roots =
+    let test name l expected =
+      let test_name = "roots: " ^ name in
+      ( test_name
+      , `Quick
+      , fun () ->
+          let t = T.of_list l in
+          let got = T.roots t in
+          Alcotest.check itv_list test_name expected got )
+    in
+    [ test "empty" [] []
+    ; test "singleton" [(1, 2)] [(1, 2)]
+    ; test "disjoint" [(1, 2); (3, 4)] [(1, 2); (3, 4)]
+    ; test "inclusion" [(1, 2); (3, 6); (4, 5)] [(1, 2); (3, 6)] ]
+
+  let test_children =
+    let test name l i expected =
+      let test_name = "children: " ^ name in
+      ( test_name
+      , `Quick
+      , fun () ->
+          let t = T.of_list l in
+          let got = T.children t i in
+          Alcotest.check itv_list test_name expected got )
+    in
+    [ test "empty" [] (1, 2) []
+    ; test "no children" [(1, 2)] (1, 2) []
+    ; test "not present" [(1, 2)] (3, 4) []
+    ; test "one level" [(1, 2); (3, 6); (4, 5)] (3, 6) [(4, 5)]
+    ; test "two levels" [(1, 2); (3, 8); (4, 7); (5, 6)] (3, 8) [(4, 7)]
+    ; test "no partial results" [(1, 2); (3, 6); (4, 5)] (3, 5) [] ]
+
+  let tests = test_dump @ test_roots @ test_children
+end
+
+let tests =
+  [ ("Location", Test_location.tests)
+  ; ("non overlapping interval tree", Test_noit.tests) ]
+
+let () = Alcotest.run "ocamlformat" tests


### PR DESCRIPTION
Hi,

In order:
- this moves `Non_overlapping_interval_tree` to its own file
- some tests are added
- it's refactored so that it does not use mutability internally (that was only during construction, but the result seems better anyway)

Let me know what you think.