### PR TITLE
Refactor Cmts (followup for #1172)

### DIFF
--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -452,21 +452,6 @@ let fmt_within t conf ~fmt_code ?(pro = Fmt.break 1 0) ?(epi = Fmt.break 1 0)
     (find_cmts t `Within loc)
     ~fmt_code ~pro ~epi ~eol:Fmt.noop loc
 
-let fmt t conf ~fmt_code ?pro ?epi ?eol ?adj loc =
-  let open Fmt in
-  (* remove the before comments from the map first *)
-  let before = fmt_before t conf ~fmt_code ?pro ?epi ?eol ?adj loc in
-  (* remove the within comments from the map by accepting the continuation *)
-  fun k ->
-    (* delay the after comments until the within comments have been removed *)
-    let after = fmt_after t conf ~fmt_code ?pro ?epi loc in
-    let inner = k in
-    before $ inner $ after
-
-let fmt_list t conf ~fmt_code ?pro ?epi ?eol locs init =
-  List.fold locs ~init ~f:(fun k loc ->
-      fmt t conf ~fmt_code ?pro ?epi ?eol loc @@ k)
-
 let drop_inside t loc =
   let clear pos =
     update_cmts t pos

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -389,7 +389,7 @@ let break_comment_group source margin {Cmt.loc= a; _} {Cmt.loc= b; _} =
     ( (Location.is_single_line a margin && Location.is_single_line b margin)
     && (vertical_align || horizontal_align) )
 
-(** Find, remove, and format comments for loc. *)
+(** Format comments for loc. *)
 let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
     ?(adj = eol) found loc =
   let open Fmt in

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -365,6 +365,7 @@ let pop_if_debug t loc =
   if t.debug && t.remove then update_remaining t ~f:(Location.Set.remove loc)
 
 let find_cmts t pos loc =
+  pop_if_debug t loc ;
   let r = find_at_position t loc pos in
   if t.remove then
     update_cmts t pos ~f:(fun m -> Location.Multimap.remove m loc) ;
@@ -374,7 +375,6 @@ let find_cmts t pos loc =
 let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
     ?(adj = eol) found loc =
   let open Fmt in
-  pop_if_debug t loc ;
   match found with
   | None | Some [] -> noop
   | Some cmts ->

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -371,6 +371,9 @@ let find_cmts t pos loc =
     update_cmts t pos ~f:(fun m -> Location.Multimap.remove m loc) ;
   r
 
+let line_dist a b =
+  b.Location.loc_start.pos_lnum - a.Location.loc_end.pos_lnum
+
 (** Find, remove, and format comments for loc. *)
 let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
     ?(adj = eol) found loc =
@@ -378,9 +381,6 @@ let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
   match found with
   | None | Some [] -> noop
   | Some cmts ->
-      let line_dist a b =
-        b.Location.loc_start.pos_lnum - a.Location.loc_end.pos_lnum
-      in
       let groups =
         List.group cmts ~break:(fun {Cmt.loc= a; _} {Cmt.loc= b; _} ->
             let vertical_align =

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -372,10 +372,10 @@ let find_cmts t pos loc =
 
 (** Find, remove, and format comments for loc. *)
 let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
-    ?(adj = eol) find loc =
+    ?(adj = eol) found loc =
   let open Fmt in
   pop_if_debug t loc ;
-  match find loc with
+  match found with
   | None | Some [] -> noop
   | Some cmts ->
       let line_dist a b =
@@ -431,20 +431,26 @@ let fmt_cmts t (conf : Conf.t) ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n")
               ( close_box
               $ fmt_or_k eol_cmt (fmt_or_k adj_cmt adj eol) (fmt_opt epi) ))
 
-let fmt_before t conf ~fmt_code ?pro ?(epi = Fmt.break 1 0) ?eol ?adj =
-  fmt_cmts t conf (find_cmts t `Before) ~fmt_code ?pro ~epi ?eol ?adj
+let fmt_before t conf ~fmt_code ?pro ?(epi = Fmt.break 1 0) ?eol ?adj loc =
+  fmt_cmts t conf (find_cmts t `Before loc) ~fmt_code ?pro ~epi ?eol ?adj loc
 
-let fmt_after t conf ~fmt_code ?(pro = Fmt.break 1 0) ?epi =
+let fmt_after t conf ~fmt_code ?(pro = Fmt.break 1 0) ?epi loc =
   let open Fmt in
-  let within = fmt_cmts t conf (find_cmts t `Within) ~fmt_code ~pro ?epi in
-  let after =
-    fmt_cmts t conf (find_cmts t `After) ~fmt_code ~pro ?epi ~eol:noop
+  let within =
+    fmt_cmts t conf (find_cmts t `Within loc) ~fmt_code ~pro ?epi loc
   in
-  fun loc -> within loc $ after loc
+  let after =
+    fmt_cmts t conf
+      (find_cmts t `After loc)
+      ~fmt_code ~pro ?epi ~eol:noop loc
+  in
+  within $ after
 
 let fmt_within t conf ~fmt_code ?(pro = Fmt.break 1 0) ?(epi = Fmt.break 1 0)
-    =
-  fmt_cmts t conf (find_cmts t `Within) ~fmt_code ~pro ~epi ~eol:Fmt.noop
+    loc =
+  fmt_cmts t conf
+    (find_cmts t `Within loc)
+    ~fmt_code ~pro ~epi ~eol:Fmt.noop loc
 
 let fmt t conf ~fmt_code ?pro ?epi ?eol ?adj loc =
   let open Fmt in

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -90,32 +90,6 @@ val fmt_within :
 (** [fmt_within loc] formats the comments associated with [loc] that appear
     within [loc]. *)
 
-val fmt :
-     t
-  -> Conf.t
-  -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
-  -> ?pro:Fmt.t
-  -> ?epi:Fmt.t
-  -> ?eol:Fmt.t
-  -> ?adj:Fmt.t
-  -> Location.t
-  -> Fmt.t
-  -> Fmt.t
-(** [fmt loc format_thunk] wraps [fmt_before] and [fmt_after] around
-    [format_thunk]. *)
-
-val fmt_list :
-     t
-  -> Conf.t
-  -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
-  -> ?pro:Fmt.t
-  -> ?epi:Fmt.t
-  -> ?eol:Fmt.t
-  -> Location.t list
-  -> Fmt.t
-  -> Fmt.t
-(** [fmt_list locs] formats as per [fmt] for each loc in [locs]. *)
-
 val drop_inside : t -> Location.t -> unit
 
 val has_before : t -> Location.t -> bool

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -31,6 +31,8 @@ module Cmts = struct
 
   let fmt_before c = fmt_before c.cmts c.conf ~fmt_code:c.fmt_code
 
+  let fmt_within c = fmt_within c.cmts c.conf ~fmt_code:c.fmt_code
+
   let fmt_after c = fmt_after c.cmts c.conf ~fmt_code:c.fmt_code
 
   let fmt c ?pro ?epi ?eol ?adj loc =
@@ -46,8 +48,6 @@ module Cmts = struct
   let fmt_list ?pro ?epi ?eol c locs init =
     List.fold locs ~init ~f:(fun k loc ->
         fmt ?pro ?epi ?eol ?adj:None c loc k)
-
-  let fmt_within c = fmt_within c.cmts c.conf ~fmt_code:c.fmt_code
 end
 
 type block =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -29,15 +29,25 @@ type c =
 module Cmts = struct
   include Cmts
 
-  let fmt c = fmt c.cmts c.conf ~fmt_code:c.fmt_code
-
   let fmt_before c = fmt_before c.cmts c.conf ~fmt_code:c.fmt_code
-
-  let fmt_within c = fmt_within c.cmts c.conf ~fmt_code:c.fmt_code
 
   let fmt_after c = fmt_after c.cmts c.conf ~fmt_code:c.fmt_code
 
-  let fmt_list c = fmt_list c.cmts c.conf ~fmt_code:c.fmt_code
+  let fmt c ?pro ?epi ?eol ?adj loc =
+    (* remove the before comments from the map first *)
+    let before = fmt_before c ?pro ?epi ?eol ?adj loc in
+    (* remove the within comments from the map by accepting the continuation *)
+    fun inner ->
+      (* delay the after comments until the within comments have been removed *)
+      let after = fmt_after c ?pro ?epi loc in
+      let open Fmt in
+      before $ inner $ after
+
+  let fmt_list ?pro ?epi ?eol c locs init =
+    List.fold locs ~init ~f:(fun k loc ->
+        fmt ?pro ?epi ?eol ?adj:None c loc k)
+
+  let fmt_within c = fmt_within c.cmts c.conf ~fmt_code:c.fmt_code
 end
 
 type block =


### PR DESCRIPTION
This is a followup for #1172.

While updating #1152 I had a look at the next steps and split a couple functions to make the flow a bit clearer. This makes `fmt_cmts` pure for example, and moves some functions that do not need to use the inner of the module directly in the `Cmts` wrapper in `Fmt_ast`, which simplifies parameter passing.

No change in behaviour is expected.

Let me know what you think.