### PR TITLE
Drop travis builds for 4.08 and 4.09

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: c
 env:
   - CI_KIND=changes
   - CI_KIND=build OCAML_VERSION=4.07.1
-  - CI_KIND=build-and-tests OCAML_VERSION=4.08.1
-  - CI_KIND=build-and-tests OCAML_VERSION=4.09.0
 cache:
   directories:
     - ${HOME}/.opam

--- a/tools/travis-ci.sh
+++ b/tools/travis-ci.sh
@@ -34,13 +34,6 @@ CheckBuild () {
     opam exec -- make
 }
 
-CheckTests () {
-    # install
-    opam install --deps-only --with-test ocamlformat
-    # script
-    opam exec -- make test
-}
-
 HasNoChangelogNeededLabel () {
     url="https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST"
     curl "$url" | jq '.labels|any(.name == "no-changelog-needed")'
@@ -61,10 +54,6 @@ CheckChangesModified () {
 case $CI_KIND in
 build)
     CheckBuild
-    ;;
-build-and-tests)
-    CheckBuild
-    CheckTests
     ;;
 changes)
     CheckChangesModified


### PR DESCRIPTION
OCaml-ci is now building and testing OCamlformat !

The reports look like this: https://ci.ocamllabs.io/github/ocaml-ppx/ocamlformat/commit/901ca2c942c300036d938a7dbefcc5c19110014b

"lint" is testing the formatting, others are building and testing (using `opam install -t`) on OCaml 4.08 and 4.09.
Build for OCaml 4.07 is disabled because the tests wouldn't pass (this is implemented in OCamlformat's opam file).

We should keep travis for testing the changelog and compilation on 4.07.