### PR TITLE
Printast: do not pass indent level

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -656,12 +656,12 @@ module T = struct
     | Top
 
   let dump fs = function
-    | Pld l -> Format.fprintf fs "Pld:@\n%a" (Printast.payload 0) l
+    | Pld l -> Format.fprintf fs "Pld:@\n%a" Printast.payload l
     | Typ t -> Format.fprintf fs "Typ:@\n%a" Pprintast.core_type t
     | Pat p -> Format.fprintf fs "Pat:@\n%a" Pprintast.pattern p
     | Exp e ->
         Format.fprintf fs "Exp:@\n%a@\n@\n%a" Pprintast.expression e
-          (Printast.expression 0) e
+          Printast.expression e
     | Vb b ->
         let str =
           let open Ast_helper in

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -91,10 +91,10 @@ module Printast = struct
 
   let interface f x = interface f (to_current.copy_signature x)
 
-  let expression n f x = expression n f (to_current.copy_expression x)
+  let expression f x = expression 0 f (to_current.copy_expression x)
 
-  let payload n f (x : Parsetree.payload) =
-    payload n f
+  let payload f (x : Parsetree.payload) =
+    payload 0 f
       ( match x with
       | PStr x -> PStr (to_current.copy_structure x)
       | PSig x -> PSig (to_current.copy_signature x)

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -116,9 +116,9 @@ module Printast : sig
 
   val interface : Format.formatter -> Parsetree.signature -> unit
 
-  val payload : int -> Format.formatter -> Parsetree.payload -> unit
+  val payload : Format.formatter -> Parsetree.payload -> unit
 
-  val expression : int -> Format.formatter -> Parsetree.expression -> unit
+  val expression : Format.formatter -> Parsetree.expression -> unit
 
   val use_file : Format.formatter -> Parsetree.toplevel_phrase list -> unit
 end


### PR DESCRIPTION
This removes the `int` argument (always set to 0) in order to decrease the diff for the ppxlib port.