### PR TITLE
Fix bad rebase between #1296 and #1299

### DIFF
--- a/test/passing/protected_object_types.ml
+++ b/test/passing/protected_object_types.ml
@@ -14,7 +14,7 @@ type t = A of {foo: < .. > [@a]}
 
 type t = [`Foo of (< .. >[@a])]
 
-type t = [`Foo of < .. >[@a]]
+type t = [`Foo of < .. > [@a]]
 
 let _ =
   object


### PR DESCRIPTION
The auto-merge during rebase of https://github.com/ocaml-ppx/ocamlformat/pull/1296 against https://github.com/ocaml-ppx/ocamlformat/pull/1299 introduced a test failure.

This re-promoted the tests to fix that error.