### PR TITLE
More precise ocamlformat version comparison

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
   + Distinguish hash-getter from hash-comparison infix operators. Operators of the form `#**#` or `#**.` where `**` can be 0 or more operator chars are considered getter operators and are not surrounded by spaces, as opposed to regular infix operators (#1376) (Guillaume Petiot)
 
+  + More precise ocamlformat version comparison (#1375) (Guillaume Petiot)
+
 #### Bug fixes
 
   + Restore previous functionality for pre-post extension points (#1342) (Josh Berdine)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ This ensures two things:
   If somebody else working on the project tries to use a different version,
   they will see an error message instead of reformatting the whole project in a
   different way.
+- This check allows the running version to be more specific than the
+  configurated version, but not the other way around.
 
 ### Can ocamlformat support my style?
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1888,7 +1888,12 @@ let check_version ~config ~exe =
           | 0 -> Ok ()
           | x when x < 0 -> Error (err_msg ^ " Please upgrade.")
           | _ -> Error (err_msg ^ " Please downgrade.") )
-      | None -> Error err_msg )
+      | None -> (
+        match exe with
+        | "unknown" ->
+            Error
+              (err_msg ^ " Could not determine current ocamlformat version.")
+        | _ -> Error err_msg ) )
   | None -> Result.failf "malformed version number %S." config
 
 let parse_line config ~from s =

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1880,27 +1880,18 @@ let strip_version ~expected ~exe =
 let check_version ~expected ~exe =
   match Semver.of_string expected with
   | Some expected_v -> (
-    match Semver.of_string exe with
-    | Some exe_v -> (
-        let exe_v = strip_version ~expected:expected_v ~exe:exe_v in
-        match Semver.compare exe_v expected_v with
-        | 0 -> Ok ()
-        | x when x < 0 ->
-            Error
-              (Format.sprintf
-                 "expected ocamlformat version to be at least %S but got \
-                  %S. Please upgrade."
-                 expected exe)
-        | _ ->
-            Error
-              (Format.sprintf
-                 "expected ocamlformat version to be at most %S but got %S. \
-                  Please downgrade."
-                 expected exe) )
-    | None ->
-        Error
-          (Format.sprintf "expected ocamlformat version to be %S but got %S."
-             expected exe) )
+      let err_msg =
+        Format.sprintf "expected ocamlformat version to be %S but got %S."
+          expected exe
+      in
+      match Semver.of_string exe with
+      | Some exe_v -> (
+          let exe_v = strip_version ~expected:expected_v ~exe:exe_v in
+          match Semver.compare exe_v expected_v with
+          | 0 -> Ok ()
+          | x when x < 0 -> Error (err_msg ^ " Please upgrade.")
+          | _ -> Error (err_msg ^ " Please downgrade.") )
+      | None -> Error err_msg )
   | None -> Error (Format.sprintf "malformed version number %S." expected)
 
 let parse_line config ~from s =

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1889,7 +1889,7 @@ let check_version ~expected ~exe =
           | x when x < 0 -> Error (err_msg ^ " Please upgrade.")
           | _ -> Error (err_msg ^ " Please downgrade.") )
       | None -> Error err_msg )
-  | None -> Error (Format.sprintf "malformed version number %S." expected)
+  | None -> Result.failf "malformed version number %S." expected
 
 let parse_line config ~from s =
   let update ~config ~from ~name ~value =

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -172,7 +172,15 @@ let info =
          $(b,.ocamlformat-enable) file specifies a filename relative to the \
          directory containing the $(b,.ocamlformat-enable) file. \
          Shell-style regular expressions are supported. Lines starting with \
-         $(b,#) are ignored and can be used as comments." ]
+         $(b,#) are ignored and can be used as comments."
+    ; `P
+        "If the $(b,version) constraint is set in the $(b,.ocamlformat) file,\n\
+         then the current project can only be formatted with a specific \
+         version of ocamlformat. Using a different version of ocamlformat \
+         will display an error message instead of reformatting the whole \
+         project in a different way. This check allows the running version \
+         to be more specific than the configurated version, but not the \
+         other way around." ]
   in
   Term.info "ocamlformat" ~version:Version.version ~doc ~man
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1868,13 +1868,10 @@ let string_of_user_error = function
 let strip_version ~expected ~exe =
   let open Semver in
   let Semver.{major; minor; patch; prerelease; build} = exe in
-  let prerelease, build =
-    match expected with
-    | {prerelease= []; build= []; _} -> ([], [])
-    | {prerelease= []; _} -> ([], build)
-    | {build= []; _} -> (prerelease, [])
-    | _ -> (prerelease, build)
+  let prerelease =
+    if List.is_empty expected.prerelease then [] else prerelease
   in
+  let build = if List.is_empty expected.build then [] else build in
   Option.value_exn (from_parts major minor patch prerelease build)
 
 let check_version ~expected ~exe =

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -117,3 +117,5 @@ val update : ?quiet:bool -> t -> Migrate_ast.Parsetree.attribute -> t
     [a]. [quiet] is false by default. *)
 
 val print_config : t -> unit
+
+val check_version : expected:string -> exe:string -> (unit, string) Result.t

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -118,4 +118,4 @@ val update : ?quiet:bool -> t -> Migrate_ast.Parsetree.attribute -> t
 
 val print_config : t -> unit
 
-val check_version : expected:string -> exe:string -> (unit, string) Result.t
+val check_version : config:string -> exe:string -> (unit, string) Result.t

--- a/lib/dune
+++ b/lib/dune
@@ -32,4 +32,4 @@
   (:standard -open Import))
  ;;INSERT_BISECT_HERE;;
  (libraries format_ import ocaml-migrate-parsetree odoc.model odoc.parser
-   parse_wyc re uuseg uuseg.string))
+   parse_wyc re semver2 uuseg uuseg.string))

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -43,6 +43,13 @@ OPTIONS (CODE FORMATTING STYLE)
        Shell-style regular expressions are supported. Lines starting with #
        are ignored and can be used as comments.
 
+       If the version constraint is set in the .ocamlformat file, then the
+       current project can only be formatted with a specific version of
+       ocamlformat. Using a different version of ocamlformat will display an
+       error message instead of reformatting the whole project in a different
+       way. This check allows the running version to be more specific than
+       the configurated version, but not the other way around.
+
        --align-cases
            Align match/try cases horizontally. The flag is unset by default.
 

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -35,6 +35,7 @@ depends: [
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
   "re"
+  "semver2"
   "stdio" {< "v0.14"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}

--- a/test/unit/test_conf.ml
+++ b/test/unit/test_conf.ml
@@ -1,0 +1,41 @@
+let test_check_version =
+  let test name ~expected ~exe res =
+    let test_name = "compare_version: " ^ name in
+    ( test_name
+    , `Quick
+    , fun () ->
+        let got = Ocamlformat_lib.Conf.check_version ~expected ~exe in
+        Alcotest.check Alcotest.(result unit string) test_name res got )
+  in
+  [ test "empty 'expected'" ~expected:"" ~exe:""
+      (Error "malformed version number \"\".")
+  ; test "invalid 'expected'" ~expected:"0.33..foo" ~exe:""
+      (Error "malformed version number \"0.33..foo\".")
+  ; test "invalid 'exe'" ~expected:"0.14.2" ~exe:"0.33..foo"
+      (Error
+         "expected ocamlformat version to be \"0.14.2\" but got \
+          \"0.33..foo\".")
+  ; test "unknown 'exe'" ~expected:"0.14.2" ~exe:"unknown"
+      (Error
+         "expected ocamlformat version to be \"0.14.2\" but got \"unknown\".")
+  ; test "equal" ~expected:"0.14.1" ~exe:"0.14.1" (Ok ())
+  ; test "accepted" ~expected:"0.14.1" ~exe:"0.14.1-15-g273f6f6-dirty"
+      (Ok ())
+  ; test "too old" ~expected:"0.14.1" ~exe:"0.14.0"
+      (Error
+         "expected ocamlformat version to be \"0.14.1\" but got \"0.14.0\". \
+          Please upgrade.")
+  ; test "too old 2" ~expected:"0.14.1" ~exe:"0.14.0-15-g273f6f6-dirty"
+      (Error
+         "expected ocamlformat version to be \"0.14.1\" but got \
+          \"0.14.0-15-g273f6f6-dirty\". Please upgrade.")
+  ; test "too recent" ~expected:"0.14.0" ~exe:"0.14.1"
+      (Error
+         "expected ocamlformat version to be \"0.14.0\" but got \"0.14.1\". \
+          Please downgrade.")
+  ; test "too recent 2" ~expected:"0.14.0" ~exe:"0.14.1-15-g273f6f6-dirty"
+      (Error
+         "expected ocamlformat version to be \"0.14.0\" but got \
+          \"0.14.1-15-g273f6f6-dirty\". Please downgrade.") ]
+
+let tests = test_check_version

--- a/test/unit/test_conf.ml
+++ b/test/unit/test_conf.ml
@@ -18,7 +18,8 @@ let test_check_version =
           \"0.33..foo\".")
   ; test "unknown 'exe'" ~config:"0.14.2" ~exe:"unknown"
       (Error
-         "expected ocamlformat version to be \"0.14.2\" but got \"unknown\".")
+         "expected ocamlformat version to be \"0.14.2\" but got \
+          \"unknown\". Could not determine current ocamlformat version.")
   ; test "equal" ~config:"0.14.1" ~exe:"0.14.1" (Ok ())
   ; test "accepted" ~config:"0.14.1" ~exe:"0.14.1-15-g273f6f6-dirty" (Ok ())
   ; test "too old" ~config:"0.14.1" ~exe:"0.14.0"

--- a/test/unit/test_conf.ml
+++ b/test/unit/test_conf.ml
@@ -37,6 +37,17 @@ let test_check_version =
   ; test "too recent 2" ~config:"0.14.0" ~exe:"0.14.1-15-g273f6f6-dirty"
       (Error
          "expected ocamlformat version to be \"0.14.0\" but got \
-          \"0.14.1-15-g273f6f6-dirty\". Please downgrade.") ]
+          \"0.14.1-15-g273f6f6-dirty\". Please downgrade.")
+  ; test "same commit" ~config:"0.14.0-15-g273f6f6" ~exe:"0.14.0-15-g273f6f6"
+      (Ok ())
+  ; test "different commit" ~config:"0.14.0-15-g273f6f6"
+      ~exe:"0.14.0-16-fooooooo"
+      (Error
+         "expected ocamlformat version to be \"0.14.0-15-g273f6f6\" but got \
+          \"0.14.0-16-fooooooo\".")
+  ; test "expected commit" ~config:"0.14.0-15-g273f6f6" ~exe:"0.14.0"
+      (Error
+         "expected ocamlformat version to be \"0.14.0-15-g273f6f6\" but got \
+          \"0.14.0\".") ]
 
 let tests = test_check_version

--- a/test/unit/test_conf.ml
+++ b/test/unit/test_conf.ml
@@ -1,39 +1,39 @@
 let test_check_version =
-  let test name ~expected ~exe res =
+  let test name ~config ~exe expected =
     let test_name = "compare_version: " ^ name in
     ( test_name
     , `Quick
     , fun () ->
-        let got = Ocamlformat_lib.Conf.check_version ~expected ~exe in
-        Alcotest.check Alcotest.(result unit string) test_name res got )
+        let got = Ocamlformat_lib.Conf.check_version ~config ~exe in
+        Alcotest.check Alcotest.(result unit string) test_name expected got
+    )
   in
-  [ test "empty 'expected'" ~expected:"" ~exe:""
+  [ test "empty config" ~config:"" ~exe:""
       (Error "malformed version number \"\".")
-  ; test "invalid 'expected'" ~expected:"0.33..foo" ~exe:""
+  ; test "invalid config" ~config:"0.33..foo" ~exe:""
       (Error "malformed version number \"0.33..foo\".")
-  ; test "invalid 'exe'" ~expected:"0.14.2" ~exe:"0.33..foo"
+  ; test "invalid exe" ~config:"0.14.2" ~exe:"0.33..foo"
       (Error
          "expected ocamlformat version to be \"0.14.2\" but got \
           \"0.33..foo\".")
-  ; test "unknown 'exe'" ~expected:"0.14.2" ~exe:"unknown"
+  ; test "unknown 'exe'" ~config:"0.14.2" ~exe:"unknown"
       (Error
          "expected ocamlformat version to be \"0.14.2\" but got \"unknown\".")
-  ; test "equal" ~expected:"0.14.1" ~exe:"0.14.1" (Ok ())
-  ; test "accepted" ~expected:"0.14.1" ~exe:"0.14.1-15-g273f6f6-dirty"
-      (Ok ())
-  ; test "too old" ~expected:"0.14.1" ~exe:"0.14.0"
+  ; test "equal" ~config:"0.14.1" ~exe:"0.14.1" (Ok ())
+  ; test "accepted" ~config:"0.14.1" ~exe:"0.14.1-15-g273f6f6-dirty" (Ok ())
+  ; test "too old" ~config:"0.14.1" ~exe:"0.14.0"
       (Error
          "expected ocamlformat version to be \"0.14.1\" but got \"0.14.0\". \
           Please upgrade.")
-  ; test "too old 2" ~expected:"0.14.1" ~exe:"0.14.0-15-g273f6f6-dirty"
+  ; test "too old 2" ~config:"0.14.1" ~exe:"0.14.0-15-g273f6f6-dirty"
       (Error
          "expected ocamlformat version to be \"0.14.1\" but got \
           \"0.14.0-15-g273f6f6-dirty\". Please upgrade.")
-  ; test "too recent" ~expected:"0.14.0" ~exe:"0.14.1"
+  ; test "too recent" ~config:"0.14.0" ~exe:"0.14.1"
       (Error
          "expected ocamlformat version to be \"0.14.0\" but got \"0.14.1\". \
           Please downgrade.")
-  ; test "too recent 2" ~expected:"0.14.0" ~exe:"0.14.1-15-g273f6f6-dirty"
+  ; test "too recent 2" ~config:"0.14.0" ~exe:"0.14.1-15-g273f6f6-dirty"
       (Error
          "expected ocamlformat version to be \"0.14.0\" but got \
           \"0.14.1-15-g273f6f6-dirty\". Please downgrade.") ]

--- a/test/unit/test_conf.mli
+++ b/test/unit/test_conf.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test_case list

--- a/test/unit/test_unit.ml
+++ b/test/unit/test_unit.ml
@@ -27,51 +27,6 @@ module Test_location = struct
   let tests = test_compare_width_decreasing
 end
 
-module Test_conf = struct
-  let test_check_version =
-    let test name ~expected ~exe res =
-      let test_name = "compare_version: " ^ name in
-      ( test_name
-      , `Quick
-      , fun () ->
-          let got = Conf.check_version ~expected ~exe in
-          Alcotest.check Alcotest.(result unit string) test_name res got )
-    in
-    [ test "empty 'expected'" ~expected:"" ~exe:""
-        (Error "malformed version number \"\".")
-    ; test "invalid 'expected'" ~expected:"0.33..foo" ~exe:""
-        (Error "malformed version number \"0.33..foo\".")
-    ; test "invalid 'exe'" ~expected:"0.14.2" ~exe:"0.33..foo"
-        (Error
-           "expected ocamlformat version to be \"0.14.2\" but got \
-            \"0.33..foo\".")
-    ; test "unknown 'exe'" ~expected:"0.14.2" ~exe:"unknown"
-        (Error
-           "expected ocamlformat version to be \"0.14.2\" but got \
-            \"unknown\".")
-    ; test "equal" ~expected:"0.14.1" ~exe:"0.14.1" (Ok ())
-    ; test "accepted" ~expected:"0.14.1" ~exe:"0.14.1-15-g273f6f6-dirty"
-        (Ok ())
-    ; test "too old" ~expected:"0.14.1" ~exe:"0.14.0"
-        (Error
-           "expected ocamlformat version to be \"0.14.1\" but got \
-            \"0.14.0\". Please upgrade.")
-    ; test "too old 2" ~expected:"0.14.1" ~exe:"0.14.0-15-g273f6f6-dirty"
-        (Error
-           "expected ocamlformat version to be \"0.14.1\" but got \
-            \"0.14.0-15-g273f6f6-dirty\". Please upgrade.")
-    ; test "too recent" ~expected:"0.14.0" ~exe:"0.14.1"
-        (Error
-           "expected ocamlformat version to be \"0.14.0\" but got \
-            \"0.14.1\". Please downgrade.")
-    ; test "too recent 2" ~expected:"0.14.0" ~exe:"0.14.1-15-g273f6f6-dirty"
-        (Error
-           "expected ocamlformat version to be \"0.14.0\" but got \
-            \"0.14.1-15-g273f6f6-dirty\". Please downgrade.") ]
-
-  let tests = test_check_version
-end
-
 module Test_noit = struct
   module Itv = struct
     module T = struct

--- a/test/unit/test_unit.ml
+++ b/test/unit/test_unit.ml
@@ -54,19 +54,19 @@ module Test_conf = struct
         (Ok ())
     ; test "too old" ~expected:"0.14.1" ~exe:"0.14.0"
         (Error
-           "expected ocamlformat version to be at least \"0.14.1\" but got \
+           "expected ocamlformat version to be \"0.14.1\" but got \
             \"0.14.0\". Please upgrade.")
     ; test "too old 2" ~expected:"0.14.1" ~exe:"0.14.0-15-g273f6f6-dirty"
         (Error
-           "expected ocamlformat version to be at least \"0.14.1\" but got \
+           "expected ocamlformat version to be \"0.14.1\" but got \
             \"0.14.0-15-g273f6f6-dirty\". Please upgrade.")
     ; test "too recent" ~expected:"0.14.0" ~exe:"0.14.1"
         (Error
-           "expected ocamlformat version to be at most \"0.14.0\" but got \
+           "expected ocamlformat version to be \"0.14.0\" but got \
             \"0.14.1\". Please downgrade.")
     ; test "too recent 2" ~expected:"0.14.0" ~exe:"0.14.1-15-g273f6f6-dirty"
         (Error
-           "expected ocamlformat version to be at most \"0.14.0\" but got \
+           "expected ocamlformat version to be \"0.14.0\" but got \
             \"0.14.1-15-g273f6f6-dirty\". Please downgrade.") ]
 
   let tests = test_check_version


### PR DESCRIPTION
The goal is to have more precise and user-friendly error messages, and to allow `X.Y.Z-fooo` versions when the `X.Y.Z` version is set in the .ocamlformat file.