### PR TITLE
Encapsulate token filtering in Source

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -915,26 +915,9 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
            ))
   | Ppat_constant const ->
       fmt_constant c ~loc:(Location.smallest ppat_loc ppat_loc_stack) const
-  | Ppat_interval (l, u) -> (
-      (* we need to reconstruct locations for both side of the interval *)
-      let toks =
-        Source.tokens_at c.source ppat_loc ~filter:(function
-          | Parser.CHAR _ | Parser.DOTDOT
-           |Parser.(INT _ | STRING _ | FLOAT _) ->
-              true
-          | _ -> false)
-      in
-      match toks with
-      | [ (Parser.(CHAR _ | INT _ | STRING _ | FLOAT _), loc1)
-        ; (Parser.DOTDOT, _)
-        ; (Parser.(CHAR _ | INT _ | STRING _ | FLOAT _), loc2) ] ->
-          fmt_constant ~loc:loc1 c l
-          $ str " .. "
-          $ fmt_constant ~loc:loc2 c u
-      | _ ->
-          impossible
-            "Ppat_interval is only produced by the sequence of 3 tokens: \
-             CONSTANT-DOTDOT-CONSTANT " )
+  | Ppat_interval (l, u) ->
+      let loc1, loc2 = Source.locs_of_interval c.source ppat_loc in
+      fmt_constant ~loc:loc1 c l $ str " .. " $ fmt_constant ~loc:loc2 c u
   | Ppat_tuple pats ->
       let parens = parens || Poly.(c.conf.parens_tuple_patterns = `Always) in
       hvbox 0

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -97,7 +97,7 @@ let lexbuf_set_pos lexbuf pos =
   lexbuf.Lexing.lex_abs_pos <- pos.Lexing.pos_cnum ;
   lexbuf.lex_curr_p <- pos
 
-let tokens_between t ?(filter = fun _ -> true) loc_start loc_end =
+let tokens_between t ~filter loc_start loc_end =
   let s = string_at t loc_start loc_end in
   let lexbuf = Lexing.from_string s in
   lexbuf_set_pos lexbuf loc_start ;
@@ -110,8 +110,8 @@ let tokens_between t ?(filter = fun _ -> true) loc_start loc_end =
   in
   loop []
 
-let tokens_at t ?filter (l : Location.t) =
-  tokens_between t ?filter l.loc_start l.loc_end
+let tokens_at t ~filter (l : Location.t) =
+  tokens_between t ~filter l.loc_start l.loc_end
 
 let find_after t f (loc : Location.t) =
   let pos_start = loc.loc_end in

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -319,3 +319,19 @@ let loc_of_underscore t flds (ppat_loc : Location.t) =
   let filter = function Parser.UNDERSCORE -> true | _ -> false in
   let tokens = tokens_at t ~filter loc_underscore in
   Option.map (List.hd tokens) ~f:snd
+
+let locs_of_interval source loc =
+  let toks =
+    tokens_at source loc ~filter:(function
+      | CHAR _ | DOTDOT | INT _ | STRING _ | FLOAT _ -> true
+      | _ -> false)
+  in
+  match toks with
+  | [ ((CHAR _ | INT _ | STRING _ | FLOAT _), loc1)
+    ; (DOTDOT, _)
+    ; ((CHAR _ | INT _ | STRING _ | FLOAT _), loc2) ] ->
+      (loc1, loc2)
+  | _ ->
+      impossible
+        "Ppat_interval is only produced by the sequence of 3 tokens: \
+         CONSTANT-DOTDOT-CONSTANT "

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -89,3 +89,7 @@ val loc_of_underscore :
     underscore at the end of the record pattern of location [loc] with fields
     [fields], if the record pattern is open (it ends with an underscore),
     otherwise returns [None]. *)
+
+val locs_of_interval : t -> Location.t -> Location.t * Location.t
+(** Given the location of an interval pattern ['a'..'b'], return the
+    locations of the constants that represent the bounds (['a'] and ['b']). *)

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -33,25 +33,9 @@ val string_literal :
 
 val char_literal : t -> Location.t -> string option
 
-val tokens_at :
-     t
-  -> ?filter:(Parser.token -> bool)
-  -> Location.t
-  -> (Parser.token * Location.t) list
-
 val position_before : t -> Lexing.position -> Lexing.position option
 (** [position_before s pos] returns the starting position of the token
     preceding the position [pos]. *)
-
-val tokens_between :
-     t
-  -> ?filter:(Parser.token -> bool)
-  -> Lexing.position
-  -> Lexing.position
-  -> (Parser.token * Location.t) list
-(** [tokens_between s ~filter from upto] returns the list of tokens starting
-    from [from] and ending before [upto] and respecting the [filter]
-    property. [from] must start before [upto]. *)
 
 val is_long_pexp_open : t -> Parsetree.expression -> bool
 (** [is_long_pexp_open source exp] holds if [exp] is a [Pexp_open] expression


### PR DESCRIPTION
This removes functions that return tokens from `Source`, so that filtering is done in that module. This allows a small refactoring to simplify the common use case:

Instead of filtering, then matching (pseudo-code)

```ocaml
    tokens_between start end ~f:(function
      | (Char _ | Int _ | String _) -> true
      | Dotdot -> true
      | _ -> false)
    |> function
      | [ ((Char _ | Int _ | String _), loc1); (* note repetition with above *)
          (Dotdot, _) ;
          ((Char _ | Int _ | String _), loc2) ] ->
          (loc1, loc2)
```

We use a `filter_map` to capture both steps:

```ocaml
    tokens_between start end ~f:(function
      | (Char _ | Int _ | String _) -> Some `Constant
      | Dotdot -> Some `Dotdot
      | _ -> None)
    |> function
      | [ (`Constant, loc1); (Dotdot, _) ; (`Constant, loc2) ] ->
          (loc1, loc2)
```