### PR TITLE
Cleaning the Translation_unit API

### DIFF
--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -24,8 +24,8 @@ let format ?output_file ~kind ~input_name ~source conf opts =
   else
     let f =
       match kind with
-      | `Impl -> Translation_unit.parse_and_format Translation_unit.impl
-      | `Intf -> Translation_unit.parse_and_format Translation_unit.intf
+      | `Impl -> Translation_unit.parse_and_format_impl
+      | `Intf -> Translation_unit.parse_and_format_intf
     in
     f ?output_file ~input_name ~source conf opts
 

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -13,37 +13,6 @@
 
 open Ocamlformat_lib
 
-let normalize norm c {Parse_with_comments.ast; _} = norm c ast
-
-let equal eq ~ignore_doc_comments c a b =
-  eq ~ignore_doc_comments c a.Parse_with_comments.ast
-    b.Parse_with_comments.ast
-
-let moved_docstrings f c a b =
-  f c a.Parse_with_comments.ast b.Parse_with_comments.ast
-
-(** Operations on implementation files. *)
-let impl : _ Translation_unit.t =
-  { parse= Migrate_ast.Parse.use_file
-  ; recover= Parse_wyc.Make_parsable.use_file
-  ; init_cmts= Cmts.init_toplevel
-  ; fmt= Fmt_ast.fmt_toplevel
-  ; equal= equal Normalize.equal_toplevel
-  ; moved_docstrings= moved_docstrings Normalize.moved_docstrings_toplevel
-  ; normalize= normalize Normalize.toplevel
-  ; printast= Migrate_ast.Printast.use_file }
-
-(** Operations on interface files. *)
-let intf : _ Translation_unit.t =
-  { parse= Migrate_ast.Parse.interface
-  ; recover= Parse_wyc.Make_parsable.signature
-  ; init_cmts= Cmts.init_intf
-  ; fmt= Fmt_ast.fmt_signature
-  ; equal= equal Normalize.equal_intf
-  ; moved_docstrings= moved_docstrings Normalize.moved_docstrings_intf
-  ; normalize= normalize Normalize.intf
-  ; printast= Migrate_ast.Printast.interface }
-
 ;;
 Caml.at_exit (Format.pp_print_flush Format.err_formatter)
 
@@ -55,8 +24,8 @@ let format ?output_file ~kind ~input_name ~source conf opts =
   else
     let f =
       match kind with
-      | `Impl -> Translation_unit.parse_and_format impl
-      | `Intf -> Translation_unit.parse_and_format intf
+      | `Impl -> Translation_unit.parse_and_format Translation_unit.impl
+      | `Intf -> Translation_unit.parse_and_format Translation_unit.intf
     in
     f ?output_file ~input_name ~source conf opts
 

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -431,3 +431,7 @@ let intf : _ t =
   ; moved_docstrings= moved_docstrings Normalize.moved_docstrings_intf
   ; normalize= normalize Normalize.intf
   ; printast= Migrate_ast.Printast.interface }
+
+let parse_and_format_impl = parse_and_format impl
+
+let parse_and_format_intf = parse_and_format intf

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -12,24 +12,7 @@
 open Parse_with_comments
 
 (** Operations on translation units. *)
-type 'a t =
-  { init_cmts: debug:bool -> Source.t -> 'a -> Cmt.t list -> Cmts.t
-  ; fmt: debug:bool -> Source.t -> Cmts.t -> Conf.t -> 'a -> Fmt.t
-  ; parse: Lexing.lexbuf -> 'a
-  ; recover: string -> string
-  ; equal:
-         ignore_doc_comments:bool
-      -> Conf.t
-      -> 'a with_comments
-      -> 'a with_comments
-      -> bool
-  ; moved_docstrings:
-         Conf.t
-      -> 'a with_comments
-      -> 'a with_comments
-      -> Normalize.docstring_error list
-  ; normalize: Conf.t -> 'a with_comments -> 'a
-  ; printast: Caml.Format.formatter -> 'a -> unit }
+type 'a t
 
 type error
 
@@ -67,3 +50,7 @@ val print_error :
   -> unit
 (** [print_error conf ?fmt ~input_name e] prints the error message
     corresponding to error [e] on the [fmt] formatter (stderr by default). *)
+
+val impl : Migrate_ast.Parsetree.toplevel_phrase list t
+
+val intf : Migrate_ast.Parsetree.signature t

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -9,21 +9,27 @@
  *                                                                    *
  **********************************************************************)
 
-(** Operations on translation units. *)
-type 'a t
-
 type error
 
-val parse_and_format :
-     'a t
-  -> ?output_file:string
+val parse_and_format_impl :
+     ?output_file:string
   -> input_name:string
   -> source:string
   -> Conf.t
   -> Conf.opts
   -> (string, error) Result.t
-(** [parse_and_format xunit conf ?output_file ~input_name ~source] is similar
-    to [format] but parses the source according to [xunit]. *)
+(** [parse_and_format_impl conf ?output_file ~input_name ~source] parses and
+    formats [source] as a list of toplevel phrases. *)
+
+val parse_and_format_intf :
+     ?output_file:string
+  -> input_name:string
+  -> source:string
+  -> Conf.t
+  -> Conf.opts
+  -> (string, error) Result.t
+(** [parse_and_format_intf conf ?output_file ~input_name ~source] parses and
+    formats [source] as a list of signature items. *)
 
 val print_error :
      ?fmt:Format.formatter
@@ -34,7 +40,3 @@ val print_error :
   -> unit
 (** [print_error conf ?fmt ~input_name e] prints the error message
     corresponding to error [e] on the [fmt] formatter (stderr by default). *)
-
-val impl : Migrate_ast.Parsetree.toplevel_phrase list t
-
-val intf : Migrate_ast.Parsetree.signature t

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -9,26 +9,10 @@
  *                                                                    *
  **********************************************************************)
 
-open Parse_with_comments
-
 (** Operations on translation units. *)
 type 'a t
 
 type error
-
-val format :
-     'a t
-  -> ?output_file:string
-  -> input_name:string
-  -> source:string
-  -> parsed:'a with_comments
-  -> Conf.t
-  -> Conf.opts
-  -> (string, error) Result.t
-(** [format xunit conf ?output_file ~input_name ~source ~parsed] formats
-    [parsed], using [input_name] for error messages, and referring to
-    [source] to improve comment placement. It returns the formatted string or
-    an error that prevented formatting. *)
 
 val parse_and_format :
      'a t


### PR DESCRIPTION
Cleaning the Translation_unit API a bit in case we release a public API for ocamlformat
(didn't manage to make it compile with a separate opam file as private/public libraries don't mix well together)