### PR TITLE
Add a github action to check changelog

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: Changelog check
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: git diff
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-needed') }}
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: |
+        ! git diff --exit-code origin/$BASE_REF -- CHANGES.md


### PR DESCRIPTION
The semantics are the same as the Travis check:

- check pull requests against master
- if pull request has label "no-changelog-needed", do nothing
- display an error if there are no diffs on `CHANGES.md`

Compared to the Travis check:

- it retriggers automatically when a label is added or removed
- it will not be subject to API rate limiting
- it is likely to be a bit faster

A couple comments on the implementation:

- the types of pull request events correspond to the default ones plus the ones related to labels (so that it triggers a check when labels change)
- this uses `actions/checkout@v1` because there is a bug in `v2` that can check out the wrong commit sometimes. See actions/checkout#237.