### PR TITLE
Line/region indentation feature (emacs integration)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,10 @@
 
   + Consistent positioning of lambda return type annotations when no-break-infix-before-func and pre/post extensions (#1581, @gpetiot)
 
+#### New features
+
+  + Line/region indentation feature (emacs integration) (#1207, @gpetiot)
+
 ### 0.16.0 (2020-11-16)
 
 #### Removed

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -65,6 +65,18 @@ let run_action action opts =
         | Error e -> Error (fun () -> print_error conf opts ~input_name e)
       in
       Result.combine_errors_unit (List.map inputs ~f)
+  | In_out ({kind= Conf.Kind k; file; name= input_name; conf}, None)
+    when Option.is_some opts.numeric -> (
+      let source = source_from_file file in
+      let range = Option.value_exn opts.numeric in
+      match
+        Translation_unit.indentation k ~input_name ~source ~range conf opts
+      with
+      | Ok indents ->
+          List.iter indents ~f:(fun i ->
+              Stdio.print_endline (Int.to_string i) ) ;
+          Ok ()
+      | Error e -> Error [(fun () -> print_error conf opts ~input_name e)] )
   | In_out ({kind; file; name= input_name; conf}, output_file) -> (
       let source = source_from_file file in
       match format ?output_file ~kind ~input_name ~source conf opts with

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -294,6 +294,94 @@ is nil."
     (delete-file bufferfile)
     (delete-file outputfile)))
 
+(defun ocamlformat-args (name start-line end-line)
+  (let*
+      ((margin-args
+        (cond
+         ((equal ocamlformat-margin-mode 'window)
+          (list "--margin" (number-to-string (window-body-width))))
+         ((equal ocamlformat-margin-mode 'fill)
+          (list "--margin" (number-to-string fill-column)))
+         (t
+          '())))
+       (enable-args
+        (cond
+         ((equal ocamlformat-enable 'disable)
+          (list "--disable"))
+         ((equal ocamlformat-enable 'enable-outside-detected-project)
+          (list "--enable-outside-detected-project"))
+         (t
+          '())))
+       (extension-args
+        (cond
+         ((eq ocamlformat-file-kind 'implementation)
+          (list "--impl"))
+         ((eq ocamlformat-file-kind 'interface)
+          (list "--intf")))))
+    (append margin-args enable-args extension-args
+            (list
+             "-"
+             "--name" name
+             "--numeric" (format "%d-%d" start-line end-line)))))
+
+(defun ocamlformat-region (start end)
+  (interactive "r")
+  (let*
+      ((ext (file-name-extension buffer-file-name t))
+       (bufferfile (file-truename (make-temp-file "ocamlformat" nil ext)))
+       (errorfile (file-truename (make-temp-file "ocamlformat" nil ext)))
+       (errbuf
+        (cond
+         ((eq ocamlformat-show-errors 'buffer)
+          (get-buffer-create "*compilation*"))
+         ((eq ocamlformat-show-errors 'echo)
+          (get-buffer-create "*OCamlFormat stderr*"))))
+       (start-line (line-number-at-pos start))
+       (end-line (line-number-at-pos end))
+       (indents-str
+        (with-output-to-string
+          (if (/= 0
+                (apply 'call-process-region
+                       (point-min) (point-max) ocamlformat-command nil
+                       (list standard-output errorfile) nil
+                       (ocamlformat-args buffer-file-name start-line end-line)))
+              (progn
+                (if errbuf
+                  (progn
+                    (with-current-buffer errbuf
+                      (setq buffer-read-only nil)
+                      (erase-buffer))
+                    (ocamlformat--process-errors
+                     (buffer-file-name) bufferfile errorfile errbuf)))
+                (message "Could not apply ocamlformat")))))
+       (indents (mapcar 'string-to-number (split-string indents-str))))
+    (save-excursion
+      (goto-char start)
+      (mapcar
+       #'(lambda (indent) (indent-line-to indent) (forward-line))
+       indents))
+    (delete-file errorfile)
+    (delete-file bufferfile)))
+
+(defun ocamlformat-line ()
+  (interactive nil)
+  (ocamlformat-region (point) (point)))
+
+;;;###autoload
+(defun ocamlformat-setup-indent ()
+  (interactive nil)
+  (set (make-local-variable 'indent-line-function) #'ocamlformat-line)
+  (set (make-local-variable 'indent-region-function) #'ocamlformat-region))
+
+;;;###autoload
+(defun ocamlformat-caml-mode-setup ()
+  (ocamlformat-setup-indent)
+  (local-unset-key "\t"))  ;; caml-mode rebinds TAB !
+
+(add-hook 'tuareg-mode-hook 'ocamlformat-setup-indent t)
+
+(add-hook 'caml-mode-hook 'ocamlformat-caml-mode-setup  t)
+
 (provide 'ocamlformat)
 
 ;;; ocamlformat.el ends here

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1284,6 +1284,20 @@ let name =
   mk ~default
     Arg.(value & opt (some string) default & info ["name"] ~doc ~docs ~docv)
 
+let numeric =
+  let doc =
+    "Instead of re-indenting the file, output one integer per line \
+     representing the indentation value, printing as many values as lines \
+     in the range between lines X and Y (included)."
+  in
+  let default = None in
+  let docv = "X-Y" in
+  mk ~default
+    Arg.(
+      value
+      & opt (some (pair ~sep:'-' int int)) default
+      & info ["numeric"] ~doc ~docs ~docv)
+
 let ocp_indent_options =
   let unsupported ocp_indent = (ocp_indent, ([], "")) in
   let alias ocp_indent ocamlformat =
@@ -2166,7 +2180,17 @@ let make_action ~enable_outside_detected_project ~root action inputs =
       Ok (Check (List.map files ~f))
   | `Check, `Stdin (name, kind) -> Ok (Check [make_stdin ?name kind])
 
-type opts = {debug: bool; margin_check: bool; format_invalid_files: bool}
+type opts =
+  { debug: bool
+  ; margin_check: bool
+  ; format_invalid_files: bool
+  ; numeric: (int * int) option }
+
+let default_opts =
+  { debug= false
+  ; margin_check= false
+  ; format_invalid_files= false
+  ; numeric= None }
 
 let validate () =
   let root =
@@ -2194,7 +2218,10 @@ let validate () =
         match !format_invalid_files with Some `Auto -> true | _ -> false
       in
       let opts =
-        {debug= !debug; margin_check= !margin_check; format_invalid_files}
+        { debug= !debug
+        ; margin_check= !margin_check
+        ; format_invalid_files
+        ; numeric= !numeric }
       in
       `Ok (action, opts)
 

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -96,12 +96,21 @@ type action =
       (** Check whether the input files already are formatted. *)
   | Print_config of t  (** Print the configuration and exit. *)
 
+val conventional_profile : t
+
+val ocamlformat_profile : t
+
+val janestreet_profile : t
+
 (** Options changing the tool's behavior *)
 type opts =
   { debug: bool  (** Generate debugging output if true. *)
   ; margin_check: bool
         (** Check whether the formatted output exceeds the margin. *)
-  ; format_invalid_files: bool }
+  ; format_invalid_files: bool
+  ; numeric: (int * int) option }
+
+val default_opts : opts
 
 val action : unit -> (action * opts) Cmdliner.Term.result
 (** Formatting action: input type and source, and output destination. *)

--- a/lib/Indent.ml
+++ b/lib/Indent.ml
@@ -1,0 +1,137 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlFormat                               *)
+(*                                                                        *)
+(*            Copyright (c) Facebook, Inc. and its affiliates.            *)
+(*                                                                        *)
+(*      This source code is licensed under the MIT license found in       *)
+(*      the LICENSE file in the root directory of this source tree.       *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Migrate_ast
+open Result.Monad_infix
+
+let rec loc_of_line loctree locs line =
+  match locs with
+  | [] -> None
+  | (h : Location.t) :: t ->
+      if h.loc_start.pos_lnum = line then Some h
+      else if h.loc_start.pos_lnum <= line && line <= h.loc_end.pos_lnum then
+        match Loc_tree.children loctree h with
+        | [] -> Some h
+        | children -> (
+          match loc_of_line loctree children line with
+          | Some loc -> Some loc
+          | None -> Some h )
+      else loc_of_line loctree t line
+
+let matching_loc loc locs locs' =
+  match List.zip locs locs' with
+  | Ok assoc -> (
+      let equal x y = Location.compare x y = 0 in
+      match List.Assoc.find assoc ~equal loc with
+      | Some loc -> Ok loc
+      | None ->
+          Error (`Msg "Cannot find matching location in formatted output.") )
+  | Unequal_lengths ->
+      Error (`Msg "Cannot match pre-post formatting locations.")
+
+let last_token x =
+  let lexbuf = Lexing.from_string x in
+  let rec loop acc =
+    match Lexer.token_with_comments lexbuf with
+    | Parser.EOF -> acc
+    | tok -> loop (Some tok)
+  in
+  loop None
+
+let indentation_1_line ?prev (loctree, locs) (_, locs') formatted_src nlines
+    ~i =
+  if i = nlines + 1 then Ok 0
+  else
+    match loc_of_line loctree locs i with
+    | Some loc -> (
+        matching_loc loc locs locs'
+        >>= fun (loc' : Location.t) ->
+        let indent =
+          match
+            Source.find_first_token_on_line formatted_src
+              loc'.loc_start.pos_lnum
+          with
+          | Some (_, loc) -> Position.column loc.loc_start
+          | None -> impossible "cannot happen"
+        in
+        match prev with
+        | Some (prev_indent, prev_line)
+          when indent = prev_indent || indent = 0 -> (
+          (* in case this is a line that is split but could fit on a single
+             line, consecutive lines will have the same indentation, we try
+             to infer some artificial indentation here, even though it will
+             be squeezed together and fit on a single line when the whole
+             file is reformatted *)
+          match last_token prev_line with
+          | Some tok -> (
+            match Source.indent_after_token tok with
+            | Some i -> Ok (prev_indent + i)
+            | None -> Ok indent )
+          | None -> Ok indent )
+        | _ -> Ok indent )
+    | None -> Ok 0
+
+let indent_from_locs fragment ~unformatted:(ast, source)
+    ~formatted:(formatted_ast, formatted_source) ~lines ~range:(low, high) =
+  let nlines = List.length lines in
+  let locs = Loc_tree.of_ast fragment ast source in
+  let locs' = Loc_tree.of_ast fragment formatted_ast formatted_source in
+  let rec aux ?prev acc i =
+    if i > high then Ok (List.rev acc)
+    else if i >= low then
+      let line = Option.value (List.nth lines (i - 1)) ~default:"" in
+      if String.is_empty (String.strip line) then aux ?prev (0 :: acc) (i + 1)
+      else
+        indentation_1_line ?prev locs locs' formatted_source nlines ~i
+        >>= fun indent -> aux ~prev:(indent, line) (indent :: acc) (i + 1)
+    else
+      let line = Option.value (List.nth lines (i - 1)) ~default:"" in
+      if String.is_empty (String.strip line) then aux ?prev acc (i + 1)
+      else
+        indentation_1_line ?prev locs locs' formatted_source nlines ~i
+        >>= fun indent -> aux ~prev:(indent, line) acc (i + 1)
+  in
+  aux [] low
+
+let indentation_of_line l = String.(length l - length (lstrip l))
+
+let indentation_1_line_fallback ?prev nlines ~i ~line =
+  if i = nlines + 1 then Ok 0
+  else
+    let indent = indentation_of_line line in
+    match prev with
+    | Some (prev_indent, prev_line) -> (
+      match last_token prev_line with
+      | Some tok -> (
+        match Source.indent_after_token tok with
+        | Some i -> Ok (prev_indent + i)
+        | None -> Ok indent )
+      | None -> Ok indent )
+    | _ -> Ok indent
+
+let indent_from_lines ~lines ~range:(low, high) =
+  let nlines = List.length lines in
+  let rec aux ?prev acc i =
+    if i > high then Ok (List.rev acc)
+    else if i >= low then
+      let line = Option.value (List.nth lines (i - 1)) ~default:"" in
+      if String.is_empty (String.strip line) then aux ?prev (0 :: acc) (i + 1)
+      else
+        indentation_1_line_fallback ?prev nlines ~i ~line
+        >>= fun indent -> aux ~prev:(indent, line) (indent :: acc) (i + 1)
+    else
+      let line = Option.value (List.nth lines (i - 1)) ~default:"" in
+      if String.is_empty (String.strip line) then aux ?prev acc (i + 1)
+      else
+        let indent = indentation_of_line line in
+        aux ~prev:(indent, line) acc (i + 1)
+  in
+  aux [] low

--- a/lib/Indent.mli
+++ b/lib/Indent.mli
@@ -10,7 +10,7 @@
 (**************************************************************************)
 
 module Valid_ast : sig
-  val indent :
+  val indent_range :
        'a Migrate_ast.Traverse.fragment
     -> unformatted:'a * Source.t
     -> formatted:'a * Source.t
@@ -20,7 +20,10 @@ module Valid_ast : sig
 end
 
 module Partial_ast : sig
-  val indent :
+  val indent_line :
+    ?prev:int * string -> i:int -> line:string -> int -> (int, 'a) Result.t
+
+  val indent_range :
        lines:string list
     -> range:int * int
     -> (int list, [`Msg of string]) Result.t

--- a/lib/Indent.mli
+++ b/lib/Indent.mli
@@ -16,15 +16,11 @@ module Valid_ast : sig
     -> formatted:'a * Source.t
     -> lines:string list
     -> range:int * int
-    -> (int list, [`Msg of string]) Result.t
+    -> int list
 end
 
 module Partial_ast : sig
-  val indent_line :
-    ?prev:int * string -> i:int -> line:string -> int -> (int, 'a) Result.t
+  val indent_line : ?prev:int * string -> i:int -> line:string -> int -> int
 
-  val indent_range :
-       lines:string list
-    -> range:int * int
-    -> (int list, [`Msg of string]) Result.t
+  val indent_range : lines:string list -> range:int * int -> int list
 end

--- a/lib/Indent.mli
+++ b/lib/Indent.mli
@@ -9,15 +9,19 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val indent_from_locs :
-     'a Migrate_ast.Traverse.fragment
-  -> unformatted:'a * Source.t
-  -> formatted:'a * Source.t
-  -> lines:string list
-  -> range:int * int
-  -> (int list, [`Msg of string]) Result.t
+module Valid_ast : sig
+  val indent :
+       'a Migrate_ast.Traverse.fragment
+    -> unformatted:'a * Source.t
+    -> formatted:'a * Source.t
+    -> lines:string list
+    -> range:int * int
+    -> (int list, [`Msg of string]) Result.t
+end
 
-val indent_from_lines :
-     lines:string list
-  -> range:int * int
-  -> (int list, [`Msg of string]) Result.t
+module Partial_ast : sig
+  val indent :
+       lines:string list
+    -> range:int * int
+    -> (int list, [`Msg of string]) Result.t
+end

--- a/lib/Indent.mli
+++ b/lib/Indent.mli
@@ -1,0 +1,23 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlFormat                               *)
+(*                                                                        *)
+(*            Copyright (c) Facebook, Inc. and its affiliates.            *)
+(*                                                                        *)
+(*      This source code is licensed under the MIT license found in       *)
+(*      the LICENSE file in the root directory of this source tree.       *)
+(*                                                                        *)
+(**************************************************************************)
+
+val indent_from_locs :
+     'a Migrate_ast.Traverse.fragment
+  -> unformatted:'a * Source.t
+  -> formatted:'a * Source.t
+  -> lines:string list
+  -> range:int * int
+  -> (int list, [`Msg of string]) Result.t
+
+val indent_from_lines :
+     lines:string list
+  -> range:int * int
+  -> (int list, [`Msg of string]) Result.t

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -49,6 +49,8 @@ val find_token_before :
   -> Lexing.position
   -> (Parser.token * Location.t) option
 
+val find_first_token_on_line : t -> int -> (Parser.token * Location.t) option
+
 val string_literal : t -> [`Normalize | `Preserve] -> Location.t -> string
 
 val char_literal : t -> Location.t -> string
@@ -98,3 +100,5 @@ val is_quoted_string : t -> Location.t -> bool
 
 val loc_of_first_token_at :
   t -> Location.t -> Parser.token -> Location.t option
+
+val indent_after_token : Parser.token -> int option

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -435,7 +435,7 @@ let indentation fragment ~input_name ~source ~range:(low, high) conf opts =
       ((parsed.ast, parsed.source), (formatted_ast.ast, formatted_ast.source))
     with
   | Ok (unformatted, formatted) ->
-      Indent.Valid_ast.indent fragment ~unformatted ~formatted ~lines
+      Indent.Valid_ast.indent_range fragment ~unformatted ~formatted ~lines
         ~range:(low, high)
-  | Error _ -> Indent.Partial_ast.indent ~lines ~range:(low, high) )
+  | Error _ -> Indent.Partial_ast.indent_range ~lines ~range:(low, high) )
   |> Result.map_error ~f:(fun (`Msg s) -> Ocamlformat_bug {exn= failwith s})

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -435,7 +435,7 @@ let indentation fragment ~input_name ~source ~range:(low, high) conf opts =
       ((parsed.ast, parsed.source), (formatted_ast.ast, formatted_ast.source))
     with
   | Ok (unformatted, formatted) ->
-      Indent.indent_from_locs fragment ~unformatted ~formatted ~lines
+      Indent.Valid_ast.indent fragment ~unformatted ~formatted ~lines
         ~range:(low, high)
-  | Error _ -> Indent.indent_from_lines ~lines ~range:(low, high) )
+  | Error _ -> Indent.Partial_ast.indent ~lines ~range:(low, high) )
   |> Result.map_error ~f:(fun (`Msg s) -> Ocamlformat_bug {exn= failwith s})

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -9,7 +9,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type error
+type error =
+  | Invalid_source of {exn: exn}
+  | Unstable of {iteration: int; prev: string; next: string}
+  | Ocamlformat_bug of {exn: exn}
+  | User_error of string
 
 val parse_and_format :
      _ list Migrate_ast.Traverse.fragment
@@ -19,8 +23,21 @@ val parse_and_format :
   -> Conf.t
   -> Conf.opts
   -> (string, error) Result.t
-(** [parse_and_format_impl conf ?output_file ~input_name ~source] parses and
+(** [parse_and_format conf ?output_file ~input_name ~source] parses and
     formats [source] as a list of fragments. *)
+
+val indentation :
+     _ list Migrate_ast.Traverse.fragment
+  -> input_name:string
+  -> source:string
+  -> range:int * int
+  -> Conf.t
+  -> Conf.opts
+  -> (int list, error) Result.t
+(** [indentation ~input_name ~source ~range conf opts] returns the
+    indentation of the range of lines [range] (line numbers ranging from 1 to
+    number of lines), where the line numbers are relative to [source] and the
+    indentation is relative to the formatted output. *)
 
 val print_error :
      fmt:Format.formatter

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -555,6 +555,11 @@ OPTIONS
            Do not check that the version matches the one specified in
            .ocamlformat.
 
+       --numeric=X-Y
+           Instead of re-indenting the file, output one integer per line
+           representing the indentation value, printing as many values as
+           lines in the range between lines X and Y (included).
+
        -o DST, --output=DST
            Output file. Mutually exclusive with --inplace. Write to stdout if
            omitted.

--- a/test/unit/test_indent.ml
+++ b/test/unit/test_indent.ml
@@ -1,0 +1,42 @@
+open Base
+open Ocamlformat_lib
+
+module Partial_ast = struct
+  let get_indent line = String.(length line - length (lstrip line))
+
+  let get_inputs input =
+    let lines = String.split_lines input in
+    let nb_lines = List.length lines in
+    match List.last lines with
+    | Some last -> (Some (get_indent last, last), nb_lines, "", nb_lines)
+    | None -> (None, 0, "", nb_lines)
+
+  let prepare_output input indent =
+    let spaces = String.make indent ' ' in
+    input ^ "\n" ^ spaces ^ "^"
+
+  let tests_indent_line =
+    let test name ~input ~expected =
+      let test_name = "Partial_ast.indent_line: " ^ name in
+      ( test_name
+      , `Quick
+      , fun () ->
+          let prev, i, line, nb_lines = get_inputs input in
+          let indent =
+            Indent.Partial_ast.indent_line ?prev ~i ~line nb_lines
+          in
+          let output = prepare_output input indent in
+          Alcotest.(check string) test_name expected output )
+    in
+    [ test "" ~input:{|
+let foo () =
+  if bar then|}
+        ~expected:{|
+let foo () =
+  if bar then
+    ^|} ]
+
+  let tests = tests_indent_line
+end
+
+let tests = Partial_ast.tests

--- a/test/unit/test_indent.ml
+++ b/test/unit/test_indent.ml
@@ -28,13 +28,44 @@ module Partial_ast = struct
           let output = prepare_output input indent in
           Alcotest.(check string) test_name expected output )
     in
-    [ test "" ~input:{|
+    [ test "empty" ~input:{||} ~expected:{|
+^|}
+    ; test "after if" ~input:{|
+if|} ~expected:{|
+if
+  ^|}
+    ; test "after then" ~input:{|
 let foo () =
   if bar then|}
         ~expected:{|
 let foo () =
   if bar then
-    ^|} ]
+    ^|}
+    ; test "after module struct" ~input:{|
+module M = struct|}
+        ~expected:{|
+module M = struct
+  ^|}
+    ; test "after module sig" ~input:{|
+module M : sig|}
+        ~expected:{|
+module M : sig
+  ^|}
+    ; test "after =" ~input:{|
+let x =
+  let y =|}
+        ~expected:{|
+let x =
+  let y =
+    ^|}
+    ; test "after = but over indented"
+        ~input:{|
+let x =
+      let y =|}
+        ~expected:{|
+let x =
+      let y =
+        ^|} ]
 
   let tests = tests_indent_line
 end

--- a/test/unit/test_indent.mli
+++ b/test/unit/test_indent.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test_case list

--- a/test/unit/test_unit.ml
+++ b/test/unit/test_unit.ml
@@ -258,6 +258,7 @@ let tests =
   ; ("Ast", Test_ast.tests)
   ; ("Literal_lexer", Test_literal_lexer.tests)
   ; ("Fmt", Test_fmt.tests)
+  ; ("Indent", Test_indent.tests)
   ; ("Translation_unit", Test_translation_unit.tests) ]
 
 let () = Alcotest.run "ocamlformat" tests

--- a/test/unit/test_unit.ml
+++ b/test/unit/test_unit.ml
@@ -110,11 +110,154 @@ module Test_noit = struct
   let tests = test_dump @ test_roots @ test_children
 end
 
+let reindent ~source ~range:(low, high) indents =
+  let lines = String.split_lines source in
+  let low = low - 1 and high = high - 1 in
+  let lines =
+    List.mapi lines ~f:(fun i line ->
+        if i < low then line
+        else if low <= i && i <= high then
+          let indent = List.nth_exn indents (i - low) in
+          let line = String.lstrip line in
+          let spaces = String.make indent ' ' in
+          spaces ^ line
+        else line )
+  in
+  String.concat ~sep:"\n" lines
+
+module Test_translation_unit = struct
+  let test_indent =
+    let test name ~source ~range expected =
+      let test_name = "indent: " ^ name in
+      ( test_name
+      , `Quick
+      , fun () ->
+          let got =
+            Translation_unit.indentation Use_file ~input_name:"_" ~source
+              ~range Conf.ocamlformat_profile Conf.default_opts
+            |> Result.map ~f:(reindent ~source ~range)
+          in
+          Alcotest.check
+            Alcotest.(result string Testable.error)
+            test_name expected got )
+    in
+    [ test "invalid low" ~source:"foo\nbar" ~range:(0, 1)
+        (Error (User_error "Invalid line number 0."))
+    ; test "invalid high" ~source:"foo\nbar" ~range:(1, 4)
+        (Error (User_error "Invalid line number 4."))
+    ; test "invalid range" ~source:"foo\nbar" ~range:(2, 1)
+        (Error (User_error "Invalid range 2-1."))
+    ; test "empty buffer" ~source:"" ~range:(1, 1) (Ok "")
+    ; test "last buffer line" ~source:"foo\nbar" ~range:(2, 3) (Ok "foo\nbar")
+    ; test "already formatted"
+        ~source:
+          {|let foooooo =
+  let baaaaar =
+    let woooooo = foooooo in
+    let xooooo = bar + foo in
+    woooooo
+  in
+  bar
+|}
+        ~range:(1, 7)
+        (Ok
+           {|let foooooo =
+  let baaaaar =
+    let woooooo = foooooo in
+    let xooooo = bar + foo in
+    woooooo
+  in
+  bar|}
+        )
+    ; test "not already formatted"
+        ~source:
+          {|let foooooooooooo = let foooooooo = foooooooooooo in foooooooooooo
+
+let foooooooooooo = let foooooooooooooo =
+let woooooooooooooooo = koooooooooooooooo in
+baaaaaar
+in
+hooohoooo
+|}
+        ~range:(1, 7)
+        (Ok
+           {|let foooooooooooo = let foooooooo = foooooooooooo in foooooooooooo
+
+let foooooooooooo = let foooooooooooooo =
+    let woooooooooooooooo = koooooooooooooooo in
+    baaaaaar
+  in
+  hooohoooo|}
+        )
+    ; test "with parens and begin/end"
+        ~source:
+          {|let x = begin
+    let y =
+      (if (k = x)
+       then
+         begin match k,v with [x; y] -> ( foo;
+                                        (if (z) then foo else bar) )
+         end
+       else
+         foo)
+    in
+    foooooo
+  end|}
+        ~range:(1, 12)
+        (Ok
+           {|let x = begin
+  let y =
+    (if (k = x)
+    then
+      begin match k,v with [x; y] -> ( foo;
+          (if (z) then foo else bar) )
+    end
+    else
+      foo)
+  in
+  foooooo
+  end|}
+        )
+    ; test "split over multiple lines"
+        ~source:{|let fooooo =
+[
+foooooo ;
+foooooooo ;
+fooooooo
+]|}
+        ~range:(1, 6)
+        (Ok {|let fooooo =
+  [
+    foooooo ;
+    foooooooo ;
+    fooooooo
+]|})
+    ; test "invalid file"
+        ~source:{|let foooooo =
+let foooooooooooo =
+(
+[
+fun x ->
+foooooo|}
+        ~range:(1, 6)
+        (Ok
+           {|let foooooo =
+  let foooooooooooo =
+    (
+      [
+        fun x ->
+          foooooo|}
+        ) ]
+
+  let tests = test_indent
+end
+
 let tests =
   [ ("Location", Test_location.tests)
   ; ("non overlapping interval tree", Test_noit.tests)
   ; ("Ast", Test_ast.tests)
   ; ("Literal_lexer", Test_literal_lexer.tests)
-  ; ("Fmt", Test_fmt.tests) ]
+  ; ("Fmt", Test_fmt.tests)
+  ; ("Translation_unit", Test_translation_unit.tests) ]
 
 let () = Alcotest.run "ocamlformat" tests

--- a/test/unit/testable.ml
+++ b/test/unit/testable.ml
@@ -1,0 +1,6 @@
+let error =
+  let pp fs =
+    Ocamlformat_lib.Translation_unit.print_error ~fmt:fs ~debug:false
+      ~quiet:false ~input_name:"_" ~exe:"ocamlformat.exe"
+  in
+  Alcotest.testable pp ( = )

--- a/test/unit/testable.mli
+++ b/test/unit/testable.mli
@@ -1,0 +1,1 @@
+val error : Ocamlformat_lib.Translation_unit.error Alcotest.testable


### PR DESCRIPTION
the workflow is:
- `dune build @install && dune install`
- add `(require 'ocamlformat)` to your .emacs

Disclaimer: so far what it does is applying the indentation of the (virtually) formatted output to the unformatted input, so if you break a line like this you can observe cases like:

```ocaml
let foo =
foooo
|> bar
```

because once formatted it is formatted on a single line (indented to 0)