### PR TITLE
Remove trailing spaces after object types inside records and variants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,7 +47,7 @@
 
   + Retain attributes on field set expressions, e.g. `(a.x <- b) [@a]` (#1284) (Craig Ferguson)
 
-  + Avoid unnecesary spacing after object types with attributes (#1296) (Craig Ferguson)
+  + Avoid unnecessary spacing after object types with attributes (#1296) (Craig Ferguson)
     * e.g. `{foo : < .. > [@a]}`, ``[`Foo of < .. >[@a]]``
 
 ### 0.13.0 (2020-01-28)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,9 @@
 
   + Retain attributes on field set expressions, e.g. `(a.x <- b) [@a]` (#1284) (Craig Ferguson)
 
+  + Avoid unnecesary spacing after object types with attributes (#1296) (Craig Ferguson)
+    * e.g. `{foo : < .. > [@a]}`, ``[`Foo of < .. >[@a]]``
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,8 +47,8 @@
 
   + Retain attributes on field set expressions, e.g. `(a.x <- b) [@a]` (#1284) (Craig Ferguson)
 
-  + Avoid unnecessary spacing after object types with attributes (#1296) (Craig Ferguson)
-    * e.g. `{foo : < .. > [@a]}`, ``[`Foo of < .. >[@a]]``
+  + Avoid unnecessary spacing after object types inside records and polymorphic variants,
+    e.g. `{foo : < .. > [@a]}` and `{ foo : < .. > }` (#1296) (Craig Ferguson)
 
 ### 0.13.0 (2020-01-28)
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -870,6 +870,10 @@ and Requires_sub_terms : sig
 
   val exposed_right_typ : core_type -> bool
 
+  val exposed_right_label_declaration : label_declaration -> bool
+
+  val exposed_right_row_field : row_field -> bool
+
   val prec_ast : T.t -> prec option
 
   val parenze_typ : core_type In_ctx.xt -> bool
@@ -2409,12 +2413,24 @@ end = struct
     | Ptyp_alias (typ, _) -> exposed_left_typ typ
     | _ -> false
 
-  let rec exposed_right_typ typ =
-    match typ.ptyp_desc with
-    | Ptyp_arrow (_, _, t) -> exposed_right_typ t
-    | Ptyp_tuple l -> exposed_right_typ (List.last_exn l)
-    | Ptyp_object _ -> true
-    | _ -> false
+  let rec exposed_right_typ = function
+    | {ptyp_attributes= _ :: _; _} -> false
+    | {ptyp_desc; _} -> (
+      match ptyp_desc with
+      | Ptyp_arrow (_, _, t) -> exposed_right_typ t
+      | Ptyp_tuple l -> exposed_right_typ (List.last_exn l)
+      | Ptyp_object _ -> true
+      | _ -> false )
+
+  let exposed_right_label_declaration = function
+    | {pld_attributes= _ :: _; _} -> false
+    | {pld_type; _} -> exposed_right_typ pld_type
+
+  let exposed_right_row_field = function
+    | {prf_attributes= _ :: _; _} -> false
+    | {prf_desc= Rinherit _; _} -> false
+    | {prf_desc= Rtag (_, _, cs); _} -> (
+      match List.last cs with None -> false | Some x -> exposed_right_typ x )
 
   let parenze_nested_exp {ctx; ast= exp} =
     let infix_prec ast =

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -193,8 +193,17 @@ val is_simple : Conf.t -> (expression xt -> int) -> expression xt -> bool
     applications of other simple expressions. *)
 
 val exposed_left_typ : core_type -> bool
+(** [exposed_left_typ typ] holds iff the given type begins with a [<]
+    character. *)
+
+(** [exposed_right_*] predicates hold iff the supplied argument ends with a
+    [>] character. *)
 
 val exposed_right_typ : core_type -> bool
+
+val exposed_right_label_declaration : label_declaration -> bool
+
+val exposed_right_row_field : row_field -> bool
 
 (** 'Classes' of expressions which are parenthesized differently. *)
 type cls = Let_match | Match | Non_apply | Sequence | Then | ThenElse

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3002,7 +3002,10 @@ and fmt_type_declaration c ?ext ?(pre = "") ctx ?fmt_name ?(eq = "=") decl =
         let fmt_decl ~first ~last x =
           fmt_if_k (not first) p.sep_before
           $ fmt_label_declaration c ctx x ~last
-          $ fmt_if (last && exposed_right_label_declaration x) " "
+          $ fmt_if
+              ( last && (not p.box_spaced)
+              && exposed_right_label_declaration x )
+              " "
           $ fmt_if_k (not last) p.sep_after
         in
         box_manifest
@@ -3138,7 +3141,9 @@ and fmt_constructor_arguments c ctx ~pre = function
       let fmt_ld ~first ~last x =
         fmt_if_k (not first) p.sep_before
         $ fmt_label_declaration c ctx x ~last
-        $ fmt_if (last && exposed_right_label_declaration x) " "
+        $ fmt_if
+            (last && (not p.box_spaced) && exposed_right_label_declaration x)
+            " "
         $ fmt_if_k (not last) p.sep_after
       in
       pre $ p.docked_before $ p.break_before

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -747,11 +747,7 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
       let protect_token =
         match List.last rfs with
         | None -> false
-        | Some {prf_desc= Rinherit _; _} -> false
-        | Some {prf_desc= Rtag (_, _, l); _} -> (
-          match List.last l with
-          | None -> false
-          | Some x -> exposed_right_typ x )
+        | Some rf -> exposed_right_row_field rf
       in
       let space_around = c.conf.space_around_variants in
       let closing =
@@ -3006,7 +3002,7 @@ and fmt_type_declaration c ?ext ?(pre = "") ctx ?fmt_name ?(eq = "=") decl =
         let fmt_decl ~first ~last x =
           fmt_if_k (not first) p.sep_before
           $ fmt_label_declaration c ctx x ~last
-          $ fmt_if (last && exposed_right_typ x.pld_type) " "
+          $ fmt_if (last && exposed_right_label_declaration x) " "
           $ fmt_if_k (not last) p.sep_after
         in
         box_manifest
@@ -3142,7 +3138,7 @@ and fmt_constructor_arguments c ctx ~pre = function
       let fmt_ld ~first ~last x =
         fmt_if_k (not first) p.sep_before
         $ fmt_label_declaration c ctx x ~last
-        $ fmt_if (last && exposed_right_typ x.pld_type) " "
+        $ fmt_if (last && exposed_right_label_declaration x) " "
         $ fmt_if_k (not last) p.sep_after
       in
       pre $ p.docked_before $ p.break_before

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -122,28 +122,27 @@ let get_record_type (c : Conf.t) =
   let sparse_type_decl = Poly.(c.type_decl = `Sparse) in
   let space = if c.space_around_records then 1 else 0 in
   let dock = c.dock_collection_brackets in
-  match c.break_separators with
-  | `Before ->
-      { docked_before= fmt_if dock " {"
-      ; break_before= fmt_or_k dock (break space 2) (fmt "@ ")
-      ; box_record= (fun k -> if dock then k else hvbox 0 (wrap_record c k))
-      ; box_spaced= c.space_around_records
-      ; sep_before= fmt_or sparse_type_decl "@;<1000 0>; " "@,; "
-      ; sep_after= noop
-      ; break_after= fmt_if_k dock (break space (-2))
-      ; docked_after= fmt_if dock "}" }
-  | `After ->
-      { docked_before= fmt_if dock " {"
-      ; break_before= fmt_or_k dock (break space 0) (fmt "@ ")
-      ; box_spaced= c.space_around_records
-      ; box_record= (fun k -> if dock then k else hvbox 0 (wrap_record c k))
-      ; sep_before= noop
-      ; sep_after=
-          fmt_or_k dock
+  let break_before, sep_before, sep_after =
+    match c.break_separators with
+    | `Before ->
+        ( fmt_or_k dock (break space 2) (fmt "@ ")
+        , fmt_or sparse_type_decl "@;<1000 0>; " "@,; "
+        , noop )
+    | `After ->
+        ( fmt_or_k dock (break space 0) (fmt "@ ")
+        , noop
+        , fmt_or_k dock
             (fmt_or sparse_type_decl "@;<1000 0>" "@ ")
-            (fmt_or sparse_type_decl "@;<1000 2>" "@;<1 2>")
-      ; break_after= fmt_if_k dock (break space (-2))
-      ; docked_after= fmt_if dock "}" }
+            (fmt_or sparse_type_decl "@;<1000 2>" "@;<1 2>") )
+  in
+  { docked_before= fmt_if dock " {"
+  ; break_before
+  ; box_record= (fun k -> if dock then k else hvbox 0 (wrap_record c k))
+  ; box_spaced= c.space_around_records
+  ; sep_before
+  ; sep_after
+  ; break_after= fmt_if_k dock (break space (-2))
+  ; docked_after= fmt_if dock "}" }
 
 type elements_collection =
   { box: Fmt.t -> Fmt.t

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -112,6 +112,7 @@ type record_type =
   { docked_before: Fmt.t
   ; break_before: Fmt.t
   ; box_record: Fmt.t -> Fmt.t
+  ; box_spaced: bool
   ; sep_before: Fmt.t
   ; sep_after: Fmt.t
   ; break_after: Fmt.t
@@ -126,6 +127,7 @@ let get_record_type (c : Conf.t) =
       { docked_before= fmt_if dock " {"
       ; break_before= fmt_or_k dock (break space 2) (fmt "@ ")
       ; box_record= (fun k -> if dock then k else hvbox 0 (wrap_record c k))
+      ; box_spaced= c.space_around_records
       ; sep_before= fmt_or sparse_type_decl "@;<1000 0>; " "@,; "
       ; sep_after= noop
       ; break_after= fmt_if_k dock (break space (-2))
@@ -133,6 +135,7 @@ let get_record_type (c : Conf.t) =
   | `After ->
       { docked_before= fmt_if dock " {"
       ; break_before= fmt_or_k dock (break space 0) (fmt "@ ")
+      ; box_spaced= c.space_around_records
       ; box_record= (fun k -> if dock then k else hvbox 0 (wrap_record c k))
       ; sep_before= noop
       ; sep_after=

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -43,6 +43,7 @@ type record_type =
   { docked_before: Fmt.t
   ; break_before: Fmt.t
   ; box_record: Fmt.t -> Fmt.t
+  ; box_spaced: bool (* True iff [box_record] adds inner spaces *)
   ; sep_before: Fmt.t
   ; sep_after: Fmt.t
   ; break_after: Fmt.t

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1966,6 +1966,17 @@
  (action (diff profiles2.ml profiles2.ml.output)))
 
 (rule
+ (targets protected_object_types.ml.output)
+ (deps .ocamlformat )
+ (action
+   (with-outputs-to %{targets}
+     (system "%{bin:ocamlformat} %{dep:protected_object_types.ml}"))))
+
+(alias
+ (name runtest)
+ (action (diff protected_object_types.ml protected_object_types.ml.output)))
+
+(rule
  (targets recmod.mli.output)
  (deps .ocamlformat )
  (action

--- a/test/passing/protected_object_types.ml
+++ b/test/passing/protected_object_types.ml
@@ -1,0 +1,22 @@
+(* Tests of special cases added to avoid emitting [>\] and [>\}], which are
+   keywords. *)
+
+(* Regression tests for https://github.com/ocaml-ppx/ocamlformat/issues/1295
+   (unnecessary tailing spaces added after object types with attributes). *)
+
+type t = {foo: (< .. >[@a]) }
+
+type t = {foo: < .. > [@a] }
+
+type t = A of {foo: (< .. >[@a]) }
+
+type t = A of {foo: < .. > [@a] }
+
+type t = [`Foo of (< .. >[@a]) ]
+
+type t = [`Foo of < .. >[@a] ]
+
+let _ =
+  object
+    inherit [b, (< f: unit >[@a]) ] foo
+  end

--- a/test/passing/protected_object_types.ml
+++ b/test/passing/protected_object_types.ml
@@ -4,19 +4,19 @@
 (* Regression tests for https://github.com/ocaml-ppx/ocamlformat/issues/1295
    (unnecessary tailing spaces added after object types with attributes). *)
 
-type t = {foo: (< .. >[@a]) }
+type t = {foo: (< .. >[@a])}
 
-type t = {foo: < .. > [@a] }
+type t = {foo: < .. > [@a]}
 
-type t = A of {foo: (< .. >[@a]) }
+type t = A of {foo: (< .. >[@a])}
 
-type t = A of {foo: < .. > [@a] }
+type t = A of {foo: < .. > [@a]}
 
-type t = [`Foo of (< .. >[@a]) ]
+type t = [`Foo of (< .. >[@a])]
 
-type t = [`Foo of < .. >[@a] ]
+type t = [`Foo of < .. >[@a]]
 
 let _ =
   object
-    inherit [b, (< f: unit >[@a]) ] foo
+    inherit [b, (< f: unit >[@a])] foo
   end

--- a/test/passing/protected_object_types.ml
+++ b/test/passing/protected_object_types.ml
@@ -20,3 +20,20 @@ let _ =
   object
     inherit [b, (< f: unit >[@a])] foo
   end
+
+module Space_around = struct
+  (* Ensure that the protection mechanism does not add extra spaces when
+     [--space-around-*] options are sufficient. *)
+
+  module Records = struct
+    type t = { foo: < .. > }
+
+    type t = A of { foo: < .. > }
+  end
+  [@@ocamlformat "space-around-records = true"]
+
+  module Variants = struct
+    type t = [ `Foo of < .. > ]
+  end
+  [@@ocamlformat "space-around-variants"]
+end

--- a/test/passing/protected_object_types.ml
+++ b/test/passing/protected_object_types.ml
@@ -2,7 +2,7 @@
    keywords. *)
 
 (* Regression tests for https://github.com/ocaml-ppx/ocamlformat/issues/1295
-   (unnecessary tailing spaces added after object types with attributes). *)
+   (unnecessary trailing spaces added after object types with attributes). *)
 
 type t = {foo: (< .. >[@a])}
 


### PR DESCRIPTION
This fixes https://github.com/ocaml-ppx/ocamlformat/issues/1295.