### PR TITLE
Fix dropped comment after a function after an infix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
   + Remove unecessary parentheses with attributes in extensions and eval items (#1230) (Jules Aguillon)
     eg. the expression `[%ext (() [@attr])]` or the structure item `(() [@attr]) ;;`
 
+  + Fix dropped comment after a function after an infix (#1231) (Jules Aguillon)
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
     eg. the expression `[%ext (() [@attr])]` or the structure item `(() [@attr]) ;;`
 
   + Fix dropped comment after a function after an infix (#1231) (Jules Aguillon)
+    eg. the comment in `(x >>= fun y -> y (* A *))` would be dropped
 
 ### 0.13.0 (2020-01-28)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1543,6 +1543,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
     when is_infix_id id && not c.conf.break_infix_before_func ->
       (* side effects of Cmts.fmt c.cmts before Sugar.fun_ is important *)
       let cmts_before = Cmts.fmt_before c pexp_loc in
+      let cmts_after = Cmts.fmt_after c pexp_loc in
       let xargs, xbody = Sugar.fun_ c.cmts (sub_exp ~ctx r) in
       let indent_wrap = if parens then -2 else 0 in
       let pre_body, body = fmt_body c ?ext xbody in
@@ -1576,7 +1577,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                        $ fmt "@ ->" ) )
                $ pre_body )
            $ fmt_or followed_by_infix_op "@;<1000 0>" "@ "
-           $ body ))
+           $ body $ cmts_after ))
   | Pexp_apply
       ( ( { pexp_desc= Pexp_ident {txt= Lident id; loc= _}
           ; pexp_attributes= []
@@ -1588,6 +1589,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
           ) ] )
     when is_infix_id id && not c.conf.break_infix_before_func ->
       let cmts_before = Cmts.fmt_before c pexp_loc in
+      let cmts_after = Cmts.fmt_after c pexp_loc in
       let xr = sub_exp ~ctx r in
       let parens_r = parenze_exp xr in
       let indent = Params.function_indent c.conf ~ctx in
@@ -1603,7 +1605,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                        $ str "function"
                        $ fmt_extension_suffix c ext )
                    $ fmt_attributes c ~key:"@" pexp_attributes ) )
-           $ fmt "@ " $ fmt_cases c (Exp r) cs $ fmt_if parens_r " )" ))
+           $ fmt "@ " $ fmt_cases c (Exp r) cs $ fmt_if parens_r " )"
+           $ cmts_after ))
   | Pexp_apply
       ( { pexp_desc= Pexp_ident {txt= Lident id; loc= _}
         ; pexp_attributes= []

--- a/test/passing/infix_bind-break.ml.ref
+++ b/test/passing/infix_bind-break.ml.ref
@@ -204,3 +204,16 @@ let f =
   >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo foooooooooooooooo *)
   function
   | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
+
+(** The tests below are testing a dropped comment with
+    `--no-break-infix-before-func` *)
+
+let _ = x |> fun y -> y (*  *)
+
+let _ = x |> function y -> y (*  *)
+
+let _ = match () with A -> ( x |> function y -> y (*  *) ) | B -> ()
+
+let _ = x |> function y -> ( function _ -> y (* A *) ) (* B *)
+
+let _ = () (* This is needed here to avoid the comment above from moving *)

--- a/test/passing/infix_bind-fit_or_vertical-break.ml.ref
+++ b/test/passing/infix_bind-fit_or_vertical-break.ml.ref
@@ -209,3 +209,16 @@ let f =
   >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo foooooooooooooooo *)
   function
   | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
+
+(** The tests below are testing a dropped comment with
+    `--no-break-infix-before-func` *)
+
+let _ = x |> fun y -> y (*  *)
+
+let _ = x |> function y -> y (*  *)
+
+let _ = match () with A -> ( x |> function y -> y (*  *) ) | B -> ()
+
+let _ = x |> function y -> ( function _ -> y (* A *) ) (* B *)
+
+let _ = () (* This is needed here to avoid the comment above from moving *)

--- a/test/passing/infix_bind-fit_or_vertical.ml.ref
+++ b/test/passing/infix_bind-fit_or_vertical.ml.ref
@@ -203,3 +203,16 @@ let f =
   (* fooooooooooooooo fooooooooooooooo fooooooooooooooo foooooooooooooooo *)
   function
   | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
+
+(** The tests below are testing a dropped comment with
+    `--no-break-infix-before-func` *)
+
+let _ = x |> fun y -> y (*  *)
+
+let _ = x |> function y -> y (*  *)
+
+let _ = match () with A -> ( x |> function y -> y (*  *) ) | B -> ()
+
+let _ = x |> function y -> ( function _ -> y (* A *) ) (* B *)
+
+let _ = () (* This is needed here to avoid the comment above from moving *)

--- a/test/passing/infix_bind.ml
+++ b/test/passing/infix_bind.ml
@@ -198,3 +198,16 @@ let f =
   (* fooooooooooooooo fooooooooooooooo fooooooooooooooo foooooooooooooooo *)
   function
   | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
+
+(** The tests below are testing a dropped comment with
+    `--no-break-infix-before-func` *)
+
+let _ = x |> fun y -> y (*  *)
+
+let _ = x |> function y -> y (*  *)
+
+let _ = match () with A -> ( x |> function y -> y (*  *) ) | B -> ()
+
+let _ = x |> function y -> ( function _ -> y (* A *) ) (* B *)
+
+let _ = () (* This is needed here to avoid the comment above from moving *)


### PR DESCRIPTION
Fixes https://github.com/ocaml-ppx/ocamlformat/issues/1227

With `--no-break-infix-before-func`, this comment was dropped:
```ocaml
let _ = (x >>= fun y -> y (* A *))
```