### PR TITLE
Parse comments as docstrings if they contain odoc constructs

### DIFF
--- a/test/passing/doc_comments.mli
+++ b/test/passing/doc_comments.mli
@@ -450,3 +450,14 @@ val f : int
 val k : int
 
 (**)
+
+(* Regular comments with odoc constructs should be formatted as docstrings:
+
+   - Fooo fooo foo foo foo foo.
+   - Foo foo foo foooooo foo foo foo foo.
+
+   {[
+     @foooooo
+     |-------- core
+   ]}
+*)

--- a/test/passing/doc_comments.mli.ref
+++ b/test/passing/doc_comments.mli.ref
@@ -417,3 +417,14 @@ val f : int
 val k : int
 
 (**)
+
+(* Regular comments with odoc constructs should be formatted as docstrings:
+
+   - Fooo fooo foo foo foo foo.
+   - Foo foo foo foooooo foo foo foo foo.
+
+   {[
+     @foooooo
+     |-------- core
+   ]}
+*)


### PR DESCRIPTION
This was suggested in the last message of #1165 (but it is not relevant to the first part of the issue)

The approach is to check if a comment contains odoc constructs (and not only checks if it can be formatted as a docstring, since regular comments can), if so: format it as a docstring.
The code is a bit ugly as we already have a dependency from Fmt_odoc to Cmt so we can't have one in the other direction (and it's not clear what code should be moved where).