### PR TITLE
gen_version: work when building without a git root

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 
 #### Bug fixes
 
+  + Fix build version detection when building in the absence of a git root (#1198) (Anil Madhavapeddy)
   + Fix wrapping of or-patterns in presence of comments with `break-cases=fit` (#1167) (Jules Aguillon)
     This also fixes an unstable comment bug in or-patterns
   + Fix an unstable comment bug in variant declarations (#1108) (Jules Aguillon)

--- a/tools/gen_version.mlt
+++ b/tools/gen_version.mlt
@@ -28,12 +28,14 @@ let file, version =
           (* file has been watermarked when building distrib archive *)
           real_watermark
         else
-          (* file has not been watermarked when building in dev git tree *)
-          let ic =
-            Unix.open_process_in "git describe --tags --dirty --always"
-          in
-          let version = input_line ic in
-          close_in ic ; version
+          try
+            (* file has not been watermarked when building in dev git tree *)
+            let ic =
+              Unix.open_process_in "git describe --tags --dirty --always 2>/dev/null"
+            in
+            let version = input_line ic in
+            close_in ic ; version
+          with End_of_file -> "unknown"
       in
       (file, version)
   | _ ->


### PR DESCRIPTION
In some cases, a development tree doesn't have a .git root
(for example, when a source monorepo is assembled using the
duniverse vendoring tool).  In this situation, instead of
leaking an exception, the gen_version tool with just stamp
the "unknown" version and let the build continue.

Signed-off-by: Anil Madhavapeddy <anil@recoil.org>