### PR TITLE
Revert deprecation of doc-comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### unreleased
+
+#### Changes
+
+  + Revert depreciation of the `doc-comments` option (#1331) (Jules Aguillon)
+
 ### 0.14.0 (2020-04-02)
 
 #### New features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 #### Changes
 
-  + Revert depreciation of the `doc-comments` option (#1331) (Jules Aguillon)
+  + Revert deprecation of the `doc-comments` option (#1331) (Jules Aguillon)
+    This reverts a change introduced in 0.14.0 (#1293).
 
 ### 0.14.0 (2020-04-02)
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -494,12 +494,7 @@ module Formatting = struct
            change their meaning and on structures, signatures and objects \
            for readability." ) ]
     in
-    let deprecated =
-      C.deprecated ~since_version:"0.14.0"
-        "Use the more restricted doc-comments-val instead. There is no \
-         equivalent to this option in the general case."
-    in
-    C.choice ~names ~all ~doc ~section ~deprecated
+    C.choice ~names ~all ~doc ~section
       (fun conf x -> {conf with doc_comments= x})
       (fun conf -> conf.doc_comments)
 

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -161,9 +161,7 @@ OPTIONS (CODE FORMATTING STYLE)
            corresponding code. This option has no effect on variant
            declarations because that would change their meaning and on
            structures, signatures and objects for readability. The default
-           value is before. Warning: This option is deprecated since version
-           0.14.0. Use the more restricted doc-comments-val instead. There is
-           no equivalent to this option in the general case.
+           value is before.
 
        --doc-comments-padding=PADDING
            Add PADDING spaces before doc comments in type declarations. The

--- a/test/passing/doc_comments-after.ml.ref
+++ b/test/passing/doc_comments-after.ml.ref
@@ -1,4 +1,3 @@
-Warning: doc-comments: This option is deprecated since version 0.14.0. Use the more restricted doc-comments-val instead. There is no equivalent to this option in the general case.
 module A = B
 (** test *)
 

--- a/test/passing/doc_comments-before.ml.ref
+++ b/test/passing/doc_comments-before.ml.ref
@@ -1,4 +1,3 @@
-Warning: doc-comments: This option is deprecated since version 0.14.0. Use the more restricted doc-comments-val instead. There is no equivalent to this option in the general case.
 (** test *)
 module A = B
 

--- a/test/passing/doc_comments-val-after.ml.ref
+++ b/test/passing/doc_comments-val-after.ml.ref
@@ -1,4 +1,3 @@
-Warning: doc-comments: This option is deprecated since version 0.14.0. Use the more restricted doc-comments-val instead. There is no equivalent to this option in the general case.
 (** test *)
 module A = B
 

--- a/test/passing/verbose1.ml.ref
+++ b/test/passing/verbose1.ml.ref
@@ -1,5 +1,3 @@
-Warning: doc-comments: This option is deprecated since version 0.14.0. Use the more restricted doc-comments-val instead. There is no equivalent to this option in the general case.
-Warning: doc-comments: This option is deprecated since version 0.14.0. Use the more restricted doc-comments-val instead. There is no equivalent to this option in the general case.
 profile=ocamlformat (file .ocamlformat:1)
 quiet=false (profile ocamlformat (file .ocamlformat:1))
 max-iters=2 (file .ocamlformat:6)

--- a/test/passing/verbose2.ml.ref
+++ b/test/passing/verbose2.ml.ref
@@ -1,5 +1,3 @@
-Warning: doc-comments: This option is deprecated since version 0.14.0. Use the more restricted doc-comments-val instead. There is no equivalent to this option in the general case.
-Warning: doc-comments: This option is deprecated since version 0.14.0. Use the more restricted doc-comments-val instead. There is no equivalent to this option in the general case.
 profile=ocamlformat (file .ocamlformat:1)
 quiet=false (profile ocamlformat (file .ocamlformat:1))
 max-iters=2 (file .ocamlformat:6)


### PR DESCRIPTION
This was done too fast, alternatives weren't tested on real projects and users.

This caused some problems, Owl is explicitly using the deprecated option and Irmin won't upgrade. This may also cause huge diffs on Infer.