### PR TITLE
Remove link to empty mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ ml` and then running `ocamlformat` on this output.
 * forum: <https://discuss.ocaml.org/tags/ocamlformat>
 * github: <https://github.com/ocaml-ppx/ocamlformat>
 * issues: <https://github.com/ocaml-ppx/ocamlformat/issues>
-* developers mailing list: <http://lists.ocaml.org/listinfo/ocamlformat-dev>
 
 See [CONTRIBUTING](./CONTRIBUTING.md) for how to help out.
 


### PR DESCRIPTION
The archives are empty so I suppose it has never been used?