### PR TITLE
Specify package version in opam file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 #### Bug fixes
 
   + Fix break between keyword and expr with `if-then-else=keyword-first` (#1419, @gpetiot)
+  + Specify version in opam file to help with pins and opam constraints (#1445, @facelesspanda)
 
 #### New features
 

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -10,6 +10,7 @@
 ##########################################################################
 
 opam-version: "2.0"
+version: "0.15"
 maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
 authors: "Josh Berdine <jjb@fb.com>"
 homepage: "https://github.com/ocaml-ppx/ocamlformat"


### PR DESCRIPTION
A lot of projects will tend to either pin ocamlformat to a certain commit or add constraints on its version in their dependency to have project-wide formatting consistency and sometimes specific features (like the recent `.eliom` support for example).

When these pins or constraint change, pulling the changes doesn't change the version of the package because it doesn't come from the opam versioned repo but from a git repo somewhere, and this file here will be read to determine the version and check it against the constraint.

I propose to maintain this version number here for every package version published, to avoid problems with pins and constraints in the future.
Unless you're alright with projects having to uninstall and reinstall ocamlformat everytime they need to change their version, of course.

Another possibility is to specify `"dev"` as the version long as it's not an actual version published on opam, and change it for the release candidates on their own branch. I'm not sure which is better.