### PR TITLE
opam file: Remove weird url field

### DIFF
--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -15,7 +15,6 @@ authors: "Josh Berdine <jjb@fb.com>"
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
-url { archive: "https://github.com/ocaml-ppx/ocamlformat/archive/%%VERSION%%.tar.gz" }
 license: "MIT"
 build: [
   ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}


### PR DESCRIPTION
I'm not sure what's the goal of having this but it feels very much out of place.
I noticed this in https://github.com/ocaml/opam-repository/pull/16133 because the `url` field is not in its usual place, and i just ignored it in previous releases.

I believe that without this PR it is not possible to pin ocamlformat locally without it being pushed upstream. Also it fetches an unnecessary archive everytime it is updated.