### PR TITLE
Add a test for ocamlformat-help.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,11 @@
 ######################################################################
 
 .PHONY: default
-default: exe gen-help
+default: exe
 
 .PHONY: exe
 exe:
 	dune build bin/ocamlformat.exe
-
-.PHONY: gen-help
-gen-help:
-	dune build ocamlformat-help.txt
 
 .PHONY: clean
 clean:

--- a/dune
+++ b/dune
@@ -15,11 +15,15 @@
    (:standard -noassert))))
 
 (rule
- (targets ocamlformat-help.txt)
- (mode promote)
+ (targets ocamlformat-help.actual)
  (action
   (with-stdout-to
    %{targets}
-   (run ./bin/ocamlformat.exe --help=plain))))
+   (run ocamlformat --help=plain))))
+
+(alias
+ (name runtest)
+ (action
+  (diff ocamlformat-help.txt ocamlformat-help.actual)))
 
 (data_only_dirs test-extra)


### PR DESCRIPTION
Use a `runtest` alias instead of `(mode promote)`:

- It is checked when running the tests, it is harder to miss updating it.
- Checked in the CI

Running `make` no longer update this file.