### PR TITLE
Set 'indicate-multiline-delimiters=no' on default profile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 #### Changes
 
+  + Set 'indicate-multiline-delimiters=no' on default profile (#1452, @gpetiot)
+
 #### Bug fixes
 
   + Fix break between keyword and expr with `if-then-else=keyword-first` (#1419, @gpetiot)

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -773,14 +773,14 @@ module Formatting = struct
     in
     let names = ["indicate-multiline-delimiters"] in
     let all =
-      [ ( "space"
-        , `Space
-        , "$(b,space) prints a space inside the delimiter to indicate the \
-           matching one is on a different line." )
-      ; ( "no"
+      [ ( "no"
         , `No
         , "$(b, no) doesn't do anything special to indicate the closing \
            delimiter." )
+      ; ( "space"
+        , `Space
+        , "$(b,space) prints a space inside the delimiter to indicate the \
+           matching one is on a different line." )
       ; ( "closing-on-separate-line"
         , `Closing_on_separate_line
         , "$(b, closing-on-separate-line) makes sure that the closing \

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -262,13 +262,13 @@ OPTIONS (CODE FORMATTING STYLE)
            another `let`. The default value is 0. Cannot be set in
            attributes.
 
-       --indicate-multiline-delimiters={space|no|closing-on-separate-line}
+       --indicate-multiline-delimiters={no|space|closing-on-separate-line}
            How to indicate that two matching delimiters live on different
-           lines. space prints a space inside the delimiter to indicate the
-           matching one is on a different line. no doesn't do anything
-           special to indicate the closing delimiter.
-           closing-on-separate-line makes sure that the closing delimiter is
-           on its own line. The default value is space.
+           lines. no doesn't do anything special to indicate the closing
+           delimiter. space prints a space inside the delimiter to indicate
+           the matching one is on a different line. closing-on-separate-line
+           makes sure that the closing delimiter is on its own line. The
+           default value is no.
 
        --indicate-nested-or-patterns={unsafe-no|space}
            Control whether or not to indicate nested or-pattern using


### PR DESCRIPTION
Setting the more "vanilla" value of this option for the default profile.
And also disabling the formatting of vendored libraries (should have been done long ago).