### PR TITLE
Remove parens after "let _"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,10 @@
   + Fix missing parentheses around `let open` (#1229) (Jules Aguillon)
     eg. `M.f (M.(x) [@attr])` would be formatted to `M.f M.(x) [@attr]`, which would crash OCamlformat
 
-  + Remove unecessary parentheses with attributes in extensions and eval items (#1230) (Jules Aguillon)
-    eg. the expression `[%ext (() [@attr])]` or the structure item `(() [@attr]) ;;`
+  + Remove unecessary parentheses with attributes in some structure items:
+    * extensions and eval items (#1230) (Jules Aguillon)
+      eg. the expression `[%ext (() [@attr])]` or the structure item `(() [@attr]) ;;`
+    * `let _ = ...`  constructs (#1244) (Etienne Millon)
 
   + Fix dropped comment after a function after an infix (#1231) (Jules Aguillon)
     eg. the comment in `(x >>= fun y -> y (* A *))` would be dropped

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2269,6 +2269,13 @@ end = struct
     ||
     match (ctx, exp) with
     | Str {pstr_desc= Pstr_eval _; _}, _ -> false
+    | ( Str
+          { pstr_desc=
+              Pstr_value
+                (Nonrecursive, [{pvb_pat= {ppat_desc= Ppat_any; _}; _}])
+          ; _ }
+      , _ ) ->
+        false
     | _, exp when has_trailing_attributes_exp exp -> true
     | ( Exp {pexp_desc= Pexp_construct ({txt= Lident id; _}, _); _}
       , {pexp_attributes= _ :: _; _} )

--- a/test/passing/extensions-indent.ml.ref
+++ b/test/passing/extensions-indent.ml.ref
@@ -1,6 +1,6 @@
 let () = [%ext expr] ; ()
 
-let _ = ([%ext match x with () -> ()] [@attr y])
+let _ = [%ext match x with () -> ()] [@attr y]
 
 let _ =
   match%ext x with
@@ -83,9 +83,9 @@ let _ =
   ; x ]
 
 let _ =
-  ( [%expr
-         let x = e in
-         f y] [@x] )
+  [%expr
+       let x = e in
+       f y] [@x]
 
 let _ =
   f

--- a/test/passing/extensions-sugar_always.ml.ref
+++ b/test/passing/extensions-sugar_always.ml.ref
@@ -1,6 +1,6 @@
 let () = [%ext expr] ; ()
 
-let _ = ([%ext match x with () -> ()] [@attr y])
+let _ = [%ext match x with () -> ()] [@attr y]
 
 let _ =
   match%ext x with
@@ -80,9 +80,9 @@ let _ =
   ; x ]
 
 let _ =
-  ( [%expr
-      let x = e in
-      f y] [@x] )
+  [%expr
+    let x = e in
+    f y] [@x]
 
 let _ =
   f

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -1,6 +1,6 @@
 let () = [%ext expr] ; ()
 
-let _ = ([%ext match x with () -> ()] [@attr y])
+let _ = [%ext match x with () -> ()] [@attr y]
 
 let _ =
   match%ext x with
@@ -83,9 +83,9 @@ let _ =
   ; x ]
 
 let _ =
-  ( [%expr
-      let x = e in
-      f y] [@x] )
+  [%expr
+    let x = e in
+    f y] [@x]
 
 let _ =
   f

--- a/test/passing/margin_80.ml.ref
+++ b/test/passing/margin_80.ml.ref
@@ -20,6 +20,6 @@ let _ =
      [@dddddddddd])
 
 let _ =
-  (aa
-     (bbbbbbbbb cccccccccccc dddddddddddddddddddddddddddddddddddddd)
-   [@dddddddddd])
+  aa
+    (bbbbbbbbb cccccccccccc dddddddddddddddddddddddddddddddddddddd)
+  [@dddddddddd]

--- a/test/passing/object_type.ml.ref
+++ b/test/passing/object_type.ml.ref
@@ -21,7 +21,7 @@ let lookup_obj : < .. > -> (< .. > as 'a) list -> 'a = fun _ -> assert false
 
 let _ = [%ext: < a ; b > ]
 
-let _ = (x [@att: < a ; b > ])
+let _ = x [@att: < a ; b > ]
 
 type t = [`A of < a ; b > ]
 


### PR DESCRIPTION
This is an extension of #1230 for `let _ = ...` structure items.

As discussed in https://github.com/ocaml-ppx/ocamlformat/pull/1238#discussion_r380832586.

Let me know what you think. Should this be extended to more let bindings?