### PR TITLE
Improve formatting of groups of items

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -627,6 +627,8 @@ module Signature_item = struct
 end
 
 module Vb = struct
+  let has_doc itm = Option.is_some (fst (doc_atrs itm.pvb_attributes))
+
   let is_simple (i, c) =
     Poly.(c.Conf.module_item_spacing = `Compact)
     && Location.is_single_line i.pvb_loc c.Conf.margin
@@ -635,6 +637,7 @@ module Vb = struct
       =
     has_cmts_after cmts i1.pvb_loc
     || has_cmts_before cmts i2.pvb_loc
+    || has_doc i1 || has_doc i2
     || (not (is_simple (i1, c1)))
     || not (is_simple (i2, c2))
 end

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3529,17 +3529,11 @@ and fmt_signature c ctx itms =
     | Psig_attribute atr -> update_config c [atr]
     | _ -> c
   in
-  let items = update_items_config c itms update_config in
-  let break_struct = c.conf.break_struct || is_top ctx in
-  hvbox 0 @@ list_pn items
-  @@ fun ~prev:_ (itm, c) ~next ->
-  maybe_disabled c itm.psig_loc [] (fun c ->
-      fmt_signature_item c (sub_sig ~ctx itm) )
-  $ opt next (fun (i_n, c_n) ->
-        fmt_or_k
-          (break_between c (Sig itm, c.conf) (Sig i_n, c_n.conf))
-          (fmt "\n@;<1000 0>")
-          (fmt_or break_struct "@;<1000 0>" "@ ") )
+  let fmt_item c ctx ~prev:_ ~next:_ i =
+    fmt_signature_item c (sub_sig ~ctx i)
+  in
+  let ast x = Sig x in
+  fmt_item_list c ctx update_config ast fmt_item itms
 
 and fmt_signature_item c ?ext {ast= si; _} =
   protect c (Sig si)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3552,13 +3552,14 @@ and fmt_signature c ctx itms =
     | Psig_attribute atr -> update_config c [atr]
     | _ -> c
   in
-  let grps = make_groups c itms (fun x -> Sig x) update_config in
-  let fmt_grp (i, c) =
-    maybe_disabled c i.psig_loc []
-    @@ fun c -> fmt_signature_item c (sub_sig ~ctx i)
-  in
-  let fmt_grp itms = list itms "@;<1000 0>" fmt_grp in
-  hvbox 0 (list grps "\n@;<1000 0>" fmt_grp)
+  let items = update_items_config c itms update_config in
+  hvbox 0 @@ list_pn items
+  @@ fun ~prev:_ (itm, c) ~next ->
+  maybe_disabled c itm.psig_loc [] (fun c ->
+      fmt_signature_item c (sub_sig ~ctx itm) )
+  $ opt next (fun (i_n, c_n) ->
+        fmt_if (break_between c (Sig itm, c.conf) (Sig i_n, c_n.conf)) "\n"
+        $ break 1000 0 )
 
 and fmt_signature_item c ?ext {ast= si; _} =
   protect c (Sig si)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -208,8 +208,7 @@ let fmt_recmodule c ctx items fmt_item ast =
   $ opt next (fun (i_n, c_n) ->
         fmt_or_k
           (break_between c (ast itm, c.conf) (ast i_n, c_n.conf))
-          ( fmt_or_k break_struct (str "\n") (fits_breaks "" "\n")
-          $ break 1000 0 )
+          (fmt "\n@;<1000 0>")
           (fmt_or break_struct "@;<1000 0>" "@ ") )
 
 (* In several places, naked newlines (i.e. not "@\n") are used to avoid
@@ -3543,13 +3542,16 @@ and fmt_signature c ctx itms =
     | _ -> c
   in
   let items = update_items_config c itms update_config in
+  let break_struct = c.conf.break_struct || is_top ctx in
   hvbox 0 @@ list_pn items
   @@ fun ~prev:_ (itm, c) ~next ->
   maybe_disabled c itm.psig_loc [] (fun c ->
       fmt_signature_item c (sub_sig ~ctx itm) )
   $ opt next (fun (i_n, c_n) ->
-        fmt_if (break_between c (Sig itm, c.conf) (Sig i_n, c_n.conf)) "\n"
-        $ break 1000 0 )
+        fmt_or_k
+          (break_between c (Sig itm, c.conf) (Sig i_n, c_n.conf))
+          (fmt "\n@;<1000 0>")
+          (fmt_or break_struct "@;<1000 0>" "@ ") )
 
 and fmt_signature_item c ?ext {ast= si; _} =
   protect c (Sig si)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4422,7 +4422,7 @@ let fmt_toplevel c ctx itms =
     | `Item {pstr_desc= Pstr_attribute atr; _} -> update_config c [atr]
     | _ -> c
   in
-  let grps = make_groups c itms (fun x -> Tli x) update_config in
+  let items = update_items_config c itms update_config in
   let break_struct = c.conf.break_struct || is_top ctx in
   let fmt_item c ~last = function
     | `Item i ->
@@ -4430,13 +4430,14 @@ let fmt_toplevel c ctx itms =
         @@ fun c -> fmt_structure_item c ~last (sub_str ~ctx i)
     | `Directive d -> fmt_toplevel_directive c d
   in
-  let fmt_grp ~first:_ ~last:last_grp itms =
-    list_fl itms (fun ~first ~last (itm, c) ->
-        let last = last && last_grp in
-        fmt_if_k (not first) (fmt_or break_struct "@\n" "@ ")
-        $ fmt_item c ~last itm )
-  in
-  hvbox 0 (fmt_groups c ctx grps fmt_grp)
+  hvbox 0 @@ list_pn items
+  @@ fun ~prev:_ (itm, c) ~next ->
+  fmt_item c ~last:(Option.is_none next) itm
+  $ opt next (fun (i_n, c_n) ->
+        fmt_or_k
+          (break_between c (Tli itm, c.conf) (Tli i_n, c_n.conf))
+          (fmt "\n@;<1000 0>")
+          (fmt_or break_struct "@;<1000 0>" "@ ") )
 
 (** Entry points *)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4386,22 +4386,13 @@ let fmt_toplevel c ctx itms =
     | `Item {pstr_desc= Pstr_attribute atr; _} -> update_config c [atr]
     | _ -> c
   in
-  let items = update_items_config c itms update_config in
-  let break_struct = c.conf.break_struct || is_top ctx in
-  let fmt_item c ~last = function
+  let fmt_item c ctx ~prev:_ ~next = function
     | `Item i ->
-        maybe_disabled c i.pstr_loc []
-        @@ fun c -> fmt_structure_item c ~last (sub_str ~ctx i)
+        fmt_structure_item c ~last:(Option.is_none next) (sub_str ~ctx i)
     | `Directive d -> fmt_toplevel_directive c d
   in
-  hvbox 0 @@ list_pn items
-  @@ fun ~prev:_ (itm, c) ~next ->
-  fmt_item c ~last:(Option.is_none next) itm
-  $ opt next (fun (i_n, c_n) ->
-        fmt_or_k
-          (break_between c (Tli itm, c.conf) (Tli i_n, c_n.conf))
-          (fmt "\n@;<1000 0>")
-          (fmt_or break_struct "@;<1000 0>" "@ ") )
+  let ast x = Tli x in
+  fmt_item_list c ctx update_config ast fmt_item itms
 
 (** Entry points *)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -58,6 +58,10 @@ module Cmts = struct
         fmt ?pro ?epi ?eol ?adj:None c loc k )
 end
 
+let break_between {source; cmts; _} =
+  Ast.break_between source ~cmts ~has_cmts_before:Cmts.has_before
+    ~has_cmts_after:Cmts.has_after
+
 type block =
   { opn: Fmt.t
   ; pro: Fmt.t option
@@ -195,10 +199,7 @@ let update_items_config c items update_config =
 let make_groups c items ast update_config =
   let items = update_items_config c items update_config in
   let break (i1, c1) (i2, c2) =
-    Ast.break_between c.source ~cmts:c.cmts ~has_cmts_before:Cmts.has_before
-      ~has_cmts_after:Cmts.has_after
-      (ast i1, c1.conf)
-      (ast i2, c2.conf)
+    break_between c (ast i1, c1.conf) (ast i2, c2.conf)
   in
   List.group items ~break
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -184,12 +184,16 @@ let update_config_maybe_disabled_block c loc l f =
   let c = update_config c l in
   maybe_disabled_k c loc l f fmt
 
-let make_groups c items ast update_config =
+let update_items_config c items update_config =
   let with_config c i =
     let c = update_config c i in
     (c, (i, c))
   in
   let _, items = List.fold_map items ~init:c ~f:with_config in
+  items
+
+let make_groups c items ast update_config =
+  let items = update_items_config c items update_config in
   let break (i1, c1) (i2, c2) =
     Ast.break_between c.source ~cmts:c.cmts ~has_cmts_before:Cmts.has_before
       ~has_cmts_after:Cmts.has_after

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4096,17 +4096,11 @@ and fmt_structure c ctx itms =
     | Pstr_attribute atr -> update_config c [atr]
     | _ -> c
   in
-  let items = update_items_config c itms update_config in
-  let break_struct = c.conf.break_struct || is_top ctx in
-  hvbox 0 @@ list_pn items
-  @@ fun ~prev:_ (itm, c) ~next ->
-  maybe_disabled c itm.pstr_loc [] (fun c ->
-      fmt_structure_item c ~last:(Option.is_none next) (sub_str ~ctx itm) )
-  $ opt next (fun (i_n, c_n) ->
-        fmt_or_k
-          (break_between c (Str itm, c.conf) (Str i_n, c_n.conf))
-          (fmt "\n@;<1000 0>")
-          (fmt_or break_struct "@;<1000 0>" "@ ") )
+  let fmt_item c ctx ~prev:_ ~next i =
+    fmt_structure_item c ~last:(Option.is_none next) (sub_str ~ctx i)
+  in
+  let ast x = Str x in
+  fmt_item_list c ctx update_config ast fmt_item itms
 
 and fmt_type c ?ext ?eq rec_flag decls ctx =
   let fmt_decl ~first ~last decl =

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -440,15 +440,17 @@ module Let_binding = struct
               (xpat, `Other (xargs, sub_typ ~ctx typ), sub_exp ~ctx exp)
           | _ -> (xpat, `None xargs, xbody) )
 
-  let of_value_bindings cmts ~ctx vbs =
-    List.mapi vbs ~f:(fun i vb ->
-        let pat, typ, exp = type_cstr cmts ~ctx vb.pvb_pat vb.pvb_expr in
-        { lb_op= Location.{txt= (if i = 0 then "let" else "and"); loc= none}
-        ; lb_pat= pat
-        ; lb_typ= typ
-        ; lb_exp= exp
-        ; lb_attrs= vb.pvb_attributes
-        ; lb_loc= vb.pvb_loc } )
+  let of_value_binding cmts ~ctx ~first vb =
+    let pat, typ, exp = type_cstr cmts ~ctx vb.pvb_pat vb.pvb_expr in
+    { lb_op= Location.{txt= (if first then "let" else "and"); loc= none}
+    ; lb_pat= pat
+    ; lb_typ= typ
+    ; lb_exp= exp
+    ; lb_attrs= vb.pvb_attributes
+    ; lb_loc= vb.pvb_loc }
+
+  let of_value_bindings cmts ~ctx =
+    List.mapi ~f:(fun i -> of_value_binding cmts ~ctx ~first:(i = 0))
 
   let of_binding_ops cmts ~ctx bos =
     List.map bos ~f:(fun bo ->

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -143,6 +143,9 @@ module Let_binding : sig
     ; lb_attrs: attribute list
     ; lb_loc: Location.t }
 
+  val of_value_binding :
+    Cmts.t -> ctx:Ast.t -> first:bool -> value_binding -> t
+
   val of_value_bindings : Cmts.t -> ctx:Ast.t -> value_binding list -> t list
 
   val of_binding_ops : Cmts.t -> ctx:Ast.t -> binding_op list -> t list

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -169,7 +169,6 @@ end
 
 (* Structure items *)
 let%foo[@foo] x = 4
-
 and[@foo] y = x
 
 type%foo t = int [@@foo]

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -169,7 +169,6 @@ end
 
 (* Structure items *)
 let%foo[@foo] x = 4
-
 and[@foo] y = x
 
 type%foo t = int [@@foo]


### PR DESCRIPTION
The goal is to remove the over-factorization that is done by using make_groups, and handle `'a list` instead of `'a list list` which would make it easier to maintain and e.g. optimize the printing of `;;`

No diff with test_branch.sh, the diff in the tests is a slight fix and is not worth mentioning in the changelog.