### PR TITLE
Fix missing open line between multi-line let-binding with poly-typexpr

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@
 
   + Do not escape `@raise` argument in docstrings (#1391) (Guillaume Petiot)
 
+  + Fix missing open line between multi-line let-binding with poly-typexpr (#1372) (Josh Berdine)
+
 ### 0.14.2 (2020-05-11)
 
 #### Changes

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -103,6 +103,7 @@ type t =
   | Cty of class_type
   | Pat of pattern
   | Exp of expression
+  | Vb of value_binding
   | Cl of class_expr
   | Mty of module_type
   | Mod of module_expr

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4191,8 +4191,8 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
         || (not (List.is_empty itmJ.pvb_attributes))
         || Ast.break_between c.source ~cmts:c.cmts
              ~has_cmts_before:Cmts.has_before ~has_cmts_after:Cmts.has_after
-             (Exp itmI.pvb_expr, cI.conf)
-             (Exp itmJ.pvb_expr, cJ.conf)
+             (Exp {itmI.pvb_expr with pexp_loc= itmI.pvb_loc}, cI.conf)
+             (Exp {itmJ.pvb_expr with pexp_loc= itmJ.pvb_loc}, cJ.conf)
       in
       let grps = List.group bindings ~break in
       let fmt_grp ~first:first_grp ~last:last_grp bindings =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4191,8 +4191,7 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
         || (not (List.is_empty itmJ.pvb_attributes))
         || Ast.break_between c.source ~cmts:c.cmts
              ~has_cmts_before:Cmts.has_before ~has_cmts_after:Cmts.has_after
-             (Exp {itmI.pvb_expr with pexp_loc= itmI.pvb_loc}, cI.conf)
-             (Exp {itmJ.pvb_expr with pexp_loc= itmJ.pvb_loc}, cJ.conf)
+             (Vb itmI, cI.conf) (Vb itmJ, cJ.conf)
       in
       let grps = List.group bindings ~break in
       let fmt_grp ~first:first_grp ~last:last_grp bindings =

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1398,6 +1398,26 @@
 (rule
  (deps .ocamlformat )
  (action
+   (with-outputs-to let_binding_spacing-double-semicolon.ml.output
+     (run %{bin:ocamlformat} --let-binding-spacing=double-semicolon %{dep:let_binding_spacing.ml}))))
+
+(rule
+ (alias runtest)
+ (action (diff let_binding_spacing-double-semicolon.ml.ref let_binding_spacing-double-semicolon.ml.output)))
+
+(rule
+ (deps .ocamlformat )
+ (action
+   (with-outputs-to let_binding_spacing-sparse.ml.output
+     (run %{bin:ocamlformat} --let-binding-spacing=sparse %{dep:let_binding_spacing.ml}))))
+
+(rule
+ (alias runtest)
+ (action (diff let_binding_spacing-sparse.ml.ref let_binding_spacing-sparse.ml.output)))
+
+(rule
+ (deps .ocamlformat )
+ (action
    (with-outputs-to let_binding_spacing.ml.output
      (run %{bin:ocamlformat} --let-binding-spacing=compact %{dep:let_binding_spacing.ml}))))
 

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1398,6 +1398,16 @@
 (rule
  (deps .ocamlformat )
  (action
+   (with-outputs-to let_binding_spacing.ml.output
+     (run %{bin:ocamlformat} --let-binding-spacing=compact %{dep:let_binding_spacing.ml}))))
+
+(rule
+ (alias runtest)
+ (action (diff let_binding_spacing.ml let_binding_spacing.ml.output)))
+
+(rule
+ (deps .ocamlformat )
+ (action
    (with-outputs-to let_in_constr.ml.output
      (run %{bin:ocamlformat} %{dep:let_in_constr.ml}))))
 

--- a/test/passing/let_binding_spacing-double-semicolon.ml.opts
+++ b/test/passing/let_binding_spacing-double-semicolon.ml.opts
@@ -1,0 +1,1 @@
+--let-binding-spacing=double-semicolon

--- a/test/passing/let_binding_spacing-double-semicolon.ml.ref
+++ b/test/passing/let_binding_spacing-double-semicolon.ml.ref
@@ -8,10 +8,12 @@ and g : 'a. (_ -> _ -> _ -> 'a) -> _ -> _ -> _ -> 'a = fun h a b -> h
 
 and g : 'a. (_ -> _ -> _ -> 'a) -> _ -> _ -> _ -> 'a =
  fun h a b -> h (i a) (i b) (i c)
+;;
 
 let f x = x
 
 let f : 'a. (_ -> _ -> _ -> 'a) -> _ -> _ -> _ -> 'a =
  fun h a b -> h (i a) (i b) (i c)
+;;
 
 let f x = x

--- a/test/passing/let_binding_spacing-sparse.ml.opts
+++ b/test/passing/let_binding_spacing-sparse.ml.opts
@@ -1,0 +1,1 @@
+--let-binding-spacing=sparse

--- a/test/passing/let_binding_spacing-sparse.ml.ref
+++ b/test/passing/let_binding_spacing-sparse.ml.ref
@@ -9,9 +9,11 @@ and g : 'a. (_ -> _ -> _ -> 'a) -> _ -> _ -> _ -> 'a = fun h a b -> h
 and g : 'a. (_ -> _ -> _ -> 'a) -> _ -> _ -> _ -> 'a =
  fun h a b -> h (i a) (i b) (i c)
 
+
 let f x = x
 
 let f : 'a. (_ -> _ -> _ -> 'a) -> _ -> _ -> _ -> 'a =
  fun h a b -> h (i a) (i b) (i c)
+
 
 let f x = x

--- a/test/passing/let_binding_spacing.ml
+++ b/test/passing/let_binding_spacing.ml
@@ -1,0 +1,4 @@
+let f x = x
+
+and g : 'a. (_ -> _ -> _ -> 'a) -> _ -> _ -> _ -> 'a =
+ fun h a b -> h (i a) (i b) (i c)

--- a/test/passing/let_binding_spacing.ml.opts
+++ b/test/passing/let_binding_spacing.ml.opts
@@ -1,0 +1,1 @@
+--let-binding-spacing=compact


### PR DESCRIPTION
The is_simple check for let bindings only considers the location of
the body exp. This location happens to usually be large enough. But
for one of a group of let bindings which has an explicit polymorphic
type constraint, the location of the body exp contains only the body,
and does not include the location of the pattern. This means that
cases such as:
```ocaml
[@@@ocamlformat "let-binding-spacing=compact"]

let f x = x

and g : 'a. (_ -> _ -> _ -> 'a) -> _ -> _ -> _ -> 'a =
 fun h a b -> h (i a) (i b) (i c)
```
get misformatted since `g` is misidentified as being a one-liner, and
 the open line between `f` and `g` gets removed.

This patch fixes this by using the location of the entire let-binding
instead of the body expression.