### PR TITLE
Use 4.11 AST

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -263,7 +263,7 @@ let doc_atrs ?(acc = []) atrs =
                 [ { pstr_desc=
                       Pstr_eval
                         ( { pexp_desc=
-                              Pexp_constant (Pconst_string (doc, None))
+                              Pexp_constant (Pconst_string (doc, _, None))
                           ; pexp_loc= loc
                           ; pexp_attributes= []
                           ; _ }
@@ -542,7 +542,7 @@ end
 
 let rec is_trivial c exp =
   match exp.pexp_desc with
-  | Pexp_constant (Pconst_string (_, None)) -> true
+  | Pexp_constant (Pconst_string (_, _, None)) -> true
   | Pexp_constant _ | Pexp_field _ | Pexp_ident _ | Pexp_send _ -> true
   | Pexp_construct (_, exp) -> Option.for_all exp ~f:(is_trivial c)
   | Pexp_apply (e0, [(_, e1)]) when is_prefix e0 -> is_trivial c e1

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -59,7 +59,8 @@ end = struct
         , PStr
             [ { pstr_desc=
                   Pstr_eval
-                    ( { pexp_desc= Pexp_constant (Pconst_string (doc, None))
+                    ( { pexp_desc=
+                          Pexp_constant (Pconst_string (doc, _, None))
                       ; pexp_attributes
                       ; _ }
                     , [] )
@@ -73,7 +74,8 @@ end = struct
                    [ { pstr_desc=
                          Pstr_eval
                            ( { pexp_desc=
-                                 Pexp_constant (Pconst_string (doc, None))
+                                 Pexp_constant
+                                   (Pconst_string (doc, Location.none, None))
                              ; pexp_loc= Location.none
                              ; pexp_attributes=
                                  m.attributes m pexp_attributes

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -2311,7 +2311,7 @@ let update ?(quiet = false) c {attr_name= {txt; loc}; attr_payload; _} =
       | PStr
           [ { pstr_desc=
                 Pstr_eval
-                  ( { pexp_desc= Pexp_constant (Pconst_string (str, None))
+                  ( { pexp_desc= Pexp_constant (Pconst_string (str, _, None))
                     ; pexp_attributes= []
                     ; _ }
                   , [] )

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -296,9 +296,9 @@ let fmt_constant c ~loc ?epi const =
   | Pconst_integer (lit, suf) | Pconst_float (lit, suf) ->
       str lit $ opt suf char
   | Pconst_char x -> wrap "'" "'" @@ str (char_escaped ~loc c x)
-  | Pconst_string (s, Some delim) ->
+  | Pconst_string (s, _, Some delim) ->
       wrap_k (str ("{" ^ delim ^ "|")) (str ("|" ^ delim ^ "}")) (str s)
-  | Pconst_string (s, None) -> (
+  | Pconst_string (s, _, None) -> (
       let delim = ["@,"; "@;"] in
       let contains_pp_commands s =
         let is_substring substring = String.is_substring s ~substring in
@@ -549,7 +549,7 @@ let rec fmt_extension c ctx key (ext, pld) =
     , PStr
         [ { pstr_desc=
               Pstr_eval
-                ({pexp_desc= Pexp_constant (Pconst_string (s, _)); _}, [])
+                ({pexp_desc= Pexp_constant (Pconst_string (s, _, _)); _}, [])
           ; _ } ]
     , _ ) ->
       str s
@@ -587,7 +587,7 @@ and fmt_attributes c ?pre ?suf ~key attrs =
       , PStr
           [ { pstr_desc=
                 Pstr_eval
-                  ( { pexp_desc= Pexp_constant (Pconst_string (doc, None))
+                  ( { pexp_desc= Pexp_constant (Pconst_string (doc, _, None))
                     ; pexp_attributes= []
                     ; _ }
                   , [] )

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -9,9 +9,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let selected_version = Migrate_parsetree.Versions.ocaml_410
+let selected_version = Migrate_parsetree.Versions.ocaml_411
 
-module Selected_version = Ast_410
+module Selected_version = Ast_411
 module Ast_mapper = Selected_version.Ast_mapper
 module Ast_helper = Selected_version.Ast_helper
 

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -10,10 +10,10 @@
 (**************************************************************************)
 
 val selected_version :
-  Migrate_parsetree.Versions.OCaml_410.types
+  Migrate_parsetree.Versions.OCaml_411.types
   Migrate_parsetree.Versions.ocaml_version
 
-module Selected_version = Ast_410
+module Selected_version = Ast_411
 module Ast_mapper = Selected_version.Ast_mapper
 module Ast_helper = Selected_version.Ast_helper
 

--- a/lib/Normalize.ml
+++ b/lib/Normalize.ml
@@ -32,7 +32,8 @@ let dedup_cmts map_ast ast comments =
             PStr
               [ { pstr_desc=
                     Pstr_eval
-                      ( { pexp_desc= Pexp_constant (Pconst_string (doc, None))
+                      ( { pexp_desc=
+                            Pexp_constant (Pconst_string (doc, _, None))
                         ; pexp_loc
                         ; _ }
                       , [] )
@@ -190,7 +191,7 @@ let make_mapper conf ~ignore_doc_comment =
       , PStr
           [ { pstr_desc=
                 Pstr_eval
-                  ( { pexp_desc= Pexp_constant (Pconst_string (doc, None))
+                  ( { pexp_desc= Pexp_constant (Pconst_string (doc, _, None))
                     ; pexp_loc
                     ; pexp_attributes
                     ; _ }
@@ -209,7 +210,8 @@ let make_mapper conf ~ignore_doc_comment =
                  [ { pstr_desc=
                        Pstr_eval
                          ( { pexp_desc=
-                               Pexp_constant (Pconst_string (doc', None))
+                               Pexp_constant
+                                 (Pconst_string (doc', loc, None))
                            ; pexp_loc= m.location m pexp_loc
                            ; pexp_attributes= m.attributes m pexp_attributes
                            ; pexp_loc_stack= [] }
@@ -405,7 +407,7 @@ let make_docstring_mapper c docstrings =
       , PStr
           [ { pstr_desc=
                 Pstr_eval
-                  ( { pexp_desc= Pexp_constant (Pconst_string (doc, None))
+                  ( { pexp_desc= Pexp_constant (Pconst_string (doc, _, None))
                     ; pexp_loc
                     ; pexp_attributes
                     ; _ }
@@ -420,7 +422,8 @@ let make_docstring_mapper c docstrings =
                  [ { pstr_desc=
                        Pstr_eval
                          ( { pexp_desc=
-                               Pexp_constant (Pconst_string (doc', None))
+                               Pexp_constant
+                                 (Pconst_string (doc', loc, None))
                            ; pexp_loc
                            ; pexp_attributes
                            ; pexp_loc_stack= [] }

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -22,7 +22,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.06" & < "4.11"}
+  "ocaml" {>= "4.06" & < "4.12"}
   "alcotest" {with-test}
   "base" {>= "v0.12.0" & < "v0.14"}
   "base-unix"

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -31,7 +31,7 @@ depends: [
   "fix"
   "fpath"
   "menhir"
-  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ocaml-migrate-parsetree" {>= "1.7.3"}
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
   "re"


### PR DESCRIPTION
This PR should add support for OCaml 4.11 to ocamlformat.
At the moment the tests fail during testing (`reformat_string.ml` gets its comments removed), however it seems to be fixed by https://github.com/ocaml-ppx/ocamlformat/pull/1383.

I'm not sure how critical the location fields are to ocamlformat so I'll let you decide whether the `loc` and `Location.none` are correctly placed here.

Concerning the deprecation of `Longident.parse` I can try to use `Parse.longident` instead, however the semantics are different between the two functions, also I'm not sure how to get it without accessing to `compiler-libs` directly as `ocaml-migrate-parsetree` does not have the function.