### PR TITLE
Type constraint on return type of anonymous functions is now always printed before the function body

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
   + Distinguish hash-getter from hash-comparison infix operators. Operators of the form `#**#` or `#**.` where `**` can be 0 or more operator chars are considered getter operators and are not surrounded by spaces, as opposed to regular infix operators (#1376) (Guillaume Petiot)
 
-  + Preserve return type constraint position (#1381) (Guillaume Petiot)
+  + Type constraint on return type of anonymous functions is now always printed before the function body (#1381) (Guillaume Petiot)
 
 #### Bug fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
   + Distinguish hash-getter from hash-comparison infix operators. Operators of the form `#**#` or `#**.` where `**` can be 0 or more operator chars are considered getter operators and are not surrounded by spaces, as opposed to regular infix operators (#1376) (Guillaume Petiot)
 
+  + Preserve return type constraint position (#1381) (Guillaume Petiot)
+
 #### Bug fixes
 
   + Restore previous functionality for pre-post extension points (#1342) (Josh Berdine)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -662,6 +662,39 @@ and fmt_type_var s =
   $ fmt_if (String.length s > 1 && Char.equal s.[1] '\'') " "
   $ str s
 
+and type_constr_and_body c xbody =
+  let body = xbody.ast in
+  let ctx = Exp body in
+  let fmt_cstr_and_xbody typ exp =
+    ( Some
+        ( fmt_or_k c.conf.ocp_indent_compat
+            (fits_breaks " " ~hint:(1000, 0) "")
+            (fmt "@;<0 -1>")
+        $ cbox_if c.conf.ocp_indent_compat 0
+            (fmt_core_type c ~pro:":"
+               ~pro_space:(not c.conf.ocp_indent_compat)
+               ~box:(not c.conf.ocp_indent_compat)
+               (sub_typ ~ctx typ)) )
+    , sub_exp ~ctx exp )
+  in
+  match xbody.ast.pexp_desc with
+  | Pexp_constraint
+      ( ({pexp_desc= Pexp_pack _; pexp_attributes= []; _} as exp)
+      , ({ptyp_desc= Ptyp_package _; ptyp_attributes= []; _} as typ) )
+    when Poly.(Source.typed_expression typ exp = `Type_first) ->
+      Cmts.relocate c.cmts ~src:body.pexp_loc ~before:exp.pexp_loc
+        ~after:exp.pexp_loc ;
+      fmt_cstr_and_xbody typ exp
+  | Pexp_constraint
+      ({pexp_desc= Pexp_pack _; _}, {ptyp_desc= Ptyp_package _; _}) ->
+      (None, xbody)
+  | Pexp_constraint (exp, typ)
+    when Poly.(Source.typed_expression typ exp = `Type_first) ->
+      Cmts.relocate c.cmts ~src:body.pexp_loc ~before:exp.pexp_loc
+        ~after:exp.pexp_loc ;
+      fmt_cstr_and_xbody typ exp
+  | _ -> (None, xbody)
+
 and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
     ?(pro_space = true) ({ast= typ; _} as xtyp) =
   protect c (Typ typ)
@@ -1743,6 +1776,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
           (* side effects of Cmts.fmt c.cmts before Sugar.fun_ is important *)
           let cmts_before = Cmts.fmt_before c pexp_loc in
           let xargs, xbody = Sugar.fun_ c.cmts (sub_exp ~ctx eN1) in
+          let fmt_cstr, xbody = type_constr_and_body c xbody in
           let box =
             match xbody.ast.pexp_desc with
             | Pexp_fun _ | Pexp_function _ -> Some false
@@ -1760,7 +1794,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                               ( str "(fun "
                               $ fmt_attributes c ~key:"@" eN1.pexp_attributes
                                   ~suf:(str " ")
-                              $ fmt_fun_args c xargs $ fmt "@ ->" ) )
+                              $ fmt_fun_args c xargs $ fmt_opt fmt_cstr
+                              $ fmt "@ ->" ) )
                       $ fmt
                           ( match xbody.ast.pexp_desc with
                           | Pexp_function _ -> "@ "
@@ -1993,6 +2028,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
            $ fmt "@,." $ fmt_longident_loc c lid $ fmt_atrs ))
   | Pexp_newtype _ | Pexp_fun _ ->
       let xargs, xbody = Sugar.fun_ c.cmts xexp in
+      let fmt_cstr, xbody = type_constr_and_body c xbody in
       let pre_body, body = fmt_body c ?ext xbody in
       let default_indent = if Option.is_none eol then 2 else 1 in
       let indent =
@@ -2008,7 +2044,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    $ hvbox_if
                        (not c.conf.wrap_fun_args)
                        0 (fmt_fun_args c xargs)
-                   $ fmt "@ " )
+                   $ fmt_opt fmt_cstr $ fmt "@ " )
                $ str "->" $ pre_body )
            $ fmt "@ " $ body ))
   | Pexp_function cs ->

--- a/test/passing/fun_decl.ml
+++ b/test/passing/fun_decl.ml
@@ -1,3 +1,21 @@
+let _ = fun (x : int) : int -> some_large_computation
+
+let _ = fun (x : int) -> (some_large_computation : int)
+
+let _ = fun (x : int) : int -> (some_large_computation : int)
+
+let fooo = List.foooo ~f:(fun foooo foooo : bool -> foooooooooooooooooooooo)
+
+let _ =
+ fun (x : int) (x : int) (x : int) (x : int) (x : int) :
+     fooooooooooooooooooooooooooo foooooooooooooo foooooooooo ->
+  some_large_computation
+
+let _ =
+ fun (x : int) (x : int) (x : int) (x : int) (x : int) (x : int) (x : int) :
+     fooooooooooooooooooooooooooo foooooooooooooo foooooooooo ->
+  some_large_computation
+
 [@@@ocamlformat "wrap-fun-args=false"]
 
 let to_loc_trace

--- a/test/passing/fun_decl.ml
+++ b/test/passing/fun_decl.ml
@@ -1,7 +1,5 @@
 let _ = fun (x : int) : int -> some_large_computation
 
-let _ = fun (x : int) -> (some_large_computation : int)
-
 let _ = fun (x : int) : int -> (some_large_computation : int)
 
 let fooo = List.foooo ~f:(fun foooo foooo : bool -> foooooooooooooooooooooo)

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -1342,11 +1342,10 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
              | `Cons p -> "Cons", Some (Tdyn (tcons, p)))
        ; sum_cases = [ "Nil", TCnoarg Thd; "Cons", TCarg (Ttl Thd, tcons) ]
        ; sum_inj =
-           (fun (type c) ->
-              (function
-                | Thd, Noarg -> `Nil
-                | Ttl Thd, v -> `Cons v
-                                : (noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist))
+           (fun (type c) : ((noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist) ->
+              function
+              | Thd, Noarg -> `Nil
+              | Ttl Thd, v -> `Cons v)
            (* One can also write the type annotation directly *)
        })
 ;;
@@ -6885,7 +6884,7 @@ end =
   M1
 
 ;;
-fun (x : M1.t) -> (x : M2.t)
+fun (x : M1.t) : M2.t -> x
 
 (* fails *)
 
@@ -9613,7 +9612,7 @@ class ['a] c () =
 
 let f : type a'. a' = assert false
 let foo : type a' b'. a' -> b' = fun a -> assert false
-let foo : type t'. t' = fun (type t') -> (assert false : t')
+let foo : type t'. t' = fun (type t') : t' -> assert false
 let foo : type t. t = assert false
 let foo : type a' b' c' t. a' -> b' -> c' -> t = fun a b c -> assert false
 

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -8744,7 +8744,7 @@ fun b -> if b then format_of_string "x" else "y"
 ;;
 fun b -> if b then "x" else format_of_string "y"
 ;;
-fun b -> (if b then "x" else "y" : (_, _, _) format)
+fun b : (_, _, _) format -> if b then "x" else "y"
 
 (* PR#7135 *)
 

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -8744,7 +8744,7 @@ fun b -> if b then format_of_string "x" else "y"
 ;;
 fun b -> if b then "x" else format_of_string "y"
 ;;
-fun b -> (if b then "x" else "y" : (_, _, _) format)
+fun b : (_, _, _) format -> if b then "x" else "y"
 
 (* PR#7135 *)
 

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -1342,11 +1342,10 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
            | `Cons p -> "Cons", Some (Tdyn (tcons, p)))
        ; sum_cases = [ "Nil", TCnoarg Thd; "Cons", TCarg (Ttl Thd, tcons) ]
        ; sum_inj =
-           (fun (type c) ->
-             (function
-              | Thd, Noarg -> `Nil
-              | Ttl Thd, v -> `Cons v
-               : (noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist))
+           (fun (type c) : ((noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist) ->
+              function
+             | Thd, Noarg -> `Nil
+             | Ttl Thd, v -> `Cons v)
            (* One can also write the type annotation directly *)
        })
 ;;
@@ -6885,7 +6884,7 @@ end =
   M1
 
 ;;
-fun (x : M1.t) -> (x : M2.t)
+fun (x : M1.t) : M2.t -> x
 
 (* fails *)
 
@@ -9613,7 +9612,7 @@ class ['a] c () =
 
 let f : type a'. a' = assert false
 let foo : type a' b'. a' -> b' = fun a -> assert false
-let foo : type t'. t' = fun (type t') -> (assert false : t')
+let foo : type t'. t' = fun (type t') : t' -> assert false
 let foo : type t. t = assert false
 let foo : type a' b' c' t. a' -> b' -> c' -> t = fun a b c -> assert false
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -8418,7 +8418,7 @@ fun b -> if b then format_of_string "x" else "y"
 fun b -> if b then "x" else format_of_string "y"
 
 ;;
-fun b -> (if b then "x" else "y" : (_, _, _) format)
+fun b : (_, _, _) format -> if b then "x" else "y"
 
 (* PR#7135 *)
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -1356,9 +1356,11 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
            | `Cons p -> ("Cons", Some (Tdyn (tcons, p))) )
        ; sum_cases= [("Nil", TCnoarg Thd); ("Cons", TCarg (Ttl Thd, tcons))]
        ; sum_inj=
-           (fun (type c) ->
-             ( function Thd, Noarg -> `Nil | Ttl Thd, v -> `Cons v
-               : (noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist ) )
+           (fun (type c) :
+                ((noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist) ->
+              function
+             | Thd, Noarg -> `Nil
+             | Ttl Thd, v -> `Cons v )
            (* One can also write the type annotation directly *) })
 
 let v = variantize Enil (ty_list Int) (`Cons (1, `Cons (2, `Nil)))
@@ -6557,7 +6559,7 @@ end =
   M1
 
 ;;
-fun (x : M1.t) -> (x : M2.t)
+fun (x : M1.t) : M2.t -> x
 
 (* fails *)
 
@@ -9118,7 +9120,7 @@ let f : type a'. a' = assert false
 
 let foo : type a' b'. a' -> b' = fun a -> assert false
 
-let foo : type t'. t' = fun (type t') -> (assert false : t')
+let foo : type t'. t' = fun (type t') : t' -> assert false
 
 let foo : type t. t = assert false
 


### PR DESCRIPTION
Fix #1368, no diff with test_branch