### PR TITLE
Handle attributes on object overrides ({< >})

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,9 @@
 
   + Fix parenthesizing when accessing field of construct application (#1247) (Guillaume Petiot)
 
+  + Fix formatting of attributes on object overrides `{< >}` (#1238) (Etienne
+    Millon)
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2399,12 +2399,15 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             $ fmt_expression c (sub_exp ~ctx f)
       in
       match l with
-      | [] -> wrap "{<" ">}" (Cmts.fmt_within c pexp_loc)
+      | [] ->
+          wrap_if parens "(" ")"
+            (wrap "{<" ">}" (Cmts.fmt_within c pexp_loc) $ fmt_atrs)
       | _ ->
           hvbox 0
             (wrap_if parens "(" ")"
-               (wrap_fits_breaks ~space:false c.conf "{<" ">}"
-                  (list l "@;<0 1>; " fmt_field))) )
+               ( wrap_fits_breaks ~space:false c.conf "{<" ">}"
+                   (list l "@;<0 1>; " fmt_field)
+               $ fmt_atrs )) )
   | Pexp_setinstvar (name, expr) ->
       hvbox 0
         (Params.wrap_exp c.conf c.source ~loc:pexp_loc ~parens

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -186,3 +186,11 @@ module M = struct
   (* ______________________________________ *)
   [@@deriving variants, sexp_of]
 end
+
+let _ = {<>} [@a]
+
+let _ = f ({<>} [@a])
+
+let _ = {<x = 1>} [@a]
+
+let _ = f ({<x = 1>} [@a])


### PR DESCRIPTION
These were silently dropped.