### PR TITLE
Fix formatting of comment with just a newline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,8 @@
   + Preserve empty doc-comments syntax. (#1311) (Guillaume Petiot)
     Previously `(**)` would be formatted to `(***)`.
 
+  + Do not crash when a comment contains just a newline (#1290) (Etienne Millon)
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -134,7 +134,8 @@ let fmt cmt src ~wrap:wrap_comments ~fmt_code =
           fmt_asterisk_prefixed_lines asterisk_prefixed_lines
     else
       match split_asterisk_prefixed cmt with
-      | [""] -> str "(* *)"
+      | [] -> assert false
+      | [""] -> assert false
       | [""; ""] -> str "(* *)"
       | [text] -> str "(*" $ fill_text text ~epi:(str "*)")
       | [text; ""] -> str "(*" $ fill_text text ~epi:(str " *)")

--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -135,6 +135,7 @@ let fmt cmt src ~wrap:wrap_comments ~fmt_code =
     else
       match split_asterisk_prefixed cmt with
       | [""] -> str "(* *)"
+      | [""; ""] -> str "(* *)"
       | [text] -> str "(*" $ fill_text text ~epi:(str "*)")
       | [text; ""] -> str "(*" $ fill_text text ~epi:(str " *)")
       | asterisk_prefixed_lines ->

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -246,6 +246,7 @@ let utf8_length s =
   Uuseg_string.fold_utf_8 `Grapheme_cluster (fun n _ -> n + 1) 0 s
 
 let fill_text ?epi text =
+  assert (not (String.is_empty text)) ;
   let fmt_line line =
     let words =
       List.filter ~f:(Fn.non String.is_empty)

--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -219,4 +219,4 @@ val hovbox_if : ?name:string -> bool -> int -> t -> t
 (** Text filling --------------------------------------------------------*)
 
 val fill_text : ?epi:t -> string -> t
-(** Format a string as filled text wrapped at the margin. *)
+(** Format a non-empty string as filled text wrapped at the margin. *)

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -1,6 +1,10 @@
 (*
 *)
 
+(**)
+
+(* *)
+
 let _ = f (*f*)a(*a*) ~b(*comment*) ~c:(*comment*)c' ?d ?e ()
 
 let _ =

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -1,3 +1,6 @@
+(*
+*)
+
 let _ = f (*f*)a(*a*) ~b(*comment*) ~c:(*comment*)c' ?d ?e ()
 
 let _ =

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -1,5 +1,9 @@
 (*  *)
 
+(**)
+
+(*  *)
+
 let _ = f (*f*) a (*a*) ~b (*comment*) ~c:(*comment*) c' ?d ?e ()
 
 let _ =

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -1,3 +1,5 @@
+(*  *)
+
 let _ = f (*f*) a (*a*) ~b (*comment*) ~c:(*comment*) c' ?d ?e ()
 
 let _ =


### PR DESCRIPTION
This reworks a bit the Cmts / `fill_text` interface to fix #1268. In particular the existing empty string branch seems to be dead since `(* *)` produces a space character and `(**)` is parsed as a doc comment.