### PR TITLE
Add doc-comments-val=unset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+### unreleased
+
+#### Changes
+
+  + Set `doc-comments-val` to `unset` by default (#1340) (Jules Aguillon)
+    Placement of documentation comments on `val` and `external` items is now
+    controled by `doc-comments` unless this option is set.
+
 ### 0.14.1 (2020-04-14)
 
 #### Changes

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -33,7 +33,7 @@ type t =
   ; disable: bool
   ; disambiguate_non_breaking_match: bool
   ; doc_comments: [`Before | `After]
-  ; doc_comments_val: [`Before | `After]
+  ; doc_comments_val: [`Before | `After | `Unset]
   ; doc_comments_padding: int
   ; doc_comments_tag_only: [`Fit | `Default]
   ; dock_collection_brackets: bool
@@ -505,7 +505,10 @@ module Formatting = struct
     in
     let names = ["doc-comments-val"] in
     let all =
-      [ ( "after"
+      [ ( "unset"
+        , `Unset
+        , "$(b,unset) lets $(b,doc-comments) set the position" )
+      ; ( "after"
         , `After
         , "$(b,after) puts documentation comments after their corresponding \
            declarations." )
@@ -1660,7 +1663,7 @@ let janestreet_profile =
   ; disable= false
   ; disambiguate_non_breaking_match= false
   ; doc_comments= `Before
-  ; doc_comments_val= `Before
+  ; doc_comments_val= `Unset
   ; doc_comments_padding= 1
   ; doc_comments_tag_only= `Fit
   ; dock_collection_brackets= false

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -507,7 +507,7 @@ module Formatting = struct
     let all =
       [ ( "unset"
         , `Unset
-        , "$(b,unset) lets $(b,doc-comments) set the position" )
+        , "$(b,unset) lets $(b,doc-comments) set the position." )
       ; ( "after"
         , `After
         , "$(b,after) puts documentation comments after their corresponding \

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -35,7 +35,7 @@ type t =
   ; disable: bool
   ; disambiguate_non_breaking_match: bool
   ; doc_comments: [`Before | `After]
-  ; doc_comments_val: [`Before | `After]
+  ; doc_comments_val: [`Before | `After | `Unset]
   ; doc_comments_padding: int
   ; doc_comments_tag_only: [`Fit | `Default]
   ; dock_collection_brackets: bool

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -465,7 +465,11 @@ let fmt_docstring_around_item' ?(is_val = false) ?(force_before = false)
         then `Fit
         else
           let ((`Before | `After) as conf) =
-            if is_val then c.conf.doc_comments_val else c.conf.doc_comments
+            if is_val then
+              match c.conf.doc_comments_val with
+              | (`Before | `After) as conf -> conf
+              | `Unset -> c.conf.doc_comments
+            else c.conf.doc_comments
           in
           conf
       in

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -172,10 +172,11 @@ OPTIONS (CODE FORMATTING STYLE)
            treatment. fit puts doc comments on the same line. The default
            value is default.
 
-       --doc-comments-val={after|before}
+       --doc-comments-val={unset|after|before}
            Documentation comments position on val and external declarations.
-           after puts documentation comments after their corresponding
-           declarations. before puts them before. The default value is after.
+           unset lets doc-comments set the position after puts documentation
+           comments after their corresponding declarations. before puts them
+           before. The default value is unset.
 
        --dock-collection-brackets
            Dock the brackets of lists, arrays and records, so that when the

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -174,7 +174,7 @@ OPTIONS (CODE FORMATTING STYLE)
 
        --doc-comments-val={unset|after|before}
            Documentation comments position on val and external declarations.
-           unset lets doc-comments set the position after puts documentation
+           unset lets doc-comments set the position. after puts documentation
            comments after their corresponding declarations. before puts them
            before. The default value is unset.
 


### PR DESCRIPTION
When `doc-comments-val` was added, the scope of `doc-comments` was reduced and
didn't overlap with the new option.
This is confusing because the name of the option suggest that `doc-comments-val`
overlap with `doc-comments` but not by default.

This also added unecessary maintainance to users of `doc-comments`, they had to
understand and add a new option to their config.

This new value is set by default. This may impact users who kept 0.14.0
defaults when upgrading to 0.14.1 (eg. setting `doc-comments=before` and
not setting `doc-comments-val`).

Closes https://github.com/ocaml-ppx/ocamlformat/issues/1338