### PR TITLE
Fix opam files for running the tests in CI

### DIFF
--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -20,6 +20,7 @@ license: "MIT"
 build: [
   ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.06"}

--- a/ocamlformat_diff.opam
+++ b/ocamlformat_diff.opam
@@ -18,7 +18,7 @@ dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 url { archive: "https://github.com/ocaml-ppx/ocamlformat/archive/%%VERSION%%.tar.gz" }
 license: "MIT"
 build: [
-  ["dune" "build" "-p" "tools/ocamlformat-diff/ocamlformat_diff.exe" "-j" jobs]
+  ["dune" "build" "-p" "ocamlformat_diff" "-j" jobs]
 ]
 depends: [
   "bos"


### PR DESCRIPTION
- Fix dune invocation in `ocamlformat_diff.opam`
- Run the tests in `ocamlformat.opam`

This is enough to have ocaml-ci build the project and run the tests.