### PR TITLE
Use base instead of Location.Set and Location.Multimap

### DIFF
--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -205,24 +205,6 @@ module Location = struct
     let min a b = if width a < width b then a else b in
     List.reduce_exn (loc :: stack) ~f:min
 
-  module Set = struct
-    type t = (location, comparator_witness) Set.t
-
-    let empty =
-      Set.empty
-        ( module struct
-          type t = location
-
-          include Location_comparator
-        end )
-
-    let add key t = Set.add t key
-
-    let remove key t = Set.remove t key
-
-    let to_list t = Set.to_list t
-  end
-
   module Multimap = struct
     type 'a t = (location, 'a list, comparator_witness) Map.t
 

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -204,43 +204,6 @@ module Location = struct
   let smallest loc stack =
     let min a b = if width a < width b then a else b in
     List.reduce_exn (loc :: stack) ~f:min
-
-  module Multimap = struct
-    type 'a t = (location, 'a list, comparator_witness) Map.t
-
-    let add_list map key data = Map.add_exn map ~key ~data
-
-    let add_multi map key data = Map.add_multi map ~key ~data
-
-    let change_multi map key data =
-      Map.change map key ~f:(function _ -> Some data)
-
-    let remove map loc = Map.remove map loc
-
-    let update_multi map ~src ~dst ~f =
-      Option.fold (Map.find map src) ~init:(Map.remove map src)
-        ~f:(fun new_map src_data ->
-          Map.update new_map dst ~f:(fun dst_data ->
-              Option.fold dst_data ~init:src_data ~f))
-
-    let empty =
-      Map.empty
-        ( module struct
-          type t = location
-
-          include Location_comparator
-        end )
-
-    let find map loc = Map.find map loc
-
-    let filter map ~f = Map.map map ~f:(List.filter ~f)
-
-    let mem map loc = Map.mem map loc
-
-    let to_list map = Map.to_alist map |> List.concat_map ~f:snd
-
-    let find_multi map loc = Map.find_multi map loc
-  end
 end
 
 module Longident = struct

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -88,39 +88,6 @@ module Location : sig
   val width : t -> int
 
   val is_single_line : t -> int -> bool
-
-  type location = t
-
-  module Multimap : sig
-    type 'a t
-
-    val empty : 'a t
-
-    val add_list : 'a t -> location -> 'a list -> 'a t
-
-    val add_multi : 'a t -> location -> 'a -> 'a t
-
-    val change_multi : 'a t -> location -> 'a list -> 'a t
-
-    val update_multi :
-         'a t
-      -> src:location
-      -> dst:location
-      -> f:('a list -> 'a list -> 'a list)
-      -> 'a t
-
-    val find : 'a t -> location -> 'a list option
-
-    val remove : 'a t -> location -> 'a t
-
-    val filter : 'a t -> f:('a -> bool) -> 'a t
-
-    val mem : 'a t -> location -> bool
-
-    val to_list : 'a t -> 'a list
-
-    val find_multi : 'a t -> location -> 'a list
-  end
 end
 
 module Parse : sig

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -91,18 +91,6 @@ module Location : sig
 
   type location = t
 
-  module Set : sig
-    type t
-
-    val empty : t
-
-    val add : location -> t -> t
-
-    val remove : location -> t -> t
-
-    val to_list : t -> location list
-  end
-
   module Multimap : sig
     type 'a t
 

--- a/lib/Multimap.ml
+++ b/lib/Multimap.ml
@@ -1,0 +1,34 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlFormat                               *)
+(*                                                                        *)
+(*            Copyright (c) Facebook, Inc. and its affiliates.            *)
+(*                                                                        *)
+(*      This source code is licensed under the MIT license found in       *)
+(*      the LICENSE file in the root directory of this source tree.       *)
+(*                                                                        *)
+(**************************************************************************)
+
+type ('key, 'value, 'cmp) t = ('key, 'value list, 'cmp) Map.t
+
+module M (K : sig
+  type t
+
+  type comparator_witness
+end) =
+struct
+  type nonrec 'v t = (K.t, 'v, K.comparator_witness) t
+end
+
+let update_multi map ~src ~dst ~f =
+  Option.fold (Map.find map src) ~init:(Map.remove map src)
+    ~f:(fun new_map src_data ->
+      Map.update new_map dst ~f:(fun dst_data ->
+          Option.fold dst_data ~init:src_data ~f))
+
+let change_multi map key data =
+  Map.change map key ~f:(function _ -> Some data)
+
+let filter map ~f = Map.map map ~f:(List.filter ~f)
+
+let to_list map = Map.to_alist map |> List.concat_map ~f:snd

--- a/lib/Multimap.mli
+++ b/lib/Multimap.mli
@@ -1,0 +1,38 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlFormat                               *)
+(*                                                                        *)
+(*            Copyright (c) Facebook, Inc. and its affiliates.            *)
+(*                                                                        *)
+(*      This source code is licensed under the MIT license found in       *)
+(*      the LICENSE file in the root directory of this source tree.       *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Maps with a list of values attached to a key. This is an extension of the
+    [Map] module, so these are compatible with [Map.mem], etc. *)
+
+type ('key, 'value, 'cmp) t = ('key, 'value list, 'cmp) Map.t
+
+module M (K : sig
+  type t
+
+  type comparator_witness
+end) : sig
+  type nonrec 'value t = (K.t, 'value, K.comparator_witness) t
+end
+
+val update_multi :
+     ('key, 'value, 'cmp) t
+  -> src:'key
+  -> dst:'key
+  -> f:('value list -> 'value list -> 'value list)
+  -> ('key, 'value, 'cmp) t
+
+val change_multi :
+  ('key, 'value, 'cmp) t -> 'key -> 'value list -> ('key, 'value, 'cmp) t
+
+val filter :
+  ('key, 'value, 'cmp) t -> f:('value -> bool) -> ('key, 'value, 'cmp) t
+
+val to_list : (_, 'value, _) t -> 'value list


### PR DESCRIPTION
When I added `Location.Set` and `Location.Multimap` I was not too familiar with some `base` APIs. This PR replaces these monomorphic containers by generic versions:

- `Location.Set` is replaced by plain `Set` calls
- `Location.Multimap` is replaced by a new `Multimap` module that contains extensions to `Map` for maps which hold a list as value.

Let me know how that looks.