### PR TITLE
Do not clear the emacs *compilation* buffer on successful reformat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -150,7 +150,6 @@
   + Add an option `--margin-check` to emit a warning if the formatted output exceeds the margin (#1110) (Guillaume Petiot)
   + Preserve comment indentation when `wrap-comments` is unset (#1138, #1159) (Jules Aguillon)
   + Improve error messages (#1147) (Jules Aguillon)
-  + Display standard output in the emacs plugin even when ocamlformat does not fail (#1189) (Guillaume Petiot)
 
 #### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -154,6 +154,7 @@
   + Add an option `--margin-check` to emit a warning if the formatted output exceeds the margin (#1110) (Guillaume Petiot)
   + Preserve comment indentation when `wrap-comments` is unset (#1138, #1159) (Jules Aguillon)
   + Improve error messages (#1147) (Jules Aguillon)
+  + Display standard output in the emacs plugin even when ocamlformat does not fail (#1189) (Guillaume Petiot)
 
 #### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 #### Bug fixes
 
+  + Do not clear the emacs `*compilation*` buffer on successful reformat (#1350) (Josh Berdine)
+
   + Fix regression with `indicate-multiline-delimiters=space` (#1169) (Josh Berdine, Guillaume Petiot)
 
 ### 0.14.2 (2020-05-11)
@@ -26,10 +28,6 @@
    (#1358) (Josh Berdine, Jules Aguillon, Guillaume Petiot)
 
    This reverts changes introduced in 0.14.1 (#1335) and 0.14.0 (#1012).
-
-#### Bug fixes
-
-  + Do not clear the emacs `*compilation*` buffer on successful reformat (#1350) (Josh Berdine)
 
 ### 0.14.1 (2020-04-14)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,10 @@
 
    This reverts changes introduced in 0.14.1 (#1335) and 0.14.0 (#1012).
 
+#### Bug fixes
+
+  + Do not clear the emacs `*compilation*` buffer on successful reformat (#1350) (Josh Berdine)
+
 ### 0.14.1 (2020-04-14)
 
 #### Changes


### PR DESCRIPTION
fix #1348
reopen #1170

Showing warnings from parsing docstrings would be good, but it isn't
workable to clobber the compilation buffer and force a rebuild on
every reformat.

This reverts commit 73eded97c944da8daf8d96f3ddbc6ba5611297f1.