### PR TITLE
Ensure optional argument rebindings use sufficiently many parens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,9 @@
   + Fix invalid (unparsable) docstrings (#1315) (Guillaume Petiot)
     When parsing a comment raises an error in odoc, it is printed as-is.
 
+  + Fix parenthesizing of optional arguments rebound to non-variables, e.g. `let
+    f ?a:(A) = ()` rather than the unparsable `let f ?a:A = ()` (#1305) (Craig Ferguson)
+
 ### 0.13.0 (2020-01-28)
 
 #### New features

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1924,8 +1924,6 @@ end = struct
     | ( Pat {ppat_desc= Ppat_construct _; _}
       , Ppat_construct ({txt= Lident "::"; _}, _) ) ->
         true
-    | Exp {pexp_desc= Pexp_fun (Optional _, _, _, _); _}, Ppat_record _ ->
-        true
     | ( ( Exp {pexp_desc= Pexp_let _ | Pexp_letop _; _}
         | Str {pstr_desc= Pstr_value _; _} )
       , ( Ppat_construct (_, Some _)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1180,6 +1180,17 @@ and fmt_fun_args c ?pro args =
       when String.equal l txt ->
         let symbol = match lbl with Labelled _ -> "~" | _ -> "?" in
         cbox 0 (str symbol $ fmt_pattern c xpat)
+    | Val ((Optional _ as lbl), xpat, None) ->
+        let outer_parens, inner_parens =
+          match xpat.ast.ppat_desc with
+          | Ppat_any | Ppat_var _ -> (false, false)
+          | Ppat_unpack _ -> (true, true)
+          | _ -> (true, false)
+        in
+        cbox 2
+          ( fmt_label lbl ":@,"
+          $ wrap_if outer_parens "(" ")"
+              (fmt_pattern ~parens:inner_parens c xpat) )
     | Val (lbl, xpat, None) ->
         cbox 2 (fmt_label lbl ":@," $ fmt_pattern c xpat)
     | Val

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1185,6 +1185,7 @@ and fmt_fun_args c ?pro args =
           match xpat.ast.ppat_desc with
           | Ppat_any | Ppat_var _ -> (false, false)
           | Ppat_unpack _ -> (true, true)
+          | Ppat_tuple _ -> (false, true)
           | _ -> (true, false)
         in
         (* If the pattern has an attribute, outer parentheses will be added

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1181,17 +1181,15 @@ and fmt_fun_args c ?pro args =
         let symbol = match lbl with Labelled _ -> "~" | _ -> "?" in
         cbox 0 (str symbol $ fmt_pattern c xpat)
     | Val ((Optional _ as lbl), xpat, None) ->
+        let has_attr = not (List.is_empty xpat.ast.ppat_attributes) in
         let outer_parens, inner_parens =
           match xpat.ast.ppat_desc with
           | Ppat_any | Ppat_var _ -> (false, false)
-          | Ppat_unpack _ -> (true, true)
+          | Ppat_unpack _ -> (not has_attr, true)
           | Ppat_tuple _ -> (false, true)
-          | _ -> (true, false)
+          | Ppat_or _ -> (has_attr, true)
+          | _ -> (not has_attr, false)
         in
-        (* If the pattern has an attribute, outer parentheses will be added
-           by [fmt_pattern] *)
-        let has_attr = not (List.is_empty xpat.ast.ppat_attributes) in
-        let outer_parens = outer_parens && not has_attr in
         cbox 2
           ( fmt_label lbl ":@,"
           $ wrap_if outer_parens "(" ")"

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1187,6 +1187,10 @@ and fmt_fun_args c ?pro args =
           | Ppat_unpack _ -> (true, true)
           | _ -> (true, false)
         in
+        (* If the pattern has an attribute, outer parentheses will be added
+           by [fmt_pattern] *)
+        let has_attr = not (List.is_empty xpat.ast.ppat_attributes) in
+        let outer_parens = outer_parens && not has_attr in
         cbox 2
           ( fmt_label lbl ":@,"
           $ wrap_if outer_parens "(" ")"

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1191,7 +1191,7 @@ and fmt_fun_args c ?pro args =
           ( fmt_label lbl ":@,"
           $ wrap_if outer_parens "(" ")"
               (fmt_pattern ~parens:inner_parens c xpat) )
-    | Val (lbl, xpat, None) ->
+    | Val (((Labelled _ | Nolabel) as lbl), xpat, None) ->
         cbox 2 (fmt_label lbl ":@," $ fmt_pattern c xpat)
     | Val
         ( Optional l

--- a/test/passing/label_option_default_args.ml
+++ b/test/passing/label_option_default_args.ml
@@ -109,10 +109,7 @@ let f ?constant:(0 [@attr]) = ()
 
 let f ?open_:(Int.(zero) [@attr]) = ()
 
-(* Test disabled because of existing issue with [Ppat_or] and attributes.
-   @see https://github.com/ocaml-ppx/ocamlformat/issues/1310 *)
-
-(* let f ?or_:((Some () | None) [@attr]) = () *)
+let f ?or_:((Some () | None) [@attr]) = ()
 
 let f ?unpack:((module P) [@attr]) = ()
 

--- a/test/passing/label_option_default_args.ml
+++ b/test/passing/label_option_default_args.ml
@@ -101,3 +101,17 @@ let f ?open_:(Int.(zero)) = ()
 
 (* Requires two pairs of parens *)
 let f ?unpack:((module P)) = ()
+
+(* May need extra parens to handle attributes *)
+let f ?any:(_ [@attr]) = ()
+
+let f ?constant:(0 [@attr]) = ()
+
+let f ?open_:(Int.(zero) [@attr]) = ()
+
+(* Test disabled because of existing issue with [Ppat_or] and attributes.
+   @see https://github.com/ocaml-ppx/ocamlformat/issues/1310 *)
+
+(* let f ?or_:((Some () | None) [@attr]) = () *)
+
+let f ?unpack:((module P) [@attr]) = ()

--- a/test/passing/label_option_default_args.ml
+++ b/test/passing/label_option_default_args.ml
@@ -61,3 +61,43 @@ let (* 0 *) f (* 1 *) ?l: (* 2 *) ((* 3 *) x (* 4 *) : (* 5 *) t (* 6 *) = (* 7 
 let f ?l:(C x = d) = e
 
 let (* 0 *) f (* 1 *) ?l: (* 2 *) ((* 3 *) C (* 4 *) x (* 5 *) = (* 6 *) d (* 7 *)) (* 8 *) = e
+
+(* Regression tests for https://github.com/ocaml-ppx/ocamlformat/issues/1260
+   (optional argument rebound to non-variable without necessary parens). *)
+
+(* Safe without parens *)
+let f ?any:_ = ()
+
+let f ?var:a = ()
+
+(* Requires parens *)
+let f ?alias:(_ as b) = ()
+
+let f ?constant:(0) = ()
+
+let f ?interval:('a' .. 'z') = ()
+
+let f ?tuple:((1, 2)) = ()
+
+let f ?construct1:(A) ?construct2:(()) ?construct3:(Some ()) = ()
+
+let f ?variant:(`A ()) = ()
+
+let f ?record:({a; b}) = ()
+
+let f ?array:([| 1; 2; 3 |]) = ()
+
+let f ?or_:(Some () | None) = ()
+
+let f ?constraint_:(() : unit) = ()
+
+let f ?type_:(#tconst) = ()
+
+let f ?lazy_:(lazy ()) = ()
+
+let f ?extension:([%ext]) = ()
+
+let f ?open_:(Int.(zero)) = ()
+
+(* Requires two pairs of parens *)
+let f ?unpack:((module P)) = ()

--- a/test/passing/label_option_default_args.ml
+++ b/test/passing/label_option_default_args.ml
@@ -115,3 +115,5 @@ let f ?open_:(Int.(zero) [@attr]) = ()
 (* let f ?or_:((Some () | None) [@attr]) = () *)
 
 let f ?unpack:((module P) [@attr]) = ()
+
+let f ?tuple:((1, 2) [@attr]) = ()

--- a/test/passing/label_option_default_args.ml.ref
+++ b/test/passing/label_option_default_args.ml.ref
@@ -174,3 +174,5 @@ let f ?open_:(Int.(zero)[@attr]) = ()
 (* let f ?or_:((Some () | None) [@attr]) = () *)
 
 let f ?unpack:((module P)[@attr]) = ()
+
+let f ?tuple:((1, 2)[@attr]) = ()

--- a/test/passing/label_option_default_args.ml.ref
+++ b/test/passing/label_option_default_args.ml.ref
@@ -168,10 +168,7 @@ let f ?constant:(0[@attr]) = ()
 
 let f ?open_:(Int.(zero)[@attr]) = ()
 
-(* Test disabled because of existing issue with [Ppat_or] and attributes.
-   @see https://github.com/ocaml-ppx/ocamlformat/issues/1310 *)
-
-(* let f ?or_:((Some () | None) [@attr]) = () *)
+let f ?or_:((Some () | None)[@attr]) = ()
 
 let f ?unpack:((module P)[@attr]) = ()
 

--- a/test/passing/label_option_default_args.ml.ref
+++ b/test/passing/label_option_default_args.ml.ref
@@ -160,3 +160,17 @@ let f ?open_:(Int.(zero)) = ()
 
 (* Requires two pairs of parens *)
 let f ?unpack:((module P)) = ()
+
+(* May need extra parens to handle attributes *)
+let f ?any:(_[@attr]) = ()
+
+let f ?constant:(0[@attr]) = ()
+
+let f ?open_:(Int.(zero)[@attr]) = ()
+
+(* Test disabled because of existing issue with [Ppat_or] and attributes.
+   @see https://github.com/ocaml-ppx/ocamlformat/issues/1310 *)
+
+(* let f ?or_:((Some () | None) [@attr]) = () *)
+
+let f ?unpack:((module P)[@attr]) = ()

--- a/test/passing/label_option_default_args.ml.ref
+++ b/test/passing/label_option_default_args.ml.ref
@@ -68,13 +68,11 @@ let (* 0 *) f
 let f ?l:(C x) = e
 
 let (* 0 *) f
-    ?l:
+    ?l:(
       (* 1 *)
       (* 2 *)
-      (* 3 *) (C (* 4 *) x) =
-  (* 5 *)
-  (* 6 *)
-  e
+      (* 3 *) C (* 4 *) x (* 5 *)) =
+  (* 6 *) e
 
 let f ?(x = d) = e
 
@@ -122,3 +120,43 @@ let (* 0 *) f
       (* 2 *)
       (* 3 *) C (* 4 *) x (* 5 *) = (* 6 *) d (* 7 *)) =
   (* 8 *) e
+
+(* Regression tests for https://github.com/ocaml-ppx/ocamlformat/issues/1260
+   (optional argument rebound to non-variable without necessary parens). *)
+
+(* Safe without parens *)
+let f ?any:_ = ()
+
+let f ?var:a = ()
+
+(* Requires parens *)
+let f ?alias:(_ as b) = ()
+
+let f ?constant:(0) = ()
+
+let f ?interval:('a' .. 'z') = ()
+
+let f ?tuple:(1, 2) = ()
+
+let f ?construct1:(A) ?construct2:(()) ?construct3:(Some ()) = ()
+
+let f ?variant:(`A ()) = ()
+
+let f ?record:({a; b}) = ()
+
+let f ?array:([|1; 2; 3|]) = ()
+
+let f ?or_:(Some () | None) = ()
+
+let f ?constraint_:(() : unit) = ()
+
+let f ?type_:(#tconst) = ()
+
+let f ?lazy_:(lazy ()) = ()
+
+let f ?extension:([%ext]) = ()
+
+let f ?open_:(Int.(zero)) = ()
+
+(* Requires two pairs of parens *)
+let f ?unpack:((module P)) = ()


### PR DESCRIPTION
This resolves https://github.com/ocaml-ppx/ocamlformat/issues/1260.

I chose to do this by adding the logic in `Fmt_ast.fmt_fun_args`. It's probably possible to do this by instead adding special cases to `Ast.parenze_pat`. Unfortunately `fmt_pattern` (via which `parenze_pat` is called) doesn't respect its `parens` argument in many cases, making that route difficult. I removed an existing special case for records in `Ast.parenze_pat` which is superceded by the new logic.