### PR TITLE
Do not add a space to minimal comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@
 
   + Remove trailing space after expression when followed by an attribute and break before attributes attached to multi-line phrases (#1382) (Guillaume Petiot)
 
+  + Do not add a space to minimal comments `(* *)`, `(** *)` and `(*$ *)` (#1407) (Guillaume Petiot)
+
 ### 0.14.2 (2020-05-11)
 
 #### Changes

--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -160,7 +160,10 @@ let fmt cmt src ~wrap:wrap_comments ~ocp_indent_compat ~fmt_code pos =
     match fmt_code source with
     | Ok formatted ->
         let cls : Fmt.s = if dollar_last then "$*)" else "*)" in
-        hvbox 2 (wrap "(*$" cls (fmt "@;" $ formatted $ fmt "@;<1 -2>"))
+        hvbox 2
+          (wrap "(*$" cls
+             ( fmt "@;" $ formatted
+             $ fmt_if (String.length str > 2) "@;<1 -2>" ))
     | Error () -> fmt_non_code ~wrap_comments:false cmt
   in
   match cmt.txt with

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -268,7 +268,7 @@ let fill_text ?epi text =
       ~equal:(fun x y -> String.is_empty x && String.is_empty y)
       (String.split (String.rstrip text) ~on:'\n')
   in
-  fmt_if (Char.is_whitespace text.[0]) " "
+  fmt_if (String.starts_with_whitespace text) " "
   $ hovbox 0
       ( hvbox 0
           (hovbox 0
@@ -280,8 +280,5 @@ let fill_text ?epi text =
                       close_box $ fmt "\n@," $ open_hovbox 0
                   | Some _ when not (String.is_empty curr) -> fmt "@ "
                   | _ -> noop )))
-      $ fmt_if
-          ( String.length text > 1
-          && Char.is_whitespace text.[String.length text - 1] )
-          " "
+      $ fmt_if (String.ends_with_whitespace text) " "
       $ opt epi Fn.id )

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -280,5 +280,8 @@ let fill_text ?epi text =
                       close_box $ fmt "\n@," $ open_hovbox 0
                   | Some _ when not (String.is_empty curr) -> fmt "@ "
                   | _ -> noop )))
-      $ fmt_if (Char.is_whitespace text.[String.length text - 1]) " "
+      $ fmt_if
+          ( String.length text > 1
+          && Char.is_whitespace text.[String.length text - 1] )
+          " "
       $ opt epi Fn.id )

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -280,5 +280,7 @@ let fill_text ?epi text =
                       close_box $ fmt "\n@," $ open_hovbox 0
                   | Some _ when not (String.is_empty curr) -> fmt "@ "
                   | _ -> noop )))
-      $ fmt_if (String.ends_with_whitespace text) " "
+      $ fmt_if
+          (String.length text > 1 && String.ends_with_whitespace text)
+          " "
       $ opt epi Fn.id )

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -408,7 +408,9 @@ let fmt_parsed_docstring c ~loc ?pro ~epi str_cmt parsed =
   let fmt_parsed parsed =
     fmt_if (space_i 0) " "
     $ Fmt_odoc.fmt ~fmt_code:(c.fmt_code c.conf) parsed
-    $ fmt_if (space_i (String.length str_cmt - 1)) " "
+    $ fmt_if
+        (String.length str_cmt > 1 && space_i (String.length str_cmt - 1))
+        " "
   in
   let fmt_raw str_cmt =
     if c.conf.wrap_comments then fill_text str_cmt else str str_cmt

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -404,13 +404,10 @@ let parse_docstring ~loc text =
 
 let fmt_parsed_docstring c ~loc ?pro ~epi str_cmt parsed =
   assert (not (String.is_empty str_cmt)) ;
-  let space_i i = Char.is_whitespace str_cmt.[i] in
   let fmt_parsed parsed =
-    fmt_if (space_i 0) " "
+    fmt_if (String.starts_with_whitespace str_cmt) " "
     $ Fmt_odoc.fmt ~fmt_code:(c.fmt_code c.conf) parsed
-    $ fmt_if
-        (String.length str_cmt > 1 && space_i (String.length str_cmt - 1))
-        " "
+    $ fmt_if (String.ends_with_whitespace str_cmt) " "
   in
   let fmt_raw str_cmt =
     if c.conf.wrap_comments then fill_text str_cmt else str str_cmt

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -407,7 +407,9 @@ let fmt_parsed_docstring c ~loc ?pro ~epi str_cmt parsed =
   let fmt_parsed parsed =
     fmt_if (String.starts_with_whitespace str_cmt) " "
     $ Fmt_odoc.fmt ~fmt_code:(c.fmt_code c.conf) parsed
-    $ fmt_if (String.ends_with_whitespace str_cmt) " "
+    $ fmt_if
+        (String.length str_cmt > 1 && String.ends_with_whitespace str_cmt)
+        " "
   in
   let fmt_raw str_cmt =
     if c.conf.wrap_comments then fill_text str_cmt else str str_cmt

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -5,6 +5,10 @@
 
 (* *)
 
+(*$*)
+(*$ *)
+(*$  *)
+
 let _ = f (*f*)a(*a*) ~b(*comment*) ~c:(*comment*)c' ?d ?e ()
 
 let _ =

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -1,8 +1,12 @@
-(*  *)
+(* *)
 
 (**)
 
-(*  *)
+(* *)
+
+(*$*)
+(*$ *)
+(*$  *)
 
 let _ = f (*f*) a (*a*) ~b (*comment*) ~c:(*comment*) c' ?d ?e ()
 
@@ -173,9 +177,9 @@ let _ =
 type t = {a: int [@default a] (* comment *); b: flag}
 
 let () =
-  (*  *)
+  (* *)
 
-  (*  *)
+  (* *)
   ()
 
 (* break when unicode sequence length measured in bytes but ¬ in code points *)

--- a/test/passing/doc_comments.mli
+++ b/test/passing/doc_comments.mli
@@ -484,3 +484,5 @@ val k : int
 (** @raise [Invalid_argument] if the argument is [None]. Sometimes [t.[x]]. *)
 
 (** \[abc\] *)
+(** *)
+(**  *)

--- a/test/passing/doc_comments.mli.ref
+++ b/test/passing/doc_comments.mli.ref
@@ -452,3 +452,7 @@ val k : int
 (** @raise [Invalid_argument] if the argument is [None]. Sometimes [t.\[x\]]. *)
 
 (** \[abc\] *)
+
+(** *)
+
+(**  *)

--- a/test/passing/infix_bind-break.ml.ref
+++ b/test/passing/infix_bind-break.ml.ref
@@ -177,19 +177,19 @@ let _ =
   >>= fun (* foo before *) [@warning "-4"] (* foo after *) x ->
   fooooooooooooooooooooooo
 
-let f = Ok () >>= (*  *) fun _ -> Ok ()
+let f = Ok () >>= (* *) fun _ -> Ok ()
 
 let f =
   (* fooooooooooooooo foooooooooooooooo *)
   Ok ()
-  >>= (*  *) fun _ -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
+  >>= (* *) fun _ -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
-let f = Ok () >>= (*  *) function Foo -> Ok ()
+let f = Ok () >>= (* *) function Foo -> Ok ()
 
 let f =
   (* fooooooooooooooo foooooooooooooooo *)
   Ok ()
-  >>= (*  *)
+  >>= (* *)
   function
   | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
@@ -208,11 +208,11 @@ let f =
 (** The tests below are testing a dropped comment with
     `--no-break-infix-before-func` *)
 
-let _ = x |> fun y -> y (*  *)
+let _ = x |> fun y -> y (* *)
 
-let _ = x |> function y -> y (*  *)
+let _ = x |> function y -> y (* *)
 
-let _ = match () with A -> ( x |> function y -> y (*  *) ) | B -> ()
+let _ = match () with A -> ( x |> function y -> y (* *) ) | B -> ()
 
 let _ = x |> function y -> ( function _ -> y (* A *) ) (* B *)
 

--- a/test/passing/infix_bind-fit_or_vertical-break.ml.ref
+++ b/test/passing/infix_bind-fit_or_vertical-break.ml.ref
@@ -182,19 +182,19 @@ let _ =
   >>= fun (* foo before *) [@warning "-4"] (* foo after *) x ->
   fooooooooooooooooooooooo
 
-let f = Ok () >>= (*  *) fun _ -> Ok ()
+let f = Ok () >>= (* *) fun _ -> Ok ()
 
 let f =
   (* fooooooooooooooo foooooooooooooooo *)
   Ok ()
-  >>= (*  *) fun _ -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
+  >>= (* *) fun _ -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
-let f = Ok () >>= (*  *) function Foo -> Ok ()
+let f = Ok () >>= (* *) function Foo -> Ok ()
 
 let f =
   (* fooooooooooooooo foooooooooooooooo *)
   Ok ()
-  >>= (*  *)
+  >>= (* *)
   function
   | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
@@ -213,11 +213,11 @@ let f =
 (** The tests below are testing a dropped comment with
     `--no-break-infix-before-func` *)
 
-let _ = x |> fun y -> y (*  *)
+let _ = x |> fun y -> y (* *)
 
-let _ = x |> function y -> y (*  *)
+let _ = x |> function y -> y (* *)
 
-let _ = match () with A -> ( x |> function y -> y (*  *) ) | B -> ()
+let _ = match () with A -> ( x |> function y -> y (* *) ) | B -> ()
 
 let _ = x |> function y -> ( function _ -> y (* A *) ) (* B *)
 

--- a/test/passing/infix_bind-fit_or_vertical.ml.ref
+++ b/test/passing/infix_bind-fit_or_vertical.ml.ref
@@ -176,18 +176,18 @@ let _ =
   foo >>= fun (* foo before *) [@warning "-4"] (* foo after *) x ->
   fooooooooooooooooooooooo
 
-let f = Ok () >>= (*  *) fun _ -> Ok ()
+let f = Ok () >>= (* *) fun _ -> Ok ()
 
 let f =
   (* fooooooooooooooo foooooooooooooooo *)
-  Ok () >>= (*  *) fun _ ->
+  Ok () >>= (* *) fun _ ->
   Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
-let f = Ok () >>= (*  *) function Foo -> Ok ()
+let f = Ok () >>= (* *) function Foo -> Ok ()
 
 let f =
   (* fooooooooooooooo foooooooooooooooo *)
-  Ok () >>= (*  *) function
+  Ok () >>= (* *) function
   | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 let f =
@@ -207,11 +207,11 @@ let f =
 (** The tests below are testing a dropped comment with
     `--no-break-infix-before-func` *)
 
-let _ = x |> fun y -> y (*  *)
+let _ = x |> fun y -> y (* *)
 
-let _ = x |> function y -> y (*  *)
+let _ = x |> function y -> y (* *)
 
-let _ = match () with A -> ( x |> function y -> y (*  *) ) | B -> ()
+let _ = match () with A -> ( x |> function y -> y (* *) ) | B -> ()
 
 let _ = x |> function y -> ( function _ -> y (* A *) ) (* B *)
 

--- a/test/passing/infix_bind.ml
+++ b/test/passing/infix_bind.ml
@@ -171,18 +171,18 @@ let _ =
   foo >>= fun (* foo before *) [@warning "-4"] (* foo after *) x ->
   fooooooooooooooooooooooo
 
-let f = Ok () >>= (*  *) fun _ -> Ok ()
+let f = Ok () >>= (* *) fun _ -> Ok ()
 
 let f =
   (* fooooooooooooooo foooooooooooooooo *)
-  Ok () >>= (*  *) fun _ ->
+  Ok () >>= (* *) fun _ ->
   Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
-let f = Ok () >>= (*  *) function Foo -> Ok ()
+let f = Ok () >>= (* *) function Foo -> Ok ()
 
 let f =
   (* fooooooooooooooo foooooooooooooooo *)
-  Ok () >>= (*  *) function
+  Ok () >>= (* *) function
   | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 let f =
@@ -202,11 +202,11 @@ let f =
 (** The tests below are testing a dropped comment with
     `--no-break-infix-before-func` *)
 
-let _ = x |> fun y -> y (*  *)
+let _ = x |> fun y -> y (* *)
 
-let _ = x |> function y -> y (*  *)
+let _ = x |> function y -> y (* *)
 
-let _ = match () with A -> ( x |> function y -> y (*  *) ) | B -> ()
+let _ = match () with A -> ( x |> function y -> y (* *) ) | B -> ()
 
 let _ = x |> function y -> ( function _ -> y (* A *) ) (* B *)
 

--- a/vendor/compat/compat.ml
+++ b/vendor/compat/compat.ml
@@ -1,2 +1,3 @@
 module List = List
+module String = String
 include Warning

--- a/vendor/compat/compat.mli
+++ b/vendor/compat/compat.mli
@@ -1,3 +1,4 @@
 module List = List
+module String = String
 
 include module type of Warning

--- a/vendor/compat/string.ml
+++ b/vendor/compat/string.ml
@@ -1,0 +1,10 @@
+open Base
+
+let starts_with_whitespace s =
+  (not (String.is_empty s)) && Char.is_whitespace s.[0]
+
+let ends_with_whitespace s =
+  let len = String.length s in
+  len > 1 && Char.is_whitespace s.[len - 1]
+
+include String

--- a/vendor/compat/string.ml
+++ b/vendor/compat/string.ml
@@ -1,10 +1,8 @@
 open Base
+include String
 
 let starts_with_whitespace s =
   (not (String.is_empty s)) && Char.is_whitespace s.[0]
 
 let ends_with_whitespace s =
-  let len = String.length s in
-  len > 1 && Char.is_whitespace s.[len - 1]
-
-include String
+  (not (String.is_empty s)) && Char.is_whitespace s.[String.length s - 1]

--- a/vendor/compat/string.mli
+++ b/vendor/compat/string.mli
@@ -1,0 +1,9 @@
+include module type of Base.String
+
+val starts_with_whitespace : string -> bool
+(** [starts_with_whitespace s] holds if [s] is non empty and starts with a
+    whitespace character. *)
+
+val ends_with_whitespace : string -> bool
+(** [ends_with_whitespace s] holds if [s] has at least two characters and
+    ends with a whitespace character. *)

--- a/vendor/compat/string.mli
+++ b/vendor/compat/string.mli
@@ -5,5 +5,5 @@ val starts_with_whitespace : string -> bool
     whitespace character. *)
 
 val ends_with_whitespace : string -> bool
-(** [ends_with_whitespace s] holds if [s] has at least two characters and
-    ends with a whitespace character. *)
+(** [ends_with_whitespace s] holds if [s] is non empty and ends with a
+    whitespace character. *)


### PR DESCRIPTION
Minimal comments as `(* *)`, `(** *)` or `(*$ *)` (containing only 1 space) were added another space after being formatted.