### PR TITLE
Update opam metadata

### DIFF
--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -24,7 +24,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06" & < "4.11"}
   "alcotest" {with-test}
-  "base" {>= "v0.11.0" & < "v0.14"}
+  "base" {>= "v0.12.0" & < "v0.14"}
   "base-unix"
   "cmdliner"
   "dune" {>= "2.2.0"}

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -22,9 +22,9 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "4.11"}
   "alcotest" {with-test}
-  "base" {>= "v0.11.0"}
+  "base" {>= "v0.11.0" & < "v0.14"}
   "base-unix"
   "cmdliner"
   "dune" {>= "2.2.0"}
@@ -35,7 +35,7 @@ depends: [
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
   "re"
-  "stdio"
+  "stdio" {< "v0.14"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
 ]


### PR DESCRIPTION
See:
- ocaml/opam-repository#16528
- ocaml/opam-repository#16484

And due to `List.equal` we're actually only compatible with base 0.12.0.