### PR TITLE
Fix dropped comment in module unpack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,8 +30,11 @@
       eg. the expression `[%ext (() [@attr])]` or the structure item `(() [@attr]) ;;`
     * `let _ = ...`  constructs (#1244) (Etienne Millon)
 
-  + Fix dropped comment after a function after an infix (#1231) (Jules Aguillon)
-    eg. the comment in `(x >>= fun y -> y (* A *))` would be dropped
+  + Fix some bugs related to comments:
+    * after a function on the rhs of an infix (#1231) (Jules Aguillon)
+      eg. the comment in `(x >>= fun y -> y (* A *))` would be dropped
+    * in module unpack (#1309) (Jules Aguillon)
+      eg. in the module expression `module M = (val x : S (* A *))`
 
   + Fix formatting of empty signature payload `[%a:]` (#1236) (Etienne Millon)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3887,6 +3887,7 @@ and fmt_module_expr ?(can_break_before_struct = false) c ({ast= m; _} as xmod)
             , {ptyp_desc= Ptyp_package (id, cnstrs); ptyp_attributes= []; _}
             )
       ; pexp_attributes= []
+      ; pexp_loc
       ; _ } ->
       (* TODO: handle ptyp_loc and pexp_loc *)
       let doc, atrs = doc_atrs pmod_attributes in
@@ -3902,11 +3903,12 @@ and fmt_module_expr ?(can_break_before_struct = false) c ({ast= m; _} as xmod)
           @@ hovbox 0
                (wrap_fits_breaks ~space:false c.conf "(" ")"
                   (hvbox 2
-                     ( hovbox 0
-                         ( str "val "
-                         $ fmt_expression c (sub_exp ~ctx e1)
-                         $ fmt "@;<1 2>: " $ fmt_longident_loc c id )
-                     $ fmt_package_type c ctx cnstrs )))
+                     (Cmts.fmt c pexp_loc
+                        ( hovbox 0
+                            ( str "val "
+                            $ fmt_expression c (sub_exp ~ctx e1)
+                            $ fmt "@;<1 2>: " $ fmt_longident_loc c id )
+                        $ fmt_package_type c ctx cnstrs ))))
       ; epi=
           Option.some_if has_epi
             ( Cmts.fmt_after c pmod_loc

--- a/test/passing/first_class_module.ml
+++ b/test/passing/first_class_module.ml
@@ -91,3 +91,9 @@ let _ =
   ( module struct
     let a = b
   end )
+
+(* Tests for dropped comment *)
+
+module M = (val x : S (* a *))
+
+module M = (val x (* b *))


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/1308

A location was ignored.