### PR TITLE
Constraint ocaml to 4.08 in opam file when tests are enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 env:
   - CI_KIND=changes
   - CI_KIND=build OCAML_VERSION=4.07.1
-  - CI_KIND=build OCAML_VERSION=4.08.1
+  - CI_KIND=build-and-tests OCAML_VERSION=4.08.1
   - CI_KIND=build-and-tests OCAML_VERSION=4.09.0
 cache:
   directories:

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -20,7 +20,7 @@ license: "MIT"
 build: [
   ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name] {with-test & ocaml:version >= "4.08"}
 ]
 depends: [
   "ocaml" {>= "4.06"}

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -24,6 +24,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06"}
+  "ocaml" {with-test & >= "4.08"}
   "alcotest" {with-test}
   "base" {>= "v0.11.0"}
   "base-unix"

--- a/tools/travis-ci.sh
+++ b/tools/travis-ci.sh
@@ -29,12 +29,14 @@ CheckBuild () {
     opam pin remove --no-action ocamlformat || true # Otherwise opam will ignored new deps
     opam update --upgrade
     opam pin add --no-action ocamlformat .
-    opam install --deps-only --with-test ocamlformat
+    opam install --deps-only ocamlformat
     # script
     opam exec -- make
 }
 
 CheckTests () {
+    # install
+    opam install --deps-only --with-test ocamlformat
     # script
     opam exec -- make test
 }


### PR DESCRIPTION
OCamlformat builds for OCaml 4.06 to 4.09 but its tests are only passing between 4.08 and 4.09.

This PR constraints OCaml to `>= 4.08` in Opam when tests are enabled.
This will improve the output of ocaml-ci as tests for these version will not be run, so they don't fail and don't consume power and are instead interpreted as a problem with the dependencies and reported differently.

Currently, that simply disable CI builds of 4.06 to 4.08. In the future, ocaml-ci may split build and test jobs and allow to test builds for these versions.

It seems that this does not prevent from installing OCamlformat on 4.06 and 4.07 but correctly prevent installation with tests (`opam install -t`).
