### PR TITLE
Preserve fun keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
   + Do not break inline elements such as `{i blah}` in docstrings (#1346) (Josh Berdine)
 
+  + Preserve `fun` keyword (#1380) (Guillaume Petiot)
+
 #### Bug fixes
 
   + Restore previous functionality for pre-post extension points (#1342) (Josh Berdine)

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -220,6 +220,12 @@ let is_long_pmty_functor source Parsetree.{pmty_desc; pmty_loc= from; _} =
       contains_token_between source ~from ~upto Parser.FUNCTOR
   | _ -> false
 
+let is_anon_fun t Parsetree.{pexp_desc; pexp_loc; _} =
+  match pexp_desc with
+  | Pexp_fun (_, _, pat, _) ->
+      contains_token_between t ~from:pexp_loc ~upto:pat.ppat_loc Parser.FUN
+  | _ -> false
+
 let lexbuf_from_loc t (l : Location.t) =
   let s = string_at t l.loc_start l.loc_end in
   Lexing.from_string s

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -51,6 +51,8 @@ val is_long_pmty_functor : t -> Parsetree.module_type -> bool
     [Pmty_functor] type that is expressed in long ('functor (M) ->') form in
     source. *)
 
+val is_anon_fun : t -> Parsetree.expression -> bool
+
 val begins_line : ?ignore_spaces:bool -> t -> Location.t -> bool
 
 val ends_line : t -> Location.t -> bool

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -63,13 +63,15 @@ type arg_kind =
   | Val of arg_label * pattern xt * expression xt option
   | Newtypes of string loc list
 
-let fun_ cmts ?(will_keep_first_ast_node = true) xexp =
+let fun_ cmts src ?(will_keep_first_ast_node = true) ~fun_kwd xexp =
   let rec fun_ ?(will_keep_first_ast_node = false) ({ast= exp; _} as xexp) =
     let ctx = Exp exp in
     let {pexp_desc; pexp_loc; pexp_attributes; _} = exp in
     if will_keep_first_ast_node || List.is_empty pexp_attributes then
       match pexp_desc with
-      | Pexp_fun (label, default, pattern, body) ->
+      | Pexp_fun (label, default, pattern, body)
+        when fun_kwd || ((not fun_kwd) && not (Source.is_anon_fun src exp))
+        ->
           if not will_keep_first_ast_node then
             Cmts.relocate cmts ~src:pexp_loc ~before:pattern.ppat_loc
               ~after:body.pexp_loc ;

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -42,12 +42,14 @@ type arg_kind =
 
 val fun_ :
      Cmts.t
+  -> Source.t
   -> ?will_keep_first_ast_node:bool
+  -> fun_kwd:bool
   -> expression Ast.xt
   -> arg_kind list * expression Ast.xt
-(** [fun_ cmts will_keep_first_ast_node exp] returns the list of arguments
-    and the body of the function [exp]. [will_keep_first_ast_node] is set by
-    default, otherwise the [exp] is returned without modification. *)
+(** [fun_ cmts src will_keep_first_ast_node exp] returns the list of
+    arguments and the body of the function [exp]. [will_keep_first_ast_node]
+    is set by default, otherwise the [exp] is returned without modification. *)
 
 val cl_fun :
      ?will_keep_first_ast_node:bool

--- a/test/passing/fun_decl.ml
+++ b/test/passing/fun_decl.ml
@@ -1,3 +1,5 @@
+let make_compare op = fun lhs rhs foooooooooo -> foooo
+
 [@@@ocamlformat "wrap-fun-args=false"]
 
 let to_loc_trace

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -7408,7 +7408,7 @@ module PR_4557 = struct
       type elt = X.t
       type t = XSet.t XMap.t
 
-      let compare x y = 0
+      let compare = fun x y -> 0
     end
 
     and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
@@ -7438,7 +7438,7 @@ module F (X : Set.OrderedType) = struct
     type elt = X.t
     type t = XSet.t XMap.t
 
-    let compare x y = 0
+    let compare = fun x y -> 0
   end
 
   and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
@@ -9533,7 +9533,7 @@ let g = function
   | { l1 = x; l2 = y; _ } -> ()
 ;;
 
-let h ?l:(p = 1) ?y:u ?(x = 3) = 2
+let h = fun ?l:(p = 1) ?y:u ?(x = 3) -> 2
 
 let _ = function
   | a, s, ba1, ba2, ba3, bg ->

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -7408,7 +7408,7 @@ module PR_4557 = struct
       type elt = X.t
       type t = XSet.t XMap.t
 
-      let compare x y = 0
+      let compare = fun x y -> 0
     end
 
     and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
@@ -7438,7 +7438,7 @@ module F (X : Set.OrderedType) = struct
     type elt = X.t
     type t = XSet.t XMap.t
 
-    let compare x y = 0
+    let compare = fun x y -> 0
   end
 
   and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
@@ -9533,7 +9533,7 @@ let g = function
   | { l1 = x; l2 = y; _ } -> ()
 ;;
 
-let h ?l:(p = 1) ?y:u ?(x = 3) = 2
+let h = fun ?l:(p = 1) ?y:u ?(x = 3) -> 2
 
 let _ = function
   | a, s, ba1, ba2, ba3, bg ->

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -7089,7 +7089,7 @@ module PR_4557 = struct
 
       type t = XSet.t XMap.t
 
-      let compare x y = 0
+      let compare = fun x y -> 0
     end
 
     and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
@@ -7123,7 +7123,7 @@ module F (X : Set.OrderedType) = struct
 
     type t = XSet.t XMap.t
 
-    let compare x y = 0
+    let compare = fun x y -> 0
   end
 
   and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
@@ -9043,7 +9043,7 @@ let g = function
   | ({l1= x; l2= y}[@foo]) -> ()
   | {l1= x; l2= y; _} -> ()
 
-let h ?l:(p = 1) ?y:u ?(x = 3) = 2
+let h = fun ?l:(p = 1) ?y:u ?(x = 3) -> 2
 
 let _ = function
   | a, s, ba1, ba2, ba3, bg ->


### PR DESCRIPTION
Fix #1373, the reason for this change is that I agree using the `fun` keyword has meaning and should be preserved.
No diff with test_branch