### PR TITLE
Preserve unwrapped comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 
   + Fix disabling with attributes on OCaml < 4.08 (#1322) (Etienne Millon)
 
+  + Preserve unwrapped comments by not adding artificial breaks when `wrap-comments=false` and `ocp-indent-compat=true` are set to avoid interfering with ocp-indent indentation. (#1352) (Guillaume Petiot)
+
 ### 0.14.2 (2020-05-11)
 
 #### Changes

--- a/lib/Cmt.mli
+++ b/lib/Cmt.mli
@@ -21,9 +21,13 @@ val txt : t -> string
 
 include Comparator.S with type t := t
 
+type pos = Before | Within | After
+
 val fmt :
      t
   -> Source.t
   -> wrap:bool
+  -> ocp_indent_compat:bool
   -> fmt_code:(string -> (Fmt.t, unit) Result.t)
+  -> pos
   -> Fmt.t

--- a/test/passing/js_source.ml
+++ b/test/passing/js_source.ml
@@ -7512,3 +7512,31 @@ type t = [
   | `XXXX (* ______________________________________ *)
   | `XXXX (* ____________________________________ *)
 ]
+
+type t =
+  { field : ty
+  (* Here is some verbatim formatted text:
+     {v
+       starting at column 7
+     v}*)
+  }
+
+module Intro_sort = struct
+  let foo_fooo_foooo fooo ~foooo m1 m2 m3 m4 m5 =
+    (* Fooooooooooooooooooooooooooo:
+       {v
+          1--o-----o-----o--------------1
+             |     |     |
+          2--o-----|--o--|-----o--o-----2
+                   |  |  |     |  |
+          3--------o--o--|--o--|--o-----3
+                         |  |  |
+          4-----o--------o--o--|-----o--4
+                |              |     |
+          5-----o--------------o-----o--5
+        v} *)
+    foooooooooo fooooo fooo;
+    foooooooooo fooooo fooo;
+    foooooooooo fooooo fooo;
+  ;;
+end

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -9846,7 +9846,7 @@ let g =
   f
     ~x
     (* this is a multiple-line-spanning
-       comment *)
+              comment *)
     ~y
 ;;
 
@@ -9890,3 +9890,31 @@ type t =
   | `XXXX (* ______________________________________ *)
   | `XXXX (* ____________________________________ *)
   ]
+
+type t =
+  { field : ty
+  (* Here is some verbatim formatted text:
+     {v
+       starting at column 7
+     v}*)
+  }
+
+module Intro_sort = struct
+  let foo_fooo_foooo fooo ~foooo m1 m2 m3 m4 m5 =
+    (* Fooooooooooooooooooooooooooo:
+       {v
+          1--o-----o-----o--------------1
+             |     |     |
+          2--o-----|--o--|-----o--o-----2
+                   |  |  |     |  |
+          3--------o--o--|--o--|--o-----3
+                         |  |  |
+          4-----o--------o--o--|-----o--4
+                |              |     |
+          5-----o--------------o-----o--5
+        v} *)
+    foooooooooo fooooo fooo;
+    foooooooooo fooooo fooo;
+    foooooooooo fooooo fooo
+  ;;
+end

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -9846,7 +9846,7 @@ let g =
   f
     ~x
       (* this is a multiple-line-spanning
-         comment *)
+                comment *)
     ~y
 ;;
 
@@ -9855,7 +9855,7 @@ let f =
     ~x:
       very_long_variable_name
       (* this is a multiple-line-spanning
-         comment *)
+       comment *)
     ~y
 ;;
 
@@ -9890,3 +9890,31 @@ type t =
   | `XXXX (* ______________________________________ *)
   | `XXXX (* ____________________________________ *)
   ]
+
+type t =
+  { field : ty
+        (* Here is some verbatim formatted text:
+     {v
+       starting at column 7
+     v}*)
+  }
+
+module Intro_sort = struct
+  let foo_fooo_foooo fooo ~foooo m1 m2 m3 m4 m5 =
+    (* Fooooooooooooooooooooooooooo:
+       {v
+          1--o-----o-----o--------------1
+             |     |     |
+          2--o-----|--o--|-----o--o-----2
+                   |  |  |     |  |
+          3--------o--o--|--o--|--o-----3
+                         |  |  |
+          4-----o--------o--o--|-----o--4
+                |              |     |
+          5-----o--------------o-----o--5
+        v} *)
+    foooooooooo fooooo fooo;
+    foooooooooo fooooo fooo;
+    foooooooooo fooooo fooo
+  ;;
+end

--- a/test/passing/wrap_comments.ml
+++ b/test/passing/wrap_comments.ml
@@ -4,6 +4,56 @@ type t =
   | Aaaaaaaaaa (* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. *)
   | Bbbbbbbbbb
 
+let _ =
+  [ "a"
+  ; "b"
+  (* first line
+     second line *)
+  ; "c"
+  (* first line
+
+     second line
+  *)
+  ; "d"
+  (* first line
+
+
+     second line *)
+  ; "e"
+  (* first line
+
+     second line
+         *)
+  ; "f"
+  (* first line
+
+     second line
+
+
+         *)
+  ; "g"
+  ]
+
+let _ =
+  let _ =
+    (* This is indented 7
+This 0 *)
+    0
+  in
+  0
+
+let _ =
+  (*no space before
+    no space after*)
+  0
+
+let _ =
+  (* 
+    blah blah
+  *)
+  ()
+;;
+
 [@@@ocamlformat "wrap-comments=false"]
 
 type t =

--- a/test/passing/wrap_comments.ml.ref
+++ b/test/passing/wrap_comments.ml.ref
@@ -6,6 +6,30 @@ type t =
      tempor incididunt ut labore et dolore magna aliqua. *)
   | Bbbbbbbbbb
 
+let _ =
+  [ "a"
+  ; "b" (* first line second line *)
+  ; "c" (* first line second line *)
+  ; "d" (* first line second line *)
+  ; "e" (* first line second line *)
+  ; "f" (* first line second line *)
+  ; "g" ]
+
+let _ =
+  let _ =
+    (* This is indented 7 This 0 *)
+    0
+  in
+  0
+
+let _ =
+  (*no space before no space after*)
+  0
+
+let _ =
+  (* blah blah *)
+  ()
+
 [@@@ocamlformat "wrap-comments=false"]
 
 type t =


### PR DESCRIPTION
The goal is to:
- fix #1165 
- not break #912 and #1100 

We have to insert a break to preserve #912 and #1100 but we have to do the least possible work (to trying to be too smart), as the wrapping is disabled it's okay not to be optimal and we should be able to preserve as much as possible from the comment shape of the input.

I'm not very satisfied with using `break_unless_newline` here as I aimed at removing every use of this function but didn't find any alternative so far.

Diff of test_branch with the `janestreet` profile (due to having a break):
```diff
diff --git a/vendor/ocamlformat_support/format_.ml b/vendor/ocamlformat_support/format_.ml
index 02269ab..aed7b32 100644
--- a/vendor/ocamlformat_support/format_.ml
+++ b/vendor/ocamlformat_support/format_.ml
@@ -85,7 +85,8 @@ type pp_token =
   | Pp_tbegin of tbox (* beginning of a tabulation box *)
   | Pp_tend (* end of a tabulation box *)
   | Pp_newline (* to force a newline inside a box *)
-  | Pp_if_newline (* to do something only if this very
+  | Pp_if_newline
+  (* to do something only if this very
                      line has been broken *)
   | Pp_string_if_newline of string
   (* print a string only if this very
diff --git a/infer/src/base/TaskBar.ml b/infer/src/base/TaskBar.ml
index 273d2ee22..0de25c495 100644
--- a/infer/src/base/TaskBar.ml
+++ b/infer/src/base/TaskBar.ml
@@ -72,7 +72,8 @@ let draw_top_bar fmt ~term_width ~total ~finished ~elapsed =
     ++ ( "%s"
@@ -72,7 +72,8 @@ let draw_top_bar fmt ~term_width ~total ~finished ~elapsed =
     ++ ( "%s"
        , max (String.length elapsed_string) 9
          (* leave some room for elapsed_string to avoid flicker. 9 characters is "XXhXXmXXs" so it
-            gives some reasonable margin. *) )
+            gives some reasonable margin. *)
+       )
   in
   let top_bar_size = min term_width top_bar_size_default in
   let progress_bar_size = top_bar_size - size_around_progress_bar in
diff --git a/infer/src/clang/cTrans.ml b/infer/src/clang/cTrans.ml
index 6d77c6f3b..912d8da20 100644
--- a/infer/src/clang/cTrans.ml
+++ b/infer/src/clang/cTrans.ml
@@ -3613,7 +3613,8 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
         (* explicit with [this] or implicit with [&] *)
         | `LCK_VLAType
         (* capture a variable-length array by reference. we probably don't handle
-           this correctly elsewhere, but it's definitely not captured by value! *) -> true
+           this correctly elsewhere, but it's definitely not captured by value! *)
+          -> true
         | `LCK_ByCopy (* explicit with [x] or implicit with [=] *) ->
           (* [=] captures this by reference and everything else by value *)
           lci_capture_this
diff --git a/infer/src/nullsafe/ClassLevelAnalysis.ml b/infer/src/nullsafe/ClassLevelAnalysis.ml
index 7985bb922..af082744d 100644
--- a/infer/src/nullsafe/ClassLevelAnalysis.ml
+++ b/infer/src/nullsafe/ClassLevelAnalysis.ml
@@ -119,7 +119,8 @@ let make_meta_issue all_issues current_mode class_name =
           | NullsafeMode.Strict
           (* We don't recommend "strict" for now as it is harder to keep a class in strict mode than it "trust none" mode.
              Trust none is almost as safe alternative, but adding a dependency will require just updating trust list,
-             without need to strictify it first. *) ->
+             without need to strictify it first. *)
+            ->
             "`@Nullsafe(value = Nullsafe.Mode.LOCAL, trustOnly = \
              @Nullsafe.TrustList({}))`"
           | NullsafeMode.Default | NullsafeMode.Local (NullsafeMode.Trust.Only _) ->
```

Diff of test_branch with the `conventional` profile (due to having a break):
```diff
diff --git a/vendor/ocamlformat_support/format_.ml b/vendor/ocamlformat_support/format_.ml
index db25deb..2bda28a 100644
--- a/vendor/ocamlformat_support/format_.ml
+++ b/vendor/ocamlformat_support/format_.ml
@@ -93,7 +93,8 @@ type pp_token =
   | Pp_tbegin of tbox (* beginning of a tabulation box *)
   | Pp_tend (* end of a tabulation box *)
   | Pp_newline (* to force a newline inside a box *)
-  | Pp_if_newline (* to do something only if this very
+  | Pp_if_newline
+  (* to do something only if this very
                      line has been broken *)
   | Pp_string_if_newline of string
   (* print a string only if this very
diff --git a/infer/src/base/Config.ml b/infer/src/base/Config.ml
index feb179d64..52742a1fc 100644
--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -1629,7 +1629,8 @@ and nullsafe_optimistic_third_party_params_in_non_strict =
          Historically this is because there was no actionable way to change third party annotations.
          Now that we have such a support, this behavior should be reconsidered, provided
          our tooling and error reporting is friendly enough to be smoothly used by developers.
-      *) ~default:true
+      *)
+    ~default:true
     "Nullsafe: in this mode we treat non annotated third party method params \
      as if they were annotated as nullable."
 
diff --git a/infer/src/base/TaskBar.ml b/infer/src/base/TaskBar.ml
index 892f93830..4672f83a7 100644
--- a/infer/src/base/TaskBar.ml
+++ b/infer/src/base/TaskBar.ml
@@ -77,7 +77,8 @@ let draw_top_bar fmt ~term_width ~total ~finished ~elapsed =
     ++ ( "%s",
          max (String.length elapsed_string) 9
          (* leave some room for elapsed_string to avoid flicker. 9 characters is "XXhXXmXXs" so it
-            gives some reasonable margin. *) )
+            gives some reasonable margin. *)
+       )
   in
   let top_bar_size = min term_width top_bar_size_default in
   let progress_bar_size = top_bar_size - size_around_progress_bar in
diff --git a/infer/src/nullsafe/ClassLevelAnalysis.ml b/infer/src/nullsafe/ClassLevelAnalysis.ml
index f6af04132..9bce6e750 100644
--- a/infer/src/nullsafe/ClassLevelAnalysis.ml
+++ b/infer/src/nullsafe/ClassLevelAnalysis.ml
@@ -103,7 +103,8 @@ let make_meta_issue all_issues current_mode class_name =
             | NullsafeMode.Strict
             (* We don't recommend "strict" for now as it is harder to keep a class in strict mode than it "trust none" mode.
                Trust none is almost as safe alternative, but adding a dependency will require just updating trust list,
-               without need to strictify it first. *) ->
+               without need to strictify it first. *)
+              ->
                 "`@Nullsafe(value = Nullsafe.Mode.LOCAL, trustOnly = \
                  @Nullsafe.TrustList({}))`"
             | NullsafeMode.Default
diff --git a/compiler/lib/js_output.ml b/compiler/lib/js_output.ml
index d584325ca..10a4bf9e5 100644
--- a/compiler/lib/js_output.ml
+++ b/compiler/lib/js_output.ml
@@ -973,7 +973,8 @@ struct
             PP.end_group f;
             PP.end_group f
             (* There MUST be a space between the return and its
-               argument. A line return will not work *) )
+               argument. A line return will not work *)
+        )
     | Labelled_statement (i, s) ->
         PP.string f (Javascript.Label.to_string i);
         PP.string f ":";
diff --git a/src/dune/foreign_rules.ml b/src/dune/foreign_rules.ml
index c6fe6f09..75a01d32 100644
--- a/src/dune/foreign_rules.ml
+++ b/src/dune/foreign_rules.ml
@@ -90,8 +90,8 @@ let build_c_file ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
     (let src = Path.build (Foreign.Source.path src) in
      Command.run
      (* We have to execute the rule in the library directory as the .o is
-        produced in the current directory *) ~dir:(Path.build dir)
-       (Ok ctx.ocamlc)
+        produced in the current directory *)
+       ~dir:(Path.build dir) (Ok ctx.ocamlc)
        [
          A "-g";
          include_flags;
@@ -124,7 +124,8 @@ let build_cxx_file ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
      let c_compiler = Ocaml_config.c_compiler ctx.ocaml_config in
      Command.run
      (* We have to execute the rule in the library directory as the .o is
-        produced in the current directory *) ~dir:(Path.build dir)
+        produced in the current directory *)
+       ~dir:(Path.build dir)
        (Super_context.resolve_program ~loc:None ~dir sctx c_compiler)
        ( [
            Command.Args.S [ A "-I"; Path ctx.stdlib_dir ];
```