### PR TITLE
Indent further args of anonymous functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
   + Restore previous functionality for pre-post extension points (#1342, @jberdine)
 
   + Fix extra break before `function` body of a `fun` (#1343, @jberdine)
+    Indent further args of anonymous functions (#1440, @gpetiot)
 
   + Do not clear the emacs `*compilation*` buffer on successful reformat (#1350, @jberdine)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1851,10 +1851,12 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                           ( fmt_args_grouped e0 e1N $ fmt "@ "
                           $ fmt_label lbl ":" $ cmts_before
                           $ hvbox 0
-                              ( str "(fun "
-                              $ fmt_attributes c ~key:"@" eN1.pexp_attributes
-                                  ~suf:(str " ")
-                              $ fmt_fun_args c xargs $ fmt_opt fmt_cstr
+                              ( hvbox 2
+                                  ( fmt "(fun@ "
+                                  $ fmt_attributes c ~key:"@"
+                                      eN1.pexp_attributes ~suf:(str " ")
+                                  $ fmt_fun_args c xargs $ fmt_opt fmt_cstr
+                                  )
                               $ fmt "@ ->" ) )
                       $ fmt
                           ( match xbody.ast.pexp_desc with

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -153,9 +153,10 @@ let extend_loc_to_include_attributes t (loc : Location.t)
   else
     let last_loc =
       List.fold l ~init:loc
-        ~f:(fun (acc : Location.t)
-           ({attr_name= {loc; _}; attr_payload= payload; _} :
-             Parsetree.attribute)
+        ~f:(fun
+             (acc : Location.t)
+             ({attr_name= {loc; _}; attr_payload= payload; _} :
+               Parsetree.attribute)
            ->
           if loc.loc_ghost then acc
           else


### PR DESCRIPTION
@jberdine  #1343 changed the indentation of arguments like this:
```diff
     let last_loc =
       List.fold l ~init:loc
         ~f:(fun (acc : Location.t)
-                ({attr_name= {loc; _}; attr_payload= payload; _} :
-                  Parsetree.attribute)
-                ->
+           ({attr_name= {loc; _}; attr_payload= payload; _} :
+             Parsetree.attribute)
+           ->
```

I didn't pay attention to it when #1343 was merged, what do you think of the new indentation suggested in this PR?

Here is the diff with test_branch:
```diff
diff --git a/lib/Source.ml b/lib/Source.ml
index 77ea664..ed4d28e 100644
--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -153,8 +153,9 @@ let extend_loc_to_include_attributes t (loc : Location.t) (l : Parsetree.attribu
       List.fold
         l
         ~init:loc
-        ~f:(fun (acc : Location.t)
-           ({ attr_name = { loc; _ }; attr_payload = payload; _ } : Parsetree.attribute)
+        ~f:(fun
+             (acc : Location.t)
+             ({ attr_name = { loc; _ }; attr_payload = payload; _ } : Parsetree.attribute)
            ->
           if loc.loc_ghost
           then acc
diff --git a/infer/src/integration/Help.ml b/infer/src/integration/Help.ml
index e5f974e17..9af75d105 100644
--- a/infer/src/integration/Help.ml
+++ b/infer/src/integration/Help.ml
@@ -153,18 +153,19 @@ let list_issue_types () =
   L.result "@[<v>";
   IssueType.all_issues ()
   |> List.iter
-       ~f:(fun ({ IssueType.unique_id
-                ; checker
-                ; visibility
-                ; user_documentation =
-                    _
-                    (* do not show this as this can be a big multi-line string and not tool-friendly *)
-                ; default_severity
-                ; enabled
-                ; hum
-                ; doc_url
-                ; linters_def_file
-                }[@warning "+9"])
+       ~f:(fun
+            ({ IssueType.unique_id
+             ; checker
+             ; visibility
+             ; user_documentation =
+                 _
+                 (* do not show this as this can be a big multi-line string and not tool-friendly *)
+             ; default_severity
+             ; enabled
+             ; hum
+             ; doc_url
+             ; linters_def_file
+             }[@warning "+9"])
           ->
          L.result
            "%s:%s:%s:%s:%b:%s:%s:%s@;"
diff --git a/infer/src/nullsafe/eradicateChecks.ml b/infer/src/nullsafe/eradicateChecks.ml
index 34e2429c2..d592b1f06 100644
--- a/infer/src/nullsafe/eradicateChecks.ml
+++ b/infer/src/nullsafe/eradicateChecks.ml
@@ -681,13 +681,14 @@ let check_inheritance_rule_for_params
          L.result
            "%s:%s:%s:%s:%b:%s:%s:%s@;"
diff --git a/infer/src/nullsafe/eradicateChecks.ml b/infer/src/nullsafe/eradicat
eChecks.ml
index 34e2429c2..d592b1f06 100644
--- a/infer/src/nullsafe/eradicateChecks.ml
+++ b/infer/src/nullsafe/eradicateChecks.ml
@@ -681,13 +681,14 @@ let check_inheritance_rule_for_params
     (* Check the rule for each pair of base and overridden param *)
     List.iteri
       base_and_overridden_params
-      ~f:(fun index
-         ( AnnotatedSignature.
-             { param_annotated_type = { nullability = annotated_nullability_base } }
-         , AnnotatedSignature.
-             { mangled = overridden_param_name
-             ; param_annotated_type = { nullability = annotated_nullability_overridden }
-             } )
+      ~f:(fun
+           index
+           ( AnnotatedSignature.
+               { param_annotated_type = { nullability = annotated_nullability_base } }
+           , AnnotatedSignature.
+               { mangled = overridden_param_name
+               ; param_annotated_type = { nullability = annotated_nullability_overridden }
+               } )
          ->
         check_inheritance_rule_for_param
           analysis_data
diff --git a/infer/src/nullsafe/typeCheck.ml b/infer/src/nullsafe/typeCheck.ml
index 208798fd3..49ba5f82d 100644
--- a/infer/src/nullsafe/typeCheck.ml
+++ b/infer/src/nullsafe/typeCheck.ml
@@ -1336,8 +1336,9 @@ let clarify_ret_by_propagates_nullable
   let nullability_of_propagates_nullable_params =
     List.filter_map
       resolved_params
-      ~f:(fun EradicateChecks.
-                { is_formal_propagates_nullable; actual = _, inferred_nullability }
+      ~f:(fun
+           EradicateChecks.
+             { is_formal_propagates_nullable; actual = _, inferred_nullability }
          -> Option.some_if is_formal_propagates_nullable inferred_nullability)
   in
   match nullability_of_propagates_nullable_params with
diff --git a/compiler/lib/parse_bytecode.ml b/compiler/lib/parse_bytecode.ml
index 6e6a7fbeb..221c65864 100644
--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -150,10 +150,11 @@ end = struct
       let paths = read_paths ic @ includes in
       List.iter
         evl
-        ~f:(fun ({ ev_module
-                 ; ev_loc = { Location.loc_start = { Lexing.pos_fname; _ }; _ }
-                 ; _
-                 } as ev)
+        ~f:(fun
+             ({ ev_module
+              ; ev_loc = { Location.loc_start = { Lexing.pos_fname; _ }; _ }
+              ; _
+              } as ev)
            ->
           let unit =
             try Hashtbl.find units (ev_module, pos_fname) with
diff --git a/src/dune/build_system.ml b/src/dune/build_system.ml
index e9ef3c0d..b8eb50ec 100644
--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -761,8 +761,9 @@ end = struct
             List.fold_left
               (Appendable_list.to_list actions)
               ~init:(rules, Path.Set.empty)
-              ~f:(fun (rules, action_stamp_files)
-                 { Rules.Dir_rules.stamp; action; locks; context; loc; env }
+              ~f:(fun
+                   (rules, action_stamp_files)
+                   { Rules.Dir_rules.stamp; action; locks; context; loc; env }
                  ->
                 let path =
                   Path.Build.extend_basename
diff --git a/src/dune/install_rules.ml b/src/dune/install_rules.ml
index ec95fc95..60dd0a74 100644
--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -408,13 +408,14 @@ end = struct
               List.fold_left
                 entries
                 ~init:Lib_name.Map.empty
-                ~f:(fun acc
-                   { Dune_file.Deprecated_library_name.old_public_name =
-                       { public = old_public_name; _ }
-                   ; new_public_name = _, new_public_name
-                   ; loc
-                   ; _
-                   }
+                ~f:(fun
+                     acc
+                     { Dune_file.Deprecated_library_name.old_public_name =
+                         { public = old_public_name; _ }
+                     ; new_public_name = _, new_public_name
+                     ; loc
+                     ; _
+                     }
                    ->
```