### PR TITLE
Update the release procedure

### DIFF
--- a/HACKING.org
+++ b/HACKING.org
@@ -4,7 +4,8 @@
   Commit
 
 - Tag and push
-  =git tag a.b.c=
+  =git tag -a a.b.c=
+  The =-a= is important, otherwise the tag will be ignored by =dune-release=
   =git push --tags=
 
 - Create the archive, the =-t a.b.c= option is to ensure that the tag is not guessed wrong

--- a/HACKING.org
+++ b/HACKING.org
@@ -4,17 +4,16 @@
   Commit
 
 - Tag and push
-  =git tag -a a.b.c=
-  The =-a= is important, otherwise the tag will be ignored by =dune-release=
+  =dune-release tag a.b.c=
   =git push --tags=
 
-- Create the archive, the =-t a.b.c= option is to ensure that the tag is not guessed wrong
-  =dune-release distrib -t a.b.c=
+- Create the archive
+  =dune-release distrib=
 
 - Publish the release on Github
-  =dune-release publish -t a.b.c distrib=
+  =dune-release publish distrib=
   To the prompt =Push tag a.b.c to ...?=, answer =s=
 
 - Release on Opam-repository
-  =dune-release opam pkg -t a.b.c=
-  =dune-release opam submit -t a.b.c=
+  =dune-release opam pkg=
+  =dune-release opam submit=

--- a/HACKING.org
+++ b/HACKING.org
@@ -1,10 +1,19 @@
-* release procedure
-- git checkout -t -b vM.N.O
-- topkg tag M.N.O
-- dune subst
-- ocaml tools/gen_version.mlt src/Version.ml M.N.O
-- git add src/Version.ml
-- git commit -a -m vM.N.O
-- topkg tag M.N.O -f
-- git push origin refs/heads/vM.N.O refs/tags/M.N.O
-- opam publish ocamlformat.opam
+* Release procedure
+
+- In =CHANGES.md=, change =(unreleased)= with the current date
+  Commit
+
+- Tag and push
+  =git tag a.b.c=
+  =git push --tags=
+
+- Create the archive, the =-t a.b.c= option is to ensure that the tag is not guessed wrong
+  =dune-release distrib -t a.b.c=
+
+- Publish the release on Github
+  =dune-release publish -t a.b.c distrib=
+  To the prompt =Push tag a.b.c to ...?=, answer =s=
+
+- Release on Opam-repository
+  =dune-release opam pkg -t a.b.c=
+  =dune-release opam submit -t a.b.c=

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -20,7 +20,7 @@ license: "MIT"
 build: [
   ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test & ocaml:version >= "4.08"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.06"}


### PR DESCRIPTION
This is how I released 0.13.0.

`dune-release` needs to be called step by step because:
- We don't have documentation, the `publish` step fails
- Because of my local configuration, it is not able to push the git tag
