### PR TITLE
Use plain Format from OCaml for debug messages

### DIFF
--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -9,7 +9,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Format = Format_
 open Migrate_ast
 
 module T = struct

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -218,7 +218,7 @@ let add_cmts t ?prev ?next position loc cmts =
             Option.value_map next ~default:"no next"
               ~f:(string_between cmt_loc)
           in
-          Format.eprintf "add %s %a: %a \"%s\" %s \"%s\"@\n%!"
+          Caml.Format.eprintf "add %s %a: %a \"%s\" %s \"%s\"@\n%!"
             (position_to_string position)
             Location.fmt loc Location.fmt cmt_loc (String.escaped btw_prev)
             cmt_txt (String.escaped btw_next)) ;
@@ -261,7 +261,7 @@ let rec place t loc_tree ?prev_loc locs cmts =
 let relocate (t : t) ~src ~before ~after =
   if t.remove then (
     if t.debug then
-      Format.eprintf "relocate %a to %a and %a@\n%!" Location.fmt src
+      Caml.Format.eprintf "relocate %a to %a and %a@\n%!" Location.fmt src
         Location.fmt before Location.fmt after ;
     let merge_and_sort x y =
       List.rev_append x y
@@ -323,7 +323,7 @@ let init map_ast ~debug source asts comments_n_docstrings =
   if debug then (
     Format.eprintf "\nComments:\n%!" ;
     List.iter comments ~f:(fun {Cmt.txt; loc} ->
-        Format.eprintf "%a %s %s@\n%!" Location.fmt loc txt
+        Caml.Format.eprintf "%a %s %s@\n%!" Location.fmt loc txt
           (if Source.ends_line source loc then "eol" else "")) ) ;
   if not (List.is_empty comments) then (
     let loc_tree, locs = Loc_tree.of_ast map_ast asts source in

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -128,7 +128,6 @@ end
 
 module Position = struct
   open Lexing
-  module Format = Format_
 
   type t = position
 
@@ -154,7 +153,6 @@ end
 
 module Location = struct
   include Selected_version.Location
-  module Format = Format_
 
   let fmt fs {loc_start; loc_end; loc_ghost} =
     Format.fprintf fs "(%a..%a)%s" Position.fmt loc_start Position.fmt

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -81,7 +81,7 @@ module Location : sig
 
   val compare_end_col : t -> t -> int
 
-  val fmt : Format_.formatter -> t -> unit
+  val fmt : Format.formatter -> t -> unit
 
   val smallest : t -> t list -> t
 


### PR DESCRIPTION
These are never put in the formatted output, so the plain Format works.