### PR TITLE
Mention test_branch in HACKING.org

### DIFF
--- a/HACKING.org
+++ b/HACKING.org
@@ -35,3 +35,5 @@ Git is used to manage the script's state:
 - Release on Opam-repository
   =dune-release opam pkg=
   =dune-release opam submit=
+
+- Each release should be announced on [[https://discuss.ocaml.org/]]

--- a/HACKING.org
+++ b/HACKING.org
@@ -15,6 +15,8 @@ Git is used to manage the script's state:
 - Review the impact of the release on real source code:
   In =test-extra/Makefile=, uncomment the extended list of projects to test
   and run =tools/test_branch.sh -a "previous_release"=.
+  Diffs should be discussed with the maintainers of these projects to gather
+  feedback before continuing the release.
 
 - In =CHANGES.md=, change =(unreleased)= with the current date
   Commit

--- a/HACKING.org
+++ b/HACKING.org
@@ -1,4 +1,20 @@
+* Testing on other projects
+
+The =tools/test_branch.sh= script builds 2 revisions of OCamlformat and run them
+on the sources of some projects.
+The list of tested project is (and can be edited) in =test-extra/Makefile=.
+
+The projects sources are cloned into =test-extra/code=.
+Git is used to manage the script's state:
+- staged changes are the diffs introduced by formatting with the first revision
+- unstaged changes are the diffs introduced by upgrading OCamlformat to the
+  second rev
+
 * Release procedure
+
+- Review the impact of the release on real source code:
+  In =test-extra/Makefile=, uncomment the extended list of projects to test
+  and run =tools/test_branch.sh -a "previous_release"=.
 
 - In =CHANGES.md=, change =(unreleased)= with the current date
   Commit


### PR DESCRIPTION
This can be useful for external contributors or to have a support for discussion.

There is a workflow I have with this script that I didn't document yet:
It is possible to modify the projects sources and run again `test_branch` but it is necessary to comment that line: `make -C test-extra test_setup test_unstage test_clean test_pull`
This should be made easier, I'll improve that.

What do you think?