### PR TITLE
Remove globals from Ast

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -14,13 +14,10 @@
 open Migrate_ast
 open Parsetree
 
-let extension_sugar = ref `Preserve
-
 let init, register_reset =
   let l = ref [] in
   let register f = l := f :: !l in
-  let init (conf : Conf.t) =
-    extension_sugar := conf.extension_sugar ;
+  let init () =
     List.iter !l ~f:(fun f -> f ())
   in
   (init, register)
@@ -1694,7 +1691,7 @@ end = struct
 
   (** [prec_ast ast] is the precedence of [ast]. Meaningful for binary
       operators, otherwise returns [None]. *)
-  let prec_ast _conf = function
+  let prec_ast (conf : Conf.t) = function
     | Pld _ -> None
     | Typ {ptyp_desc; _} -> (
       match ptyp_desc with
@@ -1765,7 +1762,7 @@ end = struct
                           ; _ } as e )
                       , _ )
                 ; _ } ] )
-        when Poly.(!extension_sugar = `Always)
+        when Poly.(conf.extension_sugar = `Always)
              || Source.extension_using_sugar ~name:ext ~payload:e ->
           Some Apply
       | Pexp_extension
@@ -1774,7 +1771,7 @@ end = struct
               [ { pstr_desc=
                     Pstr_eval (({pexp_desc= Pexp_sequence _; _} as e), _)
                 ; _ } ] )
-        when Poly.(!extension_sugar = `Always)
+        when Poly.(conf.extension_sugar = `Always)
              || Source.extension_using_sugar ~name:ext ~payload:e ->
           Some Semi
       | Pexp_setfield _ -> Some LessMinus

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -16,14 +16,11 @@ open Parsetree
 
 let extension_sugar = ref `Preserve
 
-let leading_nested_match_parens = ref false
-
 let init, register_reset =
   let l = ref [] in
   let register f = l := f :: !l in
   let init (conf : Conf.t) =
     extension_sugar := conf.extension_sugar ;
-    leading_nested_match_parens := conf.leading_nested_match_parens ;
     List.iter !l ~f:(fun f -> f ())
   in
   (init, register)
@@ -2327,7 +2324,7 @@ end = struct
        |Pexp_function cases
        |Pexp_match (_, cases)
        |Pexp_try (_, cases) ->
-          if !leading_nested_match_parens then
+          if conf.leading_nested_match_parens then
             List.iter cases ~f:(fun {pc_rhs; _} ->
                 mark_parenzed_inner_nested_match conf pc_rhs) ;
           List.exists cases ~f:(fun {pc_rhs; _} -> pc_rhs == exp)

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -14,8 +14,6 @@
 open Migrate_ast
 open Parsetree
 
-let parens_ite = ref false
-
 let extension_sugar = ref `Preserve
 
 let leading_nested_match_parens = ref false
@@ -26,7 +24,6 @@ let init, register_reset =
   let init (conf : Conf.t) =
     extension_sugar := conf.extension_sugar ;
     leading_nested_match_parens := conf.leading_nested_match_parens ;
-    parens_ite := conf.parens_ite ;
     List.iter !l ~f:(fun f -> f ())
   in
   (init, register)
@@ -2288,10 +2285,10 @@ end = struct
     | Pld _, {pexp_desc= Pexp_tuple _; _} -> false
     | Cl {pcl_desc= Pcl_apply _; _}, _ -> parenze ()
     | Exp {pexp_desc= Pexp_ifthenelse (_, e, _); _}, {pexp_desc; _}
-      when !parens_ite && e == exp && ifthenelse pexp_desc ->
+      when conf.parens_ite && e == exp && ifthenelse pexp_desc ->
         true
     | Exp {pexp_desc= Pexp_ifthenelse (_, _, Some e); _}, {pexp_desc; _}
-      when !parens_ite && e == exp && ifthenelse pexp_desc ->
+      when conf.parens_ite && e == exp && ifthenelse pexp_desc ->
         true
     | ( Exp
           {pexp_desc= Pexp_apply (op, (Nolabel, _) :: (Nolabel, e1) :: _); _}

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -14,7 +14,7 @@
 open Migrate_ast
 open Parsetree
 
-val init : Conf.t -> unit
+val init : unit -> unit
 (** Initialize internal state *)
 
 val is_prefix : expression -> bool

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -161,7 +161,7 @@ val assoc_of_prec : prec -> assoc
     immediate sub-term of [ctx]. *)
 type 'a xt = private {ctx: t; ast: 'a}
 
-val sub_typ : ctx:t -> core_type -> core_type xt
+val sub_typ : Conf.t -> ctx:t -> core_type -> core_type xt
 (** Construct a core_type-in-context. *)
 
 val sub_cty : ctx:t -> class_type -> class_type xt
@@ -203,15 +203,15 @@ val exposed_left_exp : expression -> bool
 (** [exposed_left_exp exp] holds if the left-most subexpression of [exp] is a
     prefix operators. *)
 
-val prec_ast : t -> prec option
+val prec_ast : Conf.t -> t -> prec option
 (** [prec_ast ast] is the precedence of [ast]. Meaningful for binary
     operators, otherwise returns [None]. *)
 
-val parenze_typ : core_type xt -> bool
+val parenze_typ : Conf.t -> core_type xt -> bool
 (** [parenze_typ xtyp] holds when core_type-in-context [xtyp] should be
     parenthesized. *)
 
-val parenze_cty : class_type xt -> bool
+val parenze_cty : Conf.t -> class_type xt -> bool
 (** [parenze_cty xcty] holds when class_type-in-context [xcty] should be
     parenthesized. *)
 
@@ -227,7 +227,7 @@ val parenze_exp : Conf.t -> expression xt -> bool
 (** [parenze_exp xexp] holds when expression-in-context [xexp] should be
     parenthesized. *)
 
-val parenze_nested_exp : expression xt -> bool
+val parenze_nested_exp : Conf.t -> expression xt -> bool
 (** [parenze_nested_exp xexp] holds when nested expression-in-context [xexp]
     should be parenthesized. *)
 

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -170,7 +170,7 @@ val sub_cty : ctx:t -> class_type -> class_type xt
 val sub_pat : ctx:t -> pattern -> pattern xt
 (** Construct a pattern-in-context. *)
 
-val sub_exp : ctx:t -> expression -> expression xt
+val sub_exp : Conf.t -> ctx:t -> expression -> expression xt
 (** Construct a expression-in-context. *)
 
 val sub_cl : ctx:t -> class_expr -> class_expr xt
@@ -195,7 +195,7 @@ val is_simple : Conf.t -> (expression xt -> int) -> expression xt -> bool
 (** 'Classes' of expressions which are parenthesized differently. *)
 type cls = Let_match | Match | Non_apply | Sequence | Then | ThenElse
 
-val exposed_right_exp : cls -> expression -> bool
+val exposed_right_exp : Conf.t -> cls -> expression -> bool
 (** [exposed_right_exp cls exp] holds if there is a right-most subexpression
     of [exp] which is of class [cls] and is not parenthesized. *)
 
@@ -215,7 +215,7 @@ val parenze_cty : class_type xt -> bool
 (** [parenze_cty xcty] holds when class_type-in-context [xcty] should be
     parenthesized. *)
 
-val parenze_cl : class_expr xt -> bool
+val parenze_cl : Conf.t -> class_expr xt -> bool
 (** [parenze_cl xcl] holds when class-in-context [xcl] should be
     parenthesized. *)
 
@@ -223,7 +223,7 @@ val parenze_pat : pattern xt -> bool
 (** [parenze_pat xpat] holds when pattern-in-context [xpat] should be
     parenthesized. *)
 
-val parenze_exp : expression xt -> bool
+val parenze_exp : Conf.t -> expression xt -> bool
 (** [parenze_exp xexp] holds when expression-in-context [xexp] should be
     parenthesized. *)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4453,7 +4453,7 @@ let fmt_code ~debug =
 let entry_point ~f ~ctx ~debug source cmts conf l =
   (* [Ast.init] should be called only once per file. In particular, we don't
      want to call it when formatting comments *)
-  Ast.init conf ;
+  Ast.init () ;
   let fmt_code = fmt_code ~debug in
   fmt_file ~f ~ctx ~fmt_code ~debug source cmts conf l
 

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -14,14 +14,16 @@ open Asttypes
 open Parsetree
 
 val arrow_typ :
-     Cmts.t
+     Conf.t
+  -> Cmts.t
   -> core_type Ast.xt
   -> (Location.t * arg_label * core_type Ast.xt) list
 (** [arrow_typ cmts ty] returns the list of labeled sub-arrow types of the
     type [ty]. *)
 
 val class_arrow_typ :
-     Cmts.t
+     Conf.t
+  -> Cmts.t
   -> class_type Ast.xt
   -> ( arg_label
      * [`class_type of class_type Ast.xt | `core_type of core_type Ast.xt] )

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -41,7 +41,8 @@ type arg_kind =
   | Newtypes of string loc list
 
 val fun_ :
-     Cmts.t
+     Conf.t
+  -> Cmts.t
   -> ?will_keep_first_ast_node:bool
   -> expression Ast.xt
   -> arg_kind list * expression Ast.xt
@@ -51,6 +52,7 @@ val fun_ :
 
 val cl_fun :
      ?will_keep_first_ast_node:bool
+  -> Conf.t
   -> Cmts.t
   -> class_expr Ast.xt
   -> arg_kind list * class_expr Ast.xt
@@ -59,7 +61,8 @@ val cl_fun :
     default, otherwise the [exp] is returned without modification. *)
 
 val infix :
-     Cmts.t
+     Conf.t
+  -> Cmts.t
   -> Ast.prec option
   -> expression Ast.xt
   -> (expression Ast.xt option * (arg_label * expression Ast.xt) list) list
@@ -75,19 +78,21 @@ val list_pat :
     corresponding to a list (empty list or (::) application). *)
 
 val list_exp :
-     Cmts.t
+     Conf.t
+  -> Cmts.t
   -> expression
   -> ((Warnings.loc list * expression Ast.xt) list * Warnings.loc) option
 (** [list_exp cmts exp] returns a list of expressions if [exp] is an
     expression corresponding to a list (empty list or (::) application). *)
 
 val infix_cons :
-  expression Ast.xt -> (Warnings.loc list * expression Ast.xt) list
+  Conf.t -> expression Ast.xt -> (Warnings.loc list * expression Ast.xt) list
 (** [infix_cons exp] returns a list of expressions if [exp] is an expression
     corresponding to a list ((::) application). *)
 
 val ite :
-     Cmts.t
+     Conf.t
+  -> Cmts.t
   -> expression Ast.xt
   -> (expression Ast.xt option * expression Ast.xt * attributes) list
 (** [ite cmts exp] returns a list of conditional expressions from cascading
@@ -140,7 +145,8 @@ val mod_with :
     [m]. *)
 
 val polynewtype :
-     Cmts.t
+     Conf.t
+  -> Cmts.t
   -> pattern
   -> expression
   -> (pattern Ast.xt * label loc list * core_type Ast.xt * expression Ast.xt)


### PR DESCRIPTION
`Ast.init` would take conf as argument and set 3 globals based on that. This PR replaces them by parameters. This adds a lot of boilerplate but I think this reflect the coupling that exists because of these options.

I think it'd be better if these extra parameters go away (it feels wrong to say that the precedence depends on configuration), but it's hard to say that this is a net improvement. What do you think