### PR TITLE
parse_wyc: removed unused modules from Migrate_ast

### DIFF
--- a/vendor/parse-wyc/lib/migrate_ast.ml
+++ b/vendor/parse-wyc/lib/migrate_ast.ml
@@ -58,22 +58,6 @@ module Docstrings = struct
   }
 end
 
-module Parse = struct
-  open Migrate_parsetree
-
-  let implementation = Parse.implementation selected_version
-
-  let interface = Parse.interface selected_version
-
-  let use_file lexbuf =
-    List.filter
-      (fun (p : Parsetree.toplevel_phrase) ->
-        match p with
-        | Ptop_def [] -> false
-        | Ptop_def (_ :: _) | Ptop_dir _ -> true)
-      (Parse.use_file selected_version lexbuf)
-end
-
 module Int = struct
   let compare x y = if x < y then -1 else if x > y then 1 else 0
 end

--- a/vendor/parse-wyc/lib/migrate_ast.ml
+++ b/vendor/parse-wyc/lib/migrate_ast.ml
@@ -1,5 +1,3 @@
-let selected_version = Migrate_parsetree.Versions.ocaml_408
-
 module Selected_version = Migrate_parsetree.Ast_408
 module Ast_mapper = Selected_version.Ast_mapper
 module Ast_helper = Selected_version.Ast_helper

--- a/vendor/parse-wyc/lib/migrate_ast.ml
+++ b/vendor/parse-wyc/lib/migrate_ast.ml
@@ -103,23 +103,6 @@ module Printast = struct
       x
 end
 
-module Pprintast = struct
-  open Pprintast
-
-  let structure f x = structure f (to_current.copy_structure x)
-
-  let signature f x = signature f (to_current.copy_signature x)
-
-  let core_type f x = core_type f (to_current.copy_core_type x)
-
-  let expression f x = expression f (to_current.copy_expression x)
-
-  let pattern f x = pattern f (to_current.copy_pattern x)
-
-  let toplevel_phrase f x =
-    toplevel_phrase f (to_current.copy_toplevel_phrase x)
-end
-
 module Int = struct
   let compare x y = if x < y then -1 else if x > y then 1 else 0
 end

--- a/vendor/parse-wyc/lib/migrate_ast.ml
+++ b/vendor/parse-wyc/lib/migrate_ast.ml
@@ -74,35 +74,6 @@ module Parse = struct
       (Parse.use_file selected_version lexbuf)
 end
 
-let to_current =
-  Migrate_parsetree.Versions.(migrate selected_version ocaml_current)
-
-module Printast = struct
-  open Printast
-
-  let implementation f x = implementation f (to_current.copy_structure x)
-
-  let interface f x = interface f (to_current.copy_signature x)
-
-  let expression n f x = expression n f (to_current.copy_expression x)
-
-  let payload n f (x : Parsetree.payload) =
-    payload n f
-      ( match x with
-      | PStr x -> PStr (to_current.copy_structure x)
-      | PSig x -> PSig (to_current.copy_signature x)
-      | PTyp x -> PTyp (to_current.copy_core_type x)
-      | PPat (x, Some y) ->
-          PPat (to_current.copy_pattern x, Some (to_current.copy_expression y))
-      | PPat (x, None) -> PPat (to_current.copy_pattern x, None) )
-
-  let use_file f (x : Parsetree.toplevel_phrase list) =
-    List.iter
-      (fun (p : Parsetree.toplevel_phrase) ->
-        top_phrase f (to_current.copy_toplevel_phrase p))
-      x
-end
-
 module Int = struct
   let compare x y = if x < y then -1 else if x > y then 1 else 0
 end

--- a/vendor/parse-wyc/lib/migrate_ast.mli
+++ b/vendor/parse-wyc/lib/migrate_ast.mli
@@ -68,17 +68,3 @@ module Printast : sig
 
   val use_file : Format.formatter -> Parsetree.toplevel_phrase list -> unit
 end
-
-module Pprintast : sig
-  val core_type : Format.formatter -> Parsetree.core_type -> unit
-
-  val pattern : Format.formatter -> Parsetree.pattern -> unit
-
-  val toplevel_phrase : Format.formatter -> Parsetree.toplevel_phrase -> unit
-
-  val expression : Format.formatter -> Parsetree.expression -> unit
-
-  val structure : Format.formatter -> Parsetree.structure -> unit
-
-  val signature : Format.formatter -> Parsetree.signature -> unit
-end

--- a/vendor/parse-wyc/lib/migrate_ast.mli
+++ b/vendor/parse-wyc/lib/migrate_ast.mli
@@ -48,11 +48,3 @@ module Mapper : sig
     Parsetree.toplevel_phrase list ->
     Parsetree.toplevel_phrase list
 end
-
-module Parse : sig
-  val implementation : Lexing.lexbuf -> Parsetree.structure
-
-  val interface : Lexing.lexbuf -> Parsetree.signature
-
-  val use_file : Lexing.lexbuf -> Parsetree.toplevel_phrase list
-end

--- a/vendor/parse-wyc/lib/migrate_ast.mli
+++ b/vendor/parse-wyc/lib/migrate_ast.mli
@@ -56,15 +56,3 @@ module Parse : sig
 
   val use_file : Lexing.lexbuf -> Parsetree.toplevel_phrase list
 end
-
-module Printast : sig
-  val implementation : Format.formatter -> Parsetree.structure -> unit
-
-  val interface : Format.formatter -> Parsetree.signature -> unit
-
-  val payload : int -> Format.formatter -> Parsetree.payload -> unit
-
-  val expression : int -> Format.formatter -> Parsetree.expression -> unit
-
-  val use_file : Format.formatter -> Parsetree.toplevel_phrase list -> unit
-end

--- a/vendor/parse-wyc/lib/migrate_ast.mli
+++ b/vendor/parse-wyc/lib/migrate_ast.mli
@@ -1,7 +1,3 @@
-val selected_version :
-  Migrate_parsetree.Versions.OCaml_408.types
-  Migrate_parsetree.Versions.ocaml_version
-
 module Selected_version = Migrate_parsetree.Ast_408
 module Ast_mapper = Selected_version.Ast_mapper
 module Ast_helper = Selected_version.Ast_helper


### PR DESCRIPTION
These have been copied from the main Migrate_ast but are not used (and will hinder ppxlib compatibility)