### PR TITLE
Fix escaping of other Odoc tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,8 @@
 
   + Fix placement of comments on constants (#1383) (Guillaume Petiot)
 
-  + Do not escape `@raise` argument in docstrings (#1391) (Guillaume Petiot)
+  + Do not escape arguments of some Odoc tags (#1391, 1408) (Guillaume Petiot, Jules Aguillon)
+    The characters `[]{}` must not be escaped in the arguments of `@raise`, `@author`, `@version` and others.
 
 ### 0.14.2 (2020-05-11)
 

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -212,23 +212,23 @@ let space = fmt "@ "
 
 let fmt_tag_see c wrap sr txt =
   at $ fmt "see@ "
-  $ wrap (str_normalized sr)
+  $ wrap (str sr)
   $ fmt_nestable_block_elements c ~prefix:space txt
 
 let fmt_tag c = function
-  | `Author s -> at $ fmt "author@ " $ str_normalized s
-  | `Version s -> at $ fmt "version@ " $ str_normalized s
+  | `Author s -> at $ fmt "author@ " $ str s
+  | `Version s -> at $ fmt "version@ " $ str s
   | `See (`Url, sr, txt) -> fmt_tag_see c (wrap "<" ">") sr txt
   | `See (`File, sr, txt) -> fmt_tag_see c (wrap "'" "'") sr txt
   | `See (`Document, sr, txt) -> fmt_tag_see c (wrap "\"" "\"") sr txt
-  | `Since s -> at $ fmt "since@ " $ str_normalized s
+  | `Since s -> at $ fmt "since@ " $ str s
   | `Before (s, txt) ->
-      at $ fmt "before@ " $ str_normalized s
+      at $ fmt "before@ " $ str s
       $ fmt_nestable_block_elements c ~prefix:space txt
   | `Deprecated txt ->
       at $ fmt "deprecated" $ fmt_nestable_block_elements c ~prefix:space txt
   | `Param (s, txt) ->
-      at $ fmt "param@ " $ str_normalized s
+      at $ fmt "param@ " $ str s
       $ fmt_nestable_block_elements c ~prefix:space txt
   | `Raise (s, txt) ->
       at $ fmt "raise@ " $ str s

--- a/test/passing/doc_comments.mli
+++ b/test/passing/doc_comments.mli
@@ -481,6 +481,28 @@ val k : int
       {i fooooooooooooo oooooooo oooooooooo}
     - foo *)
 
+(** Brackets must not be escaped in the first argument of some tags: *)
+
 (** @raise [Invalid_argument] if the argument is [None]. Sometimes [t.[x]]. *)
+
+(** @author [Abc] [def] \[hij\] *)
+
+(** @author {Abc} {def} \{hij\} *)
+
+(** @param [id] [def] \[hij\] *)
+
+(** @raise [exn] [def] \[hij\] *)
+
+(** @since [Abc] [def] \[hij\] *)
+
+(** @before [Abc] [def] \[hij\] *)
+
+(** @version [Abc] [def] \[hij\] *)
+
+(** @see <[Abc]> [def] \[hij\] *)
+
+(** @see '[Abc]' [def] \[hij\] *)
+
+(** @see "[Abc]" [def] \[hij\] *)
 
 (** \[abc\] *)

--- a/test/passing/doc_comments.mli.ref
+++ b/test/passing/doc_comments.mli.ref
@@ -449,6 +449,28 @@ val k : int
       {i fooooooooooooo oooooooo oooooooooo}
     - foo *)
 
+(** Brackets must not be escaped in the first argument of some tags: *)
+
 (** @raise [Invalid_argument] if the argument is [None]. Sometimes [t.\[x\]]. *)
+
+(** @author [Abc] [def] \[hij\] *)
+
+(** @author {Abc} {def} \{hij\} *)
+
+(** @param [id] [def] \[hij\] *)
+
+(** @raise [exn] [def] \[hij\] *)
+
+(** @since [Abc] [def] \[hij\] *)
+
+(** @before [Abc] [def] \[hij\] *)
+
+(** @version [Abc] [def] \[hij\] *)
+
+(** @see <[Abc]> [def] \[hij\] *)
+
+(** @see '[Abc]' [def] \[hij\] *)
+
+(** @see "[Abc]" [def] \[hij\] *)
 
 (** \[abc\] *)


### PR DESCRIPTION
Follow-up of https://github.com/ocaml-ppx/ocamlformat/pull/1391

The first arguments of some tags are parsed verbatim and must not be escaped.