### PR TITLE
Indent attributes attached to included modules better, simplify the formatting of simple modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@
 
   + Add missing break in module statement (#1431, @gpetiot)
 
+  + Indent attributes attached to included modules better (#1468, @gpetiot)
+
 #### New features
 
 ### 0.15.0 (2020-08-06)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4005,10 +4005,8 @@ and fmt_module_expr ?(can_break_before_struct = false) c ({ast= m; _} as xmod)
   | Pmod_functor _ ->
       let xargs, me = sugar_pmod_functor c ~for_functor_kw:true xmod in
       let doc, atrs = doc_atrs pmod_attributes in
-      let {opn; pro; psp; bdy; cls; esp; epi} = fmt_module_expr c me in
       { empty with
-        opn
-      ; bdy=
+        bdy=
           Cmts.fmt c pmod_loc
             ( fmt_docstring c ~epi:(fmt "@,") doc
             $ hvbox 0
@@ -4018,9 +4016,8 @@ and fmt_module_expr ?(can_break_before_struct = false) c ({ast= m; _} as xmod)
                    $ fmt "@;<1 2>"
                    $ list xargs "@;<1 2>" (fmt_functor_arg c)
                    $ fmt "@;<1 2>->@;<1 2>"
-                   $ hvbox 0 (fmt_opt pro $ psp $ bdy $ esp $ fmt_opt epi) ))
-            )
-      ; cls }
+                   $ compose_module (fmt_module_expr c me) ~f:(hvbox 0) )) )
+      }
   | Pmod_ident lid ->
       let doc, atrs = doc_atrs pmod_attributes in
       let has_pro = Cmts.has_before c.cmts pmod_loc || Option.is_some doc in

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4098,22 +4098,13 @@ and fmt_module_expr ?(can_break_before_struct = false) c ({ast= m; _} as xmod)
             $ fmt_attributes c ~pre:Space ~key:"@" atrs ) }
   | Pmod_unpack e1 ->
       let doc, atrs = doc_atrs pmod_attributes in
-      let has_epi =
-        Cmts.has_after c.cmts pmod_loc || not (List.is_empty atrs)
-      in
-      let has_pro = Cmts.has_before c.cmts pmod_loc || Option.is_some doc in
       { empty with
-        pro=
-          Option.some_if has_pro
-            (Cmts.fmt_before c pmod_loc $ fmt_docstring c ~epi:(fmt "@,") doc)
-      ; bdy=
+        bdy=
           Cmts.fmt c pmod_loc
-          @@ hvbox 2
-               (wrap_fits_breaks ~space:false c.conf "(" ")"
-                  (str "val " $ fmt_expression c (sub_exp ~ctx e1)))
-      ; epi=
-          Option.some_if has_epi
-            ( Cmts.fmt_after c pmod_loc
+            ( fmt_docstring c ~epi:(fmt "@,") doc
+            $ hvbox 2
+                (wrap_fits_breaks ~space:false c.conf "(" ")"
+                   (str "val " $ fmt_expression c (sub_exp ~ctx e1)))
             $ fmt_attributes c ~pre:Space ~key:"@" atrs ) }
   | Pmod_extension x1 ->
       let doc, atrs = doc_atrs pmod_attributes in

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3851,12 +3851,11 @@ and fmt_open_description c ?(keyword = "open") ~kw_attributes
   hovbox 0
     ( doc_before $ str keyword
     $ fmt_if (is_override popen_override) "!"
-    $ Cmts.fmt_before c popen_loc
-    $ fmt_attributes c ~key:"@" kw_attributes
-    $ str " "
-    $ fmt_longident_loc c popen_lid
-    $ fmt_attributes c ~pre:Blank ~key:"@@" atrs
-    $ Cmts.fmt_after c popen_loc
+    $ Cmts.fmt c popen_loc
+        ( fmt_attributes c ~key:"@" kw_attributes
+        $ str " "
+        $ fmt_longident_loc c popen_lid
+        $ fmt_attributes c ~pre:Blank ~key:"@@" atrs )
     $ doc_after )
 
 (** TODO: merge with `fmt_module_declaration` *)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4119,11 +4119,10 @@ and fmt_module_expr ?(can_break_before_struct = false) c ({ast= m; _} as xmod)
       let doc, atrs = doc_atrs pmod_attributes in
       { empty with
         bdy=
-          Cmts.fmt_before c pmod_loc
-          $ fmt_docstring c ~epi:(fmt "@,") doc
-          $ Cmts.fmt c pmod_loc (fmt_extension c ctx "%" x1)
-          $ Cmts.fmt_after c pmod_loc
-          $ fmt_attributes c ~pre:Space ~key:"@" atrs }
+          Cmts.fmt c pmod_loc
+            ( fmt_docstring c ~epi:(fmt "@,") doc
+            $ fmt_extension c ctx "%" x1
+            $ fmt_attributes c ~pre:Space ~key:"@" atrs ) }
 
 and fmt_structure c ctx itms =
   let update_config c i =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4117,19 +4117,13 @@ and fmt_module_expr ?(can_break_before_struct = false) c ({ast= m; _} as xmod)
             $ fmt_attributes c ~pre:Space ~key:"@" atrs ) }
   | Pmod_extension x1 ->
       let doc, atrs = doc_atrs pmod_attributes in
-      let has_pro = Cmts.has_before c.cmts pmod_loc || Option.is_some doc in
-      let has_epi =
-        Cmts.has_after c.cmts pmod_loc || not (List.is_empty atrs)
-      in
       { empty with
-        pro=
-          Option.some_if has_pro
-            (Cmts.fmt_before c pmod_loc $ fmt_docstring c ~epi:(fmt "@,") doc)
-      ; bdy= Cmts.fmt c pmod_loc @@ fmt_extension c ctx "%" x1
-      ; epi=
-          Option.some_if has_epi
-            ( Cmts.fmt_after c pmod_loc
-            $ fmt_attributes c ~pre:Space ~key:"@" atrs ) }
+        bdy=
+          Cmts.fmt_before c pmod_loc
+          $ fmt_docstring c ~epi:(fmt "@,") doc
+          $ Cmts.fmt c pmod_loc (fmt_extension c ctx "%" x1)
+          $ Cmts.fmt_after c pmod_loc
+          $ fmt_attributes c ~pre:Space ~key:"@" atrs }
 
 and fmt_structure c ctx itms =
   let update_config c i =

--- a/test/passing/module_attributes.ml.ref
+++ b/test/passing/module_attributes.ml.ref
@@ -14,15 +14,13 @@ include (M : S)
 include M (N)
 [@warning "item"] [@@warning "structure"]
 
-include [%ext]
-[@warning "item"] [@@warning "structure"]
+include [%ext] [@warning "item"] [@@warning "structure"]
 
-include (val M)
-[@warning "item"] [@@warning "structure"]
+include (val M) [@warning "item"] [@@warning "structure"]
 
 include
   (val Aaaaaaaaaaaaaaaa.Bbbbbbbbbbbbbbbb.Cccccccccccccccc.Dddddddddddddddd)
-[@warning "item"] [@@warning "structure"]
+  [@warning "item"] [@@warning "structure"]
 
 include (
   List :


### PR DESCRIPTION
The purpose of this PR was to simplify the formatting at first, fixing the indentation of the attributes is a fortunate outcome, but this PR is short enough to squeeze everything in one go.
No diff with test_branch.