### PR TITLE
Remove option doc-comments

### DIFF
--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -78,6 +78,7 @@ module Make (C : CONFIG) = struct
   let section_name = function
     | `Formatting -> Cmdliner.Manpage.s_options ^ " (CODE FORMATTING STYLE)"
     | `Operational -> Cmdliner.Manpage.s_options
+    | `Removed -> Cmdliner.Manpage.s_options ^ " (REMOVED OPTIONS)"
 
   let from = `Default
 
@@ -191,6 +192,35 @@ module Make (C : CONFIG) = struct
         all
     in
     any conv ~default ~docv ~names ~doc ~section ~allow_inline ~deprecated
+
+  let removed_option ~names ~version ~msg =
+    let msg =
+      Format.asprintf "This option has been removed in version %s. %s"
+        version msg
+    in
+    let parse _ = Error (`Msg msg) in
+    let converter = Arg.conv (parse, fun _ () -> ()) in
+    let update conf _ = conf and get_value _ = () in
+    let docs = section_name `Removed in
+    let term =
+      Arg.(value & opt (some converter) None & info names ~doc:msg ~docs)
+    in
+    let r = mk ~default:None term in
+    let to_string _ = "" in
+    let cmdline_get () = !r in
+    let opt =
+      { names
+      ; parse
+      ; update
+      ; cmdline_get
+      ; allow_inline= true
+      ; default= ()
+      ; to_string
+      ; get_value
+      ; from
+      ; deprecated= false }
+    in
+    store := Pack opt :: !store
 
   let update_from config name from =
     let is_profile_option_name x =

--- a/lib/Config_option.mli
+++ b/lib/Config_option.mli
@@ -62,6 +62,11 @@ module Make (C : CONFIG) : sig
   val any :
     'a Cmdliner.Arg.conv -> default:'a -> docv:string -> 'a option_decl
 
+  val removed_option :
+    names:string list -> version:string -> msg:string -> unit
+  (** Declare an option as removed. Using such an option will result in an
+      helpful error including [msg] and [version]. *)
+
   val default : 'a t -> 'a
 
   val update_using_cmdline : config -> config


### PR DESCRIPTION
The first commit implement removed options.
When used, an useful error will be generated (instead of "unknown option") including since which version and a custom message.

When such option is used in a `.ocamlformat` file, the error will be shown everytime OCamlformat is invoked (Dune calls it separately on each file). I opened an issue on Dune to discuss that: https://github.com/ocaml/dune/issues/3275

The second part of this PR is the removal of `doc-comments`.
There is some diffs because OCamlformat was an user of this option.
This part can be reverted or discussed separately.