### PR TITLE
Preserve empty doc-comments syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,7 +47,7 @@
   + Fix parens around binop operations with attributes (#1252) (Guillaume Petiot)
 
   + Remove unecessary parentheses in the argument of indexing operators (#1280) (Jules Aguillon)
-  
+
   + Retain attributes on various AST nodes:
     * field set expressions, e.g. `(a.x <- b) [@a]` (#1284) (Craig Ferguson)
     * instance variable set expressions, e.g. `(a <- b) [@a]` (#1288) (Craig Ferguson)
@@ -65,6 +65,9 @@
 
   + Fix crash on the expression `(0).*(0)` (#1304) (Jules Aguillon)
     It was formatting to `0.*(0)` which parses as an other expression.
+
+  + Preserve empty doc-comments syntax. (#1311) (Guillaume Petiot)
+    Previously `(**)` would be formatted to `(***)`.
 
 ### 0.13.0 (2020-01-28)
 

--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -150,7 +150,17 @@ let fmt cmt src ~wrap:wrap_comments ~fmt_code =
         hvbox 2 (wrap "(*$" cls (fmt "@;" $ formatted $ fmt "@;<1 -2>"))
     | Error () -> fmt_non_code cmt
   in
-  match cmt.txt with
-  | "" | "$" -> fmt_non_code cmt
-  | str when Char.equal str.[0] '$' -> fmt_code cmt
-  | _ -> fmt_non_code cmt
+  let src_prefix =
+    let pos_cnum = cmt.loc.loc_start.pos_cnum + 4 in
+    let loc_end = {cmt.loc.loc_start with pos_cnum} in
+    Source.string_at src cmt.loc.loc_start loc_end
+  in
+  match src_prefix with
+  (* "(**)" is not parsed as a docstring but as a regular comment containing
+     '*' and would be rewritten as "(***)" *)
+  | "(**)" -> str "(**)"
+  | _ -> (
+    match cmt.txt with
+    | "" | "$" -> fmt_non_code cmt
+    | str when Char.equal str.[0] '$' -> fmt_code cmt
+    | _ -> fmt_non_code cmt )

--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -152,14 +152,11 @@ let fmt cmt src ~wrap:wrap_comments ~fmt_code =
   in
   match cmt.txt with
   | "*" -> (
-      (* "(**)" is not parsed as a docstring but as a regular comment
-         containing '*' and would be rewritten as "(***)" *)
-      let src_prefix =
-        let pos_cnum = cmt.loc.loc_start.pos_cnum + 4 in
-        let loc_end = {cmt.loc.loc_start with pos_cnum} in
-        Source.string_at src cmt.loc.loc_start loc_end
-      in
-      match src_prefix with "(**)" -> str "(**)" | _ -> str "(***)" )
+    (* "(**)" is not parsed as a docstring but as a regular comment
+       containing '*' and would be rewritten as "(***)" *)
+    match Source.sub src ~pos:cmt.loc.loc_start.pos_cnum ~len:4 with
+    | "(**)" -> str "(**)"
+    | _ -> str "(***)" )
   | "" | "$" -> fmt_non_code cmt
   | str when Char.equal str.[0] '$' -> fmt_code cmt
   | _ -> fmt_non_code cmt

--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -150,17 +150,16 @@ let fmt cmt src ~wrap:wrap_comments ~fmt_code =
         hvbox 2 (wrap "(*$" cls (fmt "@;" $ formatted $ fmt "@;<1 -2>"))
     | Error () -> fmt_non_code cmt
   in
-  let src_prefix =
-    let pos_cnum = cmt.loc.loc_start.pos_cnum + 4 in
-    let loc_end = {cmt.loc.loc_start with pos_cnum} in
-    Source.string_at src cmt.loc.loc_start loc_end
-  in
-  match src_prefix with
-  (* "(**)" is not parsed as a docstring but as a regular comment containing
-     '*' and would be rewritten as "(***)" *)
-  | "(**)" -> str "(**)"
-  | _ -> (
-    match cmt.txt with
-    | "" | "$" -> fmt_non_code cmt
-    | str when Char.equal str.[0] '$' -> fmt_code cmt
-    | _ -> fmt_non_code cmt )
+  match cmt.txt with
+  | "*" -> (
+      (* "(**)" is not parsed as a docstring but as a regular comment
+         containing '*' and would be rewritten as "(***)" *)
+      let src_prefix =
+        let pos_cnum = cmt.loc.loc_start.pos_cnum + 4 in
+        let loc_end = {cmt.loc.loc_start with pos_cnum} in
+        Source.string_at src cmt.loc.loc_start loc_end
+      in
+      match src_prefix with "(**)" -> str "(**)" | _ -> str "(***)" )
+  | "" | "$" -> fmt_non_code cmt
+  | str when Char.equal str.[0] '$' -> fmt_code cmt
+  | _ -> fmt_non_code cmt

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -74,11 +74,14 @@ let empty_line_between t p1 p2 =
   Lexing.(p2.pos_lnum - p1.pos_lnum) > 1
   && List.exists (lines_between t p1 p2) ~f:is_line_empty
 
+let sub t ~pos ~len =
+  if String.length t < pos + len || pos < 0 || len < 0 then ""
+  else String.sub t ~pos ~len
+
 let string_at t loc_start loc_end =
   let pos = loc_start.Lexing.pos_cnum
   and len = Position.distance loc_start loc_end in
-  if String.length t < pos + len || pos < 0 || len < 0 then ""
-  else String.sub t ~pos ~len
+  sub t ~pos ~len
 
 let has_cmt_same_line_after t (loc : Location.t) =
   let loc_start = {loc.loc_end with pos_cnum= loc.loc_end.pos_cnum} in

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -26,6 +26,8 @@ val has_cmt_same_line_after : t -> Location.t -> bool
 
 val string_at : t -> Lexing.position -> Lexing.position -> string
 
+val sub : t -> pos:int -> len:int -> string
+
 val string_literal :
   t -> [`Normalize | `Preserve] -> Location.t -> string option
 

--- a/test/passing/doc_comments.mli
+++ b/test/passing/doc_comments.mli
@@ -442,3 +442,11 @@ let fooooooooooooooooo =
 (** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooo {b eee + eee eee} *)
 
 (** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooooooo {b + eee + eee eee} *)
+
+val f : int
+
+(***)
+
+val k : int
+
+(**)

--- a/test/passing/doc_comments.mli.ref
+++ b/test/passing/doc_comments.mli.ref
@@ -409,3 +409,11 @@ end
 
 (** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooooooo {b
     \+ eee + eee eee} *)
+
+val f : int
+
+(***)
+
+val k : int
+
+(**)


### PR DESCRIPTION
Fix #1282 
This fix is ugly but it looks like the parser is at fault, the empty comment is not considered a docstring so we have to check what the source looked like when formatting comments.