### PR TITLE
Fix parens around binop operations with attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@
 
   + Fix formatting of attributes on packed modules (#1243) (Etienne Millon)
 
+  + Fix parens around binop operations with attributes (#1252) (Guillaume Petiot)
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2269,6 +2269,14 @@ end = struct
     ||
     match (ctx, exp) with
     | Str {pstr_desc= Pstr_eval _; _}, _ -> false
+    | ( _
+      , { pexp_desc=
+            Pexp_apply
+              ({pexp_desc= Pexp_ident {txt= Lident id; _}; _}, _ :: _)
+        ; pexp_attributes= _ :: _
+        ; _ } )
+      when is_infix_id id ->
+        true
     | ( Str
           { pstr_desc=
               Pstr_value

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -206,3 +206,9 @@ let _ = f ((module M) [@a])
 let _ = (module M : S) [@a]
 
 let _ = f ((module M : S) [@a])
+
+let _ = ([] @ []) [@a]
+
+let _ = ("" ^ "") [@a]
+
+let _ = (0 + 0) [@a]


### PR DESCRIPTION
Partial fix of #1250 
No regression with test_branch for the preset profiles.