### PR TITLE
Fix formatting of empty sig payload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
   + Fix dropped comment after a function after an infix (#1231) (Jules Aguillon)
     eg. the comment in `(x >>= fun y -> y (* A *))` would be dropped
 
+  + Fix formatting of empty signature payload `[%a:]` (#1236) (Etienne Millon)
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -567,7 +567,9 @@ and fmt_payload c ctx pld =
   | PStr mex ->
       fmt_if (not (List.is_empty mex)) "@ " $ fmt_structure c ctx mex
   | PSig mty ->
-      fmt_if (not (List.is_empty mty)) ":@ " $ fmt_signature c ctx mty
+      str ":"
+      $ fmt_if (not (List.is_empty mty)) "@ "
+      $ fmt_signature c ctx mty
   | PTyp typ -> fmt ":@ " $ fmt_core_type c (sub_typ ~ctx typ)
   | PPat (pat, exp) ->
       let fmt_when exp =

--- a/test/passing/source.ml
+++ b/test/passing/source.ml
@@ -7359,3 +7359,5 @@ type t = |
 
 ;;
 M.(Some x) [@foo]
+
+[@@@foo:]

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -9221,3 +9221,5 @@ type t = |
 
 ;;
 M.(Some x) [@foo]
+
+[@@@foo:]


### PR DESCRIPTION
In `[@a:]`, the payload is an empty signature.

It should be formatted as such; the payload in `[@a]` is an empty structure, which is different.