### PR TITLE
Port to dune 2.0

### DIFF
--- a/dune
+++ b/dune
@@ -15,11 +15,9 @@
    (:standard -noassert))))
 
 (rule
- (targets ocamlformat-help.actual)
- (action
-  (with-stdout-to
-   %{targets}
-   (run ocamlformat --help=plain))))
+ (with-stdout-to
+  ocamlformat-help.actual
+  (run ocamlformat --help=plain)))
 
 (rule
  (alias runtest)

--- a/test/.ocamlformat_ignore
+++ b/test/.ocamlformat_ignore
@@ -1,5 +1,0 @@
-cli/**
-disabled/**
-failing/**
-passing/**
-projects/**

--- a/test/cli/dune
+++ b/test/cli/dune
@@ -402,7 +402,6 @@
   (diff max_iter_1_failing.expected max_iter_1_failing.output)))
 
 (rule
- (targets conf_bad_version.output)
  (deps
   (source_tree roots/bad_version))
  (action
@@ -411,7 +410,7 @@
    ;; (it contains the current git rev)
    %{null}
    (with-stdout-to
-    %{targets}
+    conf_bad_version.output
     (with-stdin-from
      sample/a.ml
      (chdir
@@ -426,12 +425,11 @@
   (diff conf_bad_version.expected conf_bad_version.output)))
 
 (rule
- (targets conf_malformed1.output)
  (deps
   (source_tree roots/malformed1))
  (action
   (with-outputs-to
-   %{targets}
+   conf_malformed1.output
    (with-stdin-from
     sample/a.ml
     (chdir
@@ -446,12 +444,11 @@
   (diff conf_malformed1.expected conf_malformed1.output)))
 
 (rule
- (targets conf_unknown_option.output)
  (deps
   (source_tree roots/unknown_option))
  (action
   (with-outputs-to
-   %{targets}
+   conf_unknown_option.output
    (with-stdin-from
     sample/a.ml
     (chdir
@@ -466,12 +463,11 @@
   (diff conf_unknown_option.expected conf_unknown_option.output)))
 
 (rule
- (targets conf_unknown_value.output)
  (deps
   (source_tree roots/unknown_value))
  (action
   (with-outputs-to
-   %{targets}
+   conf_unknown_value.output
    (with-stdin-from
     sample/a.ml
     (chdir
@@ -486,12 +482,11 @@
   (diff conf_unknown_value.expected conf_unknown_value.output)))
 
 (rule
- (targets env_unknown_option.output)
  (deps
   (source_tree roots/unknown_value))
  (action
   (with-outputs-to
-   %{targets}
+   env_unknown_option.output
    (with-stdin-from
     sample/a.ml
     (setenv
@@ -507,12 +502,11 @@
   (diff env_unknown_option.expected env_unknown_option.output)))
 
 (rule
- (targets env_unknown_value.output)
  (deps
   (source_tree roots/unknown_value))
  (action
   (with-outputs-to
-   %{targets}
+   env_unknown_value.output
    (setenv
     OCAMLFORMAT
     "type-decl=unknown"

--- a/test/cli/dune
+++ b/test/cli/dune
@@ -49,7 +49,9 @@
 (rule
  (with-outputs-to
   err_output_and_check.output
-  (system "! %{bin:ocamlformat} --output x.ml --check %{dep:sample/a.ml}")))
+  (with-accepted-exit-codes
+   1
+   (run %{bin:ocamlformat} --output x.ml --check %{dep:sample/a.ml}))))
 
 (rule
  (alias runtest)
@@ -59,8 +61,10 @@
 (rule
  (with-outputs-to
   err_output_several_files.output
-  (system
-    "! %{bin:ocamlformat} --output x.ml %{dep:sample/a.ml} %{dep:sample/b.ml}")))
+  (with-accepted-exit-codes
+   1
+   (run %{bin:ocamlformat} --output x.ml %{dep:sample/a.ml}
+     %{dep:sample/b.ml}))))
 
 (rule
  (alias runtest)
@@ -70,7 +74,9 @@
 (rule
  (with-outputs-to
   err_stdin_and_file.output
-  (system "! %{bin:ocamlformat} %{dep:sample/a.ml} -")))
+  (with-accepted-exit-codes
+   1
+   (run %{bin:ocamlformat} %{dep:sample/a.ml} -))))
 
 (rule
  (alias runtest)
@@ -80,7 +86,9 @@
 (rule
  (with-outputs-to
   err_stdin_and_inplace.output
-  (system "! %{bin:ocamlformat} --inplace -")))
+  (with-accepted-exit-codes
+   1
+   (run %{bin:ocamlformat} --inplace -))))
 
 (rule
  (alias runtest)
@@ -90,7 +98,9 @@
 (rule
  (with-outputs-to
   err_stdin_no_kind.output
-  (system "! %{bin:ocamlformat} -")))
+  (with-accepted-exit-codes
+   1
+   (run %{bin:ocamlformat} -))))
 
 (rule
  (alias runtest)
@@ -142,7 +152,7 @@
  (action
   (with-outputs-to
    %{targets}
-   (system "%{bin:ocamlformat} --root=. --name b.cpp %{dep:sample/b.ml}"))))
+   (run %{bin:ocamlformat} --root=. --name b.cpp %{dep:sample/b.ml}))))
 
 (rule
  (alias runtest)
@@ -152,7 +162,9 @@
 (rule
  (with-outputs-to
   err_stdin_name_unknown_ext.output
-  (system "! %{bin:ocamlformat} --name b.cpp - < %{dep:sample/b.ml}")))
+  (with-accepted-exit-codes
+   1
+   (system " %{bin:ocamlformat} --name b.cpp - < %{dep:sample/b.ml}"))))
 
 (rule
  (alias runtest)
@@ -162,8 +174,10 @@
 (rule
  (with-outputs-to
   err_several_files_and_kind.output
-  (system
-    "! %{bin:ocamlformat} --impl --check %{dep:sample/a.mli} %{dep:sample/b.ml}")))
+  (with-accepted-exit-codes
+   1
+   (run %{bin:ocamlformat} --impl --check %{dep:sample/a.mli}
+     %{dep:sample/b.ml}))))
 
 (rule
  (alias runtest)
@@ -173,8 +187,10 @@
 (rule
  (with-outputs-to
   err_several_files_and_name.output
-  (system
-    "! %{bin:ocamlformat} --name foo.ml --check %{dep:sample/a.mli} %{dep:sample/b.ml}")))
+  (with-accepted-exit-codes
+   1
+   (run %{bin:ocamlformat} --name foo.ml --check %{dep:sample/a.mli}
+     %{dep:sample/b.ml}))))
 
 (rule
  (alias runtest)
@@ -184,8 +200,10 @@
 (rule
  (with-outputs-to
   err_several_files_and_kind_inplace.output
-  (system
-    "! %{bin:ocamlformat} --impl --check %{dep:sample/a.mli} %{dep:sample/b.ml}")))
+  (with-accepted-exit-codes
+   1
+   (run %{bin:ocamlformat} --impl --check %{dep:sample/a.mli}
+     %{dep:sample/b.ml}))))
 
 (rule
  (alias runtest)
@@ -196,8 +214,10 @@
 (rule
  (with-outputs-to
   err_several_files_and_name_inplace.output
-  (system
-    "! %{bin:ocamlformat} --name foo.ml --check %{dep:sample/a.mli} %{dep:sample/b.ml}")))
+  (with-accepted-exit-codes
+   1
+   (run %{bin:ocamlformat} --name foo.ml --check %{dep:sample/a.mli}
+     %{dep:sample/b.ml}))))
 
 (rule
  (alias runtest)
@@ -211,8 +231,10 @@
  (action
   (with-outputs-to
    %{targets}
-   (system
-     "! %{bin:ocamlformat} --root=. --name foo.ml %{dep:sample/syntax_error.ml}"))))
+   (with-accepted-exit-codes
+    1
+    (run %{bin:ocamlformat} --root=. --name foo.ml
+      %{dep:sample/syntax_error.ml})))))
 
 (rule
  (alias runtest)
@@ -225,8 +247,10 @@
  (action
   (with-outputs-to
    %{targets}
-   (system
-     "! %{bin:ocamlformat} --root=. --name foo.ml - < %{dep:sample/syntax_error.ml}"))))
+   (with-accepted-exit-codes
+    1
+    (system
+      "%{bin:ocamlformat} --root=. --name foo.ml - < %{dep:sample/syntax_error.ml}")))))
 
 (rule
  (alias runtest)
@@ -239,7 +263,9 @@
  (action
   (with-outputs-to
    %{targets}
-   (system "! %{bin:ocamlformat} --root=. --impl %{dep:sample/a.mli}"))))
+   (with-accepted-exit-codes
+    1
+    (run %{bin:ocamlformat} --root=. --impl %{dep:sample/a.mli})))))
 
 (rule
  (alias runtest)
@@ -252,7 +278,9 @@
  (action
   (with-outputs-to
    %{targets}
-   (system "! %{bin:ocamlformat} --root=. --impl - < %{dep:sample/a.mli}"))))
+   (with-accepted-exit-codes
+    1
+    (system " %{bin:ocamlformat} --root=. --impl - < %{dep:sample/a.mli}")))))
 
 (rule
  (alias runtest)
@@ -265,7 +293,9 @@
  (action
   (with-outputs-to
    %{targets}
-   (system "! %{bin:ocamlformat} --root=. --name foo.ml %{dep:sample/a.mli}"))))
+   (with-accepted-exit-codes
+    1
+    (run %{bin:ocamlformat} --root=. --name foo.ml %{dep:sample/a.mli})))))
 
 (rule
  (alias runtest)
@@ -279,8 +309,10 @@
  (action
   (with-outputs-to
    %{targets}
-   (system
-     "! %{bin:ocamlformat} --root=. --name foo.ml - < %{dep:sample/a.mli}"))))
+   (with-accepted-exit-codes
+    1
+    (system
+      "%{bin:ocamlformat} --root=. --name foo.ml - < %{dep:sample/a.mli}")))))
 
 (rule
  (alias runtest)
@@ -307,7 +339,9 @@
  (action
   (with-outputs-to
    %{targets}
-   (system "! %{bin:ocamlformat} --root=. --check %{dep:sample/b.ml}"))))
+   (with-accepted-exit-codes
+    1
+    (run %{bin:ocamlformat} --root=. --check %{dep:sample/b.ml})))))
 
 (rule
  (alias runtest)
@@ -346,7 +380,9 @@
  (action
   (with-outputs-to
    %{targets}
-   (system "! %{bin:ocamlformat} --root=. --max-iters=1 %{dep:sample/b.ml}"))))
+   (with-accepted-exit-codes
+    1
+    (run %{bin:ocamlformat} --root=. --max-iters=1 %{dep:sample/b.ml})))))
 
 (rule
  (alias runtest)
@@ -365,7 +401,9 @@
    %{targets}
    (chdir
     roots/bad_version
-    (system "! %{bin:ocamlformat} --impl - < %{dep:sample/a.ml} 2>/dev/null")))))
+    (with-accepted-exit-codes
+     1
+     (system "%{bin:ocamlformat} --impl - < %{dep:sample/a.ml} 2>/dev/null"))))))
 
 (rule
  (alias runtest)
@@ -381,7 +419,9 @@
    %{targets}
    (chdir
     roots/malformed1
-    (system "! %{bin:ocamlformat} --impl - < %{dep:sample/a.ml}")))))
+    (with-accepted-exit-codes
+     1
+     (system "%{bin:ocamlformat} --impl - < %{dep:sample/a.ml}"))))))
 
 (rule
  (alias runtest)
@@ -397,7 +437,9 @@
    %{targets}
    (chdir
     roots/unknown_option
-    (system "! %{bin:ocamlformat} --impl - < %{dep:sample/a.ml}")))))
+    (with-accepted-exit-codes
+     1
+     (system "%{bin:ocamlformat} --impl - < %{dep:sample/a.ml}"))))))
 
 (rule
  (alias runtest)
@@ -413,7 +455,9 @@
    %{targets}
    (chdir
     roots/unknown_value
-    (system "! %{bin:ocamlformat} --impl - < %{dep:sample/a.ml}")))))
+    (with-accepted-exit-codes
+     1
+     (system "%{bin:ocamlformat} --impl - < %{dep:sample/a.ml}"))))))
 
 (rule
  (alias runtest)
@@ -430,7 +474,9 @@
    (setenv
     OCAMLFORMAT
     "unknown=true"
-    (system "! %{bin:ocamlformat} --impl - < %{dep:sample/a.ml}")))))
+    (with-accepted-exit-codes
+     1
+     (system "%{bin:ocamlformat} --impl - < %{dep:sample/a.ml}"))))))
 
 (rule
  (alias runtest)
@@ -447,7 +493,9 @@
    (setenv
     OCAMLFORMAT
     "type-decl=unknown"
-    (system "! %{bin:ocamlformat} --impl - < %{dep:sample/a.ml}")))))
+    (with-accepted-exit-codes
+     1
+     (system "%{bin:ocamlformat} --impl - < %{dep:sample/a.ml}"))))))
 
 (rule
  (alias runtest)

--- a/test/cli/dune
+++ b/test/cli/dune
@@ -112,8 +112,10 @@
  (deps .ocamlformat)
  (action
   (with-outputs-to
-   %{targets}
-   (system "%{bin:ocamlformat} --root=. --impl - < %{dep:sample/b.ml}"))))
+   stdin_and_impl.output
+   (with-stdin-from
+    sample/b.ml
+    (run %{bin:ocamlformat} --root=. --impl -)))))
 
 (rule
  (alias runtest)
@@ -125,8 +127,10 @@
  (deps .ocamlformat)
  (action
   (with-outputs-to
-   %{targets}
-   (system "%{bin:ocamlformat} --root=. --intf - < %{dep:sample/a.mli}"))))
+   stdin_and_intf.output
+   (with-stdin-from
+    sample/a.mli
+    (run %{bin:ocamlformat} --root=. --intf -)))))
 
 (rule
  (alias runtest)
@@ -138,8 +142,10 @@
  (deps .ocamlformat)
  (action
   (with-outputs-to
-   %{targets}
-   (system "%{bin:ocamlformat} --root=. --name a.ml - < %{dep:sample/b.ml}"))))
+   stdin_and_name.output
+   (with-stdin-from
+    sample/b.ml
+    (run %{bin:ocamlformat} --root=. --name a.ml -)))))
 
 (rule
  (alias runtest)
@@ -162,9 +168,11 @@
 (rule
  (with-outputs-to
   err_stdin_name_unknown_ext.output
-  (with-accepted-exit-codes
-   1
-   (system " %{bin:ocamlformat} --name b.cpp - < %{dep:sample/b.ml}"))))
+  (with-stdin-from
+   sample/b.ml
+   (with-accepted-exit-codes
+    1
+    (run %{bin:ocamlformat} --name b.cpp -)))))
 
 (rule
  (alias runtest)
@@ -246,11 +254,12 @@
  (deps .ocamlformat)
  (action
   (with-outputs-to
-   %{targets}
-   (with-accepted-exit-codes
-    1
-    (system
-      "%{bin:ocamlformat} --root=. --name foo.ml - < %{dep:sample/syntax_error.ml}")))))
+   fmterr_stdin_and_name.output
+   (with-stdin-from
+    sample/syntax_error.ml
+    (with-accepted-exit-codes
+     1
+     (run %{bin:ocamlformat} --root=. --name foo.ml -))))))
 
 (rule
  (alias runtest)
@@ -277,10 +286,12 @@
  (deps .ocamlformat)
  (action
   (with-outputs-to
-   %{targets}
-   (with-accepted-exit-codes
-    1
-    (system " %{bin:ocamlformat} --root=. --impl - < %{dep:sample/a.mli}")))))
+   fmterr_stdin_bad_kind.output
+   (with-stdin-from
+    sample/a.mli
+    (with-accepted-exit-codes
+     1
+     (run %{bin:ocamlformat} --root=. --impl -))))))
 
 (rule
  (alias runtest)
@@ -308,11 +319,12 @@
  (deps .ocamlformat)
  (action
   (with-outputs-to
-   %{targets}
-   (with-accepted-exit-codes
-    1
-    (system
-      "%{bin:ocamlformat} --root=. --name foo.ml - < %{dep:sample/a.mli}")))))
+   fmterr_stdin_and_name_bad_kind.output
+   (with-stdin-from
+    %{dep:sample/a.mli}
+    (with-accepted-exit-codes
+     1
+     (run %{bin:ocamlformat} --root=. --name foo.ml -))))))
 
 (rule
  (alias runtest)
@@ -389,21 +401,24 @@
  (action
   (diff max_iter_1_failing.expected max_iter_1_failing.output)))
 
-;; This test's stderr is ignored because it's not stable
-;; (it contains the current git rev)
-
 (rule
  (targets conf_bad_version.output)
  (deps
   (source_tree roots/bad_version))
  (action
-  (with-outputs-to
-   %{targets}
-   (chdir
-    roots/bad_version
-    (with-accepted-exit-codes
-     1
-     (system "%{bin:ocamlformat} --impl - < %{dep:sample/a.ml} 2>/dev/null"))))))
+  (with-stderr-to
+   ;; This test's stderr is ignored because it's not stable
+   ;; (it contains the current git rev)
+   %{null}
+   (with-stdout-to
+    %{targets}
+    (with-stdin-from
+     sample/a.ml
+     (chdir
+      roots/bad_version
+      (with-accepted-exit-codes
+       1
+       (run %{bin:ocamlformat} --impl -))))))))
 
 (rule
  (alias runtest)
@@ -417,11 +432,13 @@
  (action
   (with-outputs-to
    %{targets}
-   (chdir
-    roots/malformed1
-    (with-accepted-exit-codes
-     1
-     (system "%{bin:ocamlformat} --impl - < %{dep:sample/a.ml}"))))))
+   (with-stdin-from
+    sample/a.ml
+    (chdir
+     roots/malformed1
+     (with-accepted-exit-codes
+      1
+      (run %{bin:ocamlformat} --impl -)))))))
 
 (rule
  (alias runtest)
@@ -435,11 +452,13 @@
  (action
   (with-outputs-to
    %{targets}
-   (chdir
-    roots/unknown_option
-    (with-accepted-exit-codes
-     1
-     (system "%{bin:ocamlformat} --impl - < %{dep:sample/a.ml}"))))))
+   (with-stdin-from
+    sample/a.ml
+    (chdir
+     roots/unknown_option
+     (with-accepted-exit-codes
+      1
+      (run %{bin:ocamlformat} --impl -)))))))
 
 (rule
  (alias runtest)
@@ -453,11 +472,13 @@
  (action
   (with-outputs-to
    %{targets}
-   (chdir
-    roots/unknown_value
-    (with-accepted-exit-codes
-     1
-     (system "%{bin:ocamlformat} --impl - < %{dep:sample/a.ml}"))))))
+   (with-stdin-from
+    sample/a.ml
+    (chdir
+     roots/unknown_value
+     (with-accepted-exit-codes
+      1
+      (run %{bin:ocamlformat} --impl -)))))))
 
 (rule
  (alias runtest)
@@ -471,12 +492,14 @@
  (action
   (with-outputs-to
    %{targets}
-   (setenv
-    OCAMLFORMAT
-    "unknown=true"
-    (with-accepted-exit-codes
-     1
-     (system "%{bin:ocamlformat} --impl - < %{dep:sample/a.ml}"))))))
+   (with-stdin-from
+    sample/a.ml
+    (setenv
+     OCAMLFORMAT
+     "unknown=true"
+     (with-accepted-exit-codes
+      1
+      (run %{bin:ocamlformat} --impl -)))))))
 
 (rule
  (alias runtest)
@@ -493,9 +516,11 @@
    (setenv
     OCAMLFORMAT
     "type-decl=unknown"
-    (with-accepted-exit-codes
-     1
-     (system "%{bin:ocamlformat} --impl - < %{dep:sample/a.ml}"))))))
+    (with-stdin-from
+     sample/a.ml
+     (with-accepted-exit-codes
+      1
+      (run %{bin:ocamlformat} --impl -)))))))
 
 (rule
  (alias runtest)

--- a/test/cli/dune
+++ b/test/cli/dune
@@ -1,40 +1,48 @@
 (rule
  (with-outputs-to
   err_default_several_file.output
-  (system "! %{bin:ocamlformat} %{dep:sample/a.ml} %{dep:sample/b.ml}")))
+  (with-accepted-exit-codes
+   1
+   (run %{bin:ocamlformat} %{dep:sample/a.ml} %{dep:sample/b.ml}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_default_several_file.expected err_default_several_file.output)))
 
 (rule
  (with-outputs-to
   err_inplace_and_check.output
-  (system "! %{bin:ocamlformat} --inplace --check %{dep:sample/a.ml}")))
+  (with-accepted-exit-codes
+   1
+   (run %{bin:ocamlformat} --inplace --check %{dep:sample/a.ml}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_inplace_and_check.expected err_inplace_and_check.output)))
 
 (rule
  (with-outputs-to
   err_inplace_and_output.output
-  (system "! %{bin:ocamlformat} --inplace --output o.ml %{dep:sample/a.ml}")))
+  (with-accepted-exit-codes
+   1
+   (run %{bin:ocamlformat} --inplace --output o.ml %{dep:sample/a.ml}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_inplace_and_output.expected err_inplace_and_output.output)))
 
 (rule
  (with-outputs-to
   err_no_arg.output
-  (system "! %{bin:ocamlformat}")))
+  (with-accepted-exit-codes
+   1
+   (run %{bin:ocamlformat}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_no_arg.expected err_no_arg.output)))
 
@@ -43,8 +51,8 @@
   err_output_and_check.output
   (system "! %{bin:ocamlformat} --output x.ml --check %{dep:sample/a.ml}")))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_output_and_check.expected err_output_and_check.output)))
 
@@ -54,8 +62,8 @@
   (system
     "! %{bin:ocamlformat} --output x.ml %{dep:sample/a.ml} %{dep:sample/b.ml}")))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_output_several_files.expected err_output_several_files.output)))
 
@@ -64,8 +72,8 @@
   err_stdin_and_file.output
   (system "! %{bin:ocamlformat} %{dep:sample/a.ml} -")))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_stdin_and_file.expected err_stdin_and_file.output)))
 
@@ -74,8 +82,8 @@
   err_stdin_and_inplace.output
   (system "! %{bin:ocamlformat} --inplace -")))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_stdin_and_inplace.expected err_stdin_and_inplace.output)))
 
@@ -84,8 +92,8 @@
   err_stdin_no_kind.output
   (system "! %{bin:ocamlformat} -")))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_stdin_no_kind.expected err_stdin_no_kind.output)))
 
@@ -97,8 +105,8 @@
    %{targets}
    (system "%{bin:ocamlformat} --root=. --impl - < %{dep:sample/b.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff stdin_and_impl.expected stdin_and_impl.output)))
 
@@ -110,8 +118,8 @@
    %{targets}
    (system "%{bin:ocamlformat} --root=. --intf - < %{dep:sample/a.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff stdin_and_intf.expected stdin_and_intf.output)))
 
@@ -123,8 +131,8 @@
    %{targets}
    (system "%{bin:ocamlformat} --root=. --name a.ml - < %{dep:sample/b.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff stdin_and_name.expected stdin_and_name.output)))
 
@@ -136,8 +144,8 @@
    %{targets}
    (system "%{bin:ocamlformat} --root=. --name b.cpp %{dep:sample/b.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff name_unknown_ext.expected name_unknown_ext.output)))
 
@@ -146,8 +154,8 @@
   err_stdin_name_unknown_ext.output
   (system "! %{bin:ocamlformat} --name b.cpp - < %{dep:sample/b.ml}")))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_stdin_name_unknown_ext.expected err_stdin_name_unknown_ext.output)))
 
@@ -157,8 +165,8 @@
   (system
     "! %{bin:ocamlformat} --impl --check %{dep:sample/a.mli} %{dep:sample/b.ml}")))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_several_files_and_kind.expected err_several_files_and_kind.output)))
 
@@ -168,8 +176,8 @@
   (system
     "! %{bin:ocamlformat} --name foo.ml --check %{dep:sample/a.mli} %{dep:sample/b.ml}")))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_several_files_and_name.expected err_several_files_and_name.output)))
 
@@ -179,8 +187,8 @@
   (system
     "! %{bin:ocamlformat} --impl --check %{dep:sample/a.mli} %{dep:sample/b.ml}")))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_several_files_and_kind_inplace.expected
     err_several_files_and_kind_inplace.output)))
@@ -191,8 +199,8 @@
   (system
     "! %{bin:ocamlformat} --name foo.ml --check %{dep:sample/a.mli} %{dep:sample/b.ml}")))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff err_several_files_and_name_inplace.expected
     err_several_files_and_name_inplace.output)))
@@ -203,10 +211,11 @@
  (action
   (with-outputs-to
    %{targets}
-   (system "! %{bin:ocamlformat} --root=. --name foo.ml %{dep:sample/syntax_error.ml}"))))
+   (system
+     "! %{bin:ocamlformat} --root=. --name foo.ml %{dep:sample/syntax_error.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff fmterr_file_and_name.expected fmterr_file_and_name.output)))
 
@@ -219,8 +228,8 @@
    (system
      "! %{bin:ocamlformat} --root=. --name foo.ml - < %{dep:sample/syntax_error.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff fmterr_stdin_and_name.expected fmterr_stdin_and_name.output)))
 
@@ -232,8 +241,8 @@
    %{targets}
    (system "! %{bin:ocamlformat} --root=. --impl %{dep:sample/a.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff fmterr_file_bad_kind.expected fmterr_file_bad_kind.output)))
 
@@ -245,8 +254,8 @@
    %{targets}
    (system "! %{bin:ocamlformat} --root=. --impl - < %{dep:sample/a.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff fmterr_stdin_bad_kind.expected fmterr_stdin_bad_kind.output)))
 
@@ -258,8 +267,8 @@
    %{targets}
    (system "! %{bin:ocamlformat} --root=. --name foo.ml %{dep:sample/a.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff fmterr_file_and_name_bad_kind.expected
     fmterr_file_and_name_bad_kind.output)))
@@ -270,10 +279,11 @@
  (action
   (with-outputs-to
    %{targets}
-   (system "! %{bin:ocamlformat} --root=. --name foo.ml - < %{dep:sample/a.mli}"))))
+   (system
+     "! %{bin:ocamlformat} --root=. --name foo.ml - < %{dep:sample/a.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff fmterr_stdin_and_name_bad_kind.expected
     fmterr_stdin_and_name_bad_kind.output)))
@@ -286,8 +296,8 @@
    %{targets}
    (run %{bin:ocamlformat} --root=. --check %{dep:sample/a.ml}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff check_formatted.expected check_formatted.output)))
 
@@ -299,8 +309,8 @@
    %{targets}
    (system "! %{bin:ocamlformat} --root=. --check %{dep:sample/b.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff check_not_formatted.expected check_not_formatted.output)))
 
@@ -312,8 +322,8 @@
    %{targets}
    (run %{bin:ocamlformat} --root=. --debug %{dep:sample/b.ml}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff debug.expected debug.output)))
 
@@ -325,8 +335,8 @@
    %{targets}
    (run ocamlformat --root=. --max-iters=1 %{dep:sample/a.ml}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff max_iter_1_ok.expected max_iter_1_ok.output)))
 
@@ -338,8 +348,8 @@
    %{targets}
    (system "! %{bin:ocamlformat} --root=. --max-iters=1 %{dep:sample/b.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff max_iter_1_failing.expected max_iter_1_failing.output)))
 
@@ -357,8 +367,8 @@
     roots/bad_version
     (system "! %{bin:ocamlformat} --impl - < %{dep:sample/a.ml} 2>/dev/null")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff conf_bad_version.expected conf_bad_version.output)))
 
@@ -373,8 +383,8 @@
     roots/malformed1
     (system "! %{bin:ocamlformat} --impl - < %{dep:sample/a.ml}")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff conf_malformed1.expected conf_malformed1.output)))
 
@@ -389,8 +399,8 @@
     roots/unknown_option
     (system "! %{bin:ocamlformat} --impl - < %{dep:sample/a.ml}")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff conf_unknown_option.expected conf_unknown_option.output)))
 
@@ -405,8 +415,8 @@
     roots/unknown_value
     (system "! %{bin:ocamlformat} --impl - < %{dep:sample/a.ml}")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff conf_unknown_value.expected conf_unknown_value.output)))
 
@@ -422,8 +432,8 @@
     "unknown=true"
     (system "! %{bin:ocamlformat} --impl - < %{dep:sample/a.ml}")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff env_unknown_option.expected env_unknown_option.output)))
 
@@ -439,7 +449,7 @@
     "type-decl=unknown"
     (system "! %{bin:ocamlformat} --impl - < %{dep:sample/a.ml}")))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff env_unknown_value.expected env_unknown_value.output)))

--- a/test/cli/dune-project
+++ b/test/cli/dune-project
@@ -1,1 +1,2 @@
-(lang dune 1.11)
+(lang dune 2.2)
+(formatting disabled)

--- a/test/disabled/dune
+++ b/test/disabled/dune
@@ -1,12 +1,12 @@
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (source_tree dir1))
  (action
   (run %{bin:ocamlformat} -n 1 -i dir1/dir2/ignore_1.ml)))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (source_tree dir1))
  (action

--- a/test/disabled/dune-project
+++ b/test/disabled/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.11)
+(lang dune 2.2)

--- a/test/failing/dune
+++ b/test/failing/dune
@@ -6,8 +6,8 @@
    %{targets}
    (run %{bin:ocamlformat} %{dep:list_and_comments.ml}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps list_and_comments.ml.broken-ref list_and_comments.ml.output)
  (action
   (diff list_and_comments.ml.broken-ref list_and_comments.ml.output)))

--- a/test/failing/dune
+++ b/test/failing/dune
@@ -1,10 +1,8 @@
 (rule
- (targets list_and_comments.ml.output)
  (deps .ocamlformat)
  (action
-  (with-outputs-to
-   %{targets}
-   (run %{bin:ocamlformat} %{dep:list_and_comments.ml}))))
+   (with-outputs-to list_and_comments.ml.output
+     (run %{bin:ocamlformat} %{dep:list_and_comments.ml}))))
 
 (rule
  (alias runtest)

--- a/test/failing/dune-project
+++ b/test/failing/dune-project
@@ -1,1 +1,2 @@
-(lang dune 1.11)
+(lang dune 2.2)
+(formatting disabled)

--- a/test/passing/dune
+++ b/test/passing/dune
@@ -9,7 +9,7 @@
    %{targets}
    (run ./gen/gen.exe))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff dune.inc dune.inc.gen)))

--- a/test/passing/dune
+++ b/test/passing/dune
@@ -1,12 +1,11 @@
 (include dune.inc)
 
 (rule
- (targets dune.inc.gen)
  (deps
   (source_tree .))
  (action
   (with-stdout-to
-   %{targets}
+   dune.inc.gen
    (run ./gen/gen.exe))))
 
 (rule

--- a/test/passing/dune-project
+++ b/test/passing/dune-project
@@ -1,1 +1,2 @@
-(lang dune 1.11)
+(lang dune 2.2)
+(formatting disabled)

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1,9 +1,8 @@
 
 (rule
- (targets align_cases-break_all.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to align_cases-break_all.ml.output
      (run %{bin:ocamlformat} --align-constructors-decl --align-variants-decl --align-cases --break-cases=all %{dep:align_cases.ml}))))
 
 (rule
@@ -11,10 +10,9 @@
  (action (diff align_cases-break_all.ml.ref align_cases-break_all.ml.output)))
 
 (rule
- (targets align_cases.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to align_cases.ml.output
      (run %{bin:ocamlformat} --align-constructors-decl --align-variants-decl --align-cases %{dep:align_cases.ml}))))
 
 (rule
@@ -22,10 +20,9 @@
  (action (diff align_cases.ml align_cases.ml.output)))
 
 (rule
- (targets align_infix.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to align_infix.ml.output
      (run %{bin:ocamlformat} --break-infix=fit-or-vertical %{dep:align_infix.ml}))))
 
 (rule
@@ -33,10 +30,9 @@
  (action (diff align_infix.ml align_infix.ml.output)))
 
 (rule
- (targets apply.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to apply.ml.output
      (run %{bin:ocamlformat} %{dep:apply.ml}))))
 
 (rule
@@ -44,10 +40,9 @@
  (action (diff apply.ml apply.ml.output)))
 
 (rule
- (targets array.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to array.ml.output
      (run %{bin:ocamlformat} %{dep:array.ml}))))
 
 (rule
@@ -55,10 +50,9 @@
  (action (diff array.ml array.ml.output)))
 
 (rule
- (targets assignment_operator-op_begin_line.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to assignment_operator-op_begin_line.ml.output
      (run %{bin:ocamlformat} --assignment-operator=begin-line %{dep:assignment_operator.ml}))))
 
 (rule
@@ -66,10 +60,9 @@
  (action (diff assignment_operator-op_begin_line.ml.ref assignment_operator-op_begin_line.ml.output)))
 
 (rule
- (targets assignment_operator.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to assignment_operator.ml.output
      (run %{bin:ocamlformat} %{dep:assignment_operator.ml}))))
 
 (rule
@@ -77,10 +70,9 @@
  (action (diff assignment_operator.ml.ref assignment_operator.ml.output)))
 
 (rule
- (targets attribute_and_expression.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to attribute_and_expression.ml.output
      (run %{bin:ocamlformat} %{dep:attribute_and_expression.ml}))))
 
 (rule
@@ -88,10 +80,9 @@
  (action (diff attribute_and_expression.ml attribute_and_expression.ml.output)))
 
 (rule
- (targets attributes.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to attributes.ml.output
      (run %{bin:ocamlformat} %{dep:attributes.ml}))))
 
 (rule
@@ -100,10 +91,9 @@
  (action (diff attributes.ml attributes.ml.output)))
 
 (rule
- (targets attributes.mli.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to attributes.mli.output
      (run %{bin:ocamlformat} %{dep:attributes.mli}))))
 
 (rule
@@ -111,10 +101,9 @@
  (action (diff attributes.mli.ref attributes.mli.output)))
 
 (rule
- (targets break_before_in-auto.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_before_in-auto.ml.output
      (run %{bin:ocamlformat} --break-before-in=auto %{dep:break_before_in.ml}))))
 
 (rule
@@ -122,10 +111,9 @@
  (action (diff break_before_in-auto.ml.ref break_before_in-auto.ml.output)))
 
 (rule
- (targets break_before_in.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_before_in.ml.output
      (run %{bin:ocamlformat} --break-before-in=fit-or-vertical %{dep:break_before_in.ml}))))
 
 (rule
@@ -133,10 +121,9 @@
  (action (diff break_before_in.ml break_before_in.ml.output)))
 
 (rule
- (targets break_cases-align.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_cases-align.ml.output
      (run %{bin:ocamlformat} --nested-match=align --break-cases=all %{dep:break_cases.ml}))))
 
 (rule
@@ -144,10 +131,9 @@
  (action (diff break_cases-align.ml.ref break_cases-align.ml.output)))
 
 (rule
- (targets break_cases-all.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_cases-all.ml.output
      (run %{bin:ocamlformat} --break-cases=all %{dep:break_cases.ml}))))
 
 (rule
@@ -155,10 +141,9 @@
  (action (diff break_cases-all.ml.ref break_cases-all.ml.output)))
 
 (rule
- (targets break_cases-closing_on_separate_line.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_cases-closing_on_separate_line.ml.output
      (run %{bin:ocamlformat} --break-cases=all --indicate-multiline-delimiters=closing-on-separate-line %{dep:break_cases.ml}))))
 
 (rule
@@ -166,10 +151,9 @@
  (action (diff break_cases-closing_on_separate_line.ml.ref break_cases-closing_on_separate_line.ml.output)))
 
 (rule
- (targets break_cases-closing_on_separate_line_leading_nested_match_parens.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_cases-closing_on_separate_line_leading_nested_match_parens.ml.output
      (run %{bin:ocamlformat} --break-cases=all --indicate-multiline-delimiters=closing-on-separate-line --leading-nested-match-parens %{dep:break_cases.ml}))))
 
 (rule
@@ -177,10 +161,9 @@
  (action (diff break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref break_cases-closing_on_separate_line_leading_nested_match_parens.ml.output)))
 
 (rule
- (targets break_cases-cosl_lnmp_cmei.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_cases-cosl_lnmp_cmei.ml.output
      (run %{bin:ocamlformat} --break-cases=all --indicate-multiline-delimiters=closing-on-separate-line --leading-nested-match-parens --cases-matching-exp-indent=normal %{dep:break_cases.ml}))))
 
 (rule
@@ -188,10 +171,9 @@
  (action (diff break_cases-cosl_lnmp_cmei.ml.ref break_cases-cosl_lnmp_cmei.ml.output)))
 
 (rule
- (targets break_cases-fit_or_vertical.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_cases-fit_or_vertical.ml.output
      (run %{bin:ocamlformat} --break-cases=fit-or-vertical %{dep:break_cases.ml}))))
 
 (rule
@@ -199,10 +181,9 @@
  (action (diff break_cases-fit_or_vertical.ml.ref break_cases-fit_or_vertical.ml.output)))
 
 (rule
- (targets break_cases-nested.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_cases-nested.ml.output
      (run %{bin:ocamlformat} --break-cases=nested %{dep:break_cases.ml}))))
 
 (rule
@@ -210,10 +191,9 @@
  (action (diff break_cases-nested.ml.ref break_cases-nested.ml.output)))
 
 (rule
- (targets break_cases-normal_indent.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_cases-normal_indent.ml.output
      (run %{bin:ocamlformat} --cases-matching-exp-indent=normal --break-cases=all %{dep:break_cases.ml}))))
 
 (rule
@@ -221,10 +201,9 @@
  (action (diff break_cases-normal_indent.ml.ref break_cases-normal_indent.ml.output)))
 
 (rule
- (targets break_cases-toplevel.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_cases-toplevel.ml.output
      (run %{bin:ocamlformat} --break-cases=toplevel --max-iter=4 %{dep:break_cases.ml}))))
 
 (rule
@@ -232,10 +211,9 @@
  (action (diff break_cases-toplevel.ml.ref break_cases-toplevel.ml.output)))
 
 (rule
- (targets break_cases.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_cases.ml.output
      (run %{bin:ocamlformat} --break-cases=fit --max-iter=4 %{dep:break_cases.ml}))))
 
 (rule
@@ -243,10 +221,9 @@
  (action (diff break_cases.ml.ref break_cases.ml.output)))
 
 (rule
- (targets break_fun_decl-fit_or_vertical.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_fun_decl-fit_or_vertical.ml.output
      (run %{bin:ocamlformat} --break-fun-decl=fit-or-vertical --break-fun-sig=fit-or-vertical %{dep:break_fun_decl.ml}))))
 
 (rule
@@ -254,10 +231,9 @@
  (action (diff break_fun_decl-fit_or_vertical.ml.ref break_fun_decl-fit_or_vertical.ml.output)))
 
 (rule
- (targets break_fun_decl-smart.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_fun_decl-smart.ml.output
      (run %{bin:ocamlformat} --break-fun-decl=smart --break-fun-sig=smart %{dep:break_fun_decl.ml}))))
 
 (rule
@@ -265,10 +241,9 @@
  (action (diff break_fun_decl-smart.ml.ref break_fun_decl-smart.ml.output)))
 
 (rule
- (targets break_fun_decl-wrap.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_fun_decl-wrap.ml.output
      (run %{bin:ocamlformat} --break-fun-decl=wrap --break-fun-sig=wrap %{dep:break_fun_decl.ml}))))
 
 (rule
@@ -276,10 +251,9 @@
  (action (diff break_fun_decl-wrap.ml.ref break_fun_decl-wrap.ml.output)))
 
 (rule
- (targets break_fun_decl.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_fun_decl.ml.output
      (run %{bin:ocamlformat} %{dep:break_fun_decl.ml}))))
 
 (rule
@@ -287,10 +261,9 @@
  (action (diff break_fun_decl.ml break_fun_decl.ml.output)))
 
 (rule
- (targets break_record.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_record.ml.output
      (run %{bin:ocamlformat} --profile=janestreet --margin=58 %{dep:break_record.ml}))))
 
 (rule
@@ -298,10 +271,9 @@
  (action (diff break_record.ml break_record.ml.output)))
 
 (rule
- (targets break_separators-after.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_separators-after.ml.output
      (run %{bin:ocamlformat} --break-separators=after --max-iter=3 %{dep:break_separators.ml}))))
 
 (rule
@@ -309,10 +281,9 @@
  (action (diff break_separators-after.ml.ref break_separators-after.ml.output)))
 
 (rule
- (targets break_separators-after_docked.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_separators-after_docked.ml.output
      (run %{bin:ocamlformat} --break-separators=after --dock-collection-brackets --max-iter=3 %{dep:break_separators.ml}))))
 
 (rule
@@ -320,10 +291,9 @@
  (action (diff break_separators-after_docked.ml.ref break_separators-after_docked.ml.output)))
 
 (rule
- (targets break_separators-after_docked_transition_message.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_separators-after_docked_transition_message.ml.output
      (with-accepted-exit-codes 1
        (run %{bin:ocamlformat} --break-separators=after-and-docked %{dep:break_separators.ml})))))
 
@@ -332,10 +302,9 @@
  (action (diff break_separators-after_docked_transition_message.ml.ref break_separators-after_docked_transition_message.ml.output)))
 
 (rule
- (targets break_separators-after_docked_wrap.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_separators-after_docked_wrap.ml.output
      (run %{bin:ocamlformat} --break-separators=after --break-collection-expressions=wrap --dock-collection-brackets %{dep:break_separators.ml}))))
 
 (rule
@@ -343,10 +312,9 @@
  (action (diff break_separators-after_docked_wrap.ml.ref break_separators-after_docked_wrap.ml.output)))
 
 (rule
- (targets break_separators-after_wrap.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_separators-after_wrap.ml.output
      (run %{bin:ocamlformat} --break-separators=after --break-collection-expressions=wrap %{dep:break_separators.ml}))))
 
 (rule
@@ -354,10 +322,9 @@
  (action (diff break_separators-after_wrap.ml.ref break_separators-after_wrap.ml.output)))
 
 (rule
- (targets break_separators-before_docked.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_separators-before_docked.ml.output
      (run %{bin:ocamlformat} --break-separators=before --dock-collection-brackets --max-iter=3 %{dep:break_separators.ml}))))
 
 (rule
@@ -365,10 +332,9 @@
  (action (diff break_separators-before_docked.ml.ref break_separators-before_docked.ml.output)))
 
 (rule
- (targets break_separators-before_docked_wrap.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_separators-before_docked_wrap.ml.output
      (run %{bin:ocamlformat} --break-separators=before --break-collection-expressions=wrap --dock-collection-brackets %{dep:break_separators.ml}))))
 
 (rule
@@ -376,10 +342,9 @@
  (action (diff break_separators-before_docked_wrap.ml.ref break_separators-before_docked_wrap.ml.output)))
 
 (rule
- (targets break_separators-wrap.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_separators-wrap.ml.output
      (run %{bin:ocamlformat} --break-separators=before --break-collection-expressions=wrap %{dep:break_separators.ml}))))
 
 (rule
@@ -387,10 +352,9 @@
  (action (diff break_separators-wrap.ml.ref break_separators-wrap.ml.output)))
 
 (rule
- (targets break_separators.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_separators.ml.output
      (run %{bin:ocamlformat} --break-separators=before --max-iter=3 %{dep:break_separators.ml}))))
 
 (rule
@@ -398,10 +362,9 @@
  (action (diff break_separators.ml break_separators.ml.output)))
 
 (rule
- (targets break_sequence_before.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_sequence_before.ml.output
      (run %{bin:ocamlformat} %{dep:break_sequence_before.ml}))))
 
 (rule
@@ -409,10 +372,9 @@
  (action (diff break_sequence_before.ml break_sequence_before.ml.output)))
 
 (rule
- (targets break_string_literals-never.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_string_literals-never.ml.output
      (run %{bin:ocamlformat} --break-string-literals=never %{dep:break_string_literals.ml}))))
 
 (rule
@@ -420,10 +382,9 @@
  (action (diff break_string_literals-never.ml.ref break_string_literals-never.ml.output)))
 
 (rule
- (targets break_string_literals-wrap.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_string_literals-wrap.ml.output
      (with-accepted-exit-codes 1
        (run %{bin:ocamlformat} --break-string-literals=wrap %{dep:break_string_literals.ml})))))
 
@@ -432,10 +393,9 @@
  (action (diff break_string_literals-wrap.ml.ref break_string_literals-wrap.ml.output)))
 
 (rule
- (targets break_string_literals.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_string_literals.ml.output
      (run %{bin:ocamlformat} --break-string-literals=auto %{dep:break_string_literals.ml}))))
 
 (rule
@@ -443,10 +403,9 @@
  (action (diff break_string_literals.ml.ref break_string_literals.ml.output)))
 
 (rule
- (targets break_struct.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to break_struct.ml.output
      (run %{bin:ocamlformat} %{dep:break_struct.ml}))))
 
 (rule
@@ -454,10 +413,9 @@
  (action (diff break_struct.ml.ref break_struct.ml.output)))
 
 (rule
- (targets cinaps.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to cinaps.ml.output
      (run %{bin:ocamlformat} %{dep:cinaps.ml}))))
 
 (rule
@@ -465,10 +423,9 @@
  (action (diff cinaps.ml cinaps.ml.output)))
 
 (rule
- (targets cmdline_override.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to cmdline_override.ml.output
      (run %{bin:ocamlformat} --config=module-item-spacing=compact --module-item-spacing=sparse %{dep:cmdline_override.ml}))))
 
 (rule
@@ -476,10 +433,9 @@
  (action (diff cmdline_override.ml cmdline_override.ml.output)))
 
 (rule
- (targets cmdline_override2.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to cmdline_override2.ml.output
      (run %{bin:ocamlformat} --module-item-spacing=sparse --config=module-item-spacing=compact %{dep:cmdline_override2.ml}))))
 
 (rule
@@ -487,10 +443,9 @@
  (action (diff cmdline_override2.ml cmdline_override2.ml.output)))
 
 (rule
- (targets comment_breaking.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to comment_breaking.ml.output
      (run %{bin:ocamlformat} %{dep:comment_breaking.ml}))))
 
 (rule
@@ -498,10 +453,9 @@
  (action (diff comment_breaking.ml comment_breaking.ml.output)))
 
 (rule
- (targets comment_header.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to comment_header.ml.output
      (run %{bin:ocamlformat} %{dep:comment_header.ml}))))
 
 (rule
@@ -509,10 +463,9 @@
  (action (diff comment_header.ml.ref comment_header.ml.output)))
 
 (rule
- (targets comment_in_empty.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to comment_in_empty.ml.output
      (run %{bin:ocamlformat} %{dep:comment_in_empty.ml}))))
 
 (rule
@@ -520,10 +473,9 @@
  (action (diff comment_in_empty.ml comment_in_empty.ml.output)))
 
 (rule
- (targets comment_in_modules.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to comment_in_modules.ml.output
      (run %{bin:ocamlformat} %{dep:comment_in_modules.ml}))))
 
 (rule
@@ -531,10 +483,9 @@
  (action (diff comment_in_modules.ml.ref comment_in_modules.ml.output)))
 
 (rule
- (targets comment_last.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to comment_last.ml.output
      (run %{bin:ocamlformat} %{dep:comment_last.ml}))))
 
 (rule
@@ -542,10 +493,9 @@
  (action (diff comment_last.ml comment_last.ml.output)))
 
 (rule
- (targets comment_sparse.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to comment_sparse.ml.output
      (run %{bin:ocamlformat} %{dep:comment_sparse.ml}))))
 
 (rule
@@ -553,10 +503,9 @@
  (action (diff comment_sparse.ml comment_sparse.ml.output)))
 
 (rule
- (targets comments.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to comments.ml.output
      (run %{bin:ocamlformat} --max-iter=4 %{dep:comments.ml}))))
 
 (rule
@@ -565,10 +514,9 @@
  (action (diff comments.ml.ref comments.ml.output)))
 
 (rule
- (targets comments_args.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to comments_args.ml.output
      (run %{bin:ocamlformat} --max-iter=4 %{dep:comments_args.ml}))))
 
 (rule
@@ -576,10 +524,9 @@
  (action (diff comments_args.ml.ref comments_args.ml.output)))
 
 (rule
- (targets comments_around_disabled.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to comments_around_disabled.ml.output
      (run %{bin:ocamlformat} %{dep:comments_around_disabled.ml}))))
 
 (rule
@@ -587,10 +534,9 @@
  (action (diff comments_around_disabled.ml.ref comments_around_disabled.ml.output)))
 
 (rule
- (targets comments_in_record.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to comments_in_record.ml.output
      (run %{bin:ocamlformat} %{dep:comments_in_record.ml}))))
 
 (rule
@@ -599,10 +545,9 @@
  (action (diff comments_in_record.ml.ref comments_in_record.ml.output)))
 
 (rule
- (targets compact_lists_arrays.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to compact_lists_arrays.ml.output
      (run %{bin:ocamlformat} %{dep:compact_lists_arrays.ml}))))
 
 (rule
@@ -610,10 +555,9 @@
  (action (diff compact_lists_arrays.ml compact_lists_arrays.ml.output)))
 
 (rule
- (targets custom_list.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to custom_list.ml.output
      (run %{bin:ocamlformat} %{dep:custom_list.ml}))))
 
 (rule
@@ -621,10 +565,9 @@
  (action (diff custom_list.ml custom_list.ml.output)))
 
 (rule
- (targets directives.mlt.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to directives.mlt.output
      (run %{bin:ocamlformat} %{dep:directives.mlt}))))
 
 (rule
@@ -633,10 +576,9 @@
  (action (diff directives.mlt.ref directives.mlt.output)))
 
 (rule
- (targets disabled.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to disabled.ml.output
      (run %{bin:ocamlformat} --disable %{dep:disabled.ml}))))
 
 (rule
@@ -644,10 +586,9 @@
  (action (diff disabled.ml disabled.ml.output)))
 
 (rule
- (targets disambiguate.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to disambiguate.ml.output
      (run %{bin:ocamlformat} %{dep:disambiguate.ml}))))
 
 (rule
@@ -655,10 +596,9 @@
  (action (diff disambiguate.ml disambiguate.ml.output)))
 
 (rule
- (targets doc_comments-after.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to doc_comments-after.ml.output
      (run %{bin:ocamlformat} --doc-comments=after-when-possible %{dep:doc_comments.ml}))))
 
 (rule
@@ -667,10 +607,9 @@
  (action (diff doc_comments-after.ml.ref doc_comments-after.ml.output)))
 
 (rule
- (targets doc_comments-before-except-val.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to doc_comments-before-except-val.ml.output
      (run %{bin:ocamlformat} --doc-comments=before-except-val %{dep:doc_comments.ml}))))
 
 (rule
@@ -679,10 +618,9 @@
  (action (diff doc_comments-before-except-val.ml.ref doc_comments-before-except-val.ml.output)))
 
 (rule
- (targets doc_comments-before.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to doc_comments-before.ml.output
      (run %{bin:ocamlformat} --doc-comments=before %{dep:doc_comments.ml}))))
 
 (rule
@@ -691,10 +629,9 @@
  (action (diff doc_comments-before.ml.ref doc_comments-before.ml.output)))
 
 (rule
- (targets doc_comments.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to doc_comments.ml.output
      (run %{bin:ocamlformat} %{dep:doc_comments.ml}))))
 
 (rule
@@ -703,10 +640,9 @@
  (action (diff doc_comments.ml.ref doc_comments.ml.output)))
 
 (rule
- (targets doc_comments.mli.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to doc_comments.mli.output
      (run %{bin:ocamlformat} %{dep:doc_comments.mli}))))
 
 (rule
@@ -715,10 +651,9 @@
  (action (diff doc_comments.mli.ref doc_comments.mli.output)))
 
 (rule
- (targets doc_comments_padding.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to doc_comments_padding.ml.output
      (run %{bin:ocamlformat} %{dep:doc_comments_padding.ml}))))
 
 (rule
@@ -726,10 +661,9 @@
  (action (diff doc_comments_padding.ml doc_comments_padding.ml.output)))
 
 (rule
- (targets empty.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to empty.ml.output
      (run %{bin:ocamlformat} %{dep:empty.ml}))))
 
 (rule
@@ -737,10 +671,9 @@
  (action (diff empty.ml empty.ml.output)))
 
 (rule
- (targets empty_ml.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to empty_ml.ml.output
      (run %{bin:ocamlformat} %{dep:empty_ml.ml}))))
 
 (rule
@@ -748,10 +681,9 @@
  (action (diff empty_ml.ml empty_ml.ml.output)))
 
 (rule
- (targets empty_mli.mli.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to empty_mli.mli.output
      (run %{bin:ocamlformat} %{dep:empty_mli.mli}))))
 
 (rule
@@ -759,10 +691,9 @@
  (action (diff empty_mli.mli empty_mli.mli.output)))
 
 (rule
- (targets empty_mlt.mlt.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to empty_mlt.mlt.output
      (run %{bin:ocamlformat} %{dep:empty_mlt.mlt}))))
 
 (rule
@@ -770,10 +701,9 @@
  (action (diff empty_mlt.mlt empty_mlt.mlt.output)))
 
 (rule
- (targets error1.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to error1.ml.output
      (with-accepted-exit-codes 1
        (run %{bin:ocamlformat} %{dep:error1.ml})))))
 
@@ -782,10 +712,9 @@
  (action (diff error1.ml.ref error1.ml.output)))
 
 (rule
- (targets error2.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to error2.ml.output
      (with-accepted-exit-codes 1
        (run %{bin:ocamlformat} %{dep:error2.ml})))))
 
@@ -794,10 +723,9 @@
  (action (diff error2.ml.ref error2.ml.output)))
 
 (rule
- (targets error3.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to error3.ml.output
      (with-accepted-exit-codes 1
        (run %{bin:ocamlformat} %{dep:error3.ml})))))
 
@@ -806,10 +734,9 @@
  (action (diff error3.ml.ref error3.ml.output)))
 
 (rule
- (targets error4.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to error4.ml.output
      (run %{bin:ocamlformat} --no-comment-check %{dep:error4.ml}))))
 
 (rule
@@ -817,10 +744,9 @@
  (action (diff error4.ml.ref error4.ml.output)))
 
 (rule
- (targets exceptions.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to exceptions.ml.output
      (run %{bin:ocamlformat} %{dep:exceptions.ml}))))
 
 (rule
@@ -828,10 +754,9 @@
  (action (diff exceptions.ml exceptions.ml.output)))
 
 (rule
- (targets exp_grouping-parens.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to exp_grouping-parens.ml.output
      (run %{bin:ocamlformat} --exp-grouping=parens %{dep:exp_grouping.ml}))))
 
 (rule
@@ -839,10 +764,9 @@
  (action (diff exp_grouping-parens.ml.ref exp_grouping-parens.ml.output)))
 
 (rule
- (targets exp_grouping.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to exp_grouping.ml.output
      (run %{bin:ocamlformat} --exp-grouping=preserve %{dep:exp_grouping.ml}))))
 
 (rule
@@ -850,10 +774,9 @@
  (action (diff exp_grouping.ml.ref exp_grouping.ml.output)))
 
 (rule
- (targets exp_record.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to exp_record.ml.output
      (run %{bin:ocamlformat} %{dep:exp_record.ml}))))
 
 (rule
@@ -861,10 +784,9 @@
  (action (diff exp_record.ml exp_record.ml.output)))
 
 (rule
- (targets expect_test.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to expect_test.ml.output
      (run %{bin:ocamlformat} %{dep:expect_test.ml}))))
 
 (rule
@@ -872,10 +794,9 @@
  (action (diff expect_test.ml expect_test.ml.output)))
 
 (rule
- (targets extensions-indent.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to extensions-indent.ml.output
      (run %{bin:ocamlformat} --max-iters=3 --extension-indent=5 --stritem-extension-indent=3 %{dep:extensions.ml}))))
 
 (rule
@@ -884,10 +805,9 @@
  (action (diff extensions-indent.ml.ref extensions-indent.ml.output)))
 
 (rule
- (targets extensions-indent.mli.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to extensions-indent.mli.output
      (run %{bin:ocamlformat} --extension-indent=5 --stritem-extension-indent=3 %{dep:extensions.mli}))))
 
 (rule
@@ -895,10 +815,9 @@
  (action (diff extensions-indent.mli.ref extensions-indent.mli.output)))
 
 (rule
- (targets extensions-sugar_always.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to extensions-sugar_always.ml.output
      (run %{bin:ocamlformat} --max-iters=3 --extension-sugar=always %{dep:extensions.ml}))))
 
 (rule
@@ -907,10 +826,9 @@
  (action (diff extensions-sugar_always.ml.ref extensions-sugar_always.ml.output)))
 
 (rule
- (targets extensions.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to extensions.ml.output
      (run %{bin:ocamlformat} --max-iters=3 %{dep:extensions.ml}))))
 
 (rule
@@ -919,10 +837,9 @@
  (action (diff extensions.ml.ref extensions.ml.output)))
 
 (rule
- (targets extensions.mli.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to extensions.mli.output
      (run %{bin:ocamlformat} %{dep:extensions.mli}))))
 
 (rule
@@ -930,10 +847,9 @@
  (action (diff extensions.mli extensions.mli.output)))
 
 (rule
- (targets field-op_begin_line.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to field-op_begin_line.ml.output
      (run %{bin:ocamlformat} --assignment-operator=begin-line %{dep:field.ml}))))
 
 (rule
@@ -941,10 +857,9 @@
  (action (diff field-op_begin_line.ml.ref field-op_begin_line.ml.output)))
 
 (rule
- (targets field.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to field.ml.output
      (run %{bin:ocamlformat} %{dep:field.ml}))))
 
 (rule
@@ -952,10 +867,9 @@
  (action (diff field.ml field.ml.output)))
 
 (rule
- (targets first_class_module.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to first_class_module.ml.output
      (run %{bin:ocamlformat} %{dep:first_class_module.ml}))))
 
 (rule
@@ -963,10 +877,9 @@
  (action (diff first_class_module.ml first_class_module.ml.output)))
 
 (rule
- (targets floating_doc.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to floating_doc.ml.output
      (run %{bin:ocamlformat} %{dep:floating_doc.ml}))))
 
 (rule
@@ -974,10 +887,9 @@
  (action (diff floating_doc.ml floating_doc.ml.output)))
 
 (rule
- (targets for_while.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to for_while.ml.output
      (run %{bin:ocamlformat} %{dep:for_while.ml}))))
 
 (rule
@@ -985,10 +897,9 @@
  (action (diff for_while.ml for_while.ml.output)))
 
 (rule
- (targets format_invalid_files.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to format_invalid_files.ml.output
      (run %{bin:ocamlformat} --format-invalid-files=auto %{dep:format_invalid_files.ml}))))
 
 (rule
@@ -996,10 +907,9 @@
  (action (diff format_invalid_files.ml.ref format_invalid_files.ml.output)))
 
 (rule
- (targets fun_decl.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to fun_decl.ml.output
      (run %{bin:ocamlformat} %{dep:fun_decl.ml}))))
 
 (rule
@@ -1007,10 +917,9 @@
  (action (diff fun_decl.ml fun_decl.ml.output)))
 
 (rule
- (targets function_indent-never.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to function_indent-never.ml.output
      (run %{bin:ocamlformat} --function-indent=4 --function-indent-nested=never %{dep:function_indent.ml}))))
 
 (rule
@@ -1018,10 +927,9 @@
  (action (diff function_indent-never.ml.ref function_indent-never.ml.output)))
 
 (rule
- (targets function_indent.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to function_indent.ml.output
      (run %{bin:ocamlformat} --function-indent=4 --function-indent-nested=always %{dep:function_indent.ml}))))
 
 (rule
@@ -1029,10 +937,9 @@
  (action (diff function_indent.ml.ref function_indent.ml.output)))
 
 (rule
- (targets functor.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to functor.ml.output
      (run %{bin:ocamlformat} %{dep:functor.ml}))))
 
 (rule
@@ -1040,10 +947,9 @@
  (action (diff functor.ml functor.ml.output)))
 
 (rule
- (targets funsig.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to funsig.ml.output
      (run %{bin:ocamlformat} %{dep:funsig.ml}))))
 
 (rule
@@ -1051,10 +957,9 @@
  (action (diff funsig.ml funsig.ml.output)))
 
 (rule
- (targets gadt.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to gadt.ml.output
      (run %{bin:ocamlformat} %{dep:gadt.ml}))))
 
 (rule
@@ -1062,10 +967,9 @@
  (action (diff gadt.ml gadt.ml.output)))
 
 (rule
- (targets generative.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to generative.ml.output
      (run %{bin:ocamlformat} %{dep:generative.ml}))))
 
 (rule
@@ -1073,10 +977,9 @@
  (action (diff generative.ml generative.ml.output)))
 
 (rule
- (targets index_op.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to index_op.ml.output
      (run %{bin:ocamlformat} %{dep:index_op.ml}))))
 
 (rule
@@ -1084,10 +987,9 @@
  (action (diff index_op.ml index_op.ml.output)))
 
 (rule
- (targets infix_arg_grouping.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to infix_arg_grouping.ml.output
      (run %{bin:ocamlformat} %{dep:infix_arg_grouping.ml}))))
 
 (rule
@@ -1095,10 +997,9 @@
  (action (diff infix_arg_grouping.ml infix_arg_grouping.ml.output)))
 
 (rule
- (targets infix_bind-break.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to infix_bind-break.ml.output
      (run %{bin:ocamlformat} --break-infix=wrap --break-infix-before-func %{dep:infix_bind.ml}))))
 
 (rule
@@ -1107,10 +1008,9 @@
  (action (diff infix_bind-break.ml.ref infix_bind-break.ml.output)))
 
 (rule
- (targets infix_bind-fit_or_vertical-break.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to infix_bind-fit_or_vertical-break.ml.output
      (run %{bin:ocamlformat} --break-infix=fit-or-vertical --break-infix-before-func %{dep:infix_bind.ml}))))
 
 (rule
@@ -1119,10 +1019,9 @@
  (action (diff infix_bind-fit_or_vertical-break.ml.ref infix_bind-fit_or_vertical-break.ml.output)))
 
 (rule
- (targets infix_bind-fit_or_vertical.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to infix_bind-fit_or_vertical.ml.output
      (run %{bin:ocamlformat} --break-infix=fit-or-vertical --no-break-infix-before-func %{dep:infix_bind.ml}))))
 
 (rule
@@ -1131,10 +1030,9 @@
  (action (diff infix_bind-fit_or_vertical.ml.ref infix_bind-fit_or_vertical.ml.output)))
 
 (rule
- (targets infix_bind.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to infix_bind.ml.output
      (run %{bin:ocamlformat} --break-infix=wrap --no-break-infix-before-func %{dep:infix_bind.ml}))))
 
 (rule
@@ -1143,10 +1041,9 @@
  (action (diff infix_bind.ml infix_bind.ml.output)))
 
 (rule
- (targets infix_precedence.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to infix_precedence.ml.output
      (run %{bin:ocamlformat} --infix-precedence=parens %{dep:infix_precedence.ml}))))
 
 (rule
@@ -1154,10 +1051,9 @@
  (action (diff infix_precedence.ml infix_precedence.ml.output)))
 
 (rule
- (targets invalid.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to invalid.ml.output
      (run %{bin:ocamlformat} %{dep:invalid.ml}))))
 
 (rule
@@ -1165,10 +1061,9 @@
  (action (diff invalid.ml invalid.ml.output)))
 
 (rule
- (targets invalid_docstring.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to invalid_docstring.ml.output
      (run %{bin:ocamlformat} %{dep:invalid_docstring.ml}))))
 
 (rule
@@ -1177,10 +1072,9 @@
  (action (diff invalid_docstring.ml.ref invalid_docstring.ml.output)))
 
 (rule
- (targets issue114.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to issue114.ml.output
      (run %{bin:ocamlformat} %{dep:issue114.ml}))))
 
 (rule
@@ -1188,10 +1082,9 @@
  (action (diff issue114.ml issue114.ml.output)))
 
 (rule
- (targets issue289.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to issue289.ml.output
      (run %{bin:ocamlformat} %{dep:issue289.ml}))))
 
 (rule
@@ -1199,10 +1092,9 @@
  (action (diff issue289.ml issue289.ml.output)))
 
 (rule
- (targets issue48.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to issue48.ml.output
      (run %{bin:ocamlformat} %{dep:issue48.ml}))))
 
 (rule
@@ -1210,10 +1102,9 @@
  (action (diff issue48.ml issue48.ml.output)))
 
 (rule
- (targets issue51.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to issue51.ml.output
      (run %{bin:ocamlformat} %{dep:issue51.ml}))))
 
 (rule
@@ -1221,10 +1112,9 @@
  (action (diff issue51.ml issue51.ml.output)))
 
 (rule
- (targets issue57.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to issue57.ml.output
      (run %{bin:ocamlformat} %{dep:issue57.ml}))))
 
 (rule
@@ -1232,10 +1122,9 @@
  (action (diff issue57.ml issue57.ml.output)))
 
 (rule
- (targets issue60.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to issue60.ml.output
      (run %{bin:ocamlformat} %{dep:issue60.ml}))))
 
 (rule
@@ -1243,10 +1132,9 @@
  (action (diff issue60.ml issue60.ml.output)))
 
 (rule
- (targets issue77.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to issue77.ml.output
      (run %{bin:ocamlformat} %{dep:issue77.ml}))))
 
 (rule
@@ -1254,10 +1142,9 @@
  (action (diff issue77.ml issue77.ml.output)))
 
 (rule
- (targets issue85.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to issue85.ml.output
      (run %{bin:ocamlformat} %{dep:issue85.ml}))))
 
 (rule
@@ -1265,10 +1152,9 @@
  (action (diff issue85.ml issue85.ml.output)))
 
 (rule
- (targets issue89.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to issue89.ml.output
      (run %{bin:ocamlformat} %{dep:issue89.ml}))))
 
 (rule
@@ -1276,10 +1162,9 @@
  (action (diff issue89.ml issue89.ml.output)))
 
 (rule
- (targets ite-compact.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ite-compact.ml.output
      (run %{bin:ocamlformat} --if-then-else=compact %{dep:ite.ml}))))
 
 (rule
@@ -1287,10 +1172,9 @@
  (action (diff ite-compact.ml.ref ite-compact.ml.output)))
 
 (rule
- (targets ite-compact_closing.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ite-compact_closing.ml.output
      (run %{bin:ocamlformat} --if-then-else=compact --indicate-multiline-delimiters=closing-on-separate-line %{dep:ite.ml}))))
 
 (rule
@@ -1298,10 +1182,9 @@
  (action (diff ite-compact_closing.ml.ref ite-compact_closing.ml.output)))
 
 (rule
- (targets ite-fit_or_vertical.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ite-fit_or_vertical.ml.output
      (run %{bin:ocamlformat} --if-then-else=fit-or-vertical %{dep:ite.ml}))))
 
 (rule
@@ -1309,10 +1192,9 @@
  (action (diff ite-fit_or_vertical.ml.ref ite-fit_or_vertical.ml.output)))
 
 (rule
- (targets ite-fit_or_vertical_closing.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ite-fit_or_vertical_closing.ml.output
      (run %{bin:ocamlformat} --if-then-else fit-or-vertical --indicate-multiline-delimiters=closing-on-separate-line %{dep:ite.ml}))))
 
 (rule
@@ -1320,10 +1202,9 @@
  (action (diff ite-fit_or_vertical_closing.ml.ref ite-fit_or_vertical_closing.ml.output)))
 
 (rule
- (targets ite-fit_or_vertical_no_indicate.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ite-fit_or_vertical_no_indicate.ml.output
      (run %{bin:ocamlformat} --if-then-else=fit-or-vertical --indicate-multiline-delimiters=no %{dep:ite.ml}))))
 
 (rule
@@ -1331,10 +1212,9 @@
  (action (diff ite-fit_or_vertical_no_indicate.ml.ref ite-fit_or_vertical_no_indicate.ml.output)))
 
 (rule
- (targets ite-kr.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ite-kr.ml.output
      (run %{bin:ocamlformat} --if-then-else=k-r --max-iters=3 %{dep:ite.ml}))))
 
 (rule
@@ -1342,10 +1222,9 @@
  (action (diff ite-kr.ml.ref ite-kr.ml.output)))
 
 (rule
- (targets ite-kr_closing.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ite-kr_closing.ml.output
      (run %{bin:ocamlformat} --if-then-else=k-r --max-iters=3 --indicate-multiline-delimiters=closing-on-separate-line %{dep:ite.ml}))))
 
 (rule
@@ -1353,10 +1232,9 @@
  (action (diff ite-kr_closing.ml.ref ite-kr_closing.ml.output)))
 
 (rule
- (targets ite-kw_first.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ite-kw_first.ml.output
      (run %{bin:ocamlformat} --if-then-else=keyword-first %{dep:ite.ml}))))
 
 (rule
@@ -1364,10 +1242,9 @@
  (action (diff ite-kw_first.ml.ref ite-kw_first.ml.output)))
 
 (rule
- (targets ite-kw_first_closing.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ite-kw_first_closing.ml.output
      (run %{bin:ocamlformat} --if-then-else keyword-first --indicate-multiline-delimiters=closing-on-separate-line %{dep:ite.ml}))))
 
 (rule
@@ -1375,10 +1252,9 @@
  (action (diff ite-kw_first_closing.ml.ref ite-kw_first_closing.ml.output)))
 
 (rule
- (targets ite-kw_first_no_indicate.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ite-kw_first_no_indicate.ml.output
      (run %{bin:ocamlformat} --if-then-else=keyword-first --indicate-multiline-delimiters=no %{dep:ite.ml}))))
 
 (rule
@@ -1386,10 +1262,9 @@
  (action (diff ite-kw_first_no_indicate.ml.ref ite-kw_first_no_indicate.ml.output)))
 
 (rule
- (targets ite-no_indicate.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ite-no_indicate.ml.output
      (run %{bin:ocamlformat} --if-then-else=compact --indicate-multiline-delimiters=no %{dep:ite.ml}))))
 
 (rule
@@ -1397,10 +1272,9 @@
  (action (diff ite-no_indicate.ml.ref ite-no_indicate.ml.output)))
 
 (rule
- (targets ite.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ite.ml.output
      (run %{bin:ocamlformat} --if-then-else=compact %{dep:ite.ml}))))
 
 (rule
@@ -1408,10 +1282,9 @@
  (action (diff ite.ml.ref ite.ml.output)))
 
 (rule
- (targets js_sig.mli.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to js_sig.mli.output
      (run %{bin:ocamlformat} --profile=janestreet %{dep:js_sig.mli}))))
 
 (rule
@@ -1419,10 +1292,9 @@
  (action (diff js_sig.mli.ref js_sig.mli.output)))
 
 (rule
- (targets js_source.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to js_source.ml.output
      (run %{bin:ocamlformat} --max-iters=3 --profile=janestreet %{dep:js_source.ml}))))
 
 (rule
@@ -1431,10 +1303,9 @@
  (action (diff js_source.ml.ref js_source.ml.output)))
 
 (rule
- (targets js_source.ml.ocp.output)
  (deps .ocp-indent )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to js_source.ml.ocp.output
      (run %{bin:ocp-indent} %{dep:js_source.ml.ref}))))
 
 (rule
@@ -1442,10 +1313,9 @@
  (action (diff js_source.ml.ocp js_source.ml.ocp.output)))
 
 (rule
- (targets kw_extentions.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to kw_extentions.ml.output
      (run %{bin:ocamlformat} %{dep:kw_extentions.ml}))))
 
 (rule
@@ -1453,10 +1323,9 @@
  (action (diff kw_extentions.ml kw_extentions.ml.output)))
 
 (rule
- (targets label_option_default_args.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to label_option_default_args.ml.output
      (run %{bin:ocamlformat} --max-iters=4 %{dep:label_option_default_args.ml}))))
 
 (rule
@@ -1464,10 +1333,9 @@
  (action (diff label_option_default_args.ml.ref label_option_default_args.ml.output)))
 
 (rule
- (targets lazy.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to lazy.ml.output
      (run %{bin:ocamlformat} %{dep:lazy.ml}))))
 
 (rule
@@ -1475,10 +1343,9 @@
  (action (diff lazy.ml lazy.ml.output)))
 
 (rule
- (targets let_binding-in_indent.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to let_binding-in_indent.ml.output
      (run %{bin:ocamlformat} --indent-after-in=4 %{dep:let_binding.ml}))))
 
 (rule
@@ -1487,10 +1354,9 @@
  (action (diff let_binding-in_indent.ml.ref let_binding-in_indent.ml.output)))
 
 (rule
- (targets let_binding-indent.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to let_binding-indent.ml.output
      (run %{bin:ocamlformat} --let-binding-indent=6 %{dep:let_binding.ml}))))
 
 (rule
@@ -1499,10 +1365,9 @@
  (action (diff let_binding-indent.ml.ref let_binding-indent.ml.output)))
 
 (rule
- (targets let_binding.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to let_binding.ml.output
      (run %{bin:ocamlformat} %{dep:let_binding.ml}))))
 
 (rule
@@ -1511,10 +1376,9 @@
  (action (diff let_binding.ml.ref let_binding.ml.output)))
 
 (rule
- (targets let_in_constr.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to let_in_constr.ml.output
      (run %{bin:ocamlformat} %{dep:let_in_constr.ml}))))
 
 (rule
@@ -1522,10 +1386,9 @@
  (action (diff let_in_constr.ml let_in_constr.ml.output)))
 
 (rule
- (targets let_module-sparse.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to let_module-sparse.ml.output
      (run %{bin:ocamlformat} --let-module=sparse %{dep:let_module.ml}))))
 
 (rule
@@ -1533,10 +1396,9 @@
  (action (diff let_module-sparse.ml.ref let_module-sparse.ml.output)))
 
 (rule
- (targets let_module.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to let_module.ml.output
      (run %{bin:ocamlformat} --let-module=compact %{dep:let_module.ml}))))
 
 (rule
@@ -1544,10 +1406,9 @@
  (action (diff let_module.ml.ref let_module.ml.output)))
 
 (rule
- (targets list-space_around.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to list-space_around.ml.output
      (run %{bin:ocamlformat} --space-around-arrays --space-around-lists --space-around-records --space-around-variants %{dep:list.ml}))))
 
 (rule
@@ -1555,10 +1416,9 @@
  (action (diff list-space_around.ml.ref list-space_around.ml.output)))
 
 (rule
- (targets list.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to list.ml.output
      (run %{bin:ocamlformat} %{dep:list.ml}))))
 
 (rule
@@ -1566,10 +1426,9 @@
  (action (diff list.ml list.ml.output)))
 
 (rule
- (targets loc_stack.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to loc_stack.ml.output
      (run %{bin:ocamlformat} -n 3 %{dep:loc_stack.ml}))))
 
 (rule
@@ -1577,10 +1436,9 @@
  (action (diff loc_stack.ml.ref loc_stack.ml.output)))
 
 (rule
- (targets locally_abtract_types.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to locally_abtract_types.ml.output
      (run %{bin:ocamlformat} %{dep:locally_abtract_types.ml}))))
 
 (rule
@@ -1588,10 +1446,9 @@
  (action (diff locally_abtract_types.ml locally_abtract_types.ml.output)))
 
 (rule
- (targets margin_80.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to margin_80.ml.output
      (run %{bin:ocamlformat} --margin=80 %{dep:margin_80.ml}))))
 
 (rule
@@ -1599,10 +1456,9 @@
  (action (diff margin_80.ml.ref margin_80.ml.output)))
 
 (rule
- (targets match.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to match.ml.output
      (run %{bin:ocamlformat} %{dep:match.ml}))))
 
 (rule
@@ -1610,10 +1466,9 @@
  (action (diff match.ml match.ml.output)))
 
 (rule
- (targets match2.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to match2.ml.output
      (run %{bin:ocamlformat} --leading-nested-match-parens %{dep:match2.ml}))))
 
 (rule
@@ -1622,10 +1477,9 @@
  (action (diff match2.ml match2.ml.output)))
 
 (rule
- (targets match_indent-never.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to match_indent-never.ml.output
      (run %{bin:ocamlformat} --match-indent=4 --match-indent-nested=never %{dep:match_indent.ml}))))
 
 (rule
@@ -1633,10 +1487,9 @@
  (action (diff match_indent-never.ml.ref match_indent-never.ml.output)))
 
 (rule
- (targets match_indent.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to match_indent.ml.output
      (run %{bin:ocamlformat} --match-indent=4 --match-indent-nested=always %{dep:match_indent.ml}))))
 
 (rule
@@ -1644,10 +1497,9 @@
  (action (diff match_indent.ml.ref match_indent.ml.output)))
 
 (rule
- (targets max_indent.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to max_indent.ml.output
      (run %{bin:ocamlformat} --max-indent=2 %{dep:max_indent.ml}))))
 
 (rule
@@ -1655,10 +1507,9 @@
  (action (diff max_indent.ml max_indent.ml.output)))
 
 (rule
- (targets module.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to module.ml.output
      (run %{bin:ocamlformat} %{dep:module.ml}))))
 
 (rule
@@ -1666,10 +1517,9 @@
  (action (diff module.ml module.ml.output)))
 
 (rule
- (targets module_anonymous.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to module_anonymous.ml.output
      (run %{bin:ocamlformat} %{dep:module_anonymous.ml}))))
 
 (rule
@@ -1678,10 +1528,9 @@
  (action (diff module_anonymous.ml module_anonymous.ml.output)))
 
 (rule
- (targets module_attributes.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to module_attributes.ml.output
      (run %{bin:ocamlformat} %{dep:module_attributes.ml}))))
 
 (rule
@@ -1689,10 +1538,9 @@
  (action (diff module_attributes.ml.ref module_attributes.ml.output)))
 
 (rule
- (targets module_item_spacing-preserve.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to module_item_spacing-preserve.ml.output
      (run %{bin:ocamlformat} --max-iter=3 --module-item-spacing=preserve %{dep:module_item_spacing.ml}))))
 
 (rule
@@ -1700,10 +1548,9 @@
  (action (diff module_item_spacing-preserve.ml.ref module_item_spacing-preserve.ml.output)))
 
 (rule
- (targets module_item_spacing-sparse.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to module_item_spacing-sparse.ml.output
      (run %{bin:ocamlformat} --max-iter=3 --module-item-spacing=sparse %{dep:module_item_spacing.ml}))))
 
 (rule
@@ -1711,10 +1558,9 @@
  (action (diff module_item_spacing-sparse.ml.ref module_item_spacing-sparse.ml.output)))
 
 (rule
- (targets module_item_spacing.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to module_item_spacing.ml.output
      (run %{bin:ocamlformat} --max-iter=3 --module-item-spacing=compact %{dep:module_item_spacing.ml}))))
 
 (rule
@@ -1722,10 +1568,9 @@
  (action (diff module_item_spacing.ml.ref module_item_spacing.ml.output)))
 
 (rule
- (targets module_item_spacing.mli.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to module_item_spacing.mli.output
      (run %{bin:ocamlformat} --max-iter=3 %{dep:module_item_spacing.mli}))))
 
 (rule
@@ -1734,10 +1579,9 @@
  (action (diff module_item_spacing.mli.ref module_item_spacing.mli.output)))
 
 (rule
- (targets module_type.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to module_type.ml.output
      (run %{bin:ocamlformat} %{dep:module_type.ml}))))
 
 (rule
@@ -1745,10 +1589,9 @@
  (action (diff module_type.ml module_type.ml.output)))
 
 (rule
- (targets monadic_binding.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to monadic_binding.ml.output
      (run %{bin:ocamlformat} %{dep:monadic_binding.ml}))))
 
 (rule
@@ -1757,10 +1600,9 @@
  (action (diff monadic_binding.ml monadic_binding.ml.output)))
 
 (rule
- (targets multi_index_op.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to multi_index_op.ml.output
      (run %{bin:ocamlformat} %{dep:multi_index_op.ml}))))
 
 (rule
@@ -1769,10 +1611,9 @@
  (action (diff multi_index_op.ml multi_index_op.ml.output)))
 
 (rule
- (targets need_format.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to need_format.ml.output
      (with-accepted-exit-codes 1
        (run %{bin:ocamlformat} --max-iters=1 %{dep:need_format.ml})))))
 
@@ -1781,10 +1622,9 @@
  (action (diff need_format.ml.ref need_format.ml.output)))
 
 (rule
- (targets new.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to new.ml.output
      (run %{bin:ocamlformat} %{dep:new.ml}))))
 
 (rule
@@ -1792,10 +1632,9 @@
  (action (diff new.ml new.ml.output)))
 
 (rule
- (targets object.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to object.ml.output
      (run %{bin:ocamlformat} %{dep:object.ml}))))
 
 (rule
@@ -1803,10 +1642,9 @@
  (action (diff object.ml object.ml.output)))
 
 (rule
- (targets object_type.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to object_type.ml.output
      (run %{bin:ocamlformat} %{dep:object_type.ml}))))
 
 (rule
@@ -1814,10 +1652,9 @@
  (action (diff object_type.ml.ref object_type.ml.output)))
 
 (rule
- (targets ocp_indent_compat.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ocp_indent_compat.ml.output
      (run %{bin:ocamlformat} %{dep:ocp_indent_compat.ml}))))
 
 (rule
@@ -1825,10 +1662,9 @@
  (action (diff ocp_indent_compat.ml ocp_indent_compat.ml.output)))
 
 (rule
- (targets ocp_indent_options.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to ocp_indent_options.ml.output
      (run %{bin:ocamlformat} --ocp-indent-config %{dep:ocp_indent_options.ml}))))
 
 (rule
@@ -1836,10 +1672,9 @@
  (action (diff ocp_indent_options.ml.ref ocp_indent_options.ml.output)))
 
 (rule
- (targets open-auto.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to open-auto.ml.output
      (run %{bin:ocamlformat} --let-open=auto %{dep:open.ml}))))
 
 (rule
@@ -1848,10 +1683,9 @@
  (action (diff open-auto.ml.ref open-auto.ml.output)))
 
 (rule
- (targets open-long.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to open-long.ml.output
      (run %{bin:ocamlformat} --let-open=long %{dep:open.ml}))))
 
 (rule
@@ -1860,10 +1694,9 @@
  (action (diff open-long.ml.ref open-long.ml.output)))
 
 (rule
- (targets open-preserve.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to open-preserve.ml.output
      (run %{bin:ocamlformat} --let-open=preserve %{dep:open.ml}))))
 
 (rule
@@ -1872,10 +1705,9 @@
  (action (diff open-preserve.ml.ref open-preserve.ml.output)))
 
 (rule
- (targets open-short.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to open-short.ml.output
      (run %{bin:ocamlformat} --let-open=short %{dep:open.ml}))))
 
 (rule
@@ -1884,10 +1716,9 @@
  (action (diff open-short.ml.ref open-short.ml.output)))
 
 (rule
- (targets open.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to open.ml.output
      (run %{bin:ocamlformat} %{dep:open.ml}))))
 
 (rule
@@ -1896,10 +1727,9 @@
  (action (diff open.ml.ref open.ml.output)))
 
 (rule
- (targets open_types.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to open_types.ml.output
      (run %{bin:ocamlformat} %{dep:open_types.ml}))))
 
 (rule
@@ -1907,10 +1737,9 @@
  (action (diff open_types.ml open_types.ml.output)))
 
 (rule
- (targets option.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to option.ml.output
      (run %{bin:ocamlformat} %{dep:option.ml}))))
 
 (rule
@@ -1918,10 +1747,9 @@
  (action (diff option.ml.ref option.ml.output)))
 
 (rule
- (targets parens_tuple_patterns.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to parens_tuple_patterns.ml.output
      (run %{bin:ocamlformat} %{dep:parens_tuple_patterns.ml}))))
 
 (rule
@@ -1929,10 +1757,9 @@
  (action (diff parens_tuple_patterns.ml parens_tuple_patterns.ml.output)))
 
 (rule
- (targets precedence.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to precedence.ml.output
      (run %{bin:ocamlformat} %{dep:precedence.ml}))))
 
 (rule
@@ -1940,10 +1767,9 @@
  (action (diff precedence.ml precedence.ml.output)))
 
 (rule
- (targets prefix_infix.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to prefix_infix.ml.output
      (run %{bin:ocamlformat} %{dep:prefix_infix.ml}))))
 
 (rule
@@ -1951,10 +1777,9 @@
  (action (diff prefix_infix.ml prefix_infix.ml.output)))
 
 (rule
- (targets print_config.ml.output)
  (deps .ocamlformat dir1/dir2/.ocamlformat dir1/dir2/print_config.ml)
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to print_config.ml.output
      (run %{bin:ocamlformat} dir1/dir2/print_config.ml --print-config --let-open=short --config=max-iters=2 %{dep:print_config.ml}))))
 
 (rule
@@ -1962,10 +1787,9 @@
  (action (diff print_config.ml.ref print_config.ml.output)))
 
 (rule
- (targets profiles.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to profiles.ml.output
      (run %{bin:ocamlformat} --config=margin=20 --profile=janestreet --module-item-spacing=sparse %{dep:profiles.ml}))))
 
 (rule
@@ -1973,10 +1797,9 @@
  (action (diff profiles.ml profiles.ml.output)))
 
 (rule
- (targets profiles2.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to profiles2.ml.output
      (run %{bin:ocamlformat} --profile=janestreet %{dep:profiles2.ml}))))
 
 (rule
@@ -1984,10 +1807,9 @@
  (action (diff profiles2.ml profiles2.ml.output)))
 
 (rule
- (targets protected_object_types.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to protected_object_types.ml.output
      (run %{bin:ocamlformat} %{dep:protected_object_types.ml}))))
 
 (rule
@@ -1995,10 +1817,9 @@
  (action (diff protected_object_types.ml protected_object_types.ml.output)))
 
 (rule
- (targets recmod.mli.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to recmod.mli.output
      (run %{bin:ocamlformat} %{dep:recmod.mli}))))
 
 (rule
@@ -2006,10 +1827,9 @@
  (action (diff recmod.mli recmod.mli.output)))
 
 (rule
- (targets record-loose.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to record-loose.ml.output
      (run %{bin:ocamlformat} --field-space=loose %{dep:record.ml}))))
 
 (rule
@@ -2017,10 +1837,9 @@
  (action (diff record-loose.ml.ref record-loose.ml.output)))
 
 (rule
- (targets record-tight_decl.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to record-tight_decl.ml.output
      (run %{bin:ocamlformat} --field-space=tight-decl %{dep:record.ml}))))
 
 (rule
@@ -2028,10 +1847,9 @@
  (action (diff record-tight_decl.ml.ref record-tight_decl.ml.output)))
 
 (rule
- (targets record.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to record.ml.output
      (run %{bin:ocamlformat} --field-space=tight %{dep:record.ml}))))
 
 (rule
@@ -2039,10 +1857,9 @@
  (action (diff record.ml.ref record.ml.output)))
 
 (rule
- (targets record_punning.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to record_punning.ml.output
      (run %{bin:ocamlformat} %{dep:record_punning.ml}))))
 
 (rule
@@ -2050,10 +1867,9 @@
  (action (diff record_punning.ml record_punning.ml.output)))
 
 (rule
- (targets reformat_string.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to reformat_string.ml.output
      (run %{bin:ocamlformat} --max-iter=2 %{dep:reformat_string.ml}))))
 
 (rule
@@ -2061,10 +1877,9 @@
  (action (diff reformat_string.ml.ref reformat_string.ml.output)))
 
 (rule
- (targets refs.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to refs.ml.output
      (run %{bin:ocamlformat} %{dep:refs.ml}))))
 
 (rule
@@ -2072,10 +1887,9 @@
  (action (diff refs.ml refs.ml.output)))
 
 (rule
- (targets remove_extra_parens.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to remove_extra_parens.ml.output
      (run %{bin:ocamlformat} %{dep:remove_extra_parens.ml}))))
 
 (rule
@@ -2083,10 +1897,9 @@
  (action (diff remove_extra_parens.ml.ref remove_extra_parens.ml.output)))
 
 (rule
- (targets revapply_ext.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to revapply_ext.ml.output
      (run %{bin:ocamlformat} %{dep:revapply_ext.ml}))))
 
 (rule
@@ -2094,10 +1907,9 @@
  (action (diff revapply_ext.ml revapply_ext.ml.output)))
 
 (rule
- (targets send.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to send.ml.output
      (run %{bin:ocamlformat} %{dep:send.ml}))))
 
 (rule
@@ -2105,10 +1917,9 @@
  (action (diff send.ml send.ml.output)))
 
 (rule
- (targets sequence-preserve.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to sequence-preserve.ml.output
      (run %{bin:ocamlformat} --sequence-blank-line=preserve-one --max-iter=3 %{dep:sequence.ml}))))
 
 (rule
@@ -2117,10 +1928,9 @@
  (action (diff sequence-preserve.ml.ref sequence-preserve.ml.output)))
 
 (rule
- (targets sequence.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to sequence.ml.output
      (run %{bin:ocamlformat} --sequence-blank-line=compact --max-iter=3 %{dep:sequence.ml}))))
 
 (rule
@@ -2129,10 +1939,9 @@
  (action (diff sequence.ml.ref sequence.ml.output)))
 
 (rule
- (targets shebang.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to shebang.ml.output
      (run %{bin:ocamlformat} %{dep:shebang.ml}))))
 
 (rule
@@ -2140,10 +1949,9 @@
  (action (diff shebang.ml shebang.ml.output)))
 
 (rule
- (targets shortcut_ext_attr.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to shortcut_ext_attr.ml.output
      (run %{bin:ocamlformat} %{dep:shortcut_ext_attr.ml}))))
 
 (rule
@@ -2151,10 +1959,9 @@
  (action (diff shortcut_ext_attr.ml shortcut_ext_attr.ml.output)))
 
 (rule
- (targets skip.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to skip.ml.output
      (run %{bin:ocamlformat} %{dep:skip.ml}))))
 
 (rule
@@ -2162,10 +1969,9 @@
  (action (diff skip.ml skip.ml.output)))
 
 (rule
- (targets source.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to source.ml.output
      (run %{bin:ocamlformat} --max-iters=3 %{dep:source.ml}))))
 
 (rule
@@ -2174,10 +1980,9 @@
  (action (diff source.ml.ref source.ml.output)))
 
 (rule
- (targets str_value.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to str_value.ml.output
      (run %{bin:ocamlformat} %{dep:str_value.ml}))))
 
 (rule
@@ -2185,10 +1990,9 @@
  (action (diff str_value.ml str_value.ml.output)))
 
 (rule
- (targets string.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to string.ml.output
      (run %{bin:ocamlformat} %{dep:string.ml}))))
 
 (rule
@@ -2196,10 +2000,9 @@
  (action (diff string.ml.ref string.ml.output)))
 
 (rule
- (targets string_array.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to string_array.ml.output
      (run %{bin:ocamlformat} %{dep:string_array.ml}))))
 
 (rule
@@ -2207,10 +2010,9 @@
  (action (diff string_array.ml string_array.ml.output)))
 
 (rule
- (targets string_wrapping.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to string_wrapping.ml.output
      (run %{bin:ocamlformat} %{dep:string_wrapping.ml}))))
 
 (rule
@@ -2218,10 +2020,9 @@
  (action (diff string_wrapping.ml string_wrapping.ml.output)))
 
 (rule
- (targets symbol.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to symbol.ml.output
      (run %{bin:ocamlformat} %{dep:symbol.ml}))))
 
 (rule
@@ -2229,10 +2030,9 @@
  (action (diff symbol.ml symbol.ml.output)))
 
 (rule
- (targets tag_only.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to tag_only.ml.output
      (run %{bin:ocamlformat} %{dep:tag_only.ml}))))
 
 (rule
@@ -2240,10 +2040,9 @@
  (action (diff tag_only.ml tag_only.ml.output)))
 
 (rule
- (targets tag_only.mli.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to tag_only.mli.output
      (run %{bin:ocamlformat} %{dep:tag_only.mli}))))
 
 (rule
@@ -2251,10 +2050,9 @@
  (action (diff tag_only.mli tag_only.mli.output)))
 
 (rule
- (targets try_with_or_pattern.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to try_with_or_pattern.ml.output
      (run %{bin:ocamlformat} %{dep:try_with_or_pattern.ml}))))
 
 (rule
@@ -2262,10 +2060,9 @@
  (action (diff try_with_or_pattern.ml try_with_or_pattern.ml.output)))
 
 (rule
- (targets tuple.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to tuple.ml.output
      (run %{bin:ocamlformat} --parens-tuple=always %{dep:tuple.ml}))))
 
 (rule
@@ -2273,10 +2070,9 @@
  (action (diff tuple.ml tuple.ml.output)))
 
 (rule
- (targets tuple_less_parens.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to tuple_less_parens.ml.output
      (run %{bin:ocamlformat} --parens-tuple=multi-line-only %{dep:tuple_less_parens.ml}))))
 
 (rule
@@ -2284,10 +2080,9 @@
  (action (diff tuple_less_parens.ml tuple_less_parens.ml.output)))
 
 (rule
- (targets tuple_type_parens.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to tuple_type_parens.ml.output
      (run %{bin:ocamlformat} %{dep:tuple_type_parens.ml}))))
 
 (rule
@@ -2295,10 +2090,9 @@
  (action (diff tuple_type_parens.ml tuple_type_parens.ml.output)))
 
 (rule
- (targets type_and_constraint.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to type_and_constraint.ml.output
      (run %{bin:ocamlformat} %{dep:type_and_constraint.ml}))))
 
 (rule
@@ -2306,10 +2100,9 @@
  (action (diff type_and_constraint.ml type_and_constraint.ml.output)))
 
 (rule
- (targets type_annotations.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to type_annotations.ml.output
      (run %{bin:ocamlformat} %{dep:type_annotations.ml}))))
 
 (rule
@@ -2317,10 +2110,9 @@
  (action (diff type_annotations.ml type_annotations.ml.output)))
 
 (rule
- (targets types-compact-space_around-docked.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to types-compact-space_around-docked.ml.output
      (run %{bin:ocamlformat} --type-decl=compact --space-around-arrays --space-around-lists --space-around-records --space-around-variants --break-separators=after --dock-collection-brackets %{dep:types.ml}))))
 
 (rule
@@ -2329,10 +2121,9 @@
  (action (diff types-compact-space_around-docked.ml.ref types-compact-space_around-docked.ml.output)))
 
 (rule
- (targets types-compact-space_around.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to types-compact-space_around.ml.output
      (run %{bin:ocamlformat} --type-decl=compact --space-around-arrays --space-around-lists --space-around-records --space-around-variants %{dep:types.ml}))))
 
 (rule
@@ -2341,10 +2132,9 @@
  (action (diff types-compact-space_around.ml.ref types-compact-space_around.ml.output)))
 
 (rule
- (targets types-compact.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to types-compact.ml.output
      (run %{bin:ocamlformat} --type-decl=compact %{dep:types.ml}))))
 
 (rule
@@ -2353,10 +2143,9 @@
  (action (diff types-compact.ml.ref types-compact.ml.output)))
 
 (rule
- (targets types-indent.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to types-indent.ml.output
      (run %{bin:ocamlformat} --type-decl-indent=6 %{dep:types.ml}))))
 
 (rule
@@ -2365,10 +2154,9 @@
  (action (diff types-indent.ml.ref types-indent.ml.output)))
 
 (rule
- (targets types-sparse-space_around.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to types-sparse-space_around.ml.output
      (run %{bin:ocamlformat} --type-decl=sparse --space-around-arrays --space-around-lists --space-around-records --space-around-variants %{dep:types.ml}))))
 
 (rule
@@ -2377,10 +2165,9 @@
  (action (diff types-sparse-space_around.ml.ref types-sparse-space_around.ml.output)))
 
 (rule
- (targets types-sparse.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to types-sparse.ml.output
      (run %{bin:ocamlformat} --type-decl=sparse %{dep:types.ml}))))
 
 (rule
@@ -2389,10 +2176,9 @@
  (action (diff types-sparse.ml.ref types-sparse.ml.output)))
 
 (rule
- (targets types.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to types.ml.output
      (run %{bin:ocamlformat} %{dep:types.ml}))))
 
 (rule
@@ -2401,10 +2187,9 @@
  (action (diff types.ml types.ml.output)))
 
 (rule
- (targets unary.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to unary.ml.output
      (run %{bin:ocamlformat} %{dep:unary.ml}))))
 
 (rule
@@ -2412,10 +2197,9 @@
  (action (diff unary.ml.ref unary.ml.output)))
 
 (rule
- (targets unicode.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to unicode.ml.output
      (run %{bin:ocamlformat} --margin=80 --wrap-comments %{dep:unicode.ml}))))
 
 (rule
@@ -2423,10 +2207,9 @@
  (action (diff unicode.ml.ref unicode.ml.output)))
 
 (rule
- (targets use_file.mlt.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to use_file.mlt.output
      (run %{bin:ocamlformat} %{dep:use_file.mlt}))))
 
 (rule
@@ -2434,10 +2217,9 @@
  (action (diff use_file.mlt use_file.mlt.output)))
 
 (rule
- (targets verbose1.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to verbose1.ml.output
      (run %{bin:ocamlformat} --print-config --doc-comments=before --config=doc-comments=before %{dep:verbose1.ml}))))
 
 (rule
@@ -2445,10 +2227,9 @@
  (action (diff verbose1.ml.ref verbose1.ml.output)))
 
 (rule
- (targets verbose2.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to verbose2.ml.output
      (run %{bin:ocamlformat} --print-config --doc-comments=before --config=doc-comments=before %{dep:verbose2.ml}))))
 
 (rule
@@ -2456,10 +2237,9 @@
  (action (diff verbose2.ml.ref verbose2.ml.output)))
 
 (rule
- (targets wrap_comments.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to wrap_comments.ml.output
      (run %{bin:ocamlformat} --profile=ocamlformat %{dep:wrap_comments.ml}))))
 
 (rule
@@ -2467,10 +2247,9 @@
  (action (diff wrap_comments.ml.ref wrap_comments.ml.output)))
 
 (rule
- (targets wrap_comments_break.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to wrap_comments_break.ml.output
      (run %{bin:ocamlformat} --no-wrap-fun-args --margin=67 %{dep:wrap_comments_break.ml}))))
 
 (rule
@@ -2478,10 +2257,9 @@
  (action (diff wrap_comments_break.ml wrap_comments_break.ml.output)))
 
 (rule
- (targets wrapping_functor_args.ml.output)
  (deps .ocamlformat )
  (action
-   (with-outputs-to %{targets}
+   (with-outputs-to wrapping_functor_args.ml.output
      (run %{bin:ocamlformat} %{dep:wrapping_functor_args.ml}))))
 
 (rule

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -324,7 +324,8 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "! %{bin:ocamlformat} %{read-lines:break_separators-after_docked_transition_message.ml.opts} %{dep:break_separators.ml}"))))
+     (with-accepted-exit-codes 1
+       (run %{bin:ocamlformat} %{read-lines:break_separators-after_docked_transition_message.ml.opts} %{dep:break_separators.ml})))))
 
 (rule
  (alias runtest)
@@ -423,7 +424,8 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "! %{bin:ocamlformat} %{read-lines:break_string_literals-wrap.ml.opts} %{dep:break_string_literals.ml}"))))
+     (with-accepted-exit-codes 1
+       (run %{bin:ocamlformat} %{read-lines:break_string_literals-wrap.ml.opts} %{dep:break_string_literals.ml})))))
 
 (rule
  (alias runtest)
@@ -772,7 +774,8 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "! %{bin:ocamlformat} %{dep:error1.ml}"))))
+     (with-accepted-exit-codes 1
+       (run %{bin:ocamlformat} %{dep:error1.ml})))))
 
 (rule
  (alias runtest)
@@ -783,7 +786,8 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "! %{bin:ocamlformat} %{dep:error2.ml}"))))
+     (with-accepted-exit-codes 1
+       (run %{bin:ocamlformat} %{dep:error2.ml})))))
 
 (rule
  (alias runtest)
@@ -794,7 +798,8 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "! %{bin:ocamlformat} %{dep:error3.ml}"))))
+     (with-accepted-exit-codes 1
+       (run %{bin:ocamlformat} %{dep:error3.ml})))))
 
 (rule
  (alias runtest)
@@ -1768,7 +1773,8 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "! %{bin:ocamlformat} %{read-lines:need_format.ml.opts} %{dep:need_format.ml}"))))
+     (with-accepted-exit-codes 1
+       (run %{bin:ocamlformat} %{read-lines:need_format.ml.opts} %{dep:need_format.ml})))))
 
 (rule
  (alias runtest)

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -6,8 +6,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:align_cases-break_all.ml.opts} %{dep:align_cases.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff align_cases-break_all.ml.ref align_cases-break_all.ml.output)))
 
 (rule
@@ -17,8 +17,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:align_cases.ml.opts} %{dep:align_cases.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff align_cases.ml align_cases.ml.output)))
 
 (rule
@@ -28,8 +28,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:align_infix.ml.opts} %{dep:align_infix.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff align_infix.ml align_infix.ml.output)))
 
 (rule
@@ -39,8 +39,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:apply.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff apply.ml apply.ml.output)))
 
 (rule
@@ -50,8 +50,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:array.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff array.ml array.ml.output)))
 
 (rule
@@ -61,8 +61,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:assignment_operator-op_begin_line.ml.opts} %{dep:assignment_operator.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff assignment_operator-op_begin_line.ml.ref assignment_operator-op_begin_line.ml.output)))
 
 (rule
@@ -72,8 +72,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:assignment_operator.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff assignment_operator.ml.ref assignment_operator.ml.output)))
 
 (rule
@@ -83,8 +83,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:attribute_and_expression.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff attribute_and_expression.ml attribute_and_expression.ml.output)))
 
 (rule
@@ -94,8 +94,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:attributes.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff attributes.ml attributes.ml.output)))
 
@@ -106,8 +106,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:attributes.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff attributes.mli.ref attributes.mli.output)))
 
 (rule
@@ -117,8 +117,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_before_in-auto.ml.opts} %{dep:break_before_in.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_before_in-auto.ml.ref break_before_in-auto.ml.output)))
 
 (rule
@@ -128,8 +128,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_before_in.ml.opts} %{dep:break_before_in.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_before_in.ml break_before_in.ml.output)))
 
 (rule
@@ -139,8 +139,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_cases-align.ml.opts} %{dep:break_cases.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_cases-align.ml.ref break_cases-align.ml.output)))
 
 (rule
@@ -150,8 +150,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_cases-all.ml.opts} %{dep:break_cases.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_cases-all.ml.ref break_cases-all.ml.output)))
 
 (rule
@@ -161,8 +161,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_cases-closing_on_separate_line.ml.opts} %{dep:break_cases.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_cases-closing_on_separate_line.ml.ref break_cases-closing_on_separate_line.ml.output)))
 
 (rule
@@ -172,8 +172,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_cases-closing_on_separate_line_leading_nested_match_parens.ml.opts} %{dep:break_cases.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref break_cases-closing_on_separate_line_leading_nested_match_parens.ml.output)))
 
 (rule
@@ -183,8 +183,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_cases-cosl_lnmp_cmei.ml.opts} %{dep:break_cases.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_cases-cosl_lnmp_cmei.ml.ref break_cases-cosl_lnmp_cmei.ml.output)))
 
 (rule
@@ -194,8 +194,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_cases-fit_or_vertical.ml.opts} %{dep:break_cases.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_cases-fit_or_vertical.ml.ref break_cases-fit_or_vertical.ml.output)))
 
 (rule
@@ -205,8 +205,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_cases-nested.ml.opts} %{dep:break_cases.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_cases-nested.ml.ref break_cases-nested.ml.output)))
 
 (rule
@@ -216,8 +216,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_cases-normal_indent.ml.opts} %{dep:break_cases.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_cases-normal_indent.ml.ref break_cases-normal_indent.ml.output)))
 
 (rule
@@ -227,8 +227,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_cases-toplevel.ml.opts} %{dep:break_cases.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_cases-toplevel.ml.ref break_cases-toplevel.ml.output)))
 
 (rule
@@ -238,8 +238,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_cases.ml.opts} %{dep:break_cases.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_cases.ml.ref break_cases.ml.output)))
 
 (rule
@@ -249,8 +249,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_fun_decl-fit_or_vertical.ml.opts} %{dep:break_fun_decl.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_fun_decl-fit_or_vertical.ml.ref break_fun_decl-fit_or_vertical.ml.output)))
 
 (rule
@@ -260,8 +260,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_fun_decl-smart.ml.opts} %{dep:break_fun_decl.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_fun_decl-smart.ml.ref break_fun_decl-smart.ml.output)))
 
 (rule
@@ -271,8 +271,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_fun_decl-wrap.ml.opts} %{dep:break_fun_decl.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_fun_decl-wrap.ml.ref break_fun_decl-wrap.ml.output)))
 
 (rule
@@ -282,8 +282,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:break_fun_decl.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_fun_decl.ml break_fun_decl.ml.output)))
 
 (rule
@@ -293,8 +293,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_record.ml.opts} %{dep:break_record.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_record.ml break_record.ml.output)))
 
 (rule
@@ -304,8 +304,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_separators-after.ml.opts} %{dep:break_separators.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_separators-after.ml.ref break_separators-after.ml.output)))
 
 (rule
@@ -315,8 +315,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_separators-after_docked.ml.opts} %{dep:break_separators.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_separators-after_docked.ml.ref break_separators-after_docked.ml.output)))
 
 (rule
@@ -326,8 +326,8 @@
    (with-outputs-to %{targets}
      (system "! %{bin:ocamlformat} %{read-lines:break_separators-after_docked_transition_message.ml.opts} %{dep:break_separators.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_separators-after_docked_transition_message.ml.ref break_separators-after_docked_transition_message.ml.output)))
 
 (rule
@@ -337,8 +337,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_separators-after_docked_wrap.ml.opts} %{dep:break_separators.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_separators-after_docked_wrap.ml.ref break_separators-after_docked_wrap.ml.output)))
 
 (rule
@@ -348,8 +348,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_separators-after_wrap.ml.opts} %{dep:break_separators.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_separators-after_wrap.ml.ref break_separators-after_wrap.ml.output)))
 
 (rule
@@ -359,8 +359,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_separators-before_docked.ml.opts} %{dep:break_separators.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_separators-before_docked.ml.ref break_separators-before_docked.ml.output)))
 
 (rule
@@ -370,8 +370,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_separators-before_docked_wrap.ml.opts} %{dep:break_separators.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_separators-before_docked_wrap.ml.ref break_separators-before_docked_wrap.ml.output)))
 
 (rule
@@ -381,8 +381,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_separators-wrap.ml.opts} %{dep:break_separators.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_separators-wrap.ml.ref break_separators-wrap.ml.output)))
 
 (rule
@@ -392,8 +392,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_separators.ml.opts} %{dep:break_separators.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_separators.ml break_separators.ml.output)))
 
 (rule
@@ -403,8 +403,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:break_sequence_before.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_sequence_before.ml break_sequence_before.ml.output)))
 
 (rule
@@ -414,8 +414,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_string_literals-never.ml.opts} %{dep:break_string_literals.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_string_literals-never.ml.ref break_string_literals-never.ml.output)))
 
 (rule
@@ -425,8 +425,8 @@
    (with-outputs-to %{targets}
      (system "! %{bin:ocamlformat} %{read-lines:break_string_literals-wrap.ml.opts} %{dep:break_string_literals.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_string_literals-wrap.ml.ref break_string_literals-wrap.ml.output)))
 
 (rule
@@ -436,8 +436,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:break_string_literals.ml.opts} %{dep:break_string_literals.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_string_literals.ml.ref break_string_literals.ml.output)))
 
 (rule
@@ -447,8 +447,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:break_struct.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff break_struct.ml.ref break_struct.ml.output)))
 
 (rule
@@ -458,8 +458,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:cinaps.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff cinaps.ml cinaps.ml.output)))
 
 (rule
@@ -469,8 +469,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:cmdline_override.ml.opts} %{dep:cmdline_override.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff cmdline_override.ml cmdline_override.ml.output)))
 
 (rule
@@ -480,8 +480,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:cmdline_override2.ml.opts} %{dep:cmdline_override2.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff cmdline_override2.ml cmdline_override2.ml.output)))
 
 (rule
@@ -491,8 +491,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:comment_breaking.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff comment_breaking.ml comment_breaking.ml.output)))
 
 (rule
@@ -502,8 +502,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:comment_header.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff comment_header.ml.ref comment_header.ml.output)))
 
 (rule
@@ -513,8 +513,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:comment_in_empty.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff comment_in_empty.ml comment_in_empty.ml.output)))
 
 (rule
@@ -524,8 +524,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:comment_in_modules.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff comment_in_modules.ml.ref comment_in_modules.ml.output)))
 
 (rule
@@ -535,8 +535,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:comment_last.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff comment_last.ml comment_last.ml.output)))
 
 (rule
@@ -546,8 +546,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:comment_sparse.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff comment_sparse.ml comment_sparse.ml.output)))
 
 (rule
@@ -557,8 +557,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:comments.ml.opts} %{dep:comments.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff comments.ml.ref comments.ml.output)))
 
@@ -569,8 +569,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:comments_args.ml.opts} %{dep:comments_args.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff comments_args.ml.ref comments_args.ml.output)))
 
 (rule
@@ -580,8 +580,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:comments_around_disabled.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff comments_around_disabled.ml.ref comments_around_disabled.ml.output)))
 
 (rule
@@ -591,8 +591,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:comments_in_record.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff comments_in_record.ml.ref comments_in_record.ml.output)))
 
@@ -603,8 +603,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:compact_lists_arrays.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff compact_lists_arrays.ml compact_lists_arrays.ml.output)))
 
 (rule
@@ -614,8 +614,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:custom_list.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff custom_list.ml custom_list.ml.output)))
 
 (rule
@@ -625,8 +625,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:directives.mlt}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff directives.mlt.ref directives.mlt.output)))
 
@@ -637,8 +637,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:disabled.ml.opts} %{dep:disabled.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff disabled.ml disabled.ml.output)))
 
 (rule
@@ -648,8 +648,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:disambiguate.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff disambiguate.ml disambiguate.ml.output)))
 
 (rule
@@ -659,8 +659,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:doc_comments-after.ml.opts} %{dep:doc_comments.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff doc_comments-after.ml.ref doc_comments-after.ml.output)))
 
@@ -671,8 +671,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:doc_comments-before-except-val.ml.opts} %{dep:doc_comments.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff doc_comments-before-except-val.ml.ref doc_comments-before-except-val.ml.output)))
 
@@ -683,8 +683,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:doc_comments-before.ml.opts} %{dep:doc_comments.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff doc_comments-before.ml.ref doc_comments-before.ml.output)))
 
@@ -695,8 +695,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:doc_comments.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff doc_comments.ml.ref doc_comments.ml.output)))
 
@@ -707,8 +707,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:doc_comments.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff doc_comments.mli.ref doc_comments.mli.output)))
 
@@ -719,8 +719,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:doc_comments_padding.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff doc_comments_padding.ml doc_comments_padding.ml.output)))
 
 (rule
@@ -730,8 +730,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:empty.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff empty.ml empty.ml.output)))
 
 (rule
@@ -741,8 +741,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:empty_ml.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff empty_ml.ml empty_ml.ml.output)))
 
 (rule
@@ -752,8 +752,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:empty_mli.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff empty_mli.mli empty_mli.mli.output)))
 
 (rule
@@ -763,8 +763,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:empty_mlt.mlt}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff empty_mlt.mlt empty_mlt.mlt.output)))
 
 (rule
@@ -774,8 +774,8 @@
    (with-outputs-to %{targets}
      (system "! %{bin:ocamlformat} %{dep:error1.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff error1.ml.ref error1.ml.output)))
 
 (rule
@@ -785,8 +785,8 @@
    (with-outputs-to %{targets}
      (system "! %{bin:ocamlformat} %{dep:error2.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff error2.ml.ref error2.ml.output)))
 
 (rule
@@ -796,8 +796,8 @@
    (with-outputs-to %{targets}
      (system "! %{bin:ocamlformat} %{dep:error3.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff error3.ml.ref error3.ml.output)))
 
 (rule
@@ -807,8 +807,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:error4.ml.opts} %{dep:error4.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff error4.ml.ref error4.ml.output)))
 
 (rule
@@ -818,8 +818,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:exceptions.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff exceptions.ml exceptions.ml.output)))
 
 (rule
@@ -829,8 +829,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:exp_grouping-parens.ml.opts} %{dep:exp_grouping.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff exp_grouping-parens.ml.ref exp_grouping-parens.ml.output)))
 
 (rule
@@ -840,8 +840,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:exp_grouping.ml.opts} %{dep:exp_grouping.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff exp_grouping.ml.ref exp_grouping.ml.output)))
 
 (rule
@@ -851,8 +851,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:exp_record.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff exp_record.ml exp_record.ml.output)))
 
 (rule
@@ -862,8 +862,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:expect_test.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff expect_test.ml expect_test.ml.output)))
 
 (rule
@@ -873,8 +873,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:extensions-indent.ml.opts} %{dep:extensions.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff extensions-indent.ml.ref extensions-indent.ml.output)))
 
@@ -885,8 +885,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:extensions-indent.mli.opts} %{dep:extensions.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff extensions-indent.mli.ref extensions-indent.mli.output)))
 
 (rule
@@ -896,8 +896,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:extensions-sugar_always.ml.opts} %{dep:extensions.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff extensions-sugar_always.ml.ref extensions-sugar_always.ml.output)))
 
@@ -908,8 +908,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:extensions.ml.opts} %{dep:extensions.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff extensions.ml.ref extensions.ml.output)))
 
@@ -920,8 +920,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:extensions.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff extensions.mli extensions.mli.output)))
 
 (rule
@@ -931,8 +931,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:field-op_begin_line.ml.opts} %{dep:field.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff field-op_begin_line.ml.ref field-op_begin_line.ml.output)))
 
 (rule
@@ -942,8 +942,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:field.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff field.ml field.ml.output)))
 
 (rule
@@ -953,8 +953,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:first_class_module.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff first_class_module.ml first_class_module.ml.output)))
 
 (rule
@@ -964,8 +964,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:floating_doc.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff floating_doc.ml floating_doc.ml.output)))
 
 (rule
@@ -975,8 +975,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:for_while.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff for_while.ml for_while.ml.output)))
 
 (rule
@@ -986,8 +986,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:format_invalid_files.ml.opts} %{dep:format_invalid_files.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff format_invalid_files.ml.ref format_invalid_files.ml.output)))
 
 (rule
@@ -997,8 +997,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:fun_decl.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff fun_decl.ml fun_decl.ml.output)))
 
 (rule
@@ -1008,8 +1008,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:function_indent-never.ml.opts} %{dep:function_indent.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff function_indent-never.ml.ref function_indent-never.ml.output)))
 
 (rule
@@ -1019,8 +1019,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:function_indent.ml.opts} %{dep:function_indent.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff function_indent.ml.ref function_indent.ml.output)))
 
 (rule
@@ -1030,8 +1030,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:functor.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff functor.ml functor.ml.output)))
 
 (rule
@@ -1041,8 +1041,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:funsig.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff funsig.ml funsig.ml.output)))
 
 (rule
@@ -1052,8 +1052,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:gadt.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff gadt.ml gadt.ml.output)))
 
 (rule
@@ -1063,8 +1063,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:generative.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff generative.ml generative.ml.output)))
 
 (rule
@@ -1074,8 +1074,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:index_op.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff index_op.ml index_op.ml.output)))
 
 (rule
@@ -1085,8 +1085,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:infix_arg_grouping.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff infix_arg_grouping.ml infix_arg_grouping.ml.output)))
 
 (rule
@@ -1096,8 +1096,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:infix_bind-break.ml.opts} %{dep:infix_bind.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff infix_bind-break.ml.ref infix_bind-break.ml.output)))
 
@@ -1108,8 +1108,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:infix_bind-fit_or_vertical-break.ml.opts} %{dep:infix_bind.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff infix_bind-fit_or_vertical-break.ml.ref infix_bind-fit_or_vertical-break.ml.output)))
 
@@ -1120,8 +1120,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:infix_bind-fit_or_vertical.ml.opts} %{dep:infix_bind.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff infix_bind-fit_or_vertical.ml.ref infix_bind-fit_or_vertical.ml.output)))
 
@@ -1132,8 +1132,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:infix_bind.ml.opts} %{dep:infix_bind.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff infix_bind.ml infix_bind.ml.output)))
 
@@ -1144,8 +1144,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:infix_precedence.ml.opts} %{dep:infix_precedence.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff infix_precedence.ml infix_precedence.ml.output)))
 
 (rule
@@ -1155,8 +1155,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:invalid.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff invalid.ml invalid.ml.output)))
 
 (rule
@@ -1166,8 +1166,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:invalid_docstring.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.07.0))
  (action (diff invalid_docstring.ml.ref invalid_docstring.ml.output)))
 
@@ -1178,8 +1178,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:issue114.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff issue114.ml issue114.ml.output)))
 
 (rule
@@ -1189,8 +1189,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:issue289.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff issue289.ml issue289.ml.output)))
 
 (rule
@@ -1200,8 +1200,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:issue48.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff issue48.ml issue48.ml.output)))
 
 (rule
@@ -1211,8 +1211,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:issue51.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff issue51.ml issue51.ml.output)))
 
 (rule
@@ -1222,8 +1222,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:issue57.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff issue57.ml issue57.ml.output)))
 
 (rule
@@ -1233,8 +1233,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:issue60.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff issue60.ml issue60.ml.output)))
 
 (rule
@@ -1244,8 +1244,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:issue77.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff issue77.ml issue77.ml.output)))
 
 (rule
@@ -1255,8 +1255,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:issue85.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff issue85.ml issue85.ml.output)))
 
 (rule
@@ -1266,8 +1266,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:issue89.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff issue89.ml issue89.ml.output)))
 
 (rule
@@ -1277,8 +1277,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:ite-compact.ml.opts} %{dep:ite.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ite-compact.ml.ref ite-compact.ml.output)))
 
 (rule
@@ -1288,8 +1288,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:ite-compact_closing.ml.opts} %{dep:ite.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ite-compact_closing.ml.ref ite-compact_closing.ml.output)))
 
 (rule
@@ -1299,8 +1299,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:ite-fit_or_vertical.ml.opts} %{dep:ite.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ite-fit_or_vertical.ml.ref ite-fit_or_vertical.ml.output)))
 
 (rule
@@ -1310,8 +1310,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:ite-fit_or_vertical_closing.ml.opts} %{dep:ite.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ite-fit_or_vertical_closing.ml.ref ite-fit_or_vertical_closing.ml.output)))
 
 (rule
@@ -1321,8 +1321,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:ite-fit_or_vertical_no_indicate.ml.opts} %{dep:ite.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ite-fit_or_vertical_no_indicate.ml.ref ite-fit_or_vertical_no_indicate.ml.output)))
 
 (rule
@@ -1332,8 +1332,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:ite-kr.ml.opts} %{dep:ite.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ite-kr.ml.ref ite-kr.ml.output)))
 
 (rule
@@ -1343,8 +1343,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:ite-kr_closing.ml.opts} %{dep:ite.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ite-kr_closing.ml.ref ite-kr_closing.ml.output)))
 
 (rule
@@ -1354,8 +1354,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:ite-kw_first.ml.opts} %{dep:ite.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ite-kw_first.ml.ref ite-kw_first.ml.output)))
 
 (rule
@@ -1365,8 +1365,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:ite-kw_first_closing.ml.opts} %{dep:ite.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ite-kw_first_closing.ml.ref ite-kw_first_closing.ml.output)))
 
 (rule
@@ -1376,8 +1376,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:ite-kw_first_no_indicate.ml.opts} %{dep:ite.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ite-kw_first_no_indicate.ml.ref ite-kw_first_no_indicate.ml.output)))
 
 (rule
@@ -1387,8 +1387,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:ite-no_indicate.ml.opts} %{dep:ite.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ite-no_indicate.ml.ref ite-no_indicate.ml.output)))
 
 (rule
@@ -1398,8 +1398,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:ite.ml.opts} %{dep:ite.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ite.ml.ref ite.ml.output)))
 
 (rule
@@ -1409,8 +1409,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:js_sig.mli.opts} %{dep:js_sig.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff js_sig.mli.ref js_sig.mli.output)))
 
 (rule
@@ -1420,8 +1420,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:js_source.ml.opts} %{dep:js_source.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff js_source.ml.ref js_source.ml.output)))
 
@@ -1432,8 +1432,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocp-indent} %{dep:js_source.ml.ref}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff js_source.ml.ocp js_source.ml.ocp.output)))
 
 (rule
@@ -1443,8 +1443,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:kw_extentions.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff kw_extentions.ml kw_extentions.ml.output)))
 
 (rule
@@ -1454,8 +1454,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:label_option_default_args.ml.opts} %{dep:label_option_default_args.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff label_option_default_args.ml.ref label_option_default_args.ml.output)))
 
 (rule
@@ -1465,8 +1465,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:lazy.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff lazy.ml lazy.ml.output)))
 
 (rule
@@ -1476,8 +1476,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:let_binding-in_indent.ml.opts} %{dep:let_binding.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff let_binding-in_indent.ml.ref let_binding-in_indent.ml.output)))
 
@@ -1488,8 +1488,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:let_binding-indent.ml.opts} %{dep:let_binding.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff let_binding-indent.ml.ref let_binding-indent.ml.output)))
 
@@ -1500,8 +1500,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:let_binding.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff let_binding.ml.ref let_binding.ml.output)))
 
@@ -1512,8 +1512,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:let_in_constr.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff let_in_constr.ml let_in_constr.ml.output)))
 
 (rule
@@ -1523,8 +1523,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:let_module-sparse.ml.opts} %{dep:let_module.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff let_module-sparse.ml.ref let_module-sparse.ml.output)))
 
 (rule
@@ -1534,8 +1534,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:let_module.ml.opts} %{dep:let_module.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff let_module.ml.ref let_module.ml.output)))
 
 (rule
@@ -1545,8 +1545,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:list-space_around.ml.opts} %{dep:list.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff list-space_around.ml.ref list-space_around.ml.output)))
 
 (rule
@@ -1556,8 +1556,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:list.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff list.ml list.ml.output)))
 
 (rule
@@ -1567,8 +1567,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:loc_stack.ml.opts} %{dep:loc_stack.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff loc_stack.ml.ref loc_stack.ml.output)))
 
 (rule
@@ -1578,8 +1578,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:locally_abtract_types.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff locally_abtract_types.ml locally_abtract_types.ml.output)))
 
 (rule
@@ -1589,8 +1589,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:margin_80.ml.opts} %{dep:margin_80.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff margin_80.ml.ref margin_80.ml.output)))
 
 (rule
@@ -1600,8 +1600,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:match.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff match.ml match.ml.output)))
 
 (rule
@@ -1611,8 +1611,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:match2.ml.opts} %{dep:match2.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff match2.ml match2.ml.output)))
 
@@ -1623,8 +1623,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:match_indent-never.ml.opts} %{dep:match_indent.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff match_indent-never.ml.ref match_indent-never.ml.output)))
 
 (rule
@@ -1634,8 +1634,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:match_indent.ml.opts} %{dep:match_indent.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff match_indent.ml.ref match_indent.ml.output)))
 
 (rule
@@ -1645,8 +1645,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:max_indent.ml.opts} %{dep:max_indent.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff max_indent.ml max_indent.ml.output)))
 
 (rule
@@ -1656,8 +1656,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:module.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff module.ml module.ml.output)))
 
 (rule
@@ -1667,8 +1667,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:module_anonymous.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.10.0))
  (action (diff module_anonymous.ml module_anonymous.ml.output)))
 
@@ -1679,8 +1679,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:module_attributes.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff module_attributes.ml.ref module_attributes.ml.output)))
 
 (rule
@@ -1690,8 +1690,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:module_item_spacing-preserve.ml.opts} %{dep:module_item_spacing.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff module_item_spacing-preserve.ml.ref module_item_spacing-preserve.ml.output)))
 
 (rule
@@ -1701,8 +1701,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:module_item_spacing-sparse.ml.opts} %{dep:module_item_spacing.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff module_item_spacing-sparse.ml.ref module_item_spacing-sparse.ml.output)))
 
 (rule
@@ -1712,8 +1712,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:module_item_spacing.ml.opts} %{dep:module_item_spacing.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff module_item_spacing.ml.ref module_item_spacing.ml.output)))
 
 (rule
@@ -1723,8 +1723,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:module_item_spacing.mli.opts} %{dep:module_item_spacing.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff module_item_spacing.mli.ref module_item_spacing.mli.output)))
 
@@ -1735,8 +1735,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:module_type.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff module_type.ml module_type.ml.output)))
 
 (rule
@@ -1746,8 +1746,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:monadic_binding.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff monadic_binding.ml monadic_binding.ml.output)))
 
@@ -1758,8 +1758,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:multi_index_op.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.10.0))
  (action (diff multi_index_op.ml multi_index_op.ml.output)))
 
@@ -1770,8 +1770,8 @@
    (with-outputs-to %{targets}
      (system "! %{bin:ocamlformat} %{read-lines:need_format.ml.opts} %{dep:need_format.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff need_format.ml.ref need_format.ml.output)))
 
 (rule
@@ -1781,8 +1781,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:new.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff new.ml new.ml.output)))
 
 (rule
@@ -1792,8 +1792,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:object.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff object.ml object.ml.output)))
 
 (rule
@@ -1803,8 +1803,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:object_type.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff object_type.ml.ref object_type.ml.output)))
 
 (rule
@@ -1814,8 +1814,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:ocp_indent_compat.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ocp_indent_compat.ml ocp_indent_compat.ml.output)))
 
 (rule
@@ -1825,8 +1825,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:ocp_indent_options.ml.opts} %{dep:ocp_indent_options.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff ocp_indent_options.ml.ref ocp_indent_options.ml.output)))
 
 (rule
@@ -1836,8 +1836,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:open-auto.ml.opts} %{dep:open.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff open-auto.ml.ref open-auto.ml.output)))
 
@@ -1848,8 +1848,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:open-long.ml.opts} %{dep:open.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff open-long.ml.ref open-long.ml.output)))
 
@@ -1860,8 +1860,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:open-preserve.ml.opts} %{dep:open.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff open-preserve.ml.ref open-preserve.ml.output)))
 
@@ -1872,8 +1872,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:open-short.ml.opts} %{dep:open.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff open-short.ml.ref open-short.ml.output)))
 
@@ -1884,8 +1884,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:open.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff open.ml.ref open.ml.output)))
 
@@ -1896,8 +1896,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:open_types.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff open_types.ml open_types.ml.output)))
 
 (rule
@@ -1907,8 +1907,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:option.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff option.ml.ref option.ml.output)))
 
 (rule
@@ -1918,8 +1918,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:parens_tuple_patterns.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff parens_tuple_patterns.ml parens_tuple_patterns.ml.output)))
 
 (rule
@@ -1929,8 +1929,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:precedence.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff precedence.ml precedence.ml.output)))
 
 (rule
@@ -1940,8 +1940,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:prefix_infix.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff prefix_infix.ml prefix_infix.ml.output)))
 
 (rule
@@ -1951,8 +1951,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:print_config.ml.opts} %{dep:print_config.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff print_config.ml.ref print_config.ml.output)))
 
 (rule
@@ -1962,8 +1962,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:profiles.ml.opts} %{dep:profiles.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff profiles.ml profiles.ml.output)))
 
 (rule
@@ -1973,8 +1973,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:profiles2.ml.opts} %{dep:profiles2.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff profiles2.ml profiles2.ml.output)))
 
 (rule
@@ -1984,8 +1984,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:protected_object_types.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff protected_object_types.ml protected_object_types.ml.output)))
 
 (rule
@@ -1995,8 +1995,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:recmod.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff recmod.mli recmod.mli.output)))
 
 (rule
@@ -2006,8 +2006,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:record-loose.ml.opts} %{dep:record.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff record-loose.ml.ref record-loose.ml.output)))
 
 (rule
@@ -2017,8 +2017,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:record-tight_decl.ml.opts} %{dep:record.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff record-tight_decl.ml.ref record-tight_decl.ml.output)))
 
 (rule
@@ -2028,8 +2028,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:record.ml.opts} %{dep:record.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff record.ml.ref record.ml.output)))
 
 (rule
@@ -2039,8 +2039,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:record_punning.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff record_punning.ml record_punning.ml.output)))
 
 (rule
@@ -2050,8 +2050,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:reformat_string.ml.opts} %{dep:reformat_string.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff reformat_string.ml.ref reformat_string.ml.output)))
 
 (rule
@@ -2061,8 +2061,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:refs.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff refs.ml refs.ml.output)))
 
 (rule
@@ -2072,8 +2072,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:remove_extra_parens.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff remove_extra_parens.ml.ref remove_extra_parens.ml.output)))
 
 (rule
@@ -2083,8 +2083,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:revapply_ext.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff revapply_ext.ml revapply_ext.ml.output)))
 
 (rule
@@ -2094,8 +2094,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:send.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff send.ml send.ml.output)))
 
 (rule
@@ -2105,8 +2105,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:sequence-preserve.ml.opts} %{dep:sequence.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff sequence-preserve.ml.ref sequence-preserve.ml.output)))
 
@@ -2117,8 +2117,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:sequence.ml.opts} %{dep:sequence.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff sequence.ml.ref sequence.ml.output)))
 
@@ -2129,8 +2129,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:shebang.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff shebang.ml shebang.ml.output)))
 
 (rule
@@ -2140,8 +2140,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:shortcut_ext_attr.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff shortcut_ext_attr.ml shortcut_ext_attr.ml.output)))
 
 (rule
@@ -2151,8 +2151,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:skip.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff skip.ml skip.ml.output)))
 
 (rule
@@ -2162,8 +2162,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:source.ml.opts} %{dep:source.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff source.ml.ref source.ml.output)))
 
@@ -2174,8 +2174,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:str_value.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff str_value.ml str_value.ml.output)))
 
 (rule
@@ -2185,8 +2185,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:string.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff string.ml.ref string.ml.output)))
 
 (rule
@@ -2196,8 +2196,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:string_array.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff string_array.ml string_array.ml.output)))
 
 (rule
@@ -2207,8 +2207,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:string_wrapping.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff string_wrapping.ml string_wrapping.ml.output)))
 
 (rule
@@ -2218,8 +2218,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:symbol.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff symbol.ml symbol.ml.output)))
 
 (rule
@@ -2229,8 +2229,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:tag_only.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff tag_only.ml tag_only.ml.output)))
 
 (rule
@@ -2240,8 +2240,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:tag_only.mli}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff tag_only.mli tag_only.mli.output)))
 
 (rule
@@ -2251,8 +2251,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:try_with_or_pattern.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff try_with_or_pattern.ml try_with_or_pattern.ml.output)))
 
 (rule
@@ -2262,8 +2262,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:tuple.ml.opts} %{dep:tuple.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff tuple.ml tuple.ml.output)))
 
 (rule
@@ -2273,8 +2273,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:tuple_less_parens.ml.opts} %{dep:tuple_less_parens.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff tuple_less_parens.ml tuple_less_parens.ml.output)))
 
 (rule
@@ -2284,8 +2284,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:tuple_type_parens.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff tuple_type_parens.ml tuple_type_parens.ml.output)))
 
 (rule
@@ -2295,8 +2295,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:type_and_constraint.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff type_and_constraint.ml type_and_constraint.ml.output)))
 
 (rule
@@ -2306,8 +2306,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:type_annotations.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff type_annotations.ml type_annotations.ml.output)))
 
 (rule
@@ -2317,8 +2317,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:types-compact-space_around-docked.ml.opts} %{dep:types.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff types-compact-space_around-docked.ml.ref types-compact-space_around-docked.ml.output)))
 
@@ -2329,8 +2329,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:types-compact-space_around.ml.opts} %{dep:types.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff types-compact-space_around.ml.ref types-compact-space_around.ml.output)))
 
@@ -2341,8 +2341,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:types-compact.ml.opts} %{dep:types.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff types-compact.ml.ref types-compact.ml.output)))
 
@@ -2353,8 +2353,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:types-indent.ml.opts} %{dep:types.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff types-indent.ml.ref types-indent.ml.output)))
 
@@ -2365,8 +2365,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:types-sparse-space_around.ml.opts} %{dep:types.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff types-sparse-space_around.ml.ref types-sparse-space_around.ml.output)))
 
@@ -2377,8 +2377,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:types-sparse.ml.opts} %{dep:types.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff types-sparse.ml.ref types-sparse.ml.output)))
 
@@ -2389,8 +2389,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:types.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (enabled_if (>= %{ocaml_version} 4.08.0))
  (action (diff types.ml types.ml.output)))
 
@@ -2401,8 +2401,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:unary.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff unary.ml.ref unary.ml.output)))
 
 (rule
@@ -2412,8 +2412,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:unicode.ml.opts} %{dep:unicode.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff unicode.ml.ref unicode.ml.output)))
 
 (rule
@@ -2423,8 +2423,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:use_file.mlt}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff use_file.mlt use_file.mlt.output)))
 
 (rule
@@ -2434,8 +2434,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:verbose1.ml.opts} %{dep:verbose1.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff verbose1.ml.ref verbose1.ml.output)))
 
 (rule
@@ -2445,8 +2445,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:verbose2.ml.opts} %{dep:verbose2.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff verbose2.ml.ref verbose2.ml.output)))
 
 (rule
@@ -2456,8 +2456,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:wrap_comments.ml.opts} %{dep:wrap_comments.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff wrap_comments.ml.ref wrap_comments.ml.output)))
 
 (rule
@@ -2467,8 +2467,8 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{read-lines:wrap_comments_break.ml.opts} %{dep:wrap_comments_break.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff wrap_comments_break.ml wrap_comments_break.ml.output)))
 
 (rule
@@ -2478,6 +2478,6 @@
    (with-outputs-to %{targets}
      (system "%{bin:ocamlformat} %{dep:wrapping_functor_args.ml}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff wrapping_functor_args.ml wrapping_functor_args.ml.output)))

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -4,7 +4,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:align_cases-break_all.ml.opts} %{dep:align_cases.ml}"))))
+     (run %{bin:ocamlformat} --align-constructors-decl --align-variants-decl --align-cases --break-cases=all %{dep:align_cases.ml}))))
 
 (rule
  (alias runtest)
@@ -15,7 +15,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:align_cases.ml.opts} %{dep:align_cases.ml}"))))
+     (run %{bin:ocamlformat} --align-constructors-decl --align-variants-decl --align-cases %{dep:align_cases.ml}))))
 
 (rule
  (alias runtest)
@@ -26,7 +26,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:align_infix.ml.opts} %{dep:align_infix.ml}"))))
+     (run %{bin:ocamlformat} --break-infix=fit-or-vertical %{dep:align_infix.ml}))))
 
 (rule
  (alias runtest)
@@ -37,7 +37,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:apply.ml}"))))
+     (run %{bin:ocamlformat} %{dep:apply.ml}))))
 
 (rule
  (alias runtest)
@@ -48,7 +48,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:array.ml}"))))
+     (run %{bin:ocamlformat} %{dep:array.ml}))))
 
 (rule
  (alias runtest)
@@ -59,7 +59,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:assignment_operator-op_begin_line.ml.opts} %{dep:assignment_operator.ml}"))))
+     (run %{bin:ocamlformat} --assignment-operator=begin-line %{dep:assignment_operator.ml}))))
 
 (rule
  (alias runtest)
@@ -70,7 +70,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:assignment_operator.ml}"))))
+     (run %{bin:ocamlformat} %{dep:assignment_operator.ml}))))
 
 (rule
  (alias runtest)
@@ -81,7 +81,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:attribute_and_expression.ml}"))))
+     (run %{bin:ocamlformat} %{dep:attribute_and_expression.ml}))))
 
 (rule
  (alias runtest)
@@ -92,7 +92,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:attributes.ml}"))))
+     (run %{bin:ocamlformat} %{dep:attributes.ml}))))
 
 (rule
  (alias runtest)
@@ -104,7 +104,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:attributes.mli}"))))
+     (run %{bin:ocamlformat} %{dep:attributes.mli}))))
 
 (rule
  (alias runtest)
@@ -115,7 +115,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_before_in-auto.ml.opts} %{dep:break_before_in.ml}"))))
+     (run %{bin:ocamlformat} --break-before-in=auto %{dep:break_before_in.ml}))))
 
 (rule
  (alias runtest)
@@ -126,7 +126,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_before_in.ml.opts} %{dep:break_before_in.ml}"))))
+     (run %{bin:ocamlformat} --break-before-in=fit-or-vertical %{dep:break_before_in.ml}))))
 
 (rule
  (alias runtest)
@@ -137,7 +137,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_cases-align.ml.opts} %{dep:break_cases.ml}"))))
+     (run %{bin:ocamlformat} --nested-match=align --break-cases=all %{dep:break_cases.ml}))))
 
 (rule
  (alias runtest)
@@ -148,7 +148,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_cases-all.ml.opts} %{dep:break_cases.ml}"))))
+     (run %{bin:ocamlformat} --break-cases=all %{dep:break_cases.ml}))))
 
 (rule
  (alias runtest)
@@ -159,7 +159,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_cases-closing_on_separate_line.ml.opts} %{dep:break_cases.ml}"))))
+     (run %{bin:ocamlformat} --break-cases=all --indicate-multiline-delimiters=closing-on-separate-line %{dep:break_cases.ml}))))
 
 (rule
  (alias runtest)
@@ -170,7 +170,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_cases-closing_on_separate_line_leading_nested_match_parens.ml.opts} %{dep:break_cases.ml}"))))
+     (run %{bin:ocamlformat} --break-cases=all --indicate-multiline-delimiters=closing-on-separate-line --leading-nested-match-parens %{dep:break_cases.ml}))))
 
 (rule
  (alias runtest)
@@ -181,7 +181,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_cases-cosl_lnmp_cmei.ml.opts} %{dep:break_cases.ml}"))))
+     (run %{bin:ocamlformat} --break-cases=all --indicate-multiline-delimiters=closing-on-separate-line --leading-nested-match-parens --cases-matching-exp-indent=normal %{dep:break_cases.ml}))))
 
 (rule
  (alias runtest)
@@ -192,7 +192,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_cases-fit_or_vertical.ml.opts} %{dep:break_cases.ml}"))))
+     (run %{bin:ocamlformat} --break-cases=fit-or-vertical %{dep:break_cases.ml}))))
 
 (rule
  (alias runtest)
@@ -203,7 +203,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_cases-nested.ml.opts} %{dep:break_cases.ml}"))))
+     (run %{bin:ocamlformat} --break-cases=nested %{dep:break_cases.ml}))))
 
 (rule
  (alias runtest)
@@ -214,7 +214,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_cases-normal_indent.ml.opts} %{dep:break_cases.ml}"))))
+     (run %{bin:ocamlformat} --cases-matching-exp-indent=normal --break-cases=all %{dep:break_cases.ml}))))
 
 (rule
  (alias runtest)
@@ -225,7 +225,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_cases-toplevel.ml.opts} %{dep:break_cases.ml}"))))
+     (run %{bin:ocamlformat} --break-cases=toplevel --max-iter=4 %{dep:break_cases.ml}))))
 
 (rule
  (alias runtest)
@@ -236,7 +236,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_cases.ml.opts} %{dep:break_cases.ml}"))))
+     (run %{bin:ocamlformat} --break-cases=fit --max-iter=4 %{dep:break_cases.ml}))))
 
 (rule
  (alias runtest)
@@ -247,7 +247,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_fun_decl-fit_or_vertical.ml.opts} %{dep:break_fun_decl.ml}"))))
+     (run %{bin:ocamlformat} --break-fun-decl=fit-or-vertical --break-fun-sig=fit-or-vertical %{dep:break_fun_decl.ml}))))
 
 (rule
  (alias runtest)
@@ -258,7 +258,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_fun_decl-smart.ml.opts} %{dep:break_fun_decl.ml}"))))
+     (run %{bin:ocamlformat} --break-fun-decl=smart --break-fun-sig=smart %{dep:break_fun_decl.ml}))))
 
 (rule
  (alias runtest)
@@ -269,7 +269,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_fun_decl-wrap.ml.opts} %{dep:break_fun_decl.ml}"))))
+     (run %{bin:ocamlformat} --break-fun-decl=wrap --break-fun-sig=wrap %{dep:break_fun_decl.ml}))))
 
 (rule
  (alias runtest)
@@ -280,7 +280,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:break_fun_decl.ml}"))))
+     (run %{bin:ocamlformat} %{dep:break_fun_decl.ml}))))
 
 (rule
  (alias runtest)
@@ -291,7 +291,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_record.ml.opts} %{dep:break_record.ml}"))))
+     (run %{bin:ocamlformat} --profile=janestreet --margin=58 %{dep:break_record.ml}))))
 
 (rule
  (alias runtest)
@@ -302,7 +302,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_separators-after.ml.opts} %{dep:break_separators.ml}"))))
+     (run %{bin:ocamlformat} --break-separators=after --max-iter=3 %{dep:break_separators.ml}))))
 
 (rule
  (alias runtest)
@@ -313,7 +313,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_separators-after_docked.ml.opts} %{dep:break_separators.ml}"))))
+     (run %{bin:ocamlformat} --break-separators=after --dock-collection-brackets --max-iter=3 %{dep:break_separators.ml}))))
 
 (rule
  (alias runtest)
@@ -325,7 +325,7 @@
  (action
    (with-outputs-to %{targets}
      (with-accepted-exit-codes 1
-       (run %{bin:ocamlformat} %{read-lines:break_separators-after_docked_transition_message.ml.opts} %{dep:break_separators.ml})))))
+       (run %{bin:ocamlformat} --break-separators=after-and-docked %{dep:break_separators.ml})))))
 
 (rule
  (alias runtest)
@@ -336,7 +336,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_separators-after_docked_wrap.ml.opts} %{dep:break_separators.ml}"))))
+     (run %{bin:ocamlformat} --break-separators=after --break-collection-expressions=wrap --dock-collection-brackets %{dep:break_separators.ml}))))
 
 (rule
  (alias runtest)
@@ -347,7 +347,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_separators-after_wrap.ml.opts} %{dep:break_separators.ml}"))))
+     (run %{bin:ocamlformat} --break-separators=after --break-collection-expressions=wrap %{dep:break_separators.ml}))))
 
 (rule
  (alias runtest)
@@ -358,7 +358,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_separators-before_docked.ml.opts} %{dep:break_separators.ml}"))))
+     (run %{bin:ocamlformat} --break-separators=before --dock-collection-brackets --max-iter=3 %{dep:break_separators.ml}))))
 
 (rule
  (alias runtest)
@@ -369,7 +369,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_separators-before_docked_wrap.ml.opts} %{dep:break_separators.ml}"))))
+     (run %{bin:ocamlformat} --break-separators=before --break-collection-expressions=wrap --dock-collection-brackets %{dep:break_separators.ml}))))
 
 (rule
  (alias runtest)
@@ -380,7 +380,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_separators-wrap.ml.opts} %{dep:break_separators.ml}"))))
+     (run %{bin:ocamlformat} --break-separators=before --break-collection-expressions=wrap %{dep:break_separators.ml}))))
 
 (rule
  (alias runtest)
@@ -391,7 +391,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_separators.ml.opts} %{dep:break_separators.ml}"))))
+     (run %{bin:ocamlformat} --break-separators=before --max-iter=3 %{dep:break_separators.ml}))))
 
 (rule
  (alias runtest)
@@ -402,7 +402,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:break_sequence_before.ml}"))))
+     (run %{bin:ocamlformat} %{dep:break_sequence_before.ml}))))
 
 (rule
  (alias runtest)
@@ -413,7 +413,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_string_literals-never.ml.opts} %{dep:break_string_literals.ml}"))))
+     (run %{bin:ocamlformat} --break-string-literals=never %{dep:break_string_literals.ml}))))
 
 (rule
  (alias runtest)
@@ -425,7 +425,7 @@
  (action
    (with-outputs-to %{targets}
      (with-accepted-exit-codes 1
-       (run %{bin:ocamlformat} %{read-lines:break_string_literals-wrap.ml.opts} %{dep:break_string_literals.ml})))))
+       (run %{bin:ocamlformat} --break-string-literals=wrap %{dep:break_string_literals.ml})))))
 
 (rule
  (alias runtest)
@@ -436,7 +436,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:break_string_literals.ml.opts} %{dep:break_string_literals.ml}"))))
+     (run %{bin:ocamlformat} --break-string-literals=auto %{dep:break_string_literals.ml}))))
 
 (rule
  (alias runtest)
@@ -447,7 +447,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:break_struct.ml}"))))
+     (run %{bin:ocamlformat} %{dep:break_struct.ml}))))
 
 (rule
  (alias runtest)
@@ -458,7 +458,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:cinaps.ml}"))))
+     (run %{bin:ocamlformat} %{dep:cinaps.ml}))))
 
 (rule
  (alias runtest)
@@ -469,7 +469,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:cmdline_override.ml.opts} %{dep:cmdline_override.ml}"))))
+     (run %{bin:ocamlformat} --config=module-item-spacing=compact --module-item-spacing=sparse %{dep:cmdline_override.ml}))))
 
 (rule
  (alias runtest)
@@ -480,7 +480,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:cmdline_override2.ml.opts} %{dep:cmdline_override2.ml}"))))
+     (run %{bin:ocamlformat} --module-item-spacing=sparse --config=module-item-spacing=compact %{dep:cmdline_override2.ml}))))
 
 (rule
  (alias runtest)
@@ -491,7 +491,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:comment_breaking.ml}"))))
+     (run %{bin:ocamlformat} %{dep:comment_breaking.ml}))))
 
 (rule
  (alias runtest)
@@ -502,7 +502,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:comment_header.ml}"))))
+     (run %{bin:ocamlformat} %{dep:comment_header.ml}))))
 
 (rule
  (alias runtest)
@@ -513,7 +513,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:comment_in_empty.ml}"))))
+     (run %{bin:ocamlformat} %{dep:comment_in_empty.ml}))))
 
 (rule
  (alias runtest)
@@ -524,7 +524,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:comment_in_modules.ml}"))))
+     (run %{bin:ocamlformat} %{dep:comment_in_modules.ml}))))
 
 (rule
  (alias runtest)
@@ -535,7 +535,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:comment_last.ml}"))))
+     (run %{bin:ocamlformat} %{dep:comment_last.ml}))))
 
 (rule
  (alias runtest)
@@ -546,7 +546,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:comment_sparse.ml}"))))
+     (run %{bin:ocamlformat} %{dep:comment_sparse.ml}))))
 
 (rule
  (alias runtest)
@@ -557,7 +557,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:comments.ml.opts} %{dep:comments.ml}"))))
+     (run %{bin:ocamlformat} --max-iter=4 %{dep:comments.ml}))))
 
 (rule
  (alias runtest)
@@ -569,7 +569,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:comments_args.ml.opts} %{dep:comments_args.ml}"))))
+     (run %{bin:ocamlformat} --max-iter=4 %{dep:comments_args.ml}))))
 
 (rule
  (alias runtest)
@@ -580,7 +580,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:comments_around_disabled.ml}"))))
+     (run %{bin:ocamlformat} %{dep:comments_around_disabled.ml}))))
 
 (rule
  (alias runtest)
@@ -591,7 +591,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:comments_in_record.ml}"))))
+     (run %{bin:ocamlformat} %{dep:comments_in_record.ml}))))
 
 (rule
  (alias runtest)
@@ -603,7 +603,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:compact_lists_arrays.ml}"))))
+     (run %{bin:ocamlformat} %{dep:compact_lists_arrays.ml}))))
 
 (rule
  (alias runtest)
@@ -614,7 +614,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:custom_list.ml}"))))
+     (run %{bin:ocamlformat} %{dep:custom_list.ml}))))
 
 (rule
  (alias runtest)
@@ -625,7 +625,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:directives.mlt}"))))
+     (run %{bin:ocamlformat} %{dep:directives.mlt}))))
 
 (rule
  (alias runtest)
@@ -637,7 +637,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:disabled.ml.opts} %{dep:disabled.ml}"))))
+     (run %{bin:ocamlformat} --disable %{dep:disabled.ml}))))
 
 (rule
  (alias runtest)
@@ -648,7 +648,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:disambiguate.ml}"))))
+     (run %{bin:ocamlformat} %{dep:disambiguate.ml}))))
 
 (rule
  (alias runtest)
@@ -659,7 +659,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:doc_comments-after.ml.opts} %{dep:doc_comments.ml}"))))
+     (run %{bin:ocamlformat} --doc-comments=after-when-possible %{dep:doc_comments.ml}))))
 
 (rule
  (alias runtest)
@@ -671,7 +671,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:doc_comments-before-except-val.ml.opts} %{dep:doc_comments.ml}"))))
+     (run %{bin:ocamlformat} --doc-comments=before-except-val %{dep:doc_comments.ml}))))
 
 (rule
  (alias runtest)
@@ -683,7 +683,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:doc_comments-before.ml.opts} %{dep:doc_comments.ml}"))))
+     (run %{bin:ocamlformat} --doc-comments=before %{dep:doc_comments.ml}))))
 
 (rule
  (alias runtest)
@@ -695,7 +695,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:doc_comments.ml}"))))
+     (run %{bin:ocamlformat} %{dep:doc_comments.ml}))))
 
 (rule
  (alias runtest)
@@ -707,7 +707,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:doc_comments.mli}"))))
+     (run %{bin:ocamlformat} %{dep:doc_comments.mli}))))
 
 (rule
  (alias runtest)
@@ -719,7 +719,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:doc_comments_padding.ml}"))))
+     (run %{bin:ocamlformat} %{dep:doc_comments_padding.ml}))))
 
 (rule
  (alias runtest)
@@ -730,7 +730,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:empty.ml}"))))
+     (run %{bin:ocamlformat} %{dep:empty.ml}))))
 
 (rule
  (alias runtest)
@@ -741,7 +741,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:empty_ml.ml}"))))
+     (run %{bin:ocamlformat} %{dep:empty_ml.ml}))))
 
 (rule
  (alias runtest)
@@ -752,7 +752,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:empty_mli.mli}"))))
+     (run %{bin:ocamlformat} %{dep:empty_mli.mli}))))
 
 (rule
  (alias runtest)
@@ -763,7 +763,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:empty_mlt.mlt}"))))
+     (run %{bin:ocamlformat} %{dep:empty_mlt.mlt}))))
 
 (rule
  (alias runtest)
@@ -810,7 +810,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:error4.ml.opts} %{dep:error4.ml}"))))
+     (run %{bin:ocamlformat} --no-comment-check %{dep:error4.ml}))))
 
 (rule
  (alias runtest)
@@ -821,7 +821,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:exceptions.ml}"))))
+     (run %{bin:ocamlformat} %{dep:exceptions.ml}))))
 
 (rule
  (alias runtest)
@@ -832,7 +832,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:exp_grouping-parens.ml.opts} %{dep:exp_grouping.ml}"))))
+     (run %{bin:ocamlformat} --exp-grouping=parens %{dep:exp_grouping.ml}))))
 
 (rule
  (alias runtest)
@@ -843,7 +843,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:exp_grouping.ml.opts} %{dep:exp_grouping.ml}"))))
+     (run %{bin:ocamlformat} --exp-grouping=preserve %{dep:exp_grouping.ml}))))
 
 (rule
  (alias runtest)
@@ -854,7 +854,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:exp_record.ml}"))))
+     (run %{bin:ocamlformat} %{dep:exp_record.ml}))))
 
 (rule
  (alias runtest)
@@ -865,7 +865,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:expect_test.ml}"))))
+     (run %{bin:ocamlformat} %{dep:expect_test.ml}))))
 
 (rule
  (alias runtest)
@@ -876,7 +876,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:extensions-indent.ml.opts} %{dep:extensions.ml}"))))
+     (run %{bin:ocamlformat} --max-iters=3 --extension-indent=5 --stritem-extension-indent=3 %{dep:extensions.ml}))))
 
 (rule
  (alias runtest)
@@ -888,7 +888,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:extensions-indent.mli.opts} %{dep:extensions.mli}"))))
+     (run %{bin:ocamlformat} --extension-indent=5 --stritem-extension-indent=3 %{dep:extensions.mli}))))
 
 (rule
  (alias runtest)
@@ -899,7 +899,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:extensions-sugar_always.ml.opts} %{dep:extensions.ml}"))))
+     (run %{bin:ocamlformat} --max-iters=3 --extension-sugar=always %{dep:extensions.ml}))))
 
 (rule
  (alias runtest)
@@ -911,7 +911,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:extensions.ml.opts} %{dep:extensions.ml}"))))
+     (run %{bin:ocamlformat} --max-iters=3 %{dep:extensions.ml}))))
 
 (rule
  (alias runtest)
@@ -923,7 +923,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:extensions.mli}"))))
+     (run %{bin:ocamlformat} %{dep:extensions.mli}))))
 
 (rule
  (alias runtest)
@@ -934,7 +934,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:field-op_begin_line.ml.opts} %{dep:field.ml}"))))
+     (run %{bin:ocamlformat} --assignment-operator=begin-line %{dep:field.ml}))))
 
 (rule
  (alias runtest)
@@ -945,7 +945,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:field.ml}"))))
+     (run %{bin:ocamlformat} %{dep:field.ml}))))
 
 (rule
  (alias runtest)
@@ -956,7 +956,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:first_class_module.ml}"))))
+     (run %{bin:ocamlformat} %{dep:first_class_module.ml}))))
 
 (rule
  (alias runtest)
@@ -967,7 +967,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:floating_doc.ml}"))))
+     (run %{bin:ocamlformat} %{dep:floating_doc.ml}))))
 
 (rule
  (alias runtest)
@@ -978,7 +978,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:for_while.ml}"))))
+     (run %{bin:ocamlformat} %{dep:for_while.ml}))))
 
 (rule
  (alias runtest)
@@ -989,7 +989,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:format_invalid_files.ml.opts} %{dep:format_invalid_files.ml}"))))
+     (run %{bin:ocamlformat} --format-invalid-files=auto %{dep:format_invalid_files.ml}))))
 
 (rule
  (alias runtest)
@@ -1000,7 +1000,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:fun_decl.ml}"))))
+     (run %{bin:ocamlformat} %{dep:fun_decl.ml}))))
 
 (rule
  (alias runtest)
@@ -1011,7 +1011,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:function_indent-never.ml.opts} %{dep:function_indent.ml}"))))
+     (run %{bin:ocamlformat} --function-indent=4 --function-indent-nested=never %{dep:function_indent.ml}))))
 
 (rule
  (alias runtest)
@@ -1022,7 +1022,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:function_indent.ml.opts} %{dep:function_indent.ml}"))))
+     (run %{bin:ocamlformat} --function-indent=4 --function-indent-nested=always %{dep:function_indent.ml}))))
 
 (rule
  (alias runtest)
@@ -1033,7 +1033,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:functor.ml}"))))
+     (run %{bin:ocamlformat} %{dep:functor.ml}))))
 
 (rule
  (alias runtest)
@@ -1044,7 +1044,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:funsig.ml}"))))
+     (run %{bin:ocamlformat} %{dep:funsig.ml}))))
 
 (rule
  (alias runtest)
@@ -1055,7 +1055,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:gadt.ml}"))))
+     (run %{bin:ocamlformat} %{dep:gadt.ml}))))
 
 (rule
  (alias runtest)
@@ -1066,7 +1066,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:generative.ml}"))))
+     (run %{bin:ocamlformat} %{dep:generative.ml}))))
 
 (rule
  (alias runtest)
@@ -1077,7 +1077,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:index_op.ml}"))))
+     (run %{bin:ocamlformat} %{dep:index_op.ml}))))
 
 (rule
  (alias runtest)
@@ -1088,7 +1088,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:infix_arg_grouping.ml}"))))
+     (run %{bin:ocamlformat} %{dep:infix_arg_grouping.ml}))))
 
 (rule
  (alias runtest)
@@ -1099,7 +1099,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:infix_bind-break.ml.opts} %{dep:infix_bind.ml}"))))
+     (run %{bin:ocamlformat} --break-infix=wrap --break-infix-before-func %{dep:infix_bind.ml}))))
 
 (rule
  (alias runtest)
@@ -1111,7 +1111,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:infix_bind-fit_or_vertical-break.ml.opts} %{dep:infix_bind.ml}"))))
+     (run %{bin:ocamlformat} --break-infix=fit-or-vertical --break-infix-before-func %{dep:infix_bind.ml}))))
 
 (rule
  (alias runtest)
@@ -1123,7 +1123,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:infix_bind-fit_or_vertical.ml.opts} %{dep:infix_bind.ml}"))))
+     (run %{bin:ocamlformat} --break-infix=fit-or-vertical --no-break-infix-before-func %{dep:infix_bind.ml}))))
 
 (rule
  (alias runtest)
@@ -1135,7 +1135,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:infix_bind.ml.opts} %{dep:infix_bind.ml}"))))
+     (run %{bin:ocamlformat} --break-infix=wrap --no-break-infix-before-func %{dep:infix_bind.ml}))))
 
 (rule
  (alias runtest)
@@ -1147,7 +1147,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:infix_precedence.ml.opts} %{dep:infix_precedence.ml}"))))
+     (run %{bin:ocamlformat} --infix-precedence=parens %{dep:infix_precedence.ml}))))
 
 (rule
  (alias runtest)
@@ -1158,7 +1158,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:invalid.ml}"))))
+     (run %{bin:ocamlformat} %{dep:invalid.ml}))))
 
 (rule
  (alias runtest)
@@ -1169,7 +1169,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:invalid_docstring.ml}"))))
+     (run %{bin:ocamlformat} %{dep:invalid_docstring.ml}))))
 
 (rule
  (alias runtest)
@@ -1181,7 +1181,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:issue114.ml}"))))
+     (run %{bin:ocamlformat} %{dep:issue114.ml}))))
 
 (rule
  (alias runtest)
@@ -1192,7 +1192,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:issue289.ml}"))))
+     (run %{bin:ocamlformat} %{dep:issue289.ml}))))
 
 (rule
  (alias runtest)
@@ -1203,7 +1203,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:issue48.ml}"))))
+     (run %{bin:ocamlformat} %{dep:issue48.ml}))))
 
 (rule
  (alias runtest)
@@ -1214,7 +1214,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:issue51.ml}"))))
+     (run %{bin:ocamlformat} %{dep:issue51.ml}))))
 
 (rule
  (alias runtest)
@@ -1225,7 +1225,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:issue57.ml}"))))
+     (run %{bin:ocamlformat} %{dep:issue57.ml}))))
 
 (rule
  (alias runtest)
@@ -1236,7 +1236,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:issue60.ml}"))))
+     (run %{bin:ocamlformat} %{dep:issue60.ml}))))
 
 (rule
  (alias runtest)
@@ -1247,7 +1247,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:issue77.ml}"))))
+     (run %{bin:ocamlformat} %{dep:issue77.ml}))))
 
 (rule
  (alias runtest)
@@ -1258,7 +1258,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:issue85.ml}"))))
+     (run %{bin:ocamlformat} %{dep:issue85.ml}))))
 
 (rule
  (alias runtest)
@@ -1269,7 +1269,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:issue89.ml}"))))
+     (run %{bin:ocamlformat} %{dep:issue89.ml}))))
 
 (rule
  (alias runtest)
@@ -1280,7 +1280,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:ite-compact.ml.opts} %{dep:ite.ml}"))))
+     (run %{bin:ocamlformat} --if-then-else=compact %{dep:ite.ml}))))
 
 (rule
  (alias runtest)
@@ -1291,7 +1291,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:ite-compact_closing.ml.opts} %{dep:ite.ml}"))))
+     (run %{bin:ocamlformat} --if-then-else=compact --indicate-multiline-delimiters=closing-on-separate-line %{dep:ite.ml}))))
 
 (rule
  (alias runtest)
@@ -1302,7 +1302,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:ite-fit_or_vertical.ml.opts} %{dep:ite.ml}"))))
+     (run %{bin:ocamlformat} --if-then-else=fit-or-vertical %{dep:ite.ml}))))
 
 (rule
  (alias runtest)
@@ -1313,7 +1313,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:ite-fit_or_vertical_closing.ml.opts} %{dep:ite.ml}"))))
+     (run %{bin:ocamlformat} --if-then-else fit-or-vertical --indicate-multiline-delimiters=closing-on-separate-line %{dep:ite.ml}))))
 
 (rule
  (alias runtest)
@@ -1324,7 +1324,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:ite-fit_or_vertical_no_indicate.ml.opts} %{dep:ite.ml}"))))
+     (run %{bin:ocamlformat} --if-then-else=fit-or-vertical --indicate-multiline-delimiters=no %{dep:ite.ml}))))
 
 (rule
  (alias runtest)
@@ -1335,7 +1335,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:ite-kr.ml.opts} %{dep:ite.ml}"))))
+     (run %{bin:ocamlformat} --if-then-else=k-r --max-iters=3 %{dep:ite.ml}))))
 
 (rule
  (alias runtest)
@@ -1346,7 +1346,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:ite-kr_closing.ml.opts} %{dep:ite.ml}"))))
+     (run %{bin:ocamlformat} --if-then-else=k-r --max-iters=3 --indicate-multiline-delimiters=closing-on-separate-line %{dep:ite.ml}))))
 
 (rule
  (alias runtest)
@@ -1357,7 +1357,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:ite-kw_first.ml.opts} %{dep:ite.ml}"))))
+     (run %{bin:ocamlformat} --if-then-else=keyword-first %{dep:ite.ml}))))
 
 (rule
  (alias runtest)
@@ -1368,7 +1368,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:ite-kw_first_closing.ml.opts} %{dep:ite.ml}"))))
+     (run %{bin:ocamlformat} --if-then-else keyword-first --indicate-multiline-delimiters=closing-on-separate-line %{dep:ite.ml}))))
 
 (rule
  (alias runtest)
@@ -1379,7 +1379,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:ite-kw_first_no_indicate.ml.opts} %{dep:ite.ml}"))))
+     (run %{bin:ocamlformat} --if-then-else=keyword-first --indicate-multiline-delimiters=no %{dep:ite.ml}))))
 
 (rule
  (alias runtest)
@@ -1390,7 +1390,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:ite-no_indicate.ml.opts} %{dep:ite.ml}"))))
+     (run %{bin:ocamlformat} --if-then-else=compact --indicate-multiline-delimiters=no %{dep:ite.ml}))))
 
 (rule
  (alias runtest)
@@ -1401,7 +1401,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:ite.ml.opts} %{dep:ite.ml}"))))
+     (run %{bin:ocamlformat} --if-then-else=compact %{dep:ite.ml}))))
 
 (rule
  (alias runtest)
@@ -1412,7 +1412,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:js_sig.mli.opts} %{dep:js_sig.mli}"))))
+     (run %{bin:ocamlformat} --profile=janestreet %{dep:js_sig.mli}))))
 
 (rule
  (alias runtest)
@@ -1423,7 +1423,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:js_source.ml.opts} %{dep:js_source.ml}"))))
+     (run %{bin:ocamlformat} --max-iters=3 --profile=janestreet %{dep:js_source.ml}))))
 
 (rule
  (alias runtest)
@@ -1435,7 +1435,7 @@
  (deps .ocp-indent )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocp-indent} %{dep:js_source.ml.ref}"))))
+     (run %{bin:ocp-indent} %{dep:js_source.ml.ref}))))
 
 (rule
  (alias runtest)
@@ -1446,7 +1446,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:kw_extentions.ml}"))))
+     (run %{bin:ocamlformat} %{dep:kw_extentions.ml}))))
 
 (rule
  (alias runtest)
@@ -1457,7 +1457,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:label_option_default_args.ml.opts} %{dep:label_option_default_args.ml}"))))
+     (run %{bin:ocamlformat} --max-iters=4 %{dep:label_option_default_args.ml}))))
 
 (rule
  (alias runtest)
@@ -1468,7 +1468,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:lazy.ml}"))))
+     (run %{bin:ocamlformat} %{dep:lazy.ml}))))
 
 (rule
  (alias runtest)
@@ -1479,7 +1479,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:let_binding-in_indent.ml.opts} %{dep:let_binding.ml}"))))
+     (run %{bin:ocamlformat} --indent-after-in=4 %{dep:let_binding.ml}))))
 
 (rule
  (alias runtest)
@@ -1491,7 +1491,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:let_binding-indent.ml.opts} %{dep:let_binding.ml}"))))
+     (run %{bin:ocamlformat} --let-binding-indent=6 %{dep:let_binding.ml}))))
 
 (rule
  (alias runtest)
@@ -1503,7 +1503,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:let_binding.ml}"))))
+     (run %{bin:ocamlformat} %{dep:let_binding.ml}))))
 
 (rule
  (alias runtest)
@@ -1515,7 +1515,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:let_in_constr.ml}"))))
+     (run %{bin:ocamlformat} %{dep:let_in_constr.ml}))))
 
 (rule
  (alias runtest)
@@ -1526,7 +1526,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:let_module-sparse.ml.opts} %{dep:let_module.ml}"))))
+     (run %{bin:ocamlformat} --let-module=sparse %{dep:let_module.ml}))))
 
 (rule
  (alias runtest)
@@ -1537,7 +1537,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:let_module.ml.opts} %{dep:let_module.ml}"))))
+     (run %{bin:ocamlformat} --let-module=compact %{dep:let_module.ml}))))
 
 (rule
  (alias runtest)
@@ -1548,7 +1548,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:list-space_around.ml.opts} %{dep:list.ml}"))))
+     (run %{bin:ocamlformat} --space-around-arrays --space-around-lists --space-around-records --space-around-variants %{dep:list.ml}))))
 
 (rule
  (alias runtest)
@@ -1559,7 +1559,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:list.ml}"))))
+     (run %{bin:ocamlformat} %{dep:list.ml}))))
 
 (rule
  (alias runtest)
@@ -1570,7 +1570,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:loc_stack.ml.opts} %{dep:loc_stack.ml}"))))
+     (run %{bin:ocamlformat} -n 3 %{dep:loc_stack.ml}))))
 
 (rule
  (alias runtest)
@@ -1581,7 +1581,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:locally_abtract_types.ml}"))))
+     (run %{bin:ocamlformat} %{dep:locally_abtract_types.ml}))))
 
 (rule
  (alias runtest)
@@ -1592,7 +1592,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:margin_80.ml.opts} %{dep:margin_80.ml}"))))
+     (run %{bin:ocamlformat} --margin=80 %{dep:margin_80.ml}))))
 
 (rule
  (alias runtest)
@@ -1603,7 +1603,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:match.ml}"))))
+     (run %{bin:ocamlformat} %{dep:match.ml}))))
 
 (rule
  (alias runtest)
@@ -1614,7 +1614,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:match2.ml.opts} %{dep:match2.ml}"))))
+     (run %{bin:ocamlformat} --leading-nested-match-parens %{dep:match2.ml}))))
 
 (rule
  (alias runtest)
@@ -1626,7 +1626,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:match_indent-never.ml.opts} %{dep:match_indent.ml}"))))
+     (run %{bin:ocamlformat} --match-indent=4 --match-indent-nested=never %{dep:match_indent.ml}))))
 
 (rule
  (alias runtest)
@@ -1637,7 +1637,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:match_indent.ml.opts} %{dep:match_indent.ml}"))))
+     (run %{bin:ocamlformat} --match-indent=4 --match-indent-nested=always %{dep:match_indent.ml}))))
 
 (rule
  (alias runtest)
@@ -1648,7 +1648,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:max_indent.ml.opts} %{dep:max_indent.ml}"))))
+     (run %{bin:ocamlformat} --max-indent=2 %{dep:max_indent.ml}))))
 
 (rule
  (alias runtest)
@@ -1659,7 +1659,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:module.ml}"))))
+     (run %{bin:ocamlformat} %{dep:module.ml}))))
 
 (rule
  (alias runtest)
@@ -1670,7 +1670,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:module_anonymous.ml}"))))
+     (run %{bin:ocamlformat} %{dep:module_anonymous.ml}))))
 
 (rule
  (alias runtest)
@@ -1682,7 +1682,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:module_attributes.ml}"))))
+     (run %{bin:ocamlformat} %{dep:module_attributes.ml}))))
 
 (rule
  (alias runtest)
@@ -1693,7 +1693,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:module_item_spacing-preserve.ml.opts} %{dep:module_item_spacing.ml}"))))
+     (run %{bin:ocamlformat} --max-iter=3 --module-item-spacing=preserve %{dep:module_item_spacing.ml}))))
 
 (rule
  (alias runtest)
@@ -1704,7 +1704,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:module_item_spacing-sparse.ml.opts} %{dep:module_item_spacing.ml}"))))
+     (run %{bin:ocamlformat} --max-iter=3 --module-item-spacing=sparse %{dep:module_item_spacing.ml}))))
 
 (rule
  (alias runtest)
@@ -1715,7 +1715,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:module_item_spacing.ml.opts} %{dep:module_item_spacing.ml}"))))
+     (run %{bin:ocamlformat} --max-iter=3 --module-item-spacing=compact %{dep:module_item_spacing.ml}))))
 
 (rule
  (alias runtest)
@@ -1726,7 +1726,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:module_item_spacing.mli.opts} %{dep:module_item_spacing.mli}"))))
+     (run %{bin:ocamlformat} --max-iter=3 %{dep:module_item_spacing.mli}))))
 
 (rule
  (alias runtest)
@@ -1738,7 +1738,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:module_type.ml}"))))
+     (run %{bin:ocamlformat} %{dep:module_type.ml}))))
 
 (rule
  (alias runtest)
@@ -1749,7 +1749,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:monadic_binding.ml}"))))
+     (run %{bin:ocamlformat} %{dep:monadic_binding.ml}))))
 
 (rule
  (alias runtest)
@@ -1761,7 +1761,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:multi_index_op.ml}"))))
+     (run %{bin:ocamlformat} %{dep:multi_index_op.ml}))))
 
 (rule
  (alias runtest)
@@ -1774,7 +1774,7 @@
  (action
    (with-outputs-to %{targets}
      (with-accepted-exit-codes 1
-       (run %{bin:ocamlformat} %{read-lines:need_format.ml.opts} %{dep:need_format.ml})))))
+       (run %{bin:ocamlformat} --max-iters=1 %{dep:need_format.ml})))))
 
 (rule
  (alias runtest)
@@ -1785,7 +1785,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:new.ml}"))))
+     (run %{bin:ocamlformat} %{dep:new.ml}))))
 
 (rule
  (alias runtest)
@@ -1796,7 +1796,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:object.ml}"))))
+     (run %{bin:ocamlformat} %{dep:object.ml}))))
 
 (rule
  (alias runtest)
@@ -1807,7 +1807,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:object_type.ml}"))))
+     (run %{bin:ocamlformat} %{dep:object_type.ml}))))
 
 (rule
  (alias runtest)
@@ -1818,7 +1818,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:ocp_indent_compat.ml}"))))
+     (run %{bin:ocamlformat} %{dep:ocp_indent_compat.ml}))))
 
 (rule
  (alias runtest)
@@ -1829,7 +1829,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:ocp_indent_options.ml.opts} %{dep:ocp_indent_options.ml}"))))
+     (run %{bin:ocamlformat} --ocp-indent-config %{dep:ocp_indent_options.ml}))))
 
 (rule
  (alias runtest)
@@ -1840,7 +1840,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:open-auto.ml.opts} %{dep:open.ml}"))))
+     (run %{bin:ocamlformat} --let-open=auto %{dep:open.ml}))))
 
 (rule
  (alias runtest)
@@ -1852,7 +1852,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:open-long.ml.opts} %{dep:open.ml}"))))
+     (run %{bin:ocamlformat} --let-open=long %{dep:open.ml}))))
 
 (rule
  (alias runtest)
@@ -1864,7 +1864,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:open-preserve.ml.opts} %{dep:open.ml}"))))
+     (run %{bin:ocamlformat} --let-open=preserve %{dep:open.ml}))))
 
 (rule
  (alias runtest)
@@ -1876,7 +1876,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:open-short.ml.opts} %{dep:open.ml}"))))
+     (run %{bin:ocamlformat} --let-open=short %{dep:open.ml}))))
 
 (rule
  (alias runtest)
@@ -1888,7 +1888,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:open.ml}"))))
+     (run %{bin:ocamlformat} %{dep:open.ml}))))
 
 (rule
  (alias runtest)
@@ -1900,7 +1900,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:open_types.ml}"))))
+     (run %{bin:ocamlformat} %{dep:open_types.ml}))))
 
 (rule
  (alias runtest)
@@ -1911,7 +1911,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:option.ml}"))))
+     (run %{bin:ocamlformat} %{dep:option.ml}))))
 
 (rule
  (alias runtest)
@@ -1922,7 +1922,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:parens_tuple_patterns.ml}"))))
+     (run %{bin:ocamlformat} %{dep:parens_tuple_patterns.ml}))))
 
 (rule
  (alias runtest)
@@ -1933,7 +1933,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:precedence.ml}"))))
+     (run %{bin:ocamlformat} %{dep:precedence.ml}))))
 
 (rule
  (alias runtest)
@@ -1944,7 +1944,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:prefix_infix.ml}"))))
+     (run %{bin:ocamlformat} %{dep:prefix_infix.ml}))))
 
 (rule
  (alias runtest)
@@ -1955,7 +1955,7 @@
  (deps .ocamlformat dir1/dir2/.ocamlformat dir1/dir2/print_config.ml)
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:print_config.ml.opts} %{dep:print_config.ml}"))))
+     (run %{bin:ocamlformat} dir1/dir2/print_config.ml --print-config --let-open=short --config=max-iters=2 %{dep:print_config.ml}))))
 
 (rule
  (alias runtest)
@@ -1966,7 +1966,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:profiles.ml.opts} %{dep:profiles.ml}"))))
+     (run %{bin:ocamlformat} --config=margin=20 --profile=janestreet --module-item-spacing=sparse %{dep:profiles.ml}))))
 
 (rule
  (alias runtest)
@@ -1977,7 +1977,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:profiles2.ml.opts} %{dep:profiles2.ml}"))))
+     (run %{bin:ocamlformat} --profile=janestreet %{dep:profiles2.ml}))))
 
 (rule
  (alias runtest)
@@ -1988,7 +1988,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:protected_object_types.ml}"))))
+     (run %{bin:ocamlformat} %{dep:protected_object_types.ml}))))
 
 (rule
  (alias runtest)
@@ -1999,7 +1999,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:recmod.mli}"))))
+     (run %{bin:ocamlformat} %{dep:recmod.mli}))))
 
 (rule
  (alias runtest)
@@ -2010,7 +2010,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:record-loose.ml.opts} %{dep:record.ml}"))))
+     (run %{bin:ocamlformat} --field-space=loose %{dep:record.ml}))))
 
 (rule
  (alias runtest)
@@ -2021,7 +2021,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:record-tight_decl.ml.opts} %{dep:record.ml}"))))
+     (run %{bin:ocamlformat} --field-space=tight-decl %{dep:record.ml}))))
 
 (rule
  (alias runtest)
@@ -2032,7 +2032,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:record.ml.opts} %{dep:record.ml}"))))
+     (run %{bin:ocamlformat} --field-space=tight %{dep:record.ml}))))
 
 (rule
  (alias runtest)
@@ -2043,7 +2043,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:record_punning.ml}"))))
+     (run %{bin:ocamlformat} %{dep:record_punning.ml}))))
 
 (rule
  (alias runtest)
@@ -2054,7 +2054,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:reformat_string.ml.opts} %{dep:reformat_string.ml}"))))
+     (run %{bin:ocamlformat} --max-iter=2 %{dep:reformat_string.ml}))))
 
 (rule
  (alias runtest)
@@ -2065,7 +2065,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:refs.ml}"))))
+     (run %{bin:ocamlformat} %{dep:refs.ml}))))
 
 (rule
  (alias runtest)
@@ -2076,7 +2076,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:remove_extra_parens.ml}"))))
+     (run %{bin:ocamlformat} %{dep:remove_extra_parens.ml}))))
 
 (rule
  (alias runtest)
@@ -2087,7 +2087,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:revapply_ext.ml}"))))
+     (run %{bin:ocamlformat} %{dep:revapply_ext.ml}))))
 
 (rule
  (alias runtest)
@@ -2098,7 +2098,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:send.ml}"))))
+     (run %{bin:ocamlformat} %{dep:send.ml}))))
 
 (rule
  (alias runtest)
@@ -2109,7 +2109,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:sequence-preserve.ml.opts} %{dep:sequence.ml}"))))
+     (run %{bin:ocamlformat} --sequence-blank-line=preserve-one --max-iter=3 %{dep:sequence.ml}))))
 
 (rule
  (alias runtest)
@@ -2121,7 +2121,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:sequence.ml.opts} %{dep:sequence.ml}"))))
+     (run %{bin:ocamlformat} --sequence-blank-line=compact --max-iter=3 %{dep:sequence.ml}))))
 
 (rule
  (alias runtest)
@@ -2133,7 +2133,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:shebang.ml}"))))
+     (run %{bin:ocamlformat} %{dep:shebang.ml}))))
 
 (rule
  (alias runtest)
@@ -2144,7 +2144,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:shortcut_ext_attr.ml}"))))
+     (run %{bin:ocamlformat} %{dep:shortcut_ext_attr.ml}))))
 
 (rule
  (alias runtest)
@@ -2155,7 +2155,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:skip.ml}"))))
+     (run %{bin:ocamlformat} %{dep:skip.ml}))))
 
 (rule
  (alias runtest)
@@ -2166,7 +2166,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:source.ml.opts} %{dep:source.ml}"))))
+     (run %{bin:ocamlformat} --max-iters=3 %{dep:source.ml}))))
 
 (rule
  (alias runtest)
@@ -2178,7 +2178,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:str_value.ml}"))))
+     (run %{bin:ocamlformat} %{dep:str_value.ml}))))
 
 (rule
  (alias runtest)
@@ -2189,7 +2189,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:string.ml}"))))
+     (run %{bin:ocamlformat} %{dep:string.ml}))))
 
 (rule
  (alias runtest)
@@ -2200,7 +2200,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:string_array.ml}"))))
+     (run %{bin:ocamlformat} %{dep:string_array.ml}))))
 
 (rule
  (alias runtest)
@@ -2211,7 +2211,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:string_wrapping.ml}"))))
+     (run %{bin:ocamlformat} %{dep:string_wrapping.ml}))))
 
 (rule
  (alias runtest)
@@ -2222,7 +2222,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:symbol.ml}"))))
+     (run %{bin:ocamlformat} %{dep:symbol.ml}))))
 
 (rule
  (alias runtest)
@@ -2233,7 +2233,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:tag_only.ml}"))))
+     (run %{bin:ocamlformat} %{dep:tag_only.ml}))))
 
 (rule
  (alias runtest)
@@ -2244,7 +2244,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:tag_only.mli}"))))
+     (run %{bin:ocamlformat} %{dep:tag_only.mli}))))
 
 (rule
  (alias runtest)
@@ -2255,7 +2255,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:try_with_or_pattern.ml}"))))
+     (run %{bin:ocamlformat} %{dep:try_with_or_pattern.ml}))))
 
 (rule
  (alias runtest)
@@ -2266,7 +2266,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:tuple.ml.opts} %{dep:tuple.ml}"))))
+     (run %{bin:ocamlformat} --parens-tuple=always %{dep:tuple.ml}))))
 
 (rule
  (alias runtest)
@@ -2277,7 +2277,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:tuple_less_parens.ml.opts} %{dep:tuple_less_parens.ml}"))))
+     (run %{bin:ocamlformat} --parens-tuple=multi-line-only %{dep:tuple_less_parens.ml}))))
 
 (rule
  (alias runtest)
@@ -2288,7 +2288,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:tuple_type_parens.ml}"))))
+     (run %{bin:ocamlformat} %{dep:tuple_type_parens.ml}))))
 
 (rule
  (alias runtest)
@@ -2299,7 +2299,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:type_and_constraint.ml}"))))
+     (run %{bin:ocamlformat} %{dep:type_and_constraint.ml}))))
 
 (rule
  (alias runtest)
@@ -2310,7 +2310,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:type_annotations.ml}"))))
+     (run %{bin:ocamlformat} %{dep:type_annotations.ml}))))
 
 (rule
  (alias runtest)
@@ -2321,7 +2321,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:types-compact-space_around-docked.ml.opts} %{dep:types.ml}"))))
+     (run %{bin:ocamlformat} --type-decl=compact --space-around-arrays --space-around-lists --space-around-records --space-around-variants --break-separators=after --dock-collection-brackets %{dep:types.ml}))))
 
 (rule
  (alias runtest)
@@ -2333,7 +2333,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:types-compact-space_around.ml.opts} %{dep:types.ml}"))))
+     (run %{bin:ocamlformat} --type-decl=compact --space-around-arrays --space-around-lists --space-around-records --space-around-variants %{dep:types.ml}))))
 
 (rule
  (alias runtest)
@@ -2345,7 +2345,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:types-compact.ml.opts} %{dep:types.ml}"))))
+     (run %{bin:ocamlformat} --type-decl=compact %{dep:types.ml}))))
 
 (rule
  (alias runtest)
@@ -2357,7 +2357,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:types-indent.ml.opts} %{dep:types.ml}"))))
+     (run %{bin:ocamlformat} --type-decl-indent=6 %{dep:types.ml}))))
 
 (rule
  (alias runtest)
@@ -2369,7 +2369,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:types-sparse-space_around.ml.opts} %{dep:types.ml}"))))
+     (run %{bin:ocamlformat} --type-decl=sparse --space-around-arrays --space-around-lists --space-around-records --space-around-variants %{dep:types.ml}))))
 
 (rule
  (alias runtest)
@@ -2381,7 +2381,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:types-sparse.ml.opts} %{dep:types.ml}"))))
+     (run %{bin:ocamlformat} --type-decl=sparse %{dep:types.ml}))))
 
 (rule
  (alias runtest)
@@ -2393,7 +2393,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:types.ml}"))))
+     (run %{bin:ocamlformat} %{dep:types.ml}))))
 
 (rule
  (alias runtest)
@@ -2405,7 +2405,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:unary.ml}"))))
+     (run %{bin:ocamlformat} %{dep:unary.ml}))))
 
 (rule
  (alias runtest)
@@ -2416,7 +2416,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:unicode.ml.opts} %{dep:unicode.ml}"))))
+     (run %{bin:ocamlformat} --margin=80 --wrap-comments %{dep:unicode.ml}))))
 
 (rule
  (alias runtest)
@@ -2427,7 +2427,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:use_file.mlt}"))))
+     (run %{bin:ocamlformat} %{dep:use_file.mlt}))))
 
 (rule
  (alias runtest)
@@ -2438,7 +2438,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:verbose1.ml.opts} %{dep:verbose1.ml}"))))
+     (run %{bin:ocamlformat} --print-config --doc-comments=before --config=doc-comments=before %{dep:verbose1.ml}))))
 
 (rule
  (alias runtest)
@@ -2449,7 +2449,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:verbose2.ml.opts} %{dep:verbose2.ml}"))))
+     (run %{bin:ocamlformat} --print-config --doc-comments=before --config=doc-comments=before %{dep:verbose2.ml}))))
 
 (rule
  (alias runtest)
@@ -2460,7 +2460,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:wrap_comments.ml.opts} %{dep:wrap_comments.ml}"))))
+     (run %{bin:ocamlformat} --profile=ocamlformat %{dep:wrap_comments.ml}))))
 
 (rule
  (alias runtest)
@@ -2471,7 +2471,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{read-lines:wrap_comments_break.ml.opts} %{dep:wrap_comments_break.ml}"))))
+     (run %{bin:ocamlformat} --no-wrap-fun-args --margin=67 %{dep:wrap_comments_break.ml}))))
 
 (rule
  (alias runtest)
@@ -2482,7 +2482,7 @@
  (deps .ocamlformat )
  (action
    (with-outputs-to %{targets}
-     (system "%{bin:ocamlformat} %{dep:wrapping_functor_args.ml}"))))
+     (run %{bin:ocamlformat} %{dep:wrapping_functor_args.ml}))))
 
 (rule
  (alias runtest)

--- a/test/passing/gen/gen.ml
+++ b/test/passing/gen/gen.ml
@@ -83,17 +83,16 @@ let emit_test test_name setup =
   Printf.printf
     {|
 (rule
- (targets %s.output)
  (deps .ocamlformat %s)
  (action
-   (with-outputs-to %%{targets}
+   (with-outputs-to %s.output
      %s)))
 
 (rule
  (alias runtest)%s
  (action (diff %s %s.output)))
 |}
-    test_name extra_deps
+    extra_deps test_name
     (cmd setup.should_fail
        ( ["%{bin:ocamlformat}"] @ opts
        @ [Printf.sprintf "%%{dep:%s}" base_test_name] ))
@@ -102,17 +101,16 @@ let emit_test test_name setup =
     Printf.printf
       {|
 (rule
- (targets %s.ocp.output)
  (deps .ocp-indent %s)
  (action
-   (with-outputs-to %%{targets}
+   (with-outputs-to %s.ocp.output
      %s)))
 
 (rule
  (alias runtest)
  (action (diff %s.ocp %s.ocp.output)))
 |}
-      test_name extra_deps
+      extra_deps test_name
       (cmd setup.should_fail
          ["%{bin:ocp-indent}"; Printf.sprintf "%%{dep:%s}" ref_name])
       test_name test_name

--- a/test/passing/gen/gen.ml
+++ b/test/passing/gen/gen.ml
@@ -62,12 +62,12 @@ let cmd should_fail args =
     Printf.sprintf {|(with-accepted-exit-codes 1
        (run %s))|}
       cmd_string
-  else Printf.sprintf {|(system "%s")|} cmd_string
+  else Printf.sprintf {|(run %s)|} cmd_string
 
 let emit_test test_name setup =
-  let open Printf in
   let opts =
-    if setup.has_opts then [sprintf "%%{read-lines:%s.opts}" test_name]
+    if setup.has_opts then
+      Stdio.In_channel.read_lines (Printf.sprintf "%s.opts" test_name)
     else []
   in
   let ref_name = if setup.has_ref then test_name ^ ".ref" else test_name in

--- a/test/passing/gen/gen.ml
+++ b/test/passing/gen/gen.ml
@@ -82,8 +82,8 @@ let emit_test test_name setup =
    (with-outputs-to %%{targets}
      (system "%s%%{bin:ocamlformat}%s %%{dep:%s}"))))
 
-(alias
- (name runtest)%s
+(rule
+ (alias runtest)%s
  (action (diff %s %s.output)))
 |}
     test_name extra_deps cmd_prefix opts base_test_name enabled_if_line
@@ -98,8 +98,8 @@ let emit_test test_name setup =
    (with-outputs-to %%{targets}
      (system "%s%%{bin:ocp-indent} %%{dep:%s}"))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff %s.ocp %s.ocp.output)))
 |}
       test_name extra_deps cmd_prefix ref_name test_name test_name

--- a/test/passing/gen/gen.ml
+++ b/test/passing/gen/gen.ml
@@ -56,18 +56,25 @@ let register_file tests fname =
 
 (* ignore dune file, .foo.whatever.swp, etc *)
 
+let cmd should_fail args =
+  let cmd_string = String.concat " " args in
+  if should_fail then
+    Printf.sprintf {|(with-accepted-exit-codes 1
+       (run %s))|}
+      cmd_string
+  else Printf.sprintf {|(system "%s")|} cmd_string
+
 let emit_test test_name setup =
   let open Printf in
   let opts =
-    if setup.has_opts then sprintf " %%{read-lines:%s.opts}" test_name
-    else ""
+    if setup.has_opts then [sprintf "%%{read-lines:%s.opts}" test_name]
+    else []
   in
   let ref_name = if setup.has_ref then test_name ^ ".ref" else test_name in
   let base_test_name =
     match setup.base_file with Some n -> n | None -> test_name
   in
   let extra_deps = String.concat " " setup.extra_deps in
-  let cmd_prefix = if setup.should_fail then "! " else "" in
   let enabled_if_line =
     match setup.minimum_ocaml_version with
     | None -> ""
@@ -80,14 +87,17 @@ let emit_test test_name setup =
  (deps .ocamlformat %s)
  (action
    (with-outputs-to %%{targets}
-     (system "%s%%{bin:ocamlformat}%s %%{dep:%s}"))))
+     %s)))
 
 (rule
  (alias runtest)%s
  (action (diff %s %s.output)))
 |}
-    test_name extra_deps cmd_prefix opts base_test_name enabled_if_line
-    ref_name test_name ;
+    test_name extra_deps
+    (cmd setup.should_fail
+       ( ["%{bin:ocamlformat}"] @ opts
+       @ [Printf.sprintf "%%{dep:%s}" base_test_name] ))
+    enabled_if_line ref_name test_name ;
   if setup.has_ocp then
     Printf.printf
       {|
@@ -96,13 +106,16 @@ let emit_test test_name setup =
  (deps .ocp-indent %s)
  (action
    (with-outputs-to %%{targets}
-     (system "%s%%{bin:ocp-indent} %%{dep:%s}"))))
+     %s)))
 
 (rule
  (alias runtest)
  (action (diff %s.ocp %s.ocp.output)))
 |}
-      test_name extra_deps cmd_prefix ref_name test_name test_name
+      test_name extra_deps
+      (cmd setup.should_fail
+         ["%{bin:ocp-indent}"; Printf.sprintf "%%{dep:%s}" ref_name])
+      test_name test_name
 
 let () =
   let map = ref StringMap.empty in

--- a/test/projects/dune
+++ b/test/projects/dune
@@ -9,15 +9,16 @@
     enable_outside_detected_project
     (run ocamlformat --enable-outside-detected-project main.ml)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff enable_outside_detected_project.expected
     enable_outside_detected_project.output)))
 
 (rule
  (targets outside_detected_project.output)
- (deps outside_detected_project/dune-project outside_detected_project/main.ml .ocamlformat)
+ (deps outside_detected_project/dune-project outside_detected_project/main.ml
+   .ocamlformat)
  (action
   (with-outputs-to
    %{targets}
@@ -25,8 +26,8 @@
     outside_detected_project
     (run ocamlformat main.ml)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff outside_detected_project.expected outside_detected_project.output)))
 
@@ -41,8 +42,8 @@
     outside_detected_project_with_name/project_root
     (run ocamlformat --name a.ml ../outside_root/a.ml)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff outside_detected_project_with_name.expected
     outside_detected_project_with_name.output)))

--- a/test/projects/dune
+++ b/test/projects/dune
@@ -1,10 +1,9 @@
 (rule
- (targets enable_outside_detected_project.output)
  (deps enable_outside_detected_project/dune-project
    enable_outside_detected_project/main.ml .ocamlformat)
  (action
   (with-stdout-to
-   %{targets}
+   enable_outside_detected_project.output
    (chdir
     enable_outside_detected_project
     (run ocamlformat --enable-outside-detected-project main.ml)))))
@@ -16,12 +15,10 @@
     enable_outside_detected_project.output)))
 
 (rule
- (targets outside_detected_project.output)
- (deps outside_detected_project/dune-project outside_detected_project/main.ml
-   .ocamlformat)
+ (deps outside_detected_project/dune-project outside_detected_project/main.ml)
  (action
   (with-outputs-to
-   %{targets}
+   outside_detected_project.output
    (chdir
     outside_detected_project
     (run ocamlformat main.ml)))))
@@ -32,12 +29,11 @@
   (diff outside_detected_project.expected outside_detected_project.output)))
 
 (rule
- (targets outside_detected_project_with_name.output)
  (deps
   (source_tree outside_detected_project_with_name))
  (action
   (with-outputs-to
-   %{targets}
+   outside_detected_project_with_name.output
    (chdir
     outside_detected_project_with_name/project_root
     (run ocamlformat --name a.ml ../outside_root/a.ml)))))

--- a/test/projects/dune-project
+++ b/test/projects/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.11)
+(lang dune 2.2)


### PR DESCRIPTION
This ports to `(lang dune 2.0)` and uses all niceties from the new dune lang.

- `(with-accepted-exit-codes)` & `(with-stdin-from)` (these replace all our uses of `(system)`)
- long-form target inference thanks to @NathanReb (this means that we can use file names directly without having to declare `(targets)` and refer to them as `%{targets}`

Note that this bumps the minimum dune version to 2.0.0. This shouldn't be too much of a problem since very few packages have a `< 2.0.0` constraint on opam-repository (and almost all of them have a fixed version - the compatibility is pretty good).

Let me know what you think.