### PR TITLE
Protect against more instances of object types inside payloads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,9 @@
   + Fix missing parentheses around tuples with attributes. (#1301) (Craig Ferguson)
     Previously, `f ((0, 0) [@a])` would be formatted to `f (0, 0) [@a]`, crashing OCamlformat.
 
+  + Avoid emitting `>]` when an object type is contained in an extension point
+    or attribute payload (#1298) (Craig Ferguson)
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -866,14 +866,6 @@ and Requires_sub_terms : sig
 
   val exposed_left_exp : expression -> bool
 
-  val exposed_left_typ : core_type -> bool
-
-  val exposed_right_typ : core_type -> bool
-
-  val exposed_right_label_declaration : label_declaration -> bool
-
-  val exposed_right_row_field : row_field -> bool
-
   val prec_ast : T.t -> prec option
 
   val parenze_typ : core_type In_ctx.xt -> bool
@@ -2406,33 +2398,6 @@ end = struct
     | None -> false
     | Some (Some true) -> true
     | _ -> exposed_right_cl Non_apply cl
-
-  let rec exposed_left_typ typ =
-    match typ.ptyp_desc with
-    | Ptyp_arrow (_, t, _) -> exposed_left_typ t
-    | Ptyp_tuple l -> exposed_left_typ (List.hd_exn l)
-    | Ptyp_object _ -> true
-    | Ptyp_alias (typ, _) -> exposed_left_typ typ
-    | _ -> false
-
-  let rec exposed_right_typ = function
-    | {ptyp_attributes= _ :: _; _} -> false
-    | {ptyp_desc; _} -> (
-      match ptyp_desc with
-      | Ptyp_arrow (_, _, t) -> exposed_right_typ t
-      | Ptyp_tuple l -> exposed_right_typ (List.last_exn l)
-      | Ptyp_object _ -> true
-      | _ -> false )
-
-  let exposed_right_label_declaration = function
-    | {pld_attributes= _ :: _; _} -> false
-    | {pld_type; _} -> exposed_right_typ pld_type
-
-  let exposed_right_row_field = function
-    | {prf_attributes= _ :: _; _} -> false
-    | {prf_desc= Rinherit _; _} -> false
-    | {prf_desc= Rtag (_, _, cs); _} -> (
-      match List.last cs with None -> false | Some x -> exposed_right_typ x )
 
   let parenze_nested_exp {ctx; ast= exp} =
     let infix_prec ast =

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -192,19 +192,6 @@ val is_simple : Conf.t -> (expression xt -> int) -> expression xt -> bool
 (** Holds of "simple" expressions: constants and constructor and function
     applications of other simple expressions. *)
 
-val exposed_left_typ : core_type -> bool
-(** [exposed_left_typ typ] holds iff the given type begins with a [<]
-    character. *)
-
-(** [exposed_right_*] predicates hold iff the supplied argument ends with a
-    [>] character. *)
-
-val exposed_right_typ : core_type -> bool
-
-val exposed_right_label_declaration : label_declaration -> bool
-
-val exposed_right_row_field : row_field -> bool
-
 (** 'Classes' of expressions which are parenthesized differently. *)
 type cls = Let_match | Match | Non_apply | Sequence | Then | ThenElse
 

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -23,6 +23,42 @@ module Right = struct
       | Ptyp_object _ -> true
       | _ -> false )
 
+  let extension_constructor = function
+    | {pext_kind= Pext_decl (Pcstr_tuple args, None); pext_attributes= []; _}
+      -> (
+      match List.rev args with
+      | last :: _ -> core_type last
+      | [] ->
+          assert false (* Pext_decl (Pcstr_tuple [], None) does not occur *)
+      )
+    | _ -> false
+
+  let constructor_declaration = function
+    | {pcd_attributes= _ :: _; _} -> false
+    | {pcd_res= Some _; _} -> false
+    | {pcd_args= Pcstr_record _; _} -> false
+    | {pcd_args= Pcstr_tuple args; _} -> list ~elt:core_type args
+
+  let type_declaration = function
+    | {ptype_attributes= _ :: _; _} -> false
+    | {ptype_cstrs= _ :: _ as cstrs; _} ->
+        (* type a = ... constraint left = < ... > *)
+        list ~elt:(fun (_left, right, _loc) -> core_type right) cstrs
+    | {ptype_kind= Ptype_open | Ptype_record _; _} -> false
+    | {ptype_kind= Ptype_abstract; ptype_manifest= None; _} -> false
+    | {ptype_kind= Ptype_abstract; ptype_manifest= Some manifest; _} ->
+        (* type a = < ... > *)
+        core_type manifest
+    | {ptype_kind= Ptype_variant cdecls; _} ->
+        (* type a = ... | C of < ... > *)
+        list ~elt:constructor_declaration cdecls
+
+  let type_extension = function
+    | {ptyext_attributes= _ :: _; _} -> false
+    (* type a += A of ... * ... * < ... > *)
+    | {ptyext_constructors; _} ->
+        list ~elt:extension_constructor ptyext_constructors
+
   let label_declaration = function
     | {pld_attributes= _ :: _; _} -> false
     | {pld_type; _} -> core_type pld_type
@@ -32,4 +68,44 @@ module Right = struct
     | {prf_desc= Rinherit _; _} -> false
     | {prf_desc= Rtag (_, _, cs); _} -> (
       match List.last cs with None -> false | Some x -> core_type x )
+
+  (* exception C of ... * ... * < ... > *)
+  let type_exception = function
+    | {ptyexn_attributes= _ :: _; _} -> false
+    | {ptyexn_constructor; _} -> extension_constructor ptyexn_constructor
+
+  (* val x : < ... > *)
+  let value_description = function
+    | {pval_attributes= _ :: _; _} -> false
+    | {pval_prim= _ :: _; _} -> false
+    | {pval_type= ct; _} -> core_type ct
+
+  let structure_item {pstr_desc; pstr_loc= _} =
+    match pstr_desc with
+    | Pstr_type (_recflag, typedecls) -> list ~elt:type_declaration typedecls
+    | Pstr_typext te -> type_extension te
+    | Pstr_exception te -> type_exception te
+    | Pstr_primitive vd -> value_description vd
+    | Pstr_module _ | Pstr_recmodule _ | Pstr_modtype _ | Pstr_open _
+     |Pstr_class _ | Pstr_class_type _ | Pstr_include _ | Pstr_attribute _
+     |Pstr_extension _ | Pstr_value _ | Pstr_eval _ ->
+        false
+
+  let signature_item {psig_desc; psig_loc= _} =
+    match psig_desc with
+    | Psig_value vd -> value_description vd
+    | Psig_type (_recflag, typedecls) -> list ~elt:type_declaration typedecls
+    | Psig_typesubst typedecls -> list ~elt:type_declaration typedecls
+    | Psig_typext te -> type_extension te
+    | Psig_exception te -> type_exception te
+    | Psig_module _ | Psig_modsubst _ | Psig_recmodule _ | Psig_modtype _
+     |Psig_open _ | Psig_include _ | Psig_class _ | Psig_class_type _
+     |Psig_attribute _ | Psig_extension _ ->
+        false
+
+  let payload = function
+    | PStr items -> list ~elt:structure_item items
+    | PSig items -> list ~elt:signature_item items
+    | PTyp t -> core_type t
+    | PPat _ -> false
 end

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -1,0 +1,35 @@
+open Migrate_ast
+open Parsetree
+
+module Left = struct
+  let rec core_type typ =
+    match typ.ptyp_desc with
+    | Ptyp_arrow (_, t, _) -> core_type t
+    | Ptyp_tuple l -> core_type (List.hd_exn l)
+    | Ptyp_object _ -> true
+    | Ptyp_alias (typ, _) -> core_type typ
+    | _ -> false
+end
+
+module Right = struct
+  let list ~elt l = match List.last l with None -> false | Some x -> elt x
+
+  let rec core_type = function
+    | {ptyp_attributes= _ :: _; _} -> false
+    | {ptyp_desc; _} -> (
+      match ptyp_desc with
+      | Ptyp_arrow (_, _, t) -> core_type t
+      | Ptyp_tuple l -> core_type (List.last_exn l)
+      | Ptyp_object _ -> true
+      | _ -> false )
+
+  let label_declaration = function
+    | {pld_attributes= _ :: _; _} -> false
+    | {pld_type; _} -> core_type pld_type
+
+  let row_field = function
+    | {prf_attributes= _ :: _; _} -> false
+    | {prf_desc= Rinherit _; _} -> false
+    | {prf_desc= Rtag (_, _, cs); _} -> (
+      match List.last cs with None -> false | Some x -> core_type x )
+end

--- a/lib/Exposed.mli
+++ b/lib/Exposed.mli
@@ -21,6 +21,8 @@ module Right : sig
 
   val row_field : row_field -> bool
 
+  val payload : payload -> bool
+
   val list : elt:('a -> bool) -> 'a list -> bool
   (** [list ~elt l] holds iff [elt] holds of the {i last} element in [l], and
       is [false] if [l] is empty. *)

--- a/lib/Exposed.mli
+++ b/lib/Exposed.mli
@@ -1,0 +1,27 @@
+(** Predicates for determining if an AST starts/ends with a [<]/[>] symbol
+    (respectively) when printed.
+
+    These are used to avoid emitting the sequences [\{<], [\[<], [>\}] and
+    [>\]], which are reserved keywords. *)
+
+open Migrate_ast
+open Parsetree
+
+(** Predicates for [<] on the LHS of printed AST nodes. *)
+module Left : sig
+  val core_type : core_type -> bool
+end
+
+module Right : sig
+  (** Predicates for [>] on the RHS of printed AST nodes. *)
+
+  val core_type : core_type -> bool
+
+  val label_declaration : label_declaration -> bool
+
+  val row_field : row_field -> bool
+
+  val list : elt:('a -> bool) -> 'a list -> bool
+  (** [list ~elt l] holds iff [elt] holds of the {i last} element in [l], and
+      is [false] if [l] is empty. *)
+end

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -541,9 +541,7 @@ and fmt_attribute_or_extension c key maybe_box (pre, pld) =
         Cmts.fmt_after c pexp_loc $ Cmts.fmt_after c pstr_loc
     | _ -> noop
   in
-  let protect_token =
-    match pld with PTyp t -> Exposed.Right.core_type t | _ -> false
-  in
+  let protect_token = Exposed.Right.payload pld in
   let cmts_before = Cmts.fmt_before c pre.loc in
   cmts_before
   $ maybe_box

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -542,7 +542,7 @@ and fmt_attribute_or_extension c key maybe_box (pre, pld) =
     | _ -> noop
   in
   let protect_token =
-    match pld with PTyp t -> exposed_right_typ t | _ -> false
+    match pld with PTyp t -> Exposed.Right.core_type t | _ -> false
   in
   let cmts_before = Cmts.fmt_before c pre.loc in
   cmts_before
@@ -744,11 +744,7 @@ and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
               else "@ | " )
               (fmt_row_field c ~max_len_name ctx)
       in
-      let protect_token =
-        match List.last rfs with
-        | None -> false
-        | Some rf -> exposed_right_row_field rf
-      in
+      let protect_token = Exposed.Right.(list ~elt:row_field) rfs in
       let space_around = c.conf.space_around_variants in
       let closing =
         let empty = List.is_empty rfs in
@@ -2938,11 +2934,11 @@ and fmt_tydcl_params c ctx params =
 
 and fmt_class_params c ctx params =
   let fmt_param ~first ~last (ty, vc) =
-    fmt_if (first && exposed_left_typ ty) " "
+    fmt_if (first && Exposed.Left.core_type ty) " "
     $ fmt_if_k (not first) (fmt (Params.comma_sep c.conf))
     $ fmt_variance vc
     $ fmt_core_type c (sub_typ ~ctx ty)
-    $ fmt_if (last && exposed_right_typ ty) " "
+    $ fmt_if (last && Exposed.Right.core_type ty) " "
   in
   fmt_if_k
     (not (List.is_empty params))
@@ -3017,7 +3013,7 @@ and fmt_type_declaration c ?ext ?(pre = "") ctx ?fmt_name ?(eq = "=") decl =
           $ fmt_label_declaration c ctx x ~last
           $ fmt_if
               ( last && (not p.box_spaced)
-              && exposed_right_label_declaration x )
+              && Exposed.Right.label_declaration x )
               " "
           $ fmt_if_k (not last) p.sep_after
         in
@@ -3155,7 +3151,7 @@ and fmt_constructor_arguments c ctx ~pre = function
         fmt_if_k (not first) p.sep_before
         $ fmt_label_declaration c ctx x ~last
         $ fmt_if
-            (last && (not p.box_spaced) && exposed_right_label_declaration x)
+            (last && (not p.box_spaced) && Exposed.Right.label_declaration x)
             " "
         $ fmt_if_k (not last) p.sep_after
       in

--- a/test/passing/protected_object_types.ml
+++ b/test/passing/protected_object_types.ml
@@ -86,5 +86,6 @@ module Inside_payloads = struct
 
   [@@@a: exception C of a * b * < .. > ]
 
-  [@@@a: exception C of a * b * < .. > [@a]]
+  (* Simple attributes on exceptions not supported pre-4.08 *)
+  [@@@a: exception C of a * b * < .. > [@@a]]
 end

--- a/test/passing/protected_object_types.ml
+++ b/test/passing/protected_object_types.ml
@@ -37,3 +37,54 @@ module Space_around = struct
   end
   [@@ocamlformat "space-around-variants"]
 end
+
+module Inside_payloads = struct
+  (* Regression tests for
+     https://github.com/ocaml-ppx/ocamlformat/issues/1267 (failure to protect
+     against object types inside extension and attribute payloads). *)
+
+  let _ = [%ext: < .. > ]
+
+  [%%ext: < .. > ]
+
+  [%%ext
+  ;;
+  ()
+
+  type a = < f: t > ]
+
+  [@@@a: val b : < .. > ]
+
+  let _ = () [@a: val b : < .. > ]
+
+  let _ = () [@@a: val b : < .. > ]
+
+  [@@@a: type x = < .. > ]
+
+  [@@@a:
+  val x : t
+
+  type x = < .. > ]
+
+  [@@@a: type t = < .. > ]
+
+  [@@@a: type t = (< .. >[@a])]
+
+  [@@@a: type a = A of t | B of t | C of < .. > ]
+
+  [@@@a: type a = A of t | B of t | C of (t -> < .. >)]
+
+  [@@@a: type a += C of a * b * < .. > ]
+
+  [@@@a: type a += C of a * b * < .. > [@a]]
+
+  [@@@a: type a += C of (a -> b * < .. >)]
+
+  [@@@a: type a = t constraint t = < .. > ]
+
+  [@@@a: type a = t constraint t = (< .. >[@a])]
+
+  [@@@a: exception C of a * b * < .. > ]
+
+  [@@@a: exception C of a * b * < .. > [@a]]
+end


### PR DESCRIPTION
This resolves https://github.com/ocaml-ppx/ocamlformat/issues/1267.

There are a lot of cases where object types can appear at the end of extension point and attribute payloads. This considers many more of the possible pitfalls, extracting the logic to a new top-level `Exposed.ml` file.