### PR TITLE
Fix dropped comments around module pack expressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@
   + Fix location of comment attached to the underscore of an open record (#1208) (Guillaume Petiot)
   + Fix parentheses around optional module parameter (#1212) (Christian Barcenas)
   + Fix grouping of horizontally aligned comments (#1209) (Guillaume Petiot)
+  + Fix dropped comments around module pack expressions (#1214) (Jules Aguillon)
 
 #### Documentation
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1800,17 +1800,21 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         | `Closing_on_separate_line ->
             (str "(", fits_breaks ")" ~hint:(1000, -2) ")")
       in
+      let has_cmts =
+        Cmts.has_before c.cmts pexp_loc || Cmts.has_after c.cmts pexp_loc
+      in
       hovbox 0
         (compose_module
            (fmt_module_expr c (sub_mod ~ctx me))
            ~f:(fun m ->
              hvbox 2
-               (Cmts.fmt c pexp_loc
-                  ( hovbox 0
-                      ( opn_paren $ str "module " $ m $ fmt "@ : "
-                      $ fmt_longident_loc c id )
-                  $ fmt_package_type c ctx cnstrs
-                  $ fmt_atrs $ cls_paren ))))
+               (wrap_if has_cmts "(" ")"
+                  (Cmts.fmt c pexp_loc
+                     ( hovbox 0
+                         ( opn_paren $ str "module " $ m $ fmt "@ : "
+                         $ fmt_longident_loc c id )
+                     $ fmt_package_type c ctx cnstrs
+                     $ fmt_atrs $ cls_paren )))))
   | Pexp_constraint (e, t) ->
       hvbox 2
         ( wrap_fits_breaks ~space:false c.conf "(" ")"

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1788,7 +1788,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             ?epi const
         $ fmt_atrs )
   | Pexp_constraint
-      ( {pexp_desc= Pexp_pack me; pexp_attributes= []; pexp_loc= _; _}
+      ( {pexp_desc= Pexp_pack me; pexp_attributes= []; pexp_loc; _}
       , { ptyp_desc= Ptyp_package (id, cnstrs)
         ; ptyp_attributes= []
         ; ptyp_loc= _
@@ -1805,11 +1805,12 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
            (fmt_module_expr c (sub_mod ~ctx me))
            ~f:(fun m ->
              hvbox 2
-               ( hovbox 0
-                   ( opn_paren $ str "module " $ m $ fmt "@ : "
-                   $ fmt_longident_loc c id )
-               $ fmt_package_type c ctx cnstrs
-               $ fmt_atrs $ cls_paren )))
+               (Cmts.fmt c pexp_loc
+                  ( hovbox 0
+                      ( opn_paren $ str "module " $ m $ fmt "@ : "
+                      $ fmt_longident_loc c id )
+                  $ fmt_package_type c ctx cnstrs
+                  $ fmt_atrs $ cls_paren ))))
   | Pexp_constraint (e, t) ->
       hvbox 2
         ( wrap_fits_breaks ~space:false c.conf "(" ")"

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1800,21 +1800,17 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         | `Closing_on_separate_line ->
             (str "(", fits_breaks ")" ~hint:(1000, -2) ")")
       in
-      let has_cmts =
-        Cmts.has_before c.cmts pexp_loc || Cmts.has_after c.cmts pexp_loc
-      in
       hovbox 0
         (compose_module
            (fmt_module_expr c (sub_mod ~ctx me))
            ~f:(fun m ->
              hvbox 2
-               (wrap_if has_cmts "(" ")"
-                  (Cmts.fmt c pexp_loc
-                     ( hovbox 0
-                         ( opn_paren $ str "module " $ m $ fmt "@ : "
-                         $ fmt_longident_loc c id )
-                     $ fmt_package_type c ctx cnstrs
-                     $ fmt_atrs $ cls_paren )))))
+               (Cmts.fmt c pexp_loc
+                  ( hovbox 0
+                      ( opn_paren $ str "module " $ m $ fmt "@ : "
+                      $ fmt_longident_loc c id )
+                  $ fmt_package_type c ctx cnstrs
+                  $ fmt_atrs $ cls_paren ))))
   | Pexp_constraint (e, t) ->
       hvbox 2
         ( wrap_fits_breaks ~space:false c.conf "(" ")"

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -222,3 +222,11 @@ type t =
   | C
 
 let y = f (* a *) (* b *) x
+
+let kk = (* foo *) (module A : T)
+
+let kk = ((* foo *) (module A : T))
+
+let kk = ((module A : T) (* foo *))
+
+let kk = ((* foo *) (module A : T) (* foo *))

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -310,3 +310,11 @@ let y =
     (* a *)
     (* b *)
     x
+
+let kk = (* foo *) (module A : T)
+
+let kk = ((* foo *) (module A : T))
+
+let kk = ((module A : T) (* foo *))
+
+let kk = ((* foo *) (module A : T) (* foo *))

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -313,8 +313,10 @@ let y =
 
 let kk = (* foo *) (module A : T)
 
-let kk = ((* foo *) (module A : T))
+let kk = (* foo *) (module A : T)
 
-let kk = ((module A : T) (* foo *))
+let kk = (module A : T) (* foo *)
 
-let kk = ((* foo *) (module A : T) (* foo *))
+let kk = (* foo *) (module A : T)
+
+(* foo *)

--- a/test/passing/module.ml
+++ b/test/passing/module.ml
@@ -71,11 +71,3 @@ let helper ?x =
   match x with Some (module X : X_typ) -> X.f | None -> X_add_one.f
 
 let helper ?x:((module X) = (module X_add_one : X_typ)) = X.f
-
-let kk = (* foo *) (module A : T)
-
-let kk = ((* foo *) (module A : T))
-
-let kk = ((module A : T) (* foo *))
-
-let kk = ((* foo *) (module A : T) (* foo *))

--- a/test/passing/module.ml
+++ b/test/passing/module.ml
@@ -71,3 +71,11 @@ let helper ?x =
   match x with Some (module X : X_typ) -> X.f | None -> X_add_one.f
 
 let helper ?x:((module X) = (module X_add_one : X_typ)) = X.f
+
+let kk = (* foo *) (module A : T)
+
+let kk = ((* foo *) (module A : T))
+
+let kk = ((module A : T) (* foo *))
+
+let kk = ((* foo *) (module A : T) (* foo *))


### PR DESCRIPTION
`ocamlformat --debug` was printing a warning on this code (from https://github.com/ocaml-ppx/ocamlformat/pull/1212):
```ocaml
 let helper ?x:((module X) = (module X_add_one : X_typ)) = X.f
```

I couldn't place a comment that would be dropped, so this is not fixing a bug.