### PR TITLE
Fix missing parentheses around let open

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+### (unreleased)
+
+#### Bug fixes
+
+  + Fix missing parentheses around `let open` (#1229) (Jules Aguillon)
+    eg. `M.f (M.(x) [@attr])` would be formatted to `M.f M.(x) [@attr]`, which would crash OCamlformat
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2077,20 +2077,25 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         | _ -> Option.is_some (Sugar.list_exp c.cmts e0)
       in
       let opn, cls = if can_skip_parens then (".", "") else (".(", ")") in
-      hvbox 0
-        ( fits_breaks_if parens "" "("
-        $ fits_breaks "" "let "
-        $ Cmts.fmt c popen_loc
-            ( fits_breaks "" (if override then "open! " else "open ")
-            $ fmt_module_statement c ~attributes noop
-                (sub_mod ~ctx popen_expr) )
-        $ fits_breaks opn " in"
-        $ fmt_or_k force_fit_if (fmt "@;<0 2>")
-            (fits_breaks "" ~hint:(1000, 0) "")
-        $ fmt_expression c (sub_exp ~ctx e0)
-        $ fits_breaks cls ""
-        $ fits_breaks_if parens "" ")"
-        $ fmt_atrs )
+      let outer_parens, inner_parens =
+        if has_attr then (parens, true) else (false, parens)
+      in
+      hovbox 0
+        ( fmt_if outer_parens "("
+        $ hvbox 0
+            ( fits_breaks_if inner_parens "" "("
+            $ fits_breaks "" "let "
+            $ Cmts.fmt c popen_loc
+                ( fits_breaks "" (if override then "open! " else "open ")
+                $ fmt_module_statement c ~attributes noop
+                    (sub_mod ~ctx popen_expr) )
+            $ fits_breaks opn " in"
+            $ fmt_or_k force_fit_if (fmt "@;<0 2>")
+                (fits_breaks "" ~hint:(1000, 0) "")
+            $ fmt_expression c (sub_exp ~ctx e0)
+            $ fits_breaks cls ""
+            $ fits_breaks_if inner_parens "" ")" )
+        $ fmt_atrs $ fmt_if outer_parens ")" )
   | Pexp_match (e0, cs) | Pexp_try (e0, cs) -> (
       let keyword =
         match exp.pexp_desc with

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -82,8 +82,8 @@ let () =
     (let module M = M in
      ()) [@foo]];
   [%foo
-    (let open M in
-     ()) [@foo]];
+    ((let open M in
+      ()) [@foo])];
   [%foo fun [@foo] x -> ()];
   [%foo
     function[@foo]

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -82,8 +82,8 @@ let () =
     (let module M = M in
     ()) [@foo]];
   [%foo
-    (let open M in
-    ()) [@foo]];
+    ((let open M in
+     ()) [@foo])];
   [%foo fun [@foo] x -> ()];
   [%foo
     function[@foo]

--- a/test/passing/open-auto.ml.ref
+++ b/test/passing/open-auto.ml.ref
@@ -278,3 +278,5 @@ open (A : S) [@@attr]
 open (val x) [@@attr]
 
 open [%ext] [@@attr]
+
+let g = M.f (M.(x) [@attr])

--- a/test/passing/open-long.ml.ref
+++ b/test/passing/open-long.ml.ref
@@ -292,3 +292,8 @@ open (A : S) [@@attr]
 open (val x) [@@attr]
 
 open [%ext] [@@attr]
+
+let g =
+  M.f
+    ((let open M in
+     x) [@attr])

--- a/test/passing/open-preserve.ml.ref
+++ b/test/passing/open-preserve.ml.ref
@@ -281,3 +281,8 @@ open (A : S) [@@attr]
 open (val x) [@@attr]
 
 open [%ext] [@@attr]
+
+let g =
+  M.f
+    ((let open M in
+     x) [@attr])

--- a/test/passing/open-short.ml.ref
+++ b/test/passing/open-short.ml.ref
@@ -272,3 +272,5 @@ open (A : S) [@@attr]
 open (val x) [@@attr]
 
 open [%ext] [@@attr]
+
+let g = M.f (M.(x) [@attr])

--- a/test/passing/open.ml
+++ b/test/passing/open.ml
@@ -217,3 +217,5 @@ open[@attr] A (B)
 open[@attr] (A : S)
 open[@attr] (val x)
 open[@attr] [%ext]
+
+let g = M.f ((let open M in x) [@attr])

--- a/test/passing/open.ml.ref
+++ b/test/passing/open.ml.ref
@@ -281,3 +281,8 @@ open (A : S) [@@attr]
 open (val x) [@@attr]
 
 open [%ext] [@@attr]
+
+let g =
+  M.f
+    ((let open M in
+     x) [@attr])

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -4,7 +4,7 @@ let () =
   [%foo
     (let module M = M in
     ()) [@foo]] ;
-  [%foo M.(()) [@foo]] ;
+  [%foo (M.(()) [@foo])] ;
   [%foo fun [@foo] x -> ()] ;
   [%foo function[@foo] x -> ()] ;
   [%foo try[@foo] () with _ -> ()] ;

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -100,8 +100,8 @@ let () =
     (let module M = M in
     ()) [@foo]] ;
   [%foo
-    (let open M in
-    ()) [@foo]] ;
+    ((let open M in
+     ()) [@foo])] ;
   [%foo fun [@foo] x -> ()] ;
   [%foo function[@foo] x -> ()] ;
   [%foo try[@foo] () with _ -> ()] ;


### PR DESCRIPTION
Fixes https://github.com/ocaml-ppx/ocamlformat/issues/1226

Parentheses around  were removed, changing the AST in some cases.

This adds a regression, it is consistent with other expressions and
should be discussed separately:
```diff
-  [%foo M.(()) [@foo]] ;
+  [%foo (M.(()) [@foo])] ;
```