### PR TITLE
Fix align-cases for long patterns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@
 
   + Fix formatting of empty signature payload `[%a:]` (#1236) (Etienne Millon)
 
+  + Fix align-cases for long patterns (#1204) (Guillaume Petiot)
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2813,32 +2813,18 @@ and fmt_class_type_field c ctx (cf : class_type_field) =
     $ fmt_atrs $ doc_after )
 
 and fmt_cases c ctx cs =
-  let case_breaks case ~padding_len =
-    let fmted_case =
-      let first = false and last = false in
-      let fmt cmts = fmt_case {c with cmts} ctx ~first ~last case in
-      Cmts.preserve fmt c.cmts
-    in
-    let indent =
-      Source.indentation c.source case.pc_rhs.pexp_loc.loc_start
-    in
-    (* The first character is ignored when looking for a linebreak, as it
-       could be a forcedline break in some configuration. *)
-    String.contains fmted_case ~pos:1 '\n'
-    || String.length fmted_case + indent + padding_len >= c.conf.margin
-  in
   let pattern_len {pc_lhs; pc_guard; _} =
     if Option.is_some pc_guard then None
     else
       let xpat = sub_pat ~ctx pc_lhs in
-      let fmted_pat =
+      let fmted =
         Cmts.preserve (fun cmts -> fmt_pattern {c with cmts} xpat) c.cmts
       in
-      let len = String.length fmted_pat in
+      let len = String.length fmted in
       let indent = Source.indentation c.source pc_lhs.ppat_loc.loc_start in
       (* we add the lenght of the 5 following characters '| ' ' ->' *)
-      if len + indent + 5 >= c.conf.margin || String.contains fmted_pat '\n'
-      then None
+      if len + indent + 5 >= c.conf.margin || String.contains fmted '\n' then
+        None
       else Some len
   in
   let fold_pattern_len ~f cs =
@@ -2861,15 +2847,12 @@ and fmt_cases c ctx cs =
         | Some max_len when add_padding -> (
           match pattern_len case with
           | Some pattern_len ->
-              let padding_len = max_len - pattern_len in
-              if case_breaks case ~padding_len then None
-              else
-                let pad = String.make padding_len ' ' in
-                Some
-                  (fmt_or_k
-                     Poly.(c.conf.break_cases = `All)
-                     (str pad)
-                     (fits_breaks ~level "" pad))
+              let pad = String.make (max_len - pattern_len) ' ' in
+              Some
+                (fmt_or_k
+                   Poly.(c.conf.break_cases = `All)
+                   (str pad)
+                   (fits_breaks ~level "" pad))
           | _ -> None )
         | _ -> None
       in

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2906,7 +2906,7 @@ and fmt_case c ctx ~first ~last ?padding case =
           $ p.break_before_arrow $ str "->" $ p.break_after_arrow
           $ fmt_if parens_here " (" )
       $ p.break_after_opening_paren
-      $ hovbox 0
+      $ hovbox_if parens_here 0
           ( fmt_expression ?eol c ?parens:parens_for_exp xrhs
           $ fmt_if parens_here
               ( match c.conf.indicate_multiline_delimiters with

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2821,7 +2821,10 @@ and fmt_cases c ctx cs =
         Cmts.preserve (fun cmts -> fmt_pattern {c with cmts} xpat) c.cmts
       in
       let len = String.length fmted_pat in
-      if String.contains fmted_pat '\n' then None
+      let indent = Source.indentation c.source pc_lhs.ppat_loc.loc_start in
+      (* we add the lenght of the 5 following characters '| ' ' ->' *)
+      if len + indent + 5 >= c.conf.margin || String.contains fmted_pat '\n'
+      then None
       else
         let fmted_case =
           let first = false and last = false in

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -15,6 +15,14 @@ type t = string
 
 let create s = s
 
+let indentation t (pos : Lexing.position) =
+  let f _ c = Char.equal c '\n' in
+  let pos_linebreak = String.rfindi t ~pos:pos.pos_cnum ~f in
+  let begin_pos = Option.value_map pos_linebreak ~f:(( + ) 1) ~default:0 in
+  let substring = Caml.String.sub t begin_pos (pos.pos_cnum - begin_pos) in
+  let stripped = String.lstrip substring in
+  String.(length substring - length stripped)
+
 let position_before t (pos : Lexing.position) =
   let is_closing c =
     Char.equal c ')' || Char.equal c ']' || Char.equal c '}'

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -16,12 +16,11 @@ type t = string
 let create s = s
 
 let indentation t (pos : Lexing.position) =
-  let f _ c = Char.equal c '\n' in
-  let pos_linebreak = String.rfindi t ~pos:pos.pos_cnum ~f in
+  let is_linebreak _ c = Char.equal c '\n' in
+  let pos_linebreak = String.rfindi t ~pos:pos.pos_cnum ~f:is_linebreak in
   let begin_pos = Option.value_map pos_linebreak ~f:(( + ) 1) ~default:0 in
   let substring = Caml.String.sub t begin_pos (pos.pos_cnum - begin_pos) in
-  let stripped = String.lstrip substring in
-  String.(length substring - length stripped)
+  String.length substring - String.(length (lstrip substring))
 
 let position_before t (pos : Lexing.position) =
   let is_closing c =

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -15,6 +15,10 @@ type t
 
 val create : string -> t
 
+val indentation : t -> Lexing.position -> int
+(** [indentation t pos] returns the number of space characters at the start
+    of the line containing the position [pos]. *)
+
 val empty_line_between : t -> Lexing.position -> Lexing.position -> bool
 (** [empty_line_between t p1 p2] is [true] if there is an empty line between
     [p1] and [p2]. The lines containing [p1] and [p2] are not considered

--- a/test/passing/align_cases-break_all.ml.ref
+++ b/test/passing/align_cases-break_all.ml.ref
@@ -102,9 +102,11 @@ let _ =
 
 let _ =
   match (foooooooooooooo, foooooooooooooo) with
-  | Some a, Some b -> a + b
-  | None, _        -> 1
-  | Some _, None   -> 2
+  | Some a, Some b                     -> a + b
+  | None, _                            -> 1
+  | Some _, None                       -> 2
+  | Foo_types.Foo_fooo_foooo_fooo_fooo -> Foo.BarFoo.int_as_foo 5 bar
+  | Foo_types.Foo_foooooo              -> Fooo_bar.int_as_bar 6 foooo
 
 let _ =
   match (foooooooooooooo, foooooooooooooo) with

--- a/test/passing/align_cases.ml
+++ b/test/passing/align_cases.ml
@@ -72,16 +72,33 @@ type t =
   | ( :: ) of a * b
   | []     of looooooooooooooooooooooooooooooooooooooong_break
 
-let _ = match (a, b) with A, B -> a | AA, BB -> b | p -> c
-
-let _ = match (a, b) with A, B -> a | AA, BB -> b | longer_pattern -> c
+let _ =
+  match (a, b) with
+  | A, B   -> a
+  | AA, BB -> b
+  | p      -> c
 
 let _ =
-  match (a, b) with (A, B), B -> a | pat, BB -> b | longer_pattern -> c
+  match (a, b) with
+  | A, B           -> a
+  | AA, BB         -> b
+  | longer_pattern -> c
 
-let _ = match f with Foo -> toto | Bar ijx -> bar ijx
+let _ =
+  match (a, b) with
+  | (A, B), B      -> a
+  | pat, BB        -> b
+  | longer_pattern -> c
 
-let _ = match f with `Foo -> toto | `Bar ijx -> bar ijx
+let _ =
+  match f with
+  | Foo     -> toto
+  | Bar ijx -> bar ijx
+
+let _ =
+  match f with
+  | `Foo     -> toto
+  | `Bar ijx -> bar ijx
 
 let _ =
   match (foooooooooooooo, foooooooooooooo) with

--- a/test/passing/align_cases.ml
+++ b/test/passing/align_cases.ml
@@ -85,9 +85,11 @@ let _ = match f with `Foo -> toto | `Bar ijx -> bar ijx
 
 let _ =
   match (foooooooooooooo, foooooooooooooo) with
-  | Some a, Some b -> a + b
-  | None, _        -> 1
-  | Some _, None   -> 2
+  | Some a, Some b                     -> a + b
+  | None, _                            -> 1
+  | Some _, None                       -> 2
+  | Foo_types.Foo_fooo_foooo_fooo_fooo -> Foo.BarFoo.int_as_foo 5 bar
+  | Foo_types.Foo_foooooo              -> Fooo_bar.int_as_bar 6 foooo
 
 let _ =
   match (foooooooooooooo, foooooooooooooo) with


### PR DESCRIPTION
Fix #1202
I removed the check on the size of the formatted result not precise since we obviously don't take the final indentation into account, and overly cautious and prevented to align when it would fit on the same line.
No regression with running test_branch on the preset profiles, but there is a big diff with only `align-cases=true` (most of them are improvements, some cases can be debatable, but since it's still an heuristic it's difficult to balance).