### PR TITLE
Remove unecessary parentheses in extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
   + Fix missing parentheses around `let open` (#1229) (Jules Aguillon)
     eg. `M.f (M.(x) [@attr])` would be formatted to `M.f M.(x) [@attr]`, which would crash OCamlformat
 
+  + Remove unecessary parentheses in extensions with attributes (#1230) (Jules Aguillon)
+    eg. `[%ext () [@attr]]`
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,8 @@
   + Fix missing parentheses around `let open` (#1229) (Jules Aguillon)
     eg. `M.f (M.(x) [@attr])` would be formatted to `M.f M.(x) [@attr]`, which would crash OCamlformat
 
-  + Remove unecessary parentheses in extensions with attributes (#1230) (Jules Aguillon)
-    eg. `[%ext () [@attr]]`
+  + Remove unecessary parentheses with attributes in extensions and eval items (#1230) (Jules Aguillon)
+    eg. the expression `[%ext (() [@attr])]` or the structure item `(() [@attr]) ;;`
 
 ### 0.13.0 (2020-01-28)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+### (unreleased)
+
+#### Bug fixes
+
+  + Fix missing parentheses around `let open` (#1229) (Jules Aguillon)
+    eg. `M.f (M.(x) [@attr])` would be formatted to `M.f M.(x) [@attr]`, which would crash OCamlformat
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2269,8 +2269,7 @@ end = struct
     ||
     match (ctx, exp) with
     | Str {pstr_desc= Pstr_eval _; _}, _ -> false
-    | _, exp when has_trailing_attributes_exp exp ->
-        true
+    | _, exp when has_trailing_attributes_exp exp -> true
     | ( Exp {pexp_desc= Pexp_construct ({txt= Lident id; _}, _); _}
       , {pexp_attributes= _ :: _; _} )
       when is_infix_id id ->

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2264,11 +2264,13 @@ end = struct
     assert_check_exp xexp ;
     is_displaced_prefix_op xexp
     || is_displaced_infix_op xexp
-    || has_trailing_attributes_exp exp
     || Hashtbl.find marked_parenzed_inner_nested_match exp
        |> Option.value ~default:false
     ||
     match (ctx, exp) with
+    | Str {pstr_desc= Pstr_eval _; _}, _ -> false
+    | _, exp when has_trailing_attributes_exp exp ->
+        true
     | ( Exp {pexp_desc= Pexp_construct ({txt= Lident id; _}, _); _}
       , {pexp_attributes= _ :: _; _} )
       when is_infix_id id ->
@@ -2276,7 +2278,6 @@ end = struct
     | Exp {pexp_desc= Pexp_extension _; _}, {pexp_desc= Pexp_tuple _; _} ->
         false
     | Pld _, {pexp_desc= Pexp_tuple _; _} -> false
-    | Str {pstr_desc= Pstr_eval _; _}, {pexp_desc= Pexp_tuple _; _} -> false
     | Cl {pcl_desc= Pcl_apply _; _}, _ -> parenze ()
     | Exp {pexp_desc= Pexp_ifthenelse (_, e, _); _}, {pexp_desc; _}
       when !parens_ite && e == exp && ifthenelse pexp_desc ->

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2077,20 +2077,25 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         | _ -> Option.is_some (Sugar.list_exp c.cmts e0)
       in
       let opn, cls = if can_skip_parens then (".", "") else (".(", ")") in
-      hvbox 0
-        ( fits_breaks_if parens "" "("
-        $ fits_breaks "" "let "
-        $ Cmts.fmt c popen_loc
-            ( fits_breaks "" (if override then "open! " else "open ")
-            $ fmt_module_statement c ~attributes noop
-                (sub_mod ~ctx popen_expr) )
-        $ fits_breaks opn " in"
-        $ fmt_or_k force_fit_if (fmt "@;<0 2>")
-            (fits_breaks "" ~hint:(1000, 0) "")
-        $ fmt_expression c (sub_exp ~ctx e0)
-        $ fits_breaks cls ""
-        $ fits_breaks_if parens "" ")"
-        $ fmt_atrs )
+      let outer_parens, inner_parens =
+        if has_attr then (parens, true) else (false, parens)
+      in
+      hovbox 0
+        ( fmt_if outer_parens "("
+        $ hvbox 0
+            ( fits_breaks_if inner_parens "" "("
+            $ fits_breaks "" "let "
+            $ Cmts.fmt c popen_loc
+                ( fits_breaks "" (if override then "open! " else "open ")
+                $ fmt_module_statement c ~attributes noop
+                    (sub_mod ~ctx popen_expr) )
+            $ fits_breaks opn " in"
+            $ fmt_or_k force_fit_if (fmt "@;<0 2>")
+                (fits_breaks "" ~hint:(1000, 0) "")
+            $ fmt_expression c (sub_exp ~ctx e0)
+            $ fits_breaks cls ""
+            $ fits_breaks_if inner_parens "" ")" )
+        $ fmt_atrs $ fmt_if outer_parens ")" )
   | Pexp_match (e0, cs) | Pexp_try (e0, cs) -> (
       let keyword =
         match exp.pexp_desc with

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2081,21 +2081,21 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         if has_attr then (parens, true) else (false, parens)
       in
       hovbox 0
-        ( fmt_if outer_parens "("
-        $ hvbox 0
-            ( fits_breaks_if inner_parens "" "("
-            $ fits_breaks "" "let "
-            $ Cmts.fmt c popen_loc
-                ( fits_breaks "" (if override then "open! " else "open ")
-                $ fmt_module_statement c ~attributes noop
-                    (sub_mod ~ctx popen_expr) )
-            $ fits_breaks opn " in"
-            $ fmt_or_k force_fit_if (fmt "@;<0 2>")
-                (fits_breaks "" ~hint:(1000, 0) "")
-            $ fmt_expression c (sub_exp ~ctx e0)
-            $ fits_breaks cls ""
-            $ fits_breaks_if inner_parens "" ")" )
-        $ fmt_atrs $ fmt_if outer_parens ")" )
+        (wrap_if outer_parens "(" ")"
+           ( hvbox 0
+               ( fits_breaks_if inner_parens "" "("
+               $ fits_breaks "" "let "
+               $ Cmts.fmt c popen_loc
+                   ( fits_breaks "" (if override then "open! " else "open ")
+                   $ fmt_module_statement c ~attributes noop
+                       (sub_mod ~ctx popen_expr) )
+               $ fits_breaks opn " in"
+               $ fmt_or_k force_fit_if (fmt "@;<0 2>")
+                   (fits_breaks "" ~hint:(1000, 0) "")
+               $ fmt_expression c (sub_exp ~ctx e0)
+               $ fits_breaks cls ""
+               $ fits_breaks_if inner_parens "" ")" )
+           $ fmt_atrs ))
   | Pexp_match (e0, cs) | Pexp_try (e0, cs) -> (
       let keyword =
         match exp.pexp_desc with

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -82,8 +82,8 @@ let () =
     (let module M = M in
      ()) [@foo]];
   [%foo
-    (let open M in
-     ()) [@foo]];
+    ((let open M in
+      ()) [@foo])];
   [%foo fun [@foo] x -> ()];
   [%foo
     function[@foo]

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -82,8 +82,8 @@ let () =
     (let module M = M in
      ()) [@foo]];
   [%foo
-    ((let open M in
-      ()) [@foo])];
+    (let open M in
+     ()) [@foo]];
   [%foo fun [@foo] x -> ()];
   [%foo
     function[@foo]
@@ -93,18 +93,18 @@ let () =
     | _ -> ()];
   [%foo if [@foo] () then () else ()];
   [%foo
-    (while () do
-       ()
-     done [@foo])];
+    while () do
+      ()
+    done [@foo]];
   [%foo
-    (for x = () to () do
-       ()
-     done [@foo])];
-  [%foo (assert true [@foo])];
-  [%foo (lazy x [@foo])];
-  [%foo (object end [@foo])];
+    for x = () to () do
+      ()
+    done [@foo]];
+  [%foo assert true [@foo]];
+  [%foo lazy x [@foo]];
+  [%foo object end [@foo]];
   [%foo (3 [@foo])];
-  [%foo (new x [@foo])];
+  [%foo new x [@foo]];
   [%foo
     match[@foo] () with
     | [%foo? (* Pattern expressions *)

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -82,8 +82,8 @@ let () =
     (let module M = M in
     ()) [@foo]];
   [%foo
-    (let open M in
-    ()) [@foo]];
+    ((let open M in
+     ()) [@foo])];
   [%foo fun [@foo] x -> ()];
   [%foo
     function[@foo]

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -82,8 +82,8 @@ let () =
     (let module M = M in
     ()) [@foo]];
   [%foo
-    ((let open M in
-     ()) [@foo])];
+    (let open M in
+    ()) [@foo]];
   [%foo fun [@foo] x -> ()];
   [%foo
     function[@foo]
@@ -93,18 +93,18 @@ let () =
     | _ -> ()];
   [%foo if [@foo] () then () else ()];
   [%foo
-    (while () do
-       ()
-     done [@foo])];
+    while () do
+      ()
+    done [@foo]];
   [%foo
-    (for x = () to () do
-       ()
-     done [@foo])];
-  [%foo (assert true [@foo])];
-  [%foo (lazy x [@foo])];
-  [%foo (object end [@foo])];
+    for x = () to () do
+      ()
+    done [@foo]];
+  [%foo assert true [@foo]];
+  [%foo lazy x [@foo]];
+  [%foo object end [@foo]];
   [%foo (3 [@foo])];
-  [%foo (new x [@foo])];
+  [%foo new x [@foo]];
   [%foo
     match[@foo] () with
     | [%foo? (* Pattern expressions *)

--- a/test/passing/open-auto.ml.ref
+++ b/test/passing/open-auto.ml.ref
@@ -278,3 +278,5 @@ open (A : S) [@@attr]
 open (val x) [@@attr]
 
 open [%ext] [@@attr]
+
+let g = M.f (M.(x) [@attr])

--- a/test/passing/open-long.ml.ref
+++ b/test/passing/open-long.ml.ref
@@ -292,3 +292,8 @@ open (A : S) [@@attr]
 open (val x) [@@attr]
 
 open [%ext] [@@attr]
+
+let g =
+  M.f
+    ((let open M in
+     x) [@attr])

--- a/test/passing/open-preserve.ml.ref
+++ b/test/passing/open-preserve.ml.ref
@@ -281,3 +281,8 @@ open (A : S) [@@attr]
 open (val x) [@@attr]
 
 open [%ext] [@@attr]
+
+let g =
+  M.f
+    ((let open M in
+     x) [@attr])

--- a/test/passing/open-short.ml.ref
+++ b/test/passing/open-short.ml.ref
@@ -272,3 +272,5 @@ open (A : S) [@@attr]
 open (val x) [@@attr]
 
 open [%ext] [@@attr]
+
+let g = M.f (M.(x) [@attr])

--- a/test/passing/open.ml
+++ b/test/passing/open.ml
@@ -217,3 +217,5 @@ open[@attr] A (B)
 open[@attr] (A : S)
 open[@attr] (val x)
 open[@attr] [%ext]
+
+let g = M.f ((let open M in x) [@attr])

--- a/test/passing/open.ml.ref
+++ b/test/passing/open.ml.ref
@@ -281,3 +281,8 @@ open (A : S) [@@attr]
 open (val x) [@@attr]
 
 open [%ext] [@@attr]
+
+let g =
+  M.f
+    ((let open M in
+     x) [@attr])

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -4,26 +4,26 @@ let () =
   [%foo
     (let module M = M in
     ()) [@foo]] ;
-  [%foo (M.(()) [@foo])] ;
+  [%foo M.(()) [@foo]] ;
   [%foo fun [@foo] x -> ()] ;
   [%foo function[@foo] x -> ()] ;
   [%foo try[@foo] () with _ -> ()] ;
   [%foo if [@foo] () then () else ()] ;
   [%foo
-    ( while () do
-        ()
-      done [@foo] )] ;
+    while () do
+      ()
+    done [@foo]] ;
   [%foo
-    ( for x = () to () do
-        ()
-      done [@foo] )] ;
+    for x = () to () do
+      ()
+    done [@foo]] ;
   () ;%foo
   () ;
-  [%foo (assert true [@foo])] ;
-  [%foo (lazy x [@foo])] ;
-  [%foo (object end [@foo])] ;
+  [%foo assert true [@foo]] ;
+  [%foo lazy x [@foo]] ;
+  [%foo object end [@foo]] ;
   [%foo (3 [@foo])] ;
-  [%foo (new x [@foo])] ;
+  [%foo new x [@foo]] ;
   [%foo
     match[@foo] () with
     | [%foo? (* Pattern expressions *)

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -4,7 +4,7 @@ let () =
   [%foo
     (let module M = M in
     ()) [@foo]] ;
-  [%foo M.(()) [@foo]] ;
+  [%foo (M.(()) [@foo])] ;
   [%foo fun [@foo] x -> ()] ;
   [%foo function[@foo] x -> ()] ;
   [%foo try[@foo] () with _ -> ()] ;

--- a/test/passing/source.ml
+++ b/test/passing/source.ml
@@ -7356,3 +7356,6 @@ module Indexop = struct
 end
 
 type t = |
+
+;;
+M.(Some x) [@foo]

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -100,25 +100,25 @@ let () =
     (let module M = M in
     ()) [@foo]] ;
   [%foo
-    ((let open M in
-     ()) [@foo])] ;
+    (let open M in
+    ()) [@foo]] ;
   [%foo fun [@foo] x -> ()] ;
   [%foo function[@foo] x -> ()] ;
   [%foo try[@foo] () with _ -> ()] ;
   [%foo if [@foo] () then () else ()] ;
   [%foo
-    ( while () do
-        ()
-      done [@foo] )] ;
+    while () do
+      ()
+    done [@foo]] ;
   [%foo
-    ( for x = () to () do
-        ()
-      done [@foo] )] ;
-  [%foo (assert true [@foo])] ;
-  [%foo (lazy x [@foo])] ;
-  [%foo (object end [@foo])] ;
+    for x = () to () do
+      ()
+    done [@foo]] ;
+  [%foo assert true [@foo]] ;
+  [%foo lazy x [@foo]] ;
+  [%foo object end [@foo]] ;
   [%foo (3 [@foo])] ;
-  [%foo (new x [@foo])] ;
+  [%foo new x [@foo]] ;
   [%foo
     match[@foo] () with
     | [%foo? (* Pattern expressions *)
@@ -9220,4 +9220,4 @@ end
 type t = |
 
 ;;
-(M.(Some x) [@foo])
+M.(Some x) [@foo]

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -100,8 +100,8 @@ let () =
     (let module M = M in
     ()) [@foo]] ;
   [%foo
-    (let open M in
-    ()) [@foo]] ;
+    ((let open M in
+     ()) [@foo])] ;
   [%foo fun [@foo] x -> ()] ;
   [%foo function[@foo] x -> ()] ;
   [%foo try[@foo] () with _ -> ()] ;

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -9218,3 +9218,6 @@ module Indexop = struct
 end
 
 type t = |
+
+;;
+(M.(Some x) [@foo])


### PR DESCRIPTION
As mentioned in #1229

Remove parentheses in:
```diff
 ;;
-(() [@attr])
+() [@attr]

 ;;
-[%ext (() [@attr])]
+[%ext () [@attr]]
```

Rebased on #1229, the bug it fixes would be exacerbated. 