### PR TITLE
Externalize Prec, Assoc and better precedence ambiguity type

### DIFF
--- a/lib/Assoc.ml
+++ b/lib/Assoc.ml
@@ -1,0 +1,37 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlFormat                               *)
+(*                                                                        *)
+(*            Copyright (c) Facebook, Inc. and its affiliates.            *)
+(*                                                                        *)
+(*      This source code is licensed under the MIT license found in       *)
+(*      the LICENSE file in the root directory of this source tree.       *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Associativities of Ast terms. *)
+type t = Left | Non | Right
+
+let to_string = function Left -> "Left" | Non -> "Non" | Right -> "Right"
+
+let equal : t -> t -> bool = Poly.( = )
+
+(** Compute associativity from precedence, since associativity is uniform
+    across precedence levels. *)
+let of_prec (x : Prec.t) =
+  match x with
+  | Low | Semi | LessMinus -> Non
+  | ColonEqual -> Right
+  | As -> Non
+  | Comma -> Non
+  | MinusGreater | BarBar | AmperAmper -> Right
+  | InfixOp0 -> Left
+  | InfixOp1 -> Right
+  | ColonColon -> Right
+  | InfixOp2 | InfixOp3 -> Left
+  | InfixOp4 -> Right
+  | UMinus | Apply -> Non
+  | HashOp -> Left
+  | Dot -> Left
+  | High -> Non
+  | Atomic -> Non

--- a/lib/Assoc.mli
+++ b/lib/Assoc.mli
@@ -1,0 +1,21 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlFormat                               *)
+(*                                                                        *)
+(*            Copyright (c) Facebook, Inc. and its affiliates.            *)
+(*                                                                        *)
+(*      This source code is licensed under the MIT license found in       *)
+(*      the LICENSE file in the root directory of this source tree.       *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Associativities of Ast terms *)
+type t = Left | Non | Right
+
+val to_string : t -> string
+
+val equal : t -> t -> bool
+
+val of_prec : Prec.t -> t
+(** [of_prec prec] is the associativity of Ast terms with precedence [prec].
+    (Associativity is uniform across precedence levels.) *)

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1732,12 +1732,8 @@ end = struct
                 (* which child and assoc conflict: add parens *)
                 Assoc.equal which_child Non
                 || not (Assoc.equal (Assoc.of_prec prec_ast) which_child)
-            | cmp when cmp < 0 ->
-                (* ast higher precedence than context: no parens *)
-                false
-            | _ (* > 0 *) ->
-                (* context higher prec than ast: add parens *)
-                true
+            (* add parens only when the context has a higher prec than ast *)
+            | cmp -> cmp >= 0
           in
           if ambiguous then `Ambiguous else `Non_ambiguous
       | None -> `No_prec_ast )

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -124,13 +124,6 @@ val location : t -> Location.t
 val dump : Format.formatter -> t -> unit
 (** Debug: Dump the representation of an Ast term. *)
 
-(** Associativities of Ast terms *)
-type assoc = Left | Non | Right
-
-val assoc_of_prec : Prec.t -> assoc
-(** [assoc_of_prec prec] is the associativity of Ast terms with precedence
-    [prec]. (Associativity is uniform across precedence levels.) *)
-
 (** Term-in-context [{ctx; ast}] records that [ast] is (considered to be) an
     immediate sub-term of [ctx]. *)
 type 'a xt = private {ctx: t; ast: 'a}

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -124,36 +124,10 @@ val location : t -> Location.t
 val dump : Format.formatter -> t -> unit
 (** Debug: Dump the representation of an Ast term. *)
 
-(** Precedence levels of Ast terms. *)
-type prec =
-  | Low
-  | Semi
-  | LessMinus
-  | ColonEqual
-  | As
-  | Comma
-  | MinusGreater
-  | BarBar
-  | AmperAmper
-  | InfixOp0
-  | InfixOp1
-  | ColonColon
-  | InfixOp2
-  | InfixOp3
-  | InfixOp4
-  | UMinus
-  | Apply
-  | HashOp
-  | Dot  (** [x.y] and [x#y] *)
-  | High
-  | Atomic
-
-val equal_prec : prec -> prec -> bool
-
 (** Associativities of Ast terms *)
 type assoc = Left | Non | Right
 
-val assoc_of_prec : prec -> assoc
+val assoc_of_prec : Prec.t -> assoc
 (** [assoc_of_prec prec] is the associativity of Ast terms with precedence
     [prec]. (Associativity is uniform across precedence levels.) *)
 
@@ -203,7 +177,7 @@ val exposed_left_exp : expression -> bool
 (** [exposed_left_exp exp] holds if the left-most subexpression of [exp] is a
     prefix operators. *)
 
-val prec_ast : t -> prec option
+val prec_ast : t -> Prec.t option
 (** [prec_ast ast] is the precedence of [ast]. Meaningful for binary
     operators, otherwise returns [None]. *)
 

--- a/lib/Prec.ml
+++ b/lib/Prec.ml
@@ -1,0 +1,61 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlFormat                               *)
+(*                                                                        *)
+(*            Copyright (c) Facebook, Inc. and its affiliates.            *)
+(*                                                                        *)
+(*      This source code is licensed under the MIT license found in       *)
+(*      the LICENSE file in the root directory of this source tree.       *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Precedence levels of Ast terms. *)
+type t =
+  | Low
+  | Semi
+  | LessMinus
+  | ColonEqual
+  | As
+  | Comma
+  | MinusGreater
+  | BarBar
+  | AmperAmper
+  | InfixOp0
+  | InfixOp1
+  | ColonColon
+  | InfixOp2
+  | InfixOp3
+  | InfixOp4
+  | UMinus
+  | Apply
+  | HashOp
+  | Dot
+  | High
+  | Atomic
+
+let compare : t -> t -> int = Poly.compare
+
+let equal a b = compare a b = 0
+
+let to_string = function
+  | Low -> "Low"
+  | Semi -> "Semi"
+  | LessMinus -> "LessMinus"
+  | ColonEqual -> "ColonEqual"
+  | As -> "As"
+  | Comma -> "Comma"
+  | MinusGreater -> "MinusGreater"
+  | BarBar -> "BarBar"
+  | AmperAmper -> "AmperAmper"
+  | InfixOp0 -> "InfixOp0"
+  | InfixOp1 -> "InfixOp1"
+  | ColonColon -> "ColonColon"
+  | InfixOp2 -> "InfixOp2"
+  | InfixOp3 -> "InfixOp3"
+  | InfixOp4 -> "InfixOp4"
+  | UMinus -> "UMinus"
+  | Apply -> "Apply"
+  | Dot -> "Dot"
+  | HashOp -> "HashOp"
+  | High -> "High"
+  | Atomic -> "Atomic"

--- a/lib/Prec.mli
+++ b/lib/Prec.mli
@@ -1,0 +1,40 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlFormat                               *)
+(*                                                                        *)
+(*            Copyright (c) Facebook, Inc. and its affiliates.            *)
+(*                                                                        *)
+(*      This source code is licensed under the MIT license found in       *)
+(*      the LICENSE file in the root directory of this source tree.       *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Precedence levels of Ast terms. *)
+type t =
+  | Low
+  | Semi
+  | LessMinus
+  | ColonEqual
+  | As
+  | Comma
+  | MinusGreater
+  | BarBar
+  | AmperAmper
+  | InfixOp0
+  | InfixOp1
+  | ColonColon
+  | InfixOp2
+  | InfixOp3
+  | InfixOp4
+  | UMinus
+  | Apply
+  | HashOp
+  | Dot  (** [x.y] and [x#y] *)
+  | High
+  | Atomic
+
+val compare : t -> t -> int
+
+val equal : t -> t -> bool
+
+val to_string : t -> string

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -119,7 +119,7 @@ let cl_fun ?(will_keep_first_ast_node = true) cmts xexp =
   fun_ ~will_keep_first_ast_node xexp
 
 let infix cmts prec xexp =
-  let assoc = Option.value_map prec ~default:Non ~f:assoc_of_prec in
+  let assoc = Option.value_map prec ~default:Assoc.Non ~f:Assoc.of_prec in
   let rec infix_ ?(relocate = true) xop ((lbl, {ast= exp; _}) as xexp) =
     assert (Poly.(lbl = Nolabel)) ;
     let ctx = Exp exp in

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -125,7 +125,7 @@ let infix cmts prec xexp =
     let ctx = Exp exp in
     match (assoc, exp) with
     | Left, {pexp_desc= Pexp_apply (e0, [(l1, e1); (l2, e2)]); pexp_loc; _}
-      when Option.equal equal_prec prec (prec_ast (Exp exp)) ->
+      when Option.equal Prec.equal prec (prec_ast (Exp exp)) ->
         let op_args1 = infix_ None (l1, sub_exp ~ctx e1) in
         let src = pexp_loc in
         let after = e2.pexp_loc in
@@ -138,7 +138,7 @@ let infix cmts prec xexp =
               Cmts.relocate cmts ~src ~before:e0.pexp_loc ~after ) ;
         op_args1 @ [(Some (sub_exp ~ctx e0), [(l2, sub_exp ~ctx e2)])]
     | Right, {pexp_desc= Pexp_apply (e0, [(l1, e1); (l2, e2)]); pexp_loc; _}
-      when Option.equal equal_prec prec (prec_ast (Exp exp)) ->
+      when Option.equal Prec.equal prec (prec_ast (Exp exp)) ->
         let op_args2 =
           infix_ (Some (sub_exp ~ctx e0)) (l2, sub_exp ~ctx e2)
         in

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -60,7 +60,7 @@ val cl_fun :
 
 val infix :
      Cmts.t
-  -> Ast.prec option
+  -> Prec.t option
   -> expression Ast.xt
   -> (expression Ast.xt option * (arg_label * expression Ast.xt) list) list
 (** [infix cmts prec exp] returns the infix operator and the list of operands


### PR DESCRIPTION
No behavioral change, just some Spring cleaning in the Ast.ml file:
- externalizing precedence type in Prec.t
- externalizing associativity type in Assoc.t
- use a friendlier type for precedence ambiguity