### PR TITLE
Unecessary parens in indexing operators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,8 @@
 
   + Fix parens around binop operations with attributes (#1252) (Guillaume Petiot)
 
+  + Remove unecessary parentheses in the argument of indexing operators (#1280) (Jules Aguillon)
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1660,7 +1660,7 @@ end = struct
           else
             match op.rhs with
             | Some e when e == exp -> Some (LessMinus, Right)
-            | _ -> Some (LessMinus, Left) )
+            | _ -> None )
       | Pexp_apply
           ({pexp_desc= Pexp_ident {txt= Lident i; _}; _}, [(_, e1); _]) -> (
           let child = if e1 == exp then Left else Right in
@@ -2124,12 +2124,8 @@ end = struct
           ->
             continue (List.last_exn cases).pc_rhs
         | Pexp_apply ({pexp_desc= Pexp_ident ident; _}, args)
-          when Option.is_some (Indexing_op.get_sugar ident args) -> (
-          match Option.value_exn (Indexing_op.get_sugar ident args) with
-          | {rhs= Some e; _} -> continue e
-          | {op= Defined (arg, _); _} -> continue arg
-          | {op= Extended (args, _); _} | {op= Special (args, _); _} ->
-              continue (List.last_exn args) )
+          when Option.is_some (Indexing_op.get_sugar ident args) ->
+            false
         | Pexp_apply (_, args) -> continue (snd (List.last_exn args))
         | Pexp_tuple es -> continue (List.last_exn es)
         | Pexp_array _ | Pexp_coerce _ | Pexp_constant _ | Pexp_constraint _
@@ -2207,9 +2203,7 @@ end = struct
         when Option.is_some (Indexing_op.get_sugar ident args) -> (
         match Option.value_exn (Indexing_op.get_sugar ident args) with
         | {rhs= Some e; _} -> continue e
-        | {op= Defined (arg, _); _} -> continue arg
-        | {op= Extended (args, _); _} | {op= Special (args, _); _} ->
-            continue (List.last_exn args) )
+        | {rhs= None; _} -> false )
       | Pexp_apply (_, args) -> continue (snd (List.last_exn args))
       | Pexp_tuple es -> continue (List.last_exn es)
       | Pexp_array _ | Pexp_coerce _ | Pexp_constant _ | Pexp_constraint _

--- a/test/passing/index_op.ml
+++ b/test/passing/index_op.ml
@@ -136,3 +136,10 @@ let _ =
   | C -> ()
 
 let _ = if a then a.*(if a then b) else c
+
+(* Parentheses needed *)
+let _ = a.*{(a ; b)}
+
+let _ = a.{(a ; b)}
+
+let _ = a.{a, b}

--- a/test/passing/index_op.ml
+++ b/test/passing/index_op.ml
@@ -131,8 +131,8 @@ let _ = a.*([|a; b|])
 (* Avoid unecessary parentheses *)
 let _ =
   match a with
-  | A -> a.*((match b with B -> b))
-  | B -> a.*((match b with B -> b)) <- D
+  | A -> a.*(match b with B -> b)
+  | B -> a.*(match b with B -> b) <- D
   | C -> ()
 
-let _ = if a then a.*((if a then b)) else c
+let _ = if a then a.*(if a then b) else c

--- a/test/passing/index_op.ml
+++ b/test/passing/index_op.ml
@@ -127,3 +127,12 @@ let _ = a.A.B.*(b) ; a.A.B.*(b) <- c
 let _ = a.*((a ; b))
 
 let _ = a.*([|a; b|])
+
+(* Avoid unecessary parentheses *)
+let _ =
+  match a with
+  | A -> a.*((match b with B -> b))
+  | B -> a.*((match b with B -> b)) <- D
+  | C -> ()
+
+let _ = if a then a.*((if a then b)) else c


### PR DESCRIPTION
`test_branch` finds a fix:

```diff
--- a/infer/src/base/CommandLineOption.ml
+++ b/infer/src/base/CommandLineOption.ml
@@ -559,7 +559,7 @@ let normalize_path_in_args_being_parsed ?(f = Fn.id) ~is_anon_arg str =
        [Arg.parse_argv_dynamic ~current:arg_being_parsed !args_to_parse ...]. *)
     let root = Unix.getcwd () in
     let abs_path = Utils.filename_to_absolute ~root str in
-    !args_to_parse.((!arg_being_parsed + if is_anon_arg then 0 else 1)) <- f abs_path ;
+    !args_to_parse.(!arg_being_parsed + if is_anon_arg then 0 else 1) <- f abs_path ;
     abs_path )
   else str
```
