### PR TITLE
Retain attribute on pexp_setinstvar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,8 +44,10 @@
   + Fix parens around binop operations with attributes (#1252) (Guillaume Petiot)
 
   + Remove unecessary parentheses in the argument of indexing operators (#1280) (Jules Aguillon)
-
-  + Retain attributes on field set expressions, e.g. `(a.x <- b) [@a]` (#1284) (Craig Ferguson)
+  
+  + Retain attributes on various AST nodes:
+    * field set expressions, e.g. `(a.x <- b) [@a]` (#1284) (Craig Ferguson)
+    * instance variable set expressions, e.g. `(a <- b) [@a]` (#1288) (Craig Ferguson)
 
 ### 0.13.0 (2020-01-28)
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2279,6 +2279,7 @@ end = struct
           ; _ }
       , _ ) ->
         false
+    (* Object fields do not require parens, even with trailing attributes *)
     | Exp {pexp_desc= Pexp_object _; _}, _ -> false
     | _, exp when has_trailing_attributes_exp exp -> true
     | ( Exp {pexp_desc= Pexp_construct ({txt= Lident id; _}, _); _}

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2279,6 +2279,7 @@ end = struct
           ; _ }
       , _ ) ->
         false
+    | Exp {pexp_desc= Pexp_object _; _}, _ -> false
     | _, exp when has_trailing_attributes_exp exp -> true
     | ( Exp {pexp_desc= Pexp_construct ({txt= Lident id; _}, _); _}
       , {pexp_attributes= _ :: _; _} )

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2392,8 +2392,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
   | Pexp_setinstvar (name, expr) ->
       hvbox 0
         (Params.wrap_exp c.conf c.source ~loc:pexp_loc ~parens
-           ( fmt_str_loc c name $ fmt_assign_arrow c
-           $ hvbox 2 (fmt_expression c (sub_exp ~ctx expr)) ))
+           ( wrap_if has_attr "(" ")"
+               ( fmt_str_loc c name $ fmt_assign_arrow c
+               $ hvbox 2 (fmt_expression c (sub_exp ~ctx expr)) )
+           $ fmt_atrs ))
   | Pexp_poly _ ->
       impossible "only used for methods, handled during method formatting"
   | Pexp_letop {let_; ands; body} ->

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -216,3 +216,14 @@ let _ = (0 + 0) [@a]
 let _ = (a.x <- 1) [@a]
 
 let _ = f ((a.x <- 1) [@a])
+
+let _ =
+  object
+    method g = ((a <- b) [@a])
+
+    method h = f ((a <- b) [@a])
+
+    method i =
+      ((a <- b) [@a]) ;
+      ()
+  end

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -219,7 +219,7 @@ let _ = f ((a.x <- 1) [@a])
 
 let _ =
   object
-    method g = ((a <- b) [@a])
+    method g = (a <- b) [@a]
 
     method h = f ((a <- b) [@a])
 

--- a/test/passing/object.ml
+++ b/test/passing/object.ml
@@ -6,6 +6,8 @@ let _ =
     (* some comment *)
     method! x = 2 [@@attr]
 
+    method x = (1 [@attr])
+
     method virtual x : t
 
     method virtual private x : t


### PR DESCRIPTION
This attempts to resolve https://github.com/ocaml-ppx/ocamlformat/issues/1258.

It's unecessary to wrap `(a <- b) [@a]` in parentheses if the expression is the only one in a module definition.

I discovered and tested a few unnecessary parentheses in the process:

- `method a = (1 [@attr])`
- `method a = (0 [@attr]) ; 1`
- `let _ = (0 [@attr]) ; 1` (edit: now tested by https://github.com/ocaml-ppx/ocamlformat/pull/1291 instead)

We may want to keep these for disambiguation purposes, but it seems better to have them tested regardless.