### PR TITLE
[RFC] Only consider non-constant constructors for align-constructors-…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 #### Changes
 
+  + In `align-constructors-decl` mode, only consider non-constant constructors (#1344) (Josh Berdine)
+
   + Set `doc-comments-val` to `unset` by default (#1340) (Jules Aguillon)
     Placement of documentation comments on `val` and `external` items is now
     controled by `doc-comments` unless this option is set.

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3032,7 +3032,9 @@ and fmt_type_declaration c ?ext ?(pre = "") ctx ?fmt_name ?(eq = "=") decl =
     | Ptype_variant ctor_decls ->
         let max acc d =
           let len_around = if is_symbol_id d.pcd_name.txt then 4 else 0 in
-          max acc (String.length d.pcd_name.txt + len_around)
+          match d.pcd_args with
+          | Pcstr_tuple [] | Pcstr_record [] -> max acc len_around
+          | _ -> max acc (String.length d.pcd_name.txt + len_around)
         in
         let max_len_name = List.fold_left ctor_decls ~init:0 ~f:max in
         box_manifest
@@ -3144,7 +3146,7 @@ and fmt_constructor_declaration c ctx ~max_len_name ~first ~last:_ cstr_decl
     in
     let len_around = if is_symbol_id txt then 4 else 0 in
     let pad =
-      String.make (max_len_name - String.length txt - len_around) ' '
+      String.make (max 0 (max_len_name - String.length txt - len_around)) ' '
     in
     fmt_if_k
       ( c.conf.align_constructors_decl && (not is_empty)

--- a/test/passing/align_cases-break_all.ml.ref
+++ b/test/passing/align_cases-break_all.ml.ref
@@ -3,19 +3,19 @@ type x =
   | Fooooooooooooo
   | Fooooooooooooooo
   | Foooooooooooooooooo
-  | Foo                 of padding * int array
-  | Foooooooo           of padding * int array
-  | Fooooooooo          of padding * int array
-  | Fooooooooooo        of padding * int array * int array
+  | Foo          of padding * int array
+  | Foooooooo    of padding * int array
+  | Fooooooooo   of padding * int array
+  | Fooooooooooo of padding * int array * int array
   (* fooooooooooooooooo *)
   | Fooooooooooo
       (* fooooooooooooooooooo *) of
       padding * int array * int array
   (* fooooooooooooooooo *)
-  | Foooooooooo         of padding * int array * int array
-  | Foooo               of padding * int array * int array
-  | Fooooooo            of padding * int array * int array
-  | Foooooo             of int array
+  | Foooooooooo  of padding * int array * int array
+  | Foooo        of padding * int array * int array
+  | Fooooooo     of padding * int array * int array
+  | Foooooo      of int array
 
 type x =
   [ `Foooooooooooooo

--- a/test/passing/align_cases.ml
+++ b/test/passing/align_cases.ml
@@ -3,19 +3,19 @@ type x =
   | Fooooooooooooo
   | Fooooooooooooooo
   | Foooooooooooooooooo
-  | Foo                 of padding * int array
-  | Foooooooo           of padding * int array
-  | Fooooooooo          of padding * int array
-  | Fooooooooooo        of padding * int array * int array
+  | Foo          of padding * int array
+  | Foooooooo    of padding * int array
+  | Fooooooooo   of padding * int array
+  | Fooooooooooo of padding * int array * int array
   (* fooooooooooooooooo *)
   | Fooooooooooo
       (* fooooooooooooooooooo *) of
       padding * int array * int array
   (* fooooooooooooooooo *)
-  | Foooooooooo         of padding * int array * int array
-  | Foooo               of padding * int array * int array
-  | Fooooooo            of padding * int array * int array
-  | Foooooo             of int array
+  | Foooooooooo  of padding * int array * int array
+  | Foooo        of padding * int array * int array
+  | Fooooooo     of padding * int array * int array
+  | Foooooo      of int array
 
 type x =
   [ `Foooooooooooooo


### PR DESCRIPTION
…decl

Essentially the idea is to align the `of` so produce e.g.:
```
type t =
  | An  of a
  | The of b
  | Other
```
instead of:
```
type t =
  | An    of a
  | The   of b
  | Other
```