### PR TITLE
Abstract types of AST iterations in terms of a "fragment" type

### DIFF
--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -45,14 +45,13 @@ let find_at_position t loc pos =
 module Loc_tree : sig
   include Non_overlapping_interval_tree.S with type itv = Location.t
 
-  val of_ast :
-    (Ast_mapper.mapper -> 'a -> _) -> 'a -> Source.t -> t * Location.t list
+  val of_ast : 'a Mapper.fragment -> 'a -> Source.t -> t * Location.t list
 end = struct
   include Non_overlapping_interval_tree.Make (Location)
 
   (* Use Ast_mapper to collect all locs in ast, and create tree of them. *)
 
-  let of_ast map_ast ast src =
+  let of_ast fragment ast src =
     let attribute (m : Ast_mapper.mapper) attr =
       (* ignore location of docstrings *)
       if Ast.Attr.is_doc attr then attr
@@ -81,7 +80,7 @@ end = struct
     let mapper =
       Ast_mapper.{default_mapper with location; pat; attribute; expr}
     in
-    map_ast mapper ast |> ignore ;
+    Mapper.map_ast fragment mapper ast |> ignore ;
     (of_list !locs, !locs)
 end
 
@@ -309,7 +308,7 @@ let relocate_wrongfully_attached_cmts t src exp =
   | _ -> ()
 
 (** Initialize global state and place comments. *)
-let init map_ast ~debug source asts comments_n_docstrings =
+let init fragment ~debug source asts comments_n_docstrings =
   let t =
     { debug
     ; cmts_before= Map.empty (module Location)
@@ -319,14 +318,14 @@ let init map_ast ~debug source asts comments_n_docstrings =
     ; remaining= Set.empty (module Location)
     ; remove= true }
   in
-  let comments = Normalize.dedup_cmts map_ast asts comments_n_docstrings in
+  let comments = Normalize.dedup_cmts fragment asts comments_n_docstrings in
   if debug then (
     Format.eprintf "\nComments:\n%!" ;
     List.iter comments ~f:(fun {Cmt.txt; loc} ->
         Caml.Format.eprintf "%a %s %s@\n%!" Location.fmt loc txt
           (if Source.ends_line source loc then "eol" else "")) ) ;
   if not (List.is_empty comments) then (
-    let loc_tree, locs = Loc_tree.of_ast map_ast asts source in
+    let loc_tree, locs = Loc_tree.of_ast fragment asts source in
     if debug then
       List.iter locs ~f:(fun loc ->
           if not (Location.compare loc Location.none = 0) then
@@ -356,16 +355,14 @@ let init map_ast ~debug source asts comments_n_docstrings =
       relocate_loc_stack x.ppat_loc x.ppat_loc_stack ;
       Ast_mapper.default_mapper.pat m x
     in
-    let _ = map_ast Ast_mapper.{default_mapper with pat; typ; expr} asts in
+    let _ =
+      Mapper.map_ast fragment
+        Ast_mapper.{default_mapper with pat; typ; expr}
+        asts
+    in
     ()
   in
   t
-
-let init_impl = init Mapper.structure
-
-let init_intf = init Mapper.signature
-
-let init_toplevel = init Mapper.use_file
 
 let preserve fmt_x t =
   let buf = Buffer.create 128 in
@@ -507,8 +504,8 @@ let diff (conf : Conf.t) x y =
             let len = String.length str - chars_removed in
             let str = String.sub ~pos:1 ~len str in
             try
-              Migrate_ast.Parse.implementation (Lexing.from_string str)
-              |> Normalize.impl conf
+              Migrate_ast.Parse.fragment Structure (Lexing.from_string str)
+              |> Normalize.normalize Structure conf
               |> Caml.Format.asprintf "%a" Printast.implementation
             with _ -> norm_non_code z
           else norm_non_code z

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -28,26 +28,11 @@ open Migrate_ast
 
 type t
 
-val init_impl :
-  debug:bool -> Source.t -> Parsetree.structure -> Cmt.t list -> t
-(** [init_impl source structure comments] associates each comment in
-    [comments] with a source location appearing in [structure]. It uses
-    [Source] to help resolve ambiguities. Initializes the state used by the
-    [fmt] functions. *)
-
-val init_intf :
-  debug:bool -> Source.t -> Parsetree.signature -> Cmt.t list -> t
-(** [init_inft source signature comments] associates each comment in
-    [comments] with a source location appearing in [signature]. It uses
-    [Source] to help resolve ambiguities. Initializes the state used by the
-    [fmt] functions. *)
-
-val init_toplevel :
-  debug:bool -> Source.t -> Parsetree.toplevel_phrase list -> Cmt.t list -> t
-(** [init_toplevel source toplevel comments] associates each comment in
-    [comments] with a source location appearing in [toplevel]. It uses
-    [Source] to help resolve ambiguities. Initializes the state used by the
-    [fmt] functions. *)
+val init :
+  'a Mapper.fragment -> debug:bool -> Source.t -> 'a -> Cmt.t list -> t
+(** [init fragment source x comments] associates each comment in [comments]
+    with a source location appearing in [x]. It uses [Source] to help resolve
+    ambiguities. Initializes the state used by the [fmt] functions. *)
 
 val relocate :
   t -> src:Location.t -> before:Location.t -> after:Location.t -> unit

--- a/lib/Fmt_ast.mli
+++ b/lib/Fmt_ast.mli
@@ -9,21 +9,14 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Format = Format_
-
 (** Format OCaml Ast *)
 
-open Migrate_ast
-open Parsetree
-
-val fmt_signature :
-  debug:bool -> Source.t -> Cmts.t -> Conf.t -> signature -> Fmt.t
-(** Format a signature. *)
-
-val fmt_structure :
-  debug:bool -> Source.t -> Cmts.t -> Conf.t -> structure -> Fmt.t
-(** Format a structure. *)
-
-val fmt_toplevel :
-  debug:bool -> Source.t -> Cmts.t -> Conf.t -> toplevel_phrase list -> Fmt.t
-(** Format a toplevel structure. *)
+val fmt_fragment :
+     'a list Migrate_ast.Mapper.fragment
+  -> debug:bool
+  -> Source.t
+  -> Cmts.t
+  -> Conf.t
+  -> 'a list
+  -> Fmt.t
+(** Format a fragment. *)

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -90,25 +90,19 @@ module Location : sig
   val is_single_line : t -> int -> bool
 end
 
-module Parse : sig
-  val implementation : Lexing.lexbuf -> Parsetree.structure
+module Mapper : sig
+  type 'a fragment =
+    | Structure : Parsetree.structure fragment
+    | Signature : Parsetree.signature fragment
+    | Use_file : Parsetree.toplevel_phrase list fragment
 
-  val interface : Lexing.lexbuf -> Parsetree.signature
+  val equal : 'a fragment -> 'a -> 'a -> bool
 
-  val use_file : Lexing.lexbuf -> Parsetree.toplevel_phrase list
+  val map_ast : 'a fragment -> Ast_mapper.mapper -> 'a -> 'a
 end
 
-module Mapper : sig
-  val structure :
-    Ast_mapper.mapper -> Parsetree.structure -> Parsetree.structure
-
-  val signature :
-    Ast_mapper.mapper -> Parsetree.signature -> Parsetree.signature
-
-  val use_file :
-       Ast_mapper.mapper
-    -> Parsetree.toplevel_phrase list
-    -> Parsetree.toplevel_phrase list
+module Parse : sig
+  val fragment : 'a Mapper.fragment -> Lexing.lexbuf -> 'a
 end
 
 module Printast : sig
@@ -121,6 +115,8 @@ module Printast : sig
   val expression : Format.formatter -> Parsetree.expression -> unit
 
   val use_file : Format.formatter -> Parsetree.toplevel_phrase list -> unit
+
+  val fragment : 'a Mapper.fragment -> Format.formatter -> 'a -> unit
 end
 
 module Pprintast : sig

--- a/lib/Normalize.mli
+++ b/lib/Normalize.mli
@@ -12,10 +12,8 @@
 (** Normalize abstract syntax trees *)
 
 open Migrate_ast
-open Parsetree
 
-val dedup_cmts :
-  (Ast_mapper.mapper -> 'a -> 'a) -> 'a -> Cmt.t list -> Cmt.t list
+val dedup_cmts : 'a Mapper.fragment -> 'a -> Cmt.t list -> Cmt.t list
 
 val comment : string -> string
 (** Normalize a comment. *)
@@ -23,46 +21,21 @@ val comment : string -> string
 val docstring : Conf.t -> string -> string
 (** Normalize a docstring. *)
 
-val impl : Conf.t -> structure -> structure
-(** Normalize a structure. *)
+val normalize : 'a Mapper.fragment -> Conf.t -> 'a -> 'a
+(** Normalize an AST fragment. *)
 
-val intf : Conf.t -> signature -> signature
-(** Normalize a signature. *)
-
-val toplevel : Conf.t -> toplevel_phrase list -> toplevel_phrase list
-(** Normalize a toplevel structure. *)
-
-val equal_impl :
-  ignore_doc_comments:bool -> Conf.t -> structure -> structure -> bool
-(** Compare structures for equality up to normalization. *)
-
-val equal_intf :
-  ignore_doc_comments:bool -> Conf.t -> signature -> signature -> bool
-(** Compare signatures for equality up to normalization. *)
-
-val equal_toplevel :
-     ignore_doc_comments:bool
+val equal :
+     'a Mapper.fragment
+  -> ignore_doc_comments:bool
   -> Conf.t
-  -> toplevel_phrase list
-  -> toplevel_phrase list
+  -> 'a
+  -> 'a
   -> bool
-(** Compare toplevel for equality up to normalization. *)
-
-val mapper : Conf.t -> Ast_mapper.mapper
-(** Ast_mapper for normalization transformations. *)
+(** Compare fragments for equality up to normalization. *)
 
 type docstring_error =
   | Moved of Location.t * Location.t * string
   | Unstable of Location.t * string
 
-val moved_docstrings_impl :
-  Conf.t -> structure -> structure -> docstring_error list
-
-val moved_docstrings_intf :
-  Conf.t -> signature -> signature -> docstring_error list
-
-val moved_docstrings_toplevel :
-     Conf.t
-  -> toplevel_phrase list
-  -> toplevel_phrase list
-  -> docstring_error list
+val moved_docstrings :
+  'a Mapper.fragment -> Conf.t -> 'a -> 'a -> docstring_error list

--- a/lib/Parse_with_comments.ml
+++ b/lib/Parse_with_comments.ml
@@ -26,7 +26,7 @@ end
 
 exception Warning50 of (Location.t * Warnings.t) list
 
-let parse parse_ast (conf : Conf.t) ~source =
+let parse fragment (conf : Conf.t) ~source =
   let lexbuf = Lexing.from_string source in
   let warnings =
     W.enable 50
@@ -49,7 +49,7 @@ let parse parse_ast (conf : Conf.t) ~source =
             false
         | _ -> not conf.quiet)
       ~f:(fun () ->
-        let ast = parse_ast lexbuf in
+        let ast = Migrate_ast.Parse.fragment fragment lexbuf in
         Warnings.check_fatal () ;
         let comments =
           List.map

--- a/lib/Parse_with_comments.mli
+++ b/lib/Parse_with_comments.mli
@@ -26,4 +26,7 @@ end
 exception Warning50 of (Location.t * Warnings.t) list
 
 val parse :
-  (Lexing.lexbuf -> 'a) -> Conf.t -> source:string -> 'a with_comments
+     'a Migrate_ast.Mapper.fragment
+  -> Conf.t
+  -> source:string
+  -> 'a with_comments

--- a/vendor/parse-wyc/lib/migrate_ast.ml
+++ b/vendor/parse-wyc/lib/migrate_ast.ml
@@ -32,6 +32,17 @@ module Mapper = struct
                 pdir_loc = mapper.location mapper pdir_loc;
               })
       use_file
+
+  type 'a fragment =
+    | Structure : Parsetree.structure fragment
+    | Signature : Parsetree.signature fragment
+    | Use_file : Parsetree.toplevel_phrase list fragment
+
+  let map_ast (type a) (x : a fragment) : Ast_mapper.mapper -> a -> a =
+    match x with
+    | Structure -> structure
+    | Signature -> signature
+    | Use_file -> use_file
 end
 
 module Docstrings = struct

--- a/vendor/parse-wyc/lib/migrate_ast.mli
+++ b/vendor/parse-wyc/lib/migrate_ast.mli
@@ -33,14 +33,10 @@ module Location : sig
 end
 
 module Mapper : sig
-  val structure :
-    Ast_mapper.mapper -> Parsetree.structure -> Parsetree.structure
+  type 'a fragment =
+    | Structure : Parsetree.structure fragment
+    | Signature : Parsetree.signature fragment
+    | Use_file : Parsetree.toplevel_phrase list fragment
 
-  val signature :
-    Ast_mapper.mapper -> Parsetree.signature -> Parsetree.signature
-
-  val use_file :
-    Ast_mapper.mapper ->
-    Parsetree.toplevel_phrase list ->
-    Parsetree.toplevel_phrase list
+  val map_ast : 'a fragment -> Ast_mapper.mapper -> 'a -> 'a
 end


### PR DESCRIPTION
In several places, we are doing the same kind of processing but on different bits of the AST. For example normalizing structures/signatures/use_files, or collecting comments in structure/signatures/use_file. The current abstraction is to pass mapping functions to the bits that do the processing, but this has several drawbacks: this is not very regular (sometimes we need to pass `mapper -> 'a -> 'a`, sometimes `'a -> 'a -> bool`, etc), and it leaks `mapper` in the interface.

This PR adds a type `'a fragment` which represents operations on `'a`, and replaces completely `Translation_unit.t` (which took the dual approach of putting all operations in a record).

This simplifies many places by only exposing 1 function that operates on fragments rather than the 3 variants, and in the context of ppxlib migration this means that we will only have to change the type of `map_ast` so that it takes a ppxlib-based mapper instead of an OMP mapper.