### PR TITLE
Put type annotation of function return type before definition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
   + Distinguish hash-getter from hash-comparison infix operators. Operators of the form `#**#` or `#**.` where `**` can be 0 or more operator chars are considered getter operators and are not surrounded by spaces, as opposed to regular infix operators (#1376) (Guillaume Petiot)
 
-  + Type constraint on return type of anonymous functions is now always printed before the function body (#1381) (Guillaume Petiot)
+  + Type constraint on return type of functions is now always printed before the function body (#1381, #1397) (Guillaume Petiot)
 
 #### Bug fixes
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4390,6 +4390,13 @@ and fmt_value_binding c let_op ~rec_flag ?ext ?in_ ?epi ctx ~attributes ~loc
                 Cmts.relocate c.cmts ~src:body.pexp_loc ~before:exp.pexp_loc
                   ~after:exp.pexp_loc ;
                 fmt_cstr_and_xbody typ exp
+            (* The type constraint is always printed before the declaration
+               for functions, for other value bindings we preserve its
+               position. *)
+            | Pexp_constraint (exp, typ), _ when not (List.is_empty xargs) ->
+                Cmts.relocate c.cmts ~src:body.pexp_loc ~before:exp.pexp_loc
+                  ~after:exp.pexp_loc ;
+                fmt_cstr_and_xbody typ exp
             | _ -> (None, xbody)
           in
           (xpat, xargs, fmt_cstr, xbody)

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -108,7 +108,7 @@ end
 
 let f = (* comment *) function x -> x
 
-let foo x = (* comment *) (y : z)
+let foo x : z = (* comment *) y
 
 let _ =
   (*a*)

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -4629,7 +4629,7 @@ type foo =
 
 type bar = { x : int }
 
-let f (r : bar) = ({ r with z = 3 } : foo)
+let f (r : bar) : foo = { r with z = 3 }
 
 type foo = { x : int }
 
@@ -4684,8 +4684,8 @@ module Hash2 : sig
 end =
   Hash
 
-let f1 (x : (_, _) Hash1.t) = (x : (_, _) Hashtbl.t)
-let f2 (x : (_, _) Hash2.t) = (x : (_, _) Hashtbl.t)
+let f1 (x : (_, _) Hash1.t) : (_, _) Hashtbl.t = x
+let f2 (x : (_, _) Hash2.t) : (_, _) Hashtbl.t = x
 
 (* Another case, not using include *)
 
@@ -4698,7 +4698,7 @@ end
 module Std' = Std2
 module M' : module type of Std'.M = Std2.M
 
-let f3 (x : M'.t) = (x : Std2.M.t)
+let f3 (x : M'.t) : Std2.M.t = x
 
 (* original report required Core_kernel:
    module type S = sig
@@ -5641,7 +5641,7 @@ module S = String
 module StringSet = Set.Make (String)
 module SSet = Set.Make (S)
 
-let f (x : StringSet.t) = (x : SSet.t)
+let f (x : StringSet.t) : SSet.t = x
 
 (* Also using include (cf. Leo's mail 2013-11-16) *)
 module F (M : sig end) : sig
@@ -5996,7 +5996,7 @@ end
 
 (* ok to convert between structurally equal signatures, and parameters
    are inferred *)
-let f (x : (module S with type t = 'a and type u = 'b)) = (x : (module S'))
+let f (x : (module S with type t = 'a and type u = 'b)) : (module S') = x
 let g x = (x : (module S with type t = 'a and type u = 'b) :> (module S'))
 
 (* with subtyping it is also ok to forget some types *)
@@ -6008,10 +6008,10 @@ end
 
 let g2 x = (x : (module S2 with type t = 'a and type u = 'b) :> (module S'))
 let h x = (x : (module S2 with type t = 'a) :> (module S with type t = 'a))
-let f2 (x : (module S2 with type t = 'a and type u = 'b)) = (x : (module S'))
+let f2 (x : (module S2 with type t = 'a and type u = 'b)) : (module S') = x
 
 (* fail *)
-let k (x : (module S2 with type t = 'a)) = (x : (module S with type t = 'a))
+let k (x : (module S2 with type t = 'a)) : (module S with type t = 'a) = x
 
 (* fail *)
 
@@ -6610,7 +6610,7 @@ type refer1 = < poly : 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 type refer2 = < poly : 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 
 (* Actually this should succeed ... *)
-let f (x : refer1) = (x : refer2)
+let f (x : refer1) : refer2 = x
 
 module Classdef = struct
   class virtual ['a, 'b, 'c] cl0 =
@@ -6646,7 +6646,7 @@ end
 open Pr3918b
 
 let f x = (x : 'a vlist :> 'b vlist)
-let f (x : 'a vlist) = (x : 'b vlist)
+let f (x : 'a vlist) : 'b vlist = x
 
 module type Poly = sig
   type 'a t = 'a constraint 'a = [> ]
@@ -6861,13 +6861,13 @@ module F0 : sig
 end =
   Foobar
 
-let f (x : F0.t) = (x : Foobar.t)
+let f (x : F0.t) : Foobar.t = x
 
 (* fails *)
 
 module F = Foobar
 
-let f (x : F.t) = (x : Foobar.t)
+let f (x : F.t) : Foobar.t = x
 
 module M = struct
   type t = < m : int >
@@ -6935,7 +6935,7 @@ module Bar : sig
 end = struct
   type t = int
 
-  let f (x : int) = (x : t)
+  let f (x : int) : t = x
 end
 
 (* must fail *)
@@ -7036,7 +7036,7 @@ end
 
 module Test2 : module type of Test with type t = Test.t = Test
 
-let f (x : Test.t) = (x : Test2.t)
+let f (x : Test.t) : Test2.t = x
 let f Test2.A = ()
 let a = Test2.A
 
@@ -7379,7 +7379,7 @@ module PR_4758 = struct
     type t
   end
 
-  let f (x : F(C).t) = (x : F(C').t)
+  let f (x : F(C).t) : F(C').t = x
 end
 
 (* PR 4557 *)

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -4629,7 +4629,7 @@ type foo =
 
 type bar = { x : int }
 
-let f (r : bar) = ({ r with z = 3 } : foo)
+let f (r : bar) : foo = { r with z = 3 }
 
 type foo = { x : int }
 
@@ -4684,8 +4684,8 @@ module Hash2 : sig
 end =
   Hash
 
-let f1 (x : (_, _) Hash1.t) = (x : (_, _) Hashtbl.t)
-let f2 (x : (_, _) Hash2.t) = (x : (_, _) Hashtbl.t)
+let f1 (x : (_, _) Hash1.t) : (_, _) Hashtbl.t = x
+let f2 (x : (_, _) Hash2.t) : (_, _) Hashtbl.t = x
 
 (* Another case, not using include *)
 
@@ -4698,7 +4698,7 @@ end
 module Std' = Std2
 module M' : module type of Std'.M = Std2.M
 
-let f3 (x : M'.t) = (x : Std2.M.t)
+let f3 (x : M'.t) : Std2.M.t = x
 
 (* original report required Core_kernel:
 module type S = sig
@@ -5641,7 +5641,7 @@ module S = String
 module StringSet = Set.Make (String)
 module SSet = Set.Make (S)
 
-let f (x : StringSet.t) = (x : SSet.t)
+let f (x : StringSet.t) : SSet.t = x
 
 (* Also using include (cf. Leo's mail 2013-11-16) *)
 module F (M : sig end) : sig
@@ -5996,7 +5996,7 @@ end
 
 (* ok to convert between structurally equal signatures, and parameters
    are inferred *)
-let f (x : (module S with type t = 'a and type u = 'b)) = (x : (module S'))
+let f (x : (module S with type t = 'a and type u = 'b)) : (module S') = x
 let g x = (x : (module S with type t = 'a and type u = 'b) :> (module S'))
 
 (* with subtyping it is also ok to forget some types *)
@@ -6008,10 +6008,10 @@ end
 
 let g2 x = (x : (module S2 with type t = 'a and type u = 'b) :> (module S'))
 let h x = (x : (module S2 with type t = 'a) :> (module S with type t = 'a))
-let f2 (x : (module S2 with type t = 'a and type u = 'b)) = (x : (module S'))
+let f2 (x : (module S2 with type t = 'a and type u = 'b)) : (module S') = x
 
 (* fail *)
-let k (x : (module S2 with type t = 'a)) = (x : (module S with type t = 'a))
+let k (x : (module S2 with type t = 'a)) : (module S with type t = 'a) = x
 
 (* fail *)
 
@@ -6610,7 +6610,7 @@ type refer1 = < poly : 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 type refer2 = < poly : 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 
 (* Actually this should succeed ... *)
-let f (x : refer1) = (x : refer2)
+let f (x : refer1) : refer2 = x
 
 module Classdef = struct
   class virtual ['a, 'b, 'c] cl0 =
@@ -6646,7 +6646,7 @@ end
 open Pr3918b
 
 let f x = (x : 'a vlist :> 'b vlist)
-let f (x : 'a vlist) = (x : 'b vlist)
+let f (x : 'a vlist) : 'b vlist = x
 
 module type Poly = sig
   type 'a t = 'a constraint 'a = [> ]
@@ -6861,13 +6861,13 @@ module F0 : sig
 end =
   Foobar
 
-let f (x : F0.t) = (x : Foobar.t)
+let f (x : F0.t) : Foobar.t = x
 
 (* fails *)
 
 module F = Foobar
 
-let f (x : F.t) = (x : Foobar.t)
+let f (x : F.t) : Foobar.t = x
 
 module M = struct
   type t = < m : int >
@@ -6935,7 +6935,7 @@ module Bar : sig
 end = struct
   type t = int
 
-  let f (x : int) = (x : t)
+  let f (x : int) : t = x
 end
 
 (* must fail *)
@@ -7036,7 +7036,7 @@ end
 
 module Test2 : module type of Test with type t = Test.t = Test
 
-let f (x : Test.t) = (x : Test2.t)
+let f (x : Test.t) : Test2.t = x
 let f Test2.A = ()
 let a = Test2.A
 
@@ -7379,7 +7379,7 @@ module PR_4758 = struct
     type t
   end
 
-  let f (x : F(C).t) = (x : F(C').t)
+  let f (x : F(C).t) : F(C').t = x
 end
 
 (* PR 4557 *)

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -4349,7 +4349,7 @@ type foo = {y: int; z: int}
 
 type bar = {x: int}
 
-let f (r : bar) = ({r with z= 3} : foo)
+let f (r : bar) : foo = {r with z= 3}
 
 type foo = {x: int}
 
@@ -4401,9 +4401,9 @@ module Hash2 : sig
 end =
   Hash
 
-let f1 (x : (_, _) Hash1.t) = (x : (_, _) Hashtbl.t)
+let f1 (x : (_, _) Hash1.t) : (_, _) Hashtbl.t = x
 
-let f2 (x : (_, _) Hash2.t) = (x : (_, _) Hashtbl.t)
+let f2 (x : (_, _) Hash2.t) : (_, _) Hashtbl.t = x
 
 (* Another case, not using include *)
 
@@ -4417,7 +4417,7 @@ module Std' = Std2
 
 module M' : module type of Std'.M = Std2.M
 
-let f3 (x : M'.t) = (x : Std2.M.t)
+let f3 (x : M'.t) : Std2.M.t = x
 
 (* original report required Core_kernel: module type S = sig open
    Core_kernel.Std
@@ -5352,7 +5352,7 @@ module S = String
 module StringSet = Set.Make (String)
 module SSet = Set.Make (S)
 
-let f (x : StringSet.t) = (x : SSet.t)
+let f (x : StringSet.t) : SSet.t = x
 
 (* Also using include (cf. Leo's mail 2013-11-16) *)
 module F (M : sig end) : sig
@@ -5711,7 +5711,7 @@ end
 
 (* ok to convert between structurally equal signatures, and parameters are
    inferred *)
-let f (x : (module S with type t = 'a and type u = 'b)) = (x : (module S'))
+let f (x : (module S with type t = 'a and type u = 'b)) : (module S') = x
 
 let g x = (x : (module S with type t = 'a and type u = 'b) :> (module S'))
 
@@ -5728,10 +5728,10 @@ let g2 x = (x : (module S2 with type t = 'a and type u = 'b) :> (module S'))
 
 let h x = (x : (module S2 with type t = 'a) :> (module S with type t = 'a))
 
-let f2 (x : (module S2 with type t = 'a and type u = 'b)) = (x : (module S'))
+let f2 (x : (module S2 with type t = 'a and type u = 'b)) : (module S') = x
 
 (* fail *)
-let k (x : (module S2 with type t = 'a)) = (x : (module S with type t = 'a))
+let k (x : (module S2 with type t = 'a)) : (module S with type t = 'a) = x
 
 (* fail *)
 
@@ -6318,7 +6318,7 @@ type refer1 = < poly: 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 type refer2 = < poly: 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 
 (* Actually this should succeed ... *)
-let f (x : refer1) = (x : refer2)
+let f (x : refer1) : refer2 = x
 
 module Classdef = struct
   class virtual ['a, 'b, 'c] cl0 =
@@ -6351,7 +6351,7 @@ open Pr3918b
 
 let f x = (x : 'a vlist :> 'b vlist)
 
-let f (x : 'a vlist) = (x : 'b vlist)
+let f (x : 'a vlist) : 'b vlist = x
 
 module type Poly = sig
   type 'a t = 'a constraint 'a = [> ]
@@ -6536,13 +6536,13 @@ module F0 : sig
 end =
   Foobar
 
-let f (x : F0.t) = (x : Foobar.t)
+let f (x : F0.t) : Foobar.t = x
 
 (* fails *)
 
 module F = Foobar
 
-let f (x : F.t) = (x : Foobar.t)
+let f (x : F.t) : Foobar.t = x
 
 module M = struct
   type t = < m: int >
@@ -6611,7 +6611,7 @@ module Bar : sig
 end = struct
   type t = int
 
-  let f (x : int) = (x : t)
+  let f (x : int) : t = x
 end
 
 (* must fail *)
@@ -6714,7 +6714,7 @@ end
 
 module Test2 : module type of Test with type t = Test.t = Test
 
-let f (x : Test.t) = (x : Test2.t)
+let f (x : Test.t) : Test2.t = x
 
 let f Test2.A = ()
 
@@ -7059,7 +7059,7 @@ module PR_4758 = struct
     type t
   end
 
-  let f (x : F(C).t) = (x : F(C').t)
+  let f (x : F(C).t) : F(C').t = x
 end
 
 (* PR 4557 *)


### PR DESCRIPTION
Fix #1394 

test_branch diff with the janestreet profile:

```diff
diff --git a/src/memo/implicit_output.ml b/src/memo/implicit_output.ml
index a0bcdde2..125451cc 100644
--- a/src/memo/implicit_output.ml
+++ b/src/memo/implicit_output.ml
@@ -29,14 +29,13 @@ end = struct
 
   type 'a t = (module T with type a = 'a)
 
-  let create (type a) (module I : Implicit_output with type t = a) =
-    ((module struct
-       type nonrec a = a
-       type _ w += W : a w
-
-       include I
-     end)
-      : a t)
+  let create (type a) (module I : Implicit_output with type t = a) : a t =
+    (module struct
+      type nonrec a = a
+      type _ w += W : a w
+
+      include I
+    end)
   ;;
 
   let get (type a) (module T : T with type a = a) =
diff --git a/src/stdune/type_eq.ml b/src/stdune/type_eq.ml
index d0c847a6..698c6a6c 100644
--- a/src/stdune/type_eq.ml
+++ b/src/stdune/type_eq.ml
@@ -22,12 +22,11 @@ module Id = struct
     | _ -> false
   ;;
 
-  let create (type a) () =
-    ((module struct
-       type nonrec a = a
-       type _ w += W : a w
-     end)
-      : a t)
+  let create (type a) () : a t =
+    (module struct
+      type nonrec a = a
+      type _ w += W : a w
+    end)
   ;;
```