### PR TITLE
Preserve cinaps comments containing code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,10 @@
   + Fix missing parentheses around tuples with attributes. (#1301) (Craig Ferguson)
     Previously, `f ((0, 0) [@a])` would be formatted to `f (0, 0) [@a]`, crashing OCamlformat.
 
+  + Preserve cinaps comments containing unparsable code (#1303) (Jules Aguillon)
+    Previously, OCamlformat would fallback to "wrapping" logic, making the comment unreadable
+    and crashing in some cases.
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -126,7 +126,7 @@ let fmt cmt src ~wrap:wrap_comments ~fmt_code =
           first_line tl
     | _ -> str s
   in
-  let fmt_non_code cmt =
+  let fmt_non_code ?(wrap_comments = wrap_comments) cmt =
     if not wrap_comments then
       match split_asterisk_prefixed cmt with
       | [""] | [_] | [_; ""] -> wrap "(*" "*)" (fmt_unwrapped_cmt cmt)
@@ -148,7 +148,7 @@ let fmt cmt src ~wrap:wrap_comments ~fmt_code =
     | Ok formatted ->
         let cls : Fmt.s = if dollar_last then "$*)" else "*)" in
         hvbox 2 (wrap "(*$" cls (fmt "@;" $ formatted $ fmt "@;<1 -2>"))
-    | Error () -> fmt_non_code cmt
+    | Error () -> fmt_non_code ~wrap_comments:false cmt
   in
   match cmt.txt with
   | "" | "$" -> fmt_non_code cmt

--- a/test/passing/cinaps.ml
+++ b/test/passing/cinaps.ml
@@ -42,3 +42,18 @@ let foo = foo
 (*$QR foo Q.small_int (fun i-> foo i (+) [1;2;3] = List.fold_left (+) i
   [1;2;3] ) *)
 let foo = foo
+
+(* Cinaps comment should not wrap if they don't parse. The first one would
+   crash and the second become a mess *)
+
+(*$(**)"
+"*)
+
+(*$
+  print_newline () ;
+  <SYNTAX ERROR>
+  List.iter
+    (fun s -> Printf.printf "let ( %s ) = Pervasives.( %s )\n" s s)
+    ["+"; "-"; "*"; "/"]
+*)
+(*$*)


### PR DESCRIPTION
Inserting a syntax error in a cinaps comment would make OCamlformat fallback to wrapping them, resulting in a mess:

```diff
-(*$
-  print_newline () ;
-  <SYNTAX ERROR>
-  List.iter
-    (fun s -> Printf.printf "let ( %s ) = Pervasives.( %s )\n" s s)
-    ["+"; "-"; "*"; "/"]
-*)
+(*$ print_newline () ; <SYNTAX ERROR> List.iter (fun s -> Printf.printf "let
+  ( %s ) = Pervasives.( %s )\n" s s) ["+"; "-"; "*"; "/"] *)
```

This patch fixes that by keeping the comment as it is.

This comment changes meaning when wrapped because OCaml treat quotes in comments specially: (fixes https://github.com/ocaml-ppx/ocamlformat/issues/1269)

```ocaml
(*$(**)"
"*)
```