### PR TITLE
Use `bos` instead of `stdio` for file operations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 #### Packaging
 
   + Work with base v0.13.0 (#1163) (Jules Aguillon)
+  + Remove dependency to the stdio package (#1206) (Guillaume Petiot)
 
 #### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,8 @@
 #### Packaging
 
   + Work with base v0.13.0 (#1163) (Jules Aguillon)
-  + Remove dependency to the stdio package (#1206) (Guillaume Petiot)
+  + Add dependency to the `bos` package
+    Remove dependency to the `stdio` package (#1206) (Guillaume Petiot)
 
 #### Bug fixes
 

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -61,7 +61,10 @@ let format ?output_file ~kind ~input_name ~source conf opts =
 let to_output_file output_file data =
   match output_file with
   | None -> Caml.output_string Caml.stdout data
-  | Some output_file -> Out_channel.write_all output_file ~data
+  | Some output_file ->
+      Rresult.R.ignore_error
+        (Bos.OS.File.write (Fpath.v output_file) data)
+        ~use:(fun _ -> ())
 
 let source_from_file = function
   | Conf.Stdin -> In_channel.input_all Caml.stdin
@@ -87,7 +90,7 @@ let run_action action opts =
         match result with
         | Ok formatted ->
             if not (String.equal formatted source) then
-              Out_channel.write_all input_file ~data:formatted ;
+              to_output_file (Some input_file) formatted ;
             Ok ()
         | Error e -> Error (fun () -> print_error conf opts ~input_name e)
       in

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -60,11 +60,11 @@ let format ?output_file ~kind ~input_name ~source conf opts =
 
 let to_output_file output_file data =
   match output_file with
-  | None -> Out_channel.output_string Out_channel.stdout data
+  | None -> Caml.output_string Caml.stdout data
   | Some output_file -> Out_channel.write_all output_file ~data
 
 let source_from_file = function
-  | Conf.Stdin -> In_channel.input_all In_channel.stdin
+  | Conf.Stdin -> In_channel.input_all Caml.stdin
   | File f -> In_channel.with_file f ~f:In_channel.input_all
 
 let print_error conf opts ~input_name e =

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -66,9 +66,9 @@ let to_output_file output_file data =
         (Bos.OS.File.write (Fpath.v output_file) data)
         ~use:(fun _ -> ())
 
-let source_from_file = function
-  | Conf.Stdin -> Bos.OS.File.read Bos.OS.File.dash
-  | File f -> Bos.OS.File.read (Fpath.v f)
+let fpath_from_file = function
+  | Conf.Stdin -> Bos.OS.File.dash
+  | File f -> Fpath.v f
 
 let print_error conf opts ~input_name e =
   Translation_unit.print_error ~debug:opts.Conf.debug ~quiet:conf.Conf.quiet
@@ -95,7 +95,7 @@ let run_action action opts =
       in
       Result.combine_errors_unit (List.map inputs ~f)
   | In_out ({kind; file; name= input_name; conf}, output_file) -> (
-    match source_from_file file with
+    match Bos.OS.File.read (fpath_from_file file) with
     | Ok source -> (
       match format ?output_file ~kind ~input_name ~source conf opts with
       | Ok s ->
@@ -106,7 +106,7 @@ let run_action action opts =
     )
   | Check inputs ->
       let f {Conf.kind; name= input_name; file; conf} =
-        match source_from_file file with
+        match Bos.OS.File.read (fpath_from_file file) with
         | Ok source -> (
           match format ~kind ~input_name ~source conf opts with
           | Ok res when String.equal res source -> Ok ()

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -122,11 +122,15 @@ let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~input_name error
         let p =
           Filename.temp_file input_name (Printf.sprintf ".prev%s" ext)
         in
-        Out_channel.write_all p ~data:prev ;
+        Rresult.R.ignore_error
+          (Bos.OS.File.write (Fpath.v p) prev)
+          ~use:(fun _ -> ()) ;
         let n =
           Filename.temp_file input_name (Printf.sprintf ".next%s" ext)
         in
-        Out_channel.write_all n ~data:next ;
+        Rresult.R.ignore_error
+          (Bos.OS.File.write (Fpath.v n) next)
+          ~use:(fun _ -> ()) ;
         ignore (Unix.system (Printf.sprintf "diff %S %S 1>&2" p n)) ;
         Unix.unlink p ;
         Unix.unlink n ) ;

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -68,7 +68,7 @@ let with_file input_name output_file suf ext f x =
   let base = Filename.remove_extension (Filename.basename input_name) in
   let tmp = Filename.concat dir (base ^ suf ^ ext) in
   let res = Bos.OS.File.with_oc (Fpath.v tmp) f x in
-  ignore (Rresult.R.ignore_error res ~use:(fun _ -> Caml.Result.ok ())) ;
+  ignore (Rresult.R.ignore_error res ~use:(fun _ -> Rresult.R.ok ())) ;
   tmp
 
 let dump_ast ~input_name ?output_file ~suffix fmt =

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -78,7 +78,7 @@ let dump_ast ~input_name ?output_file ~suffix fmt =
 let dump_formatted ~input_name ?output_file ~suffix fmted =
   let ext = Filename.extension input_name in
   with_file input_name output_file suffix ext (fun oc ->
-      Out_channel.output_string oc fmted)
+      Caml.output_string oc fmted)
 
 let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~input_name error
     =

--- a/lib/dune
+++ b/lib/dune
@@ -21,4 +21,4 @@
   (:standard -open Import))
  ;;INSERT_BISECT_HERE;;
  (libraries format_ import ocaml-migrate-parsetree odoc.model odoc.parser re
-   uuseg uuseg.string))
+   bos uuseg uuseg.string))

--- a/lib/import/Import.ml
+++ b/lib/import/Import.ml
@@ -26,7 +26,6 @@ include (
     end )
 
 include Option.Monad_infix
-include Stdio
 
 let ( >> ) f g x = g (f x)
 

--- a/lib/import/Import.mli
+++ b/lib/import/Import.mli
@@ -45,7 +45,7 @@ val check : ('a -> _) -> 'a -> 'a
     returns [x]. *)
 
 module Fpath : sig
-  include module type of Fpath
+  include module type of Fpath with type t = Fpath.t
 
   val cwd : unit -> t
   (** Current working directory, relying on [Unix]. *)

--- a/lib/import/Import.mli
+++ b/lib/import/Import.mli
@@ -27,8 +27,6 @@ include module type of (
 
 include module type of Option.Monad_infix
 
-include module type of Stdio
-
 external ( @@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
 (** Function application: [g @@ f @@ x] is exactly equivalent to [g (f (x))].
     Right associative. *)

--- a/lib/import/dune
+++ b/lib/import/dune
@@ -11,4 +11,4 @@
 
 (library
  (name import)
- (libraries base cmdliner fpath stdio unix))
+ (libraries base cmdliner fpath unix))

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -36,7 +36,6 @@ depends: [
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
   "re"
-  "stdio"
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
 ]

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -28,6 +28,7 @@ depends: [
   "alcotest" {with-test}
   "base" {>= "v0.11.0"}
   "base-unix"
+  "bos"
   "cmdliner"
   "dune" {>= "1.11.1"}
   "fpath"


### PR DESCRIPTION
More precise handling of errors, maybe could still be simplified with a cleaner propagation of errors.