### PR TITLE
Fix break between keyword and expr with if-then-else=keyword-first

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 #### Bug fixes
 
+  + Fix break between keyword and expr with `if-then-else=keyword-first` (#1419, @gpetiot)
+
 #### New features
 
 ### 0.15.0 (2020-08-06)

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -369,7 +369,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
                 ( fmt_or_k first
                     (str "if" $ fmt_extension_suffix)
                     (str "else if")
-                $ fmt_attributes $ str " " $ fmt_cond xcnd )
+                $ fmt_attributes $ fmt "@ " $ fmt_cond xcnd )
               $ fmt "@ ")
       ; box_keyword_and_expr=
           (fun k ->

--- a/test/passing/ite-kw_first.ml.ref
+++ b/test/passing/ite-kw_first.ml.ref
@@ -45,8 +45,9 @@ f
 
 ;;
 f
-  ( if and_ even
-         loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  ( if
+      and_ even
+        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
   then ()
   else () )
 

--- a/test/passing/ite-kw_first_closing.ml.ref
+++ b/test/passing/ite-kw_first_closing.ml.ref
@@ -52,8 +52,9 @@ f
 
 ;;
 f
-  ( if and_ even
-         loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  ( if
+      and_ even
+        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
   then ()
   else ()
   )

--- a/test/passing/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/ite-kw_first_no_indicate.ml.ref
@@ -45,8 +45,9 @@ f
 
 ;;
 f
-  (if and_ even
-        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  (if
+     and_ even
+       loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
   then ()
   else ())
 

--- a/test/passing/js_source.ml
+++ b/test/passing/js_source.ml
@@ -7559,3 +7559,10 @@ let nullsafe_optimistic_third_party_params_in_non_strict =
     ~default:true
     "Nullsafe: in this mode we treat non annotated third party method \
      params as if they were annotated as nullable."
+
+let foo () =
+  if%bind
+    (* this is a medium length comment of some sort *)
+    this is a medium length expression of_some sort
+  then x
+  else y

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -9938,3 +9938,11 @@ let nullsafe_optimistic_third_party_params_in_non_strict =
     "Nullsafe: in this mode we treat non annotated third party method params as if they \
      were annotated as nullable."
 ;;
+
+let foo () =
+  if%bind
+    (* this is a medium length comment of some sort *)
+    this is a medium length expression of_some sort
+  then x
+  else y
+;;

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -9938,3 +9938,11 @@ let nullsafe_optimistic_third_party_params_in_non_strict =
     "Nullsafe: in this mode we treat non annotated third party method params as if they \
      were annotated as nullable."
 ;;
+
+let foo () =
+  if%bind
+    (* this is a medium length comment of some sort *)
+    this is a medium length expression of_some sort
+  then x
+  else y
+;;


### PR DESCRIPTION
Fix #1417

Not breaking used to cause excessive indentation:
```diff
diff --git a/infer/src/base/FileDiff.ml b/infer/src/base/FileDiff.ml
index c39d9b75c..147b5fddc 100644
--- a/infer/src/base/FileDiff.ml
+++ b/infer/src/base/FileDiff.ml
@@ -67,8 +67,9 @@ let parse_directives directives =
   if List.is_empty directives
   then (* handle the case where both files are empty *)
     []
-  else if (* handle the case where the new-file is empty *)
-          List.for_all ~f:(UnixDiff.equal UnixDiff.Old) directives
+  else if
+    (* handle the case where the new-file is empty *)
+    List.for_all ~f:(UnixDiff.equal UnixDiff.Old) directives
```

Some cases are debatable:
```diff
diff --git a/infer/src/IR/ProcAttributes.ml b/infer/src/IR/ProcAttributes.ml
index e7e999c0a..452156773 100644
--- a/infer/src/IR/ProcAttributes.ml
+++ b/infer/src/IR/ProcAttributes.ml
@@ -202,10 +202,11 @@ let pp
     translation_unit;
   if not (PredSymb.equal_access default.access access)
   then F.fprintf f "; access= %a@," (Pp.of_string ~f:PredSymb.string_of_access)
 access;
-  if not
-       ([%compare.equal: (Mangled.t * Typ.t * Pvar.capture_mode) list]
-          default.captured
-          captured)
+  if
+    not
+      ([%compare.equal: (Mangled.t * Typ.t * Pvar.capture_mode) list]
+         default.captured
+         captured)
```

but we can't have have specific treatments without making it even more difficult to maintain.