### PR TITLE
Revert doc-comments change to the default profile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 #### Changes
 
   + The default for `doc-comments` is changed to `after` (#1335) (Jules Aguillon)
-    This revert a change introduced in 0.14.0.
+    This reverts a change introduced in 0.14.0 (#1012).
 
   + Revert deprecation of the `doc-comments` option (#1331) (Jules Aguillon)
     This reverts a change introduced in 0.14.0 (#1293).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 #### Changes
 
+  + The default for `doc-comments` is changed to `after` (#1335) (Jules Aguillon)
+    This revert a change introduced in 0.14.0.
+
   + Revert deprecation of the `doc-comments` option (#1331) (Jules Aguillon)
     This reverts a change introduced in 0.14.0 (#1293).
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -484,15 +484,15 @@ module Formatting = struct
     let doc = "Doc comments position." in
     let names = ["doc-comments"] in
     let all =
-      [ ( "before"
-        , `Before
-        , "$(b,before) puts comments before the corresponding code." )
-      ; ( "after"
+      [ ( "after"
         , `After
         , "$(b,after) puts doc comments after the corresponding code. This \
            option has no effect on variant declarations because that would \
            change their meaning and on structures, signatures and objects \
-           for readability." ) ]
+           for readability." )
+      ; ( "before"
+        , `Before
+        , "$(b,before) puts comments before the corresponding code." ) ]
     in
     C.choice ~names ~all ~doc ~section
       (fun conf x -> {conf with doc_comments= x})

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -155,13 +155,13 @@ OPTIONS (CODE FORMATTING STYLE)
            Add parentheses around matching constructs that fit on a single
            line. The flag is unset by default.
 
-       --doc-comments={before|after}
-           Doc comments position. before puts comments before the
-           corresponding code. after puts doc comments after the
+       --doc-comments={after|before}
+           Doc comments position. after puts doc comments after the
            corresponding code. This option has no effect on variant
            declarations because that would change their meaning and on
-           structures, signatures and objects for readability. The default
-           value is before.
+           structures, signatures and objects for readability. before puts
+           comments before the corresponding code. The default value is
+           after.
 
        --doc-comments-padding=PADDING
            Add PADDING spaces before doc comments in type declarations. The

--- a/vendor/parse-wyc/menhir-recover/attributes.ml
+++ b/vendor/parse-wyc/menhir-recover/attributes.ml
@@ -16,8 +16,8 @@ open Utils
 
 (** Specification of attributes that are meaningful for recovery *)
 module type ATTRIBUTES = sig
-  (** The Menhir grammar to which these apply *)
   module G : GRAMMAR
+  (** The Menhir grammar to which these apply *)
 
   (** Recovery cost
 

--- a/vendor/parse-wyc/menhir-recover/recovery_custom.ml
+++ b/vendor/parse-wyc/menhir-recover/recovery_custom.ml
@@ -6,6 +6,7 @@ module type RECOVERY = sig
 
   type item = G.lr1 * G.production * int
 
+  type recovery = { prefix : int; cases : (G.lr1 option * item list) list }
   (** [prefix] is the size of the known prefix of the stack. It means that in
       the kernel of current state, there is an item whose dot is at position
       [prefix]. (we know the incoming symbols for these stack frames and we can
@@ -17,7 +18,6 @@ module type RECOVERY = sig
 
       The actual list of actions to reduce an item [(state, prod, pos)] is given
       by [Synthesizer.solution (Trail (state, prod, pos))] *)
-  type recovery = { prefix : int; cases : (G.lr1 option * item list) list }
 
   val recover : G.lr1 -> recovery
 

--- a/vendor/parse-wyc/menhir-recover/recovery_intf.ml
+++ b/vendor/parse-wyc/menhir-recover/recovery_intf.ml
@@ -5,6 +5,7 @@ module type RECOVERY = sig
 
   type item = G.lr1 * G.production * int
 
+  type recovery = { prefix : int; cases : (G.lr1 option * item list) list }
   (** [prefix] is the size of the known prefix of the stack. It means that in
       the kernel of current state, there is an item whose dot is at position
       [prefix]. (we know the incoming symbols for these stack frames and we can
@@ -16,7 +17,6 @@ module type RECOVERY = sig
 
       The actual list of actions to reduce an item [(state, prod, pos)] is given
       by [Synthesizer.solution (Trail (state, prod, pos))] *)
-  type recovery = { prefix : int; cases : (G.lr1 option * item list) list }
 
   val recover : G.lr1 -> recovery
 end


### PR DESCRIPTION
This surprised users.

We should release 0.14.1 with this patch.

cc @samoht 