### PR TITLE
CmtSet: implement in with Position, not Location

### DIFF
--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -130,16 +130,24 @@ module Position = struct
   open Lexing
   module Format = Format_
 
+  type t = position
+
   let column {pos_bol; pos_cnum; _} = pos_cnum - pos_bol
 
   let fmt fs {pos_lnum; pos_bol; pos_cnum; _} =
     if pos_lnum = -1 then Format.fprintf fs "[%d]" pos_cnum
     else Format.fprintf fs "[%d,%d+%d]" pos_lnum pos_bol (pos_cnum - pos_bol)
 
+  let to_string x = Format.asprintf "%a" fmt x
+
+  let sexp_of_t x = Sexp.Atom (to_string x)
+
   let compare_col p1 p2 = Int.compare (column p1) (column p2)
 
   let compare p1 p2 =
     if phys_equal p1 p2 then 0 else Int.compare p1.pos_cnum p2.pos_cnum
+
+  include (val Comparator.make ~compare ~sexp_of_t)
 
   let distance p1 p2 = p2.pos_cnum - p1.pos_cnum
 end

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -42,11 +42,13 @@ module Asttypes : sig
 end
 
 module Position : sig
-  val column : Lexing.position -> int
+  type t = Lexing.position
 
-  val compare : Lexing.position -> Lexing.position -> int
+  include Comparator.S with type t := t
 
-  val distance : Lexing.position -> Lexing.position -> int
+  val column : t -> int
+
+  val distance : t -> t -> int
 end
 
 module Location : sig


### PR DESCRIPTION
All operations are done comparing the start of the locs, so this transforms the map into one taking locs and returning all comments starting there.

I also tried to rework a bit how `split` is implemented since I found it a bit hard to follow.