### PR TITLE
Display standard output in the emacs plugin even when ocamlformat does not fail

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
   + Add an option `--margin-check` to emit a warning if the formatted output exceeds the margin (#1110) (Guillaume Petiot)
   + Preserve comment indentation when `wrap-comments` is unset (#1138, #1159) (Jules Aguillon)
   + Improve error messages (#1147) (Jules Aguillon)
+  + Display standard output in the emacs plugin even when ocamlformat does not fail (#1189) (Guillaume Petiot)
 
 #### Removed
 

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -261,6 +261,13 @@ function."
                (if ocamlformat--support-replace-buffer-contents
                    (ocamlformat--replace-buffer-contents outputfile)
 		 (ocamlformat--patch-buffer outputfile))
+               (if errbuf
+                 (progn
+                   (with-current-buffer errbuf
+                     (setq buffer-read-only nil)
+                     (erase-buffer))
+                   (ocamlformat--process-errors
+                    (buffer-file-name) bufferfile errorfile errbuf)))
                (message "Applied ocamlformat"))
              (if errbuf
                (progn

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -164,7 +164,7 @@ function."
         (erase-buffer))
       (with-current-buffer errbuf
         (if (eq ocamlformat-show-errors 'echo)
-            (message "%s" (buffer-string))
+          (message "%s" (buffer-string))
           (insert-file-contents errorfile nil nil nil)
           ;; Convert the ocamlformat stderr to something understood by the
           ;; compilation mode.

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -165,15 +165,18 @@ function."
       (with-current-buffer errbuf
         (if (eq ocamlformat-show-errors 'echo)
           (message "%s" (buffer-string))
-          (insert-file-contents errorfile nil nil nil)
-          ;; Convert the ocamlformat stderr to something understood by the
-          ;; compilation mode.
-          (goto-char (point-min))
-          (insert "ocamlformat errors:\n")
-          (while (search-forward-regexp (regexp-quote tmpfile) nil t)
-            (replace-match (file-name-nondirectory filename)))
-          (compilation-mode)
-          (display-buffer errbuf))))))
+          ;; Checks the size of errorfile
+          (if (> (nth 7 (file-attributes errorfile)) 0)
+            (progn
+              (insert-file-contents errorfile nil nil nil)
+              ;; Convert the ocamlformat stderr to something understood by the
+              ;; compilation mode.
+              (goto-char (point-min))
+              (insert "ocamlformat errors:\n")
+              (while (search-forward-regexp (regexp-quote tmpfile) nil t)
+                (replace-match (file-name-nondirectory filename)))
+              (compilation-mode)
+              (display-buffer errbuf))))))))
 
 (defun ocamlformat--kill-error-buffer (errbuf)
   (let ((win (get-buffer-window errbuf)))

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -271,12 +271,10 @@ function."
                (if ocamlformat--support-replace-buffer-contents
                    (ocamlformat--replace-buffer-contents outputfile)
 		 (ocamlformat--patch-buffer outputfile))
-               (ocamlformat--process-errors
-                 (buffer-file-name) bufferfile errorfile errbuf)
                (message "Applied ocamlformat"))
-             (ocamlformat--process-errors
-               (buffer-file-name) bufferfile errorfile errbuf)
-             (message "Could not apply ocamlformat"))))
+             (message "Could not apply ocamlformat"))
+           (ocamlformat--process-errors
+            (buffer-file-name) bufferfile errorfile errbuf)))
      (delete-file errorfile)
      (delete-file bufferfile)
      (delete-file outputfile)))

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -166,6 +166,7 @@ function."
         (if (eq ocamlformat-show-errors 'echo)
           (message "%s" (buffer-string))
           ;; Checks the size of errorfile
+          ;; Accessor 'file-attribute-size' only exists in emacs-26 and later
           (if (> (nth 7 (file-attributes errorfile)) 0)
             (progn
               (insert-file-contents errorfile nil nil nil)

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -158,26 +158,24 @@ function."
 
 (defun ocamlformat--process-errors (filename tmpfile errorfile errbuf)
   (if errbuf
-    (progn
-      (with-current-buffer errbuf
+    (with-current-buffer errbuf
+      (if (eq ocamlformat-show-errors 'echo)
+        (message "%s" (buffer-string))
         (setq buffer-read-only nil)
-        (erase-buffer))
-      (with-current-buffer errbuf
-        (if (eq ocamlformat-show-errors 'echo)
-          (message "%s" (buffer-string))
-          ;; Checks the size of errorfile
-          ;; Accessor 'file-attribute-size' only exists in emacs-26 and later
-          (if (> (nth 7 (file-attributes errorfile)) 0)
-            (progn
-              (insert-file-contents errorfile nil nil nil)
-              ;; Convert the ocamlformat stderr to something understood by the
-              ;; compilation mode.
-              (goto-char (point-min))
-              (insert "ocamlformat errors:\n")
-              (while (search-forward-regexp (regexp-quote tmpfile) nil t)
-                (replace-match (file-name-nondirectory filename)))
-              (compilation-mode)
-              (display-buffer errbuf))))))))
+        (erase-buffer)
+        ;; Checks the size of errorfile
+        ;; Accessor 'file-attribute-size' only exists in emacs-26 and later
+        (if (> (nth 7 (file-attributes errorfile)) 0)
+          (progn
+            (insert-file-contents errorfile nil nil nil)
+            ;; Convert the ocamlformat stderr to something understood by the
+            ;; compilation mode.
+            (goto-char (point-min))
+            (insert "ocamlformat errors:\n")
+            (while (search-forward-regexp (regexp-quote tmpfile) nil t)
+              (replace-match (file-name-nondirectory filename)))
+            (compilation-mode)
+            (display-buffer errbuf)))))))
 
 (defun ocamlformat--kill-error-buffer (errbuf)
   (let ((win (get-buffer-window errbuf)))


### PR DESCRIPTION
Fix #1170