### PR TITLE
Fix attribute formatting on Pexp_pack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@
 
   + Fix attributes on coercion (#1239) (Etienne Millon)
 
+  + Fix formatting of attributes on packed modules (#1243) (Etienne Millon)
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2191,8 +2191,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    | `Closing_on_separate_line -> "@;<1000 -2>)" ) )) )
   | Pexp_pack me ->
       let fmt_mod m =
-        Params.wrap_exp c.conf c.source ~parens:true ~loc:pexp_loc
-          (str "module " $ m $ fmt_atrs)
+        wrap_if parens "(" ")"
+          ( Params.wrap_exp c.conf c.source ~parens:true ~loc:pexp_loc
+              (str "module " $ m)
+          $ fmt_atrs )
       in
       hovbox 0
         (compose_module (fmt_module_expr c (sub_mod ~ctx me)) ~f:fmt_mod)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1818,13 +1818,14 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         (compose_module
            (fmt_module_expr c (sub_mod ~ctx me))
            ~f:(fun m ->
-             hvbox 2
-               (Cmts.fmt c pexp_loc
-                  ( hovbox 0
-                      ( opn_paren $ str "module " $ m $ fmt "@ : "
-                      $ fmt_longident_loc c id )
-                  $ fmt_package_type c ctx cnstrs
-                  $ cls_paren $ fmt_atrs ))))
+             wrap_if parens "(" ")"
+               (hvbox 2
+                  (Cmts.fmt c pexp_loc
+                     ( hovbox 0
+                         ( opn_paren $ str "module " $ m $ fmt "@ : "
+                         $ fmt_longident_loc c id )
+                     $ fmt_package_type c ctx cnstrs
+                     $ cls_paren $ fmt_atrs )))))
   | Pexp_constraint (e, t) ->
       hvbox 2
         ( wrap_fits_breaks ~space:false c.conf "(" ")"

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1824,7 +1824,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                       ( opn_paren $ str "module " $ m $ fmt "@ : "
                       $ fmt_longident_loc c id )
                   $ fmt_package_type c ctx cnstrs
-                  $ fmt_atrs $ cls_paren ))))
+                  $ cls_paren $ fmt_atrs ))))
   | Pexp_constraint (e, t) ->
       hvbox 2
         ( wrap_fits_breaks ~space:false c.conf "(" ")"

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -202,3 +202,5 @@ let _ = f ((x :> t) [@a])
 let _ = (module M) [@a]
 
 let _ = f ((module M) [@a])
+
+let _ = (module M : S) [@a]

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -198,3 +198,7 @@ let _ = f ({<x = 1>} [@a])
 let _ = (x :> t) [@a]
 
 let _ = f ((x :> t) [@a])
+
+let _ = (module struct end) [@a]
+
+let _ = f ((module struct end) [@a])

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -199,6 +199,6 @@ let _ = (x :> t) [@a]
 
 let _ = f ((x :> t) [@a])
 
-let _ = (module struct end) [@a]
+let _ = (module M) [@a]
 
-let _ = f ((module struct end) [@a])
+let _ = f ((module M) [@a])

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -204,3 +204,5 @@ let _ = (module M) [@a]
 let _ = f ((module M) [@a])
 
 let _ = (module M : S) [@a]
+
+let _ = f ((module M : S) [@a])


### PR DESCRIPTION
(It was formatted as `(module struct end [@a])`)