### PR TITLE
Surround indexing operators lhs when it's an integer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,9 @@
   + Fix missing parentheses around tuples with attributes. (#1301) (Craig Ferguson)
     Previously, `f ((0, 0) [@a])` would be formatted to `f (0, 0) [@a]`, crashing OCamlformat.
 
+  + Fix crash on the expression `(0).*(0)` (#1304) (Jules Aguillon)
+    It was formatting to `0.*(0)` which parses as an other expression.
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2311,7 +2311,8 @@ end = struct
       , {pexp_desc= Pexp_construct _ | Pexp_variant _; _} )
       when e == exp ->
         true
-    (* Integers without suffixes must be parenthesised on the lhs of an indexing operator *)
+    (* Integers without suffixes must be parenthesised on the lhs of an
+       indexing operator *)
     | ( Exp {pexp_desc= Pexp_apply (op, (Nolabel, left) :: _); _}
       , {pexp_desc= Pexp_constant (Pconst_integer (_, None)); _} )
       when exp == left && is_index_op op ->

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2311,6 +2311,11 @@ end = struct
       , {pexp_desc= Pexp_construct _ | Pexp_variant _; _} )
       when e == exp ->
         true
+    (* Integers must be parenthesed on the lhs of an indexing operator *)
+    | ( Exp {pexp_desc= Pexp_apply (op, (Nolabel, left) :: _); _}
+      , {pexp_desc= Pexp_constant (Pconst_integer (_, None)); _} )
+      when exp == left && is_index_op op ->
+        true
     | Exp {pexp_desc= Pexp_field (e, _); _}, {pexp_desc= Pexp_construct _; _}
       when e == exp ->
         true

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2311,7 +2311,7 @@ end = struct
       , {pexp_desc= Pexp_construct _ | Pexp_variant _; _} )
       when e == exp ->
         true
-    (* Integers must be parenthesed on the lhs of an indexing operator *)
+    (* Integers without suffixes must be parenthesised on the lhs of an indexing operator *)
     | ( Exp {pexp_desc= Pexp_apply (op, (Nolabel, left) :: _); _}
       , {pexp_desc= Pexp_constant (Pconst_integer (_, None)); _} )
       when exp == left && is_index_op op ->

--- a/test/passing/index_op.ml
+++ b/test/passing/index_op.ml
@@ -143,3 +143,18 @@ let _ = a.*{(a ; b)}
 let _ = a.{(a ; b)}
 
 let _ = a.{a, b}
+
+(* Integers on the left of indexing operators must be surrounded by
+   parentheses *)
+let _ = (0).*(0)
+
+(* Integers with suffix and floats are fine *)
+let _ = 0l.*(0)
+
+let _ = 0..*(0)
+
+let _ = 0.2.*(0)
+
+let _ = 2e5.*(0)
+
+let _ = 2e-2.*(0)


### PR DESCRIPTION
Fixes https://github.com/ocaml-ppx/ocamlformat/issues/1255

This is fixed by adding yet an other case to the `parenze_ast` function.

Fun fact: Intergers with a suffix or floats don't need parentheses.