### PR TITLE
Distinguish hash-getter from hash-comparison infix operators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
   + Do not break inline elements such as `{i blah}` in docstrings (#1346) (Josh Berdine)
 
+  + Distinguish hash-getter from hash-comparison infix operators (#1376) (Guillaume Petiot)
+
 #### Bug fixes
 
   + Restore previous functionality for pre-post extension points (#1342) (Josh Berdine)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
   + Do not break inline elements such as `{i blah}` in docstrings (#1346) (Josh Berdine)
 
-  + Distinguish hash-getter from hash-comparison infix operators (#1376) (Guillaume Petiot)
+  + Distinguish hash-getter from hash-comparison infix operators. Operators of the form `#**#` or `#**.` where `**` can be 0 or more operator chars are considered getter operators and are not surrounded by spaces, as opposed to regular infix operators (#1376) (Guillaume Petiot)
 
 #### Bug fixes
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -77,6 +77,17 @@ let is_infix e =
   | Pexp_ident {txt= Lident i; _} -> is_infix_id i
   | _ -> false
 
+let is_hash_getter_id i =
+  let is_infix_char = function
+    | '$' | '%' | '*' | '+' | '-' | '/' | '<' | '=' | '>' | '|' | '&' | '@'
+     |'^' | '#' | '.' ->
+        true
+    | _ -> false
+  in
+  match (i.[0], i.[String.length i - 1]) with
+  | '#', ('#' | '.') when String.for_all i ~f:is_infix_char -> true
+  | _ -> false
+
 module Indexing_op = struct
   type brackets = Round | Square | Curly
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -61,16 +61,20 @@ let is_monadic_binding e =
   | Pexp_ident {txt= Lident i; _} -> is_monadic_binding_id i
   | _ -> false
 
-let is_infix_id i =
-  match (i.[0], i) with
-  | ( ( '$' | '%' | '*' | '+' | '-' | '/' | '<' | '=' | '>' | '|' | '&' | '@'
-      | '^' | '#' )
-    , _ )
-   |( _
-    , ( "!=" | "land" | "lor" | "lxor" | "mod" | "::" | ":=" | "asr" | "lsl"
-      | "lsr" | "or" | "||" ) ) ->
+let is_infixopchar = function
+  | '$' | '%' | '*' | '+' | '-' | '/' | '<' | '=' | '>' | '|' | '&' | '@'
+   |'^' | '#' ->
       true
-  | _ -> is_monadic_binding_id i
+  | _ -> false
+
+let is_infix_id i =
+  if is_infixopchar i.[0] then true
+  else
+    match i with
+    | "!=" | "land" | "lor" | "lxor" | "mod" | "::" | ":=" | "asr" | "lsl"
+     |"lsr" | "or" | "||" ->
+        true
+    | _ -> is_monadic_binding_id i
 
 let is_infix e =
   match e.pexp_desc with
@@ -78,12 +82,7 @@ let is_infix e =
   | _ -> false
 
 let is_hash_getter_id i =
-  let is_infix_char = function
-    | '$' | '%' | '*' | '+' | '-' | '/' | '<' | '=' | '>' | '|' | '&' | '@'
-     |'^' | '#' | '.' ->
-        true
-    | _ -> false
-  in
+  let is_infix_char c = Char.equal c '.' || is_infixopchar c in
   match (i.[0], i.[String.length i - 1]) with
   | '#', ('#' | '.') when String.for_all i ~f:is_infix_char -> true
   | _ -> false

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -27,6 +27,9 @@ val is_infix : expression -> bool
 (** Holds of infix symbol expressions. *)
 
 val is_hash_getter_id : string -> bool
+(** [is_hash_getter_id id] returns whether [id] is considered a hash-getter
+    operator, of the form [#**#] or [#**.] where [**] can be 0 or more
+    operator chars. *)
 
 module Indexing_op : sig
   type brackets = Round | Square | Curly

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -26,6 +26,8 @@ val is_infix_id : string -> bool
 val is_infix : expression -> bool
 (** Holds of infix symbol expressions. *)
 
+val is_hash_getter_id : string -> bool
+
 module Indexing_op : sig
   type brackets = Round | Square | Curly
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1593,12 +1593,12 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
           @@ hvbox 2 (str op $ spc $ fmt_expression c (sub_exp ~ctx e1))
         $ fmt_atrs )
   | Pexp_apply
-      ( ( { pexp_desc= Pexp_ident {txt= Lident maybe_hash; loc}
+      ( ( { pexp_desc= Pexp_ident {txt= Lident id; loc}
           ; pexp_attributes= []
           ; pexp_loc
           ; _ } as op )
       , [(Nolabel, l); (Nolabel, ({pexp_desc= Pexp_ident _; _} as r))] )
-    when String.is_prefix ~prefix:"#" maybe_hash ->
+    when is_hash_getter_id id ->
       Cmts.relocate c.cmts ~src:pexp_loc ~before:loc ~after:loc ;
       wrap_if parens "(" ")"
         ( fmt_expression c (sub_exp ~ctx l)

--- a/test/passing/source.ml
+++ b/test/passing/source.ml
@@ -7365,3 +7365,9 @@ M.(Some x) [@foo]
 let x = (A(B)).a
 
 let x = A(B).a
+
+let formula_base x =
+  let open Formula.Infix in
+  (Expr.typeof x) #== (Lit (Type IntType))
+  #&& (x #<= (Expr.int 4))
+  #&& ((Expr.int 0) #< x)

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -9228,3 +9228,9 @@ M.(Some x) [@foo]
 let x = (A B).a
 
 let x = A (B).a
+
+let formula_base x =
+  let open Formula.Infix in
+  (Expr.typeof x) #== (Lit (Type IntType))
+  #&& (x #<= (Expr.int 4))
+  #&& ((Expr.int 0) #< x)


### PR DESCRIPTION
fix #1371 
