### PR TITLE
Internal: extract the comment formatting function as Cmt.fmt

### DIFF
--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -32,3 +32,125 @@ include T
 include Comparator.Make (T)
 
 let create txt loc = {txt; loc}
+
+let split_asterisk_prefixed {txt; loc= {Location.loc_start; _}} =
+  let len = Position.column loc_start + 3 in
+  let pat =
+    String.Search_pattern.create
+      (String.init len ~f:(function
+        | 0 -> '\n'
+        | n when n < len - 1 -> ' '
+        | _ -> '*'))
+  in
+  let rec split_asterisk_prefixed_ pos =
+    match String.Search_pattern.index pat ~pos ~in_:txt with
+    | Some 0 -> "" :: split_asterisk_prefixed_ len
+    | Some idx ->
+        String.sub txt ~pos ~len:(idx - pos)
+        :: split_asterisk_prefixed_ (idx + len)
+    | _ ->
+        let drop = function ' ' | '\t' -> true | _ -> false in
+        let line = String.rstrip ~drop (String.drop_prefix txt pos) in
+        if String.is_empty line then [" "]
+        else if Char.equal line.[String.length line - 1] '\n' then
+          [String.drop_suffix line 1; ""]
+        else if Char.is_whitespace txt.[String.length txt - 1] then
+          [line ^ " "]
+        else [line]
+  in
+  split_asterisk_prefixed_ 0
+
+let unindent_lines ~opn_pos first_line tl_lines =
+  let indent_of_line s =
+    (* index of first non-whitespace is indentation, None means white line *)
+    String.lfindi s ~f:(fun _ c -> not (Char.is_whitespace c))
+  in
+  (* The indentation of the first line must account for the location of the
+     comment opening *)
+  let fl_spaces = Option.value ~default:0 (indent_of_line first_line) in
+  let fl_offset = opn_pos.Lexing.pos_cnum - opn_pos.pos_bol + 2 in
+  let fl_indent = fl_spaces + fl_offset in
+  let min_indent =
+    List.fold_left ~init:fl_indent
+      ~f:(fun acc s ->
+        Option.value_map ~default:acc ~f:(min acc) (indent_of_line s))
+      tl_lines
+  in
+  (* Completely trim the first line *)
+  String.drop_prefix first_line fl_spaces
+  :: List.map ~f:(fun s -> String.drop_prefix s min_indent) tl_lines
+
+let fmt_multiline_cmt ?epi ~opn_pos ~starts_with_sp first_line tl_lines =
+  let open Fmt in
+  let is_white_line s = String.for_all s ~f:Char.is_whitespace in
+  let unindented = unindent_lines ~opn_pos first_line tl_lines in
+  let fmt_line ~first ~last:_ s =
+    let sep, sp =
+      if is_white_line s then (str "\n", noop)
+      else (fmt "@;<1000 0>", fmt_if starts_with_sp " ")
+    in
+    fmt_if_k (not first) sep $ sp $ str (String.rstrip s)
+  in
+  vbox 0 (list_fl unindented fmt_line $ fmt_opt epi)
+
+let fmt cmt src (conf : Conf.t) ~fmt_code =
+  let open Fmt in
+  let fmt_asterisk_prefixed_lines lines =
+    vbox 1
+      ( fmt "(*"
+      $ list_pn lines (fun ~prev:_ line ~next ->
+            match (line, next) with
+            | "", None -> fmt ")"
+            | _, None -> str line $ fmt "*)"
+            | _, Some _ -> str line $ fmt "@,*") )
+  in
+  let fmt_unwrapped_cmt {txt= s; loc} =
+    let begins_line = Source.begins_line src loc ~ignore_spaces:false in
+    let is_sp = function ' ' | '\t' -> true | _ -> false in
+    let epi =
+      (* Preserve position of closing but strip empty lines at the end *)
+      match String.rfindi s ~f:(fun _ c -> not (is_sp c)) with
+      | Some i when Char.( = ) s.[i] '\n' ->
+          break 1000 (-2) (* Break before closing *)
+      | Some i when i < String.length s - 1 ->
+          str " " (* Preserve a space at the end *)
+      | _ -> noop
+    in
+    let stripped = String.rstrip s in
+    match String.split_lines stripped with
+    | first_line :: (_ :: _ as tl)
+      when (not begins_line) && not (String.is_empty first_line) ->
+        (* Preserve the first level of indentation *)
+        let starts_with_sp = is_sp first_line.[0] in
+        fmt_multiline_cmt ~opn_pos:loc.loc_start ~epi ~starts_with_sp
+          first_line tl
+    | _ -> str s
+  in
+  let fmt_non_code cmt =
+    if not conf.wrap_comments then
+      match split_asterisk_prefixed cmt with
+      | [""] | [_] | [_; ""] -> wrap "(*" "*)" (fmt_unwrapped_cmt cmt)
+      | asterisk_prefixed_lines ->
+          fmt_asterisk_prefixed_lines asterisk_prefixed_lines
+    else
+      match split_asterisk_prefixed cmt with
+      | [""] -> str "(* *)"
+      | [text] -> str "(*" $ fill_text text ~epi:(str "*)")
+      | [text; ""] -> str "(*" $ fill_text text ~epi:(str " *)")
+      | asterisk_prefixed_lines ->
+          fmt_asterisk_prefixed_lines asterisk_prefixed_lines
+  in
+  let fmt_code ({txt= str; _} as cmt) =
+    let dollar_last = Char.equal str.[String.length str - 1] '$' in
+    let len = String.length str - if dollar_last then 2 else 1 in
+    let source = String.sub ~pos:1 ~len str in
+    match fmt_code conf source with
+    | Ok formatted ->
+        let cls : Fmt.s = if dollar_last then "$*)" else "*)" in
+        hvbox 2 (wrap "(*$" cls (fmt "@;" $ formatted $ fmt "@;<1 -2>"))
+    | Error () -> fmt_non_code cmt
+  in
+  match cmt.txt with
+  | "" | "$" -> fmt_non_code cmt
+  | str when Char.equal str.[0] '$' -> fmt_code cmt
+  | _ -> fmt_non_code cmt

--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -93,7 +93,7 @@ let fmt_multiline_cmt ?epi ~opn_pos ~starts_with_sp first_line tl_lines =
   in
   vbox 0 (list_fl unindented fmt_line $ fmt_opt epi)
 
-let fmt cmt src (conf : Conf.t) ~fmt_code =
+let fmt cmt src ~wrap:wrap_comments ~fmt_code =
   let open Fmt in
   let fmt_asterisk_prefixed_lines lines =
     vbox 1
@@ -127,7 +127,7 @@ let fmt cmt src (conf : Conf.t) ~fmt_code =
     | _ -> str s
   in
   let fmt_non_code cmt =
-    if not conf.wrap_comments then
+    if not wrap_comments then
       match split_asterisk_prefixed cmt with
       | [""] | [_] | [_; ""] -> wrap "(*" "*)" (fmt_unwrapped_cmt cmt)
       | asterisk_prefixed_lines ->
@@ -144,7 +144,7 @@ let fmt cmt src (conf : Conf.t) ~fmt_code =
     let dollar_last = Char.equal str.[String.length str - 1] '$' in
     let len = String.length str - if dollar_last then 2 else 1 in
     let source = String.sub ~pos:1 ~len str in
-    match fmt_code conf source with
+    match fmt_code source with
     | Ok formatted ->
         let cls : Fmt.s = if dollar_last then "$*)" else "*)" in
         hvbox 2 (wrap "(*$" cls (fmt "@;" $ formatted $ fmt "@;<1 -2>"))

--- a/lib/Cmt.mli
+++ b/lib/Cmt.mli
@@ -24,6 +24,6 @@ include Comparator.S with type t := t
 val fmt :
      t
   -> Source.t
-  -> Conf.t
-  -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
+  -> wrap:bool
+  -> fmt_code:(string -> (Fmt.t, unit) Result.t)
   -> Fmt.t

--- a/lib/Cmt.mli
+++ b/lib/Cmt.mli
@@ -20,3 +20,10 @@ val loc : t -> Location.t
 val txt : t -> string
 
 include Comparator.S with type t := t
+
+val fmt :
+     t
+  -> Source.t
+  -> Conf.t
+  -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
+  -> Fmt.t

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -419,7 +419,10 @@ let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
           $ ( match group with
             | [] -> impossible "previous match"
             | [cmt] ->
-                Cmt.fmt cmt t.source conf ~fmt_code $ maybe_newline ~next cmt
+                let wrap = conf.wrap_comments in
+                let fmt_code = fmt_code conf in
+                Cmt.fmt cmt t.source ~wrap ~fmt_code
+                $ maybe_newline ~next cmt
             | group ->
                 list group "@;<1000 0>" (fun cmt ->
                     wrap "(*" "*)" (str (Cmt.txt cmt)))

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -421,7 +421,7 @@ let fmt_multiline_cmt ?epi ~opn_pos ~starts_with_sp first_line tl_lines =
   in
   vbox 0 (list_fl unindented fmt_line $ fmt_opt epi)
 
-let fmt_cmt t (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
+let fmt_cmt src (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
   let open Fmt in
   let fmt_asterisk_prefixed_lines lines =
     vbox 1
@@ -433,7 +433,7 @@ let fmt_cmt t (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
             | _, Some _ -> str line $ fmt "@,*") )
   in
   let fmt_unwrapped_cmt ({txt= s; loc} : Cmt.t) =
-    let begins_line = Source.begins_line t.source loc ~ignore_spaces:false in
+    let begins_line = Source.begins_line src loc ~ignore_spaces:false in
     let is_sp = function ' ' | '\t' -> true | _ -> false in
     let epi =
       (* Preserve position of closing but strip empty lines at the end *)
@@ -540,7 +540,8 @@ let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
             (fmt "@ ")
           $ ( match group with
             | [] -> impossible "previous match"
-            | [cmt] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt
+            | [cmt] ->
+                fmt_cmt t.source conf cmt ~fmt_code $ maybe_newline ~next cmt
             | group ->
                 list group "@;<1000 0>" (fun cmt ->
                     wrap "(*" "*)" (str (Cmt.txt cmt)))

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -361,128 +361,6 @@ let preserve fmt_x t =
   Format.pp_print_flush fs () ;
   Buffer.contents buf
 
-let split_asterisk_prefixed {Cmt.txt; loc= {Location.loc_start; _}} =
-  let len = Position.column loc_start + 3 in
-  let pat =
-    String.Search_pattern.create
-      (String.init len ~f:(function
-        | 0 -> '\n'
-        | n when n < len - 1 -> ' '
-        | _ -> '*'))
-  in
-  let rec split_asterisk_prefixed_ pos =
-    match String.Search_pattern.index pat ~pos ~in_:txt with
-    | Some 0 -> "" :: split_asterisk_prefixed_ len
-    | Some idx ->
-        String.sub txt ~pos ~len:(idx - pos)
-        :: split_asterisk_prefixed_ (idx + len)
-    | _ ->
-        let drop = function ' ' | '\t' -> true | _ -> false in
-        let line = String.rstrip ~drop (String.drop_prefix txt pos) in
-        if String.is_empty line then [" "]
-        else if Char.equal line.[String.length line - 1] '\n' then
-          [String.drop_suffix line 1; ""]
-        else if Char.is_whitespace txt.[String.length txt - 1] then
-          [line ^ " "]
-        else [line]
-  in
-  split_asterisk_prefixed_ 0
-
-let unindent_lines ~opn_pos first_line tl_lines =
-  let indent_of_line s =
-    (* index of first non-whitespace is indentation, None means white line *)
-    String.lfindi s ~f:(fun _ c -> not (Char.is_whitespace c))
-  in
-  (* The indentation of the first line must account for the location of the
-     comment opening *)
-  let fl_spaces = Option.value ~default:0 (indent_of_line first_line) in
-  let fl_offset = opn_pos.Lexing.pos_cnum - opn_pos.pos_bol + 2 in
-  let fl_indent = fl_spaces + fl_offset in
-  let min_indent =
-    List.fold_left ~init:fl_indent
-      ~f:(fun acc s ->
-        Option.value_map ~default:acc ~f:(min acc) (indent_of_line s))
-      tl_lines
-  in
-  (* Completely trim the first line *)
-  String.drop_prefix first_line fl_spaces
-  :: List.map ~f:(fun s -> String.drop_prefix s min_indent) tl_lines
-
-let fmt_multiline_cmt ?epi ~opn_pos ~starts_with_sp first_line tl_lines =
-  let open Fmt in
-  let is_white_line s = String.for_all s ~f:Char.is_whitespace in
-  let unindented = unindent_lines ~opn_pos first_line tl_lines in
-  let fmt_line ~first ~last:_ s =
-    let sep, sp =
-      if is_white_line s then (str "\n", noop)
-      else (fmt "@;<1000 0>", fmt_if starts_with_sp " ")
-    in
-    fmt_if_k (not first) sep $ sp $ str (String.rstrip s)
-  in
-  vbox 0 (list_fl unindented fmt_line $ fmt_opt epi)
-
-let fmt_cmt src (conf : Conf.t) ~fmt_code (cmt : Cmt.t) =
-  let open Fmt in
-  let fmt_asterisk_prefixed_lines lines =
-    vbox 1
-      ( fmt "(*"
-      $ list_pn lines (fun ~prev:_ line ~next ->
-            match (line, next) with
-            | "", None -> fmt ")"
-            | _, None -> str line $ fmt "*)"
-            | _, Some _ -> str line $ fmt "@,*") )
-  in
-  let fmt_unwrapped_cmt ({txt= s; loc} : Cmt.t) =
-    let begins_line = Source.begins_line src loc ~ignore_spaces:false in
-    let is_sp = function ' ' | '\t' -> true | _ -> false in
-    let epi =
-      (* Preserve position of closing but strip empty lines at the end *)
-      match String.rfindi s ~f:(fun _ c -> not (is_sp c)) with
-      | Some i when Char.( = ) s.[i] '\n' ->
-          break 1000 (-2) (* Break before closing *)
-      | Some i when i < String.length s - 1 ->
-          str " " (* Preserve a space at the end *)
-      | _ -> noop
-    in
-    let stripped = String.rstrip s in
-    match String.split_lines stripped with
-    | first_line :: (_ :: _ as tl)
-      when (not begins_line) && not (String.is_empty first_line) ->
-        (* Preserve the first level of indentation *)
-        let starts_with_sp = is_sp first_line.[0] in
-        fmt_multiline_cmt ~opn_pos:loc.loc_start ~epi ~starts_with_sp
-          first_line tl
-    | _ -> str s
-  in
-  let fmt_non_code cmt =
-    if not conf.wrap_comments then
-      match split_asterisk_prefixed cmt with
-      | [""] | [_] | [_; ""] -> wrap "(*" "*)" (fmt_unwrapped_cmt cmt)
-      | asterisk_prefixed_lines ->
-          fmt_asterisk_prefixed_lines asterisk_prefixed_lines
-    else
-      match split_asterisk_prefixed cmt with
-      | [""] -> str "(* *)"
-      | [text] -> str "(*" $ fill_text text ~epi:(str "*)")
-      | [text; ""] -> str "(*" $ fill_text text ~epi:(str " *)")
-      | asterisk_prefixed_lines ->
-          fmt_asterisk_prefixed_lines asterisk_prefixed_lines
-  in
-  let fmt_code ({Cmt.txt= str; _} as cmt) =
-    let dollar_last = Char.equal str.[String.length str - 1] '$' in
-    let len = String.length str - if dollar_last then 2 else 1 in
-    let source = String.sub ~pos:1 ~len str in
-    match fmt_code conf source with
-    | Ok formatted ->
-        let cls : Fmt.s = if dollar_last then "$*)" else "*)" in
-        hvbox 2 (wrap "(*$" cls (fmt "@;" $ formatted $ fmt "@;<1 -2>"))
-    | Error () -> fmt_non_code cmt
-  in
-  match Cmt.txt cmt with
-  | "" | "$" -> fmt_non_code cmt
-  | str when Char.equal str.[0] '$' -> fmt_code cmt
-  | _ -> fmt_non_code cmt
-
 let pop_if_debug t loc =
   if t.debug && t.remove then update_remaining t ~f:(Location.Set.remove loc)
 
@@ -541,7 +419,7 @@ let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
           $ ( match group with
             | [] -> impossible "previous match"
             | [cmt] ->
-                fmt_cmt t.source conf cmt ~fmt_code $ maybe_newline ~next cmt
+                Cmt.fmt cmt t.source conf ~fmt_code $ maybe_newline ~next cmt
             | group ->
                 list group "@;<1000 0>" (fun cmt ->
                     wrap "(*" "*)" (str (Cmt.txt cmt)))


### PR DESCRIPTION
This is a minor cleaning of Cmts.ml