### PR TITLE
Bump stdio version threshold to v0.15

### DIFF
--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -35,7 +35,7 @@ depends: [
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
   "re"
-  "stdio" {< "v0.14"}
+  "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
 ]


### PR DESCRIPTION
Fixes #1398.

Does not, at this stage, make any changes to the ocamlformat code
itself; just the opam metadata.  This seems to work locally, but I may
need to do some additional commits if any issues do arise.