### PR TITLE
Use OMP2 + ppxlib instead of OMP1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,10 @@
 
 #### New features
 
+#### Internal
+
+  + Use ppxlib instead of ocaml-migrate-parsetree 1.x. (#1482, @emillon)
+
 ### 0.15.0 (2020-08-06)
 
 #### Changes

--- a/dune-project
+++ b/dune-project
@@ -49,13 +49,11 @@
   fix
   fpath
   menhir
-  (ocaml-migrate-parsetree
-   (and
-    (>= 1.7.3)
-    (< 2.0.0)))
   (ocp-indent :with-test)
   (odoc
    (>= 1.4.2))
+  (ppxlib
+   (>= 0.18.0))
   re
   (stdio
    (< v0.15))

--- a/lib/Loc_tree.ml
+++ b/lib/Loc_tree.ml
@@ -13,34 +13,39 @@ open Migrate_ast
 open Parsetree
 include Non_overlapping_interval_tree.Make (Location)
 
+(** Use Ast_mapper to collect all locs in ast, and create tree of them. *)
 let of_ast fragment ast src =
-  let attribute (m : Ast_mapper.mapper) attr =
-    (* ignore location of docstrings *)
-    if Ast.Attr.is_doc attr then attr
-    else Ast_mapper.default_mapper.attribute m attr
-  in
   let locs = ref [] in
-  let location _ loc =
-    locs := loc :: !locs ;
-    loc
-  in
-  let pat m p =
-    ( match p.ppat_desc with
-    | Ppat_record (flds, Open) ->
-        Option.iter (Source.loc_of_underscore src flds p.ppat_loc)
-          ~f:(fun loc -> locs := loc :: !locs)
-    | Ppat_constant _ -> locs := Source.loc_of_pat_constant src p :: !locs
-    | _ -> () ) ;
-    Ast_mapper.default_mapper.pat m p
-  in
-  let expr m e =
-    ( match e.pexp_desc with
-    | Pexp_constant _ -> locs := Source.loc_of_expr_constant src e :: !locs
-    | _ -> () ) ;
-    Ast_mapper.default_mapper.expr m e
-  in
+  let add_loc loc = locs := loc :: !locs in
   let mapper =
-    Ast_mapper.{default_mapper with location; pat; attribute; expr}
+    object
+      inherit Ppxlib.Ast_traverse.map as super
+
+      method! location loc = add_loc loc ; loc
+
+      method! pattern p =
+        ( match p.ppat_desc with
+        | Ppat_record (flds, Open) ->
+            Option.iter
+              (Source.loc_of_underscore src flds p.ppat_loc)
+              ~f:add_loc
+        | _ -> () ) ;
+        super#pattern p
+
+      method! attribute attr =
+        (* ignore location of docstrings *)
+        if Ast.Attr.is_doc attr then attr else super#attribute attr
+
+      (** Ast_traverse recurses down to locations in stacks *)
+      method! location_stack l = l
+
+      method! expression e =
+        ( match e.pexp_desc with
+        | Pexp_constant _ ->
+            locs := Source.loc_of_expr_constant src e :: !locs
+        | _ -> () ) ;
+        super#expression e
+    end
   in
   Mapper.map_ast fragment mapper ast |> ignore ;
   (of_list !locs, !locs)

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -9,16 +9,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val selected_version :
-  Migrate_parsetree.Versions.OCaml_411.types
-  Migrate_parsetree.Versions.ocaml_version
-
-module Selected_version = Ast_411
-module Ast_mapper = Selected_version.Ast_mapper
-module Ast_helper = Selected_version.Ast_helper
+module Ast_helper = Ppxlib.Ast_helper
 
 module Parsetree : sig
-  include module type of Selected_version.Parsetree
+  include module type of Ppxlib.Parsetree
 
   val equal_core_type : core_type -> core_type -> bool
 
@@ -30,7 +24,7 @@ module Parsetree : sig
 end
 
 module Asttypes : sig
-  include module type of Selected_version.Asttypes
+  include module type of Ppxlib.Asttypes
 
   val is_private : private_flag -> bool
 
@@ -52,7 +46,7 @@ module Position : sig
 end
 
 module Location : sig
-  include module type of Selected_version.Location
+  include module type of Ppxlib.Location
 
   type comparator_witness
 
@@ -98,7 +92,7 @@ module Mapper : sig
 
   val equal : 'a fragment -> 'a -> 'a -> bool
 
-  val map_ast : 'a fragment -> Ast_mapper.mapper -> 'a -> 'a
+  val map_ast : 'a fragment -> Ppxlib.Ast_traverse.map -> 'a -> 'a
 end
 
 module Parse : sig
@@ -119,19 +113,7 @@ module Printast : sig
   val fragment : 'a Mapper.fragment -> Format.formatter -> 'a -> unit
 end
 
-module Pprintast : sig
-  val core_type : Format.formatter -> Parsetree.core_type -> unit
-
-  val pattern : Format.formatter -> Parsetree.pattern -> unit
-
-  val toplevel_phrase : Format.formatter -> Parsetree.toplevel_phrase -> unit
-
-  val expression : Format.formatter -> Parsetree.expression -> unit
-
-  val structure : Format.formatter -> Parsetree.structure -> unit
-
-  val signature : Format.formatter -> Parsetree.signature -> unit
-end
+module Pprintast = Ppxlib.Pprintast
 
 module Longident : sig
   type t = Longident.t =

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -106,7 +106,7 @@ let tokens_between t ~filter loc_start loc_end =
     match Lexer.token lexbuf with
     | Parser.EOF -> List.rev acc
     | tok ->
-        if filter tok then loop ((tok, Location.curr lexbuf) :: acc)
+        if filter tok then loop ((tok, Location.of_lexbuf lexbuf) :: acc)
         else loop acc
   in
   loop []
@@ -129,7 +129,7 @@ let find_after t f (loc : Location.t) =
   let rec loop () =
     match Lexer.token lexbuf with
     | Parser.EOF -> None
-    | tok -> if f tok then Some (Location.curr lexbuf) else loop ()
+    | tok -> if f tok then Some (Location.of_lexbuf lexbuf) else loop ()
   in
   loop ()
 

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -311,7 +311,7 @@ let rec functor_type cmts ~for_functor_kw ~source_is_long
         | [] -> functor_type cmts ~for_functor_kw ~source_is_long body
         | _ -> ([], body)
       in
-      (Location.mkloc functor_arg pmty_loc :: xargs, xbody)
+      (Ppxlib.Loc.make ~loc:pmty_loc functor_arg :: xargs, xbody)
   | _ -> ([], xmty)
 
 (* The sugar is different when used with the [functor] keyword. The syntax
@@ -334,7 +334,7 @@ let rec functor_ cmts ~for_functor_kw ~source_is_long ({ast= me; _} as xme) =
         | [] -> functor_ cmts ~for_functor_kw ~source_is_long body
         | _ -> ([], body)
       in
-      (Location.mkloc functor_arg pmod_loc :: xargs, xbody_me)
+      (Ppxlib.Loc.make ~loc:pmod_loc functor_arg :: xargs, xbody_me)
   | _ -> ([], xme)
 
 let mod_with pmty =

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -150,21 +150,21 @@ let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~input_name error
                         "%!@{<loc>%a@}:@,\
                          @{<error>Error@}: Docstring (** %s *) added.\n\
                          %!"
-                        Location.print_loc loc_after (ellipsis_cmt msg)
+                        Location.print loc_after (ellipsis_cmt msg)
                     else if Location.compare loc_after Location.none = 0 then
                       Format.fprintf fmt
                         "%!@{<loc>%a@}:@,\
                          @{<error>Error@}: Docstring (** %s *) dropped.\n\
                          %!"
-                        Location.print_loc loc_before (ellipsis_cmt msg)
+                        Location.print loc_before (ellipsis_cmt msg)
                     else
                       Format.fprintf fmt
                         "%!@{<loc>%a@}:@,\
                          @{<error>Error@}: Docstring (** %s *) moved to \
                          @{<loc>%a@}.\n\
                          %!"
-                        Location.print_loc loc_before (ellipsis_cmt msg)
-                        Location.print_loc loc_after
+                        Location.print loc_before (ellipsis_cmt msg)
+                        Location.print loc_after
                 | Normalize.Unstable (loc, s) ->
                     Format.fprintf fmt
                       "%!@{<loc>%a@}:@,\
@@ -174,14 +174,14 @@ let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~input_name error
                        source or disable the formatting using the option \
                        --no-parse-docstrings.\n\
                        %!"
-                      Location.print_loc loc (ellipsis_cmt s))
+                      Location.print loc (ellipsis_cmt s))
           | `Comment_dropped l when not quiet ->
               List.iter l ~f:(fun Cmt.{txt= msg; loc} ->
                   Format.fprintf fmt
                     "%!@{<loc>%a@}:@,\
                      @{<error>Error@}: Comment (* %s *) dropped.\n\
                      %!"
-                    Location.print_loc loc (ellipsis_cmt msg))
+                    Location.print loc (ellipsis_cmt msg))
           | `Cannot_parse ((Syntaxerr.Error _ | Lexer.Error _) as exn) ->
               if debug then Location.report_exception fmt exn
           | `Warning50 l ->
@@ -199,7 +199,7 @@ let check_all_locations fmt cmts_t =
   match Cmts.remaining_locs cmts_t with
   | [] -> ()
   | l ->
-      let print l = Format.fprintf fmt "%a\n%!" Location.print_loc l in
+      let print l = Format.fprintf fmt "%a\n%!" Location.print l in
       Format.fprintf fmt
         "Warning: Some locations have not been considered\n%!" ;
       List.iter ~f:print (List.sort l ~compare:Location.compare)
@@ -247,7 +247,7 @@ let format fragment ?output_file ~input_name ~source ~parsed conf opts =
       Some (dump_formatted ~input_name ?output_file ~suffix fmted)
     else None
   in
-  Location.input_name := input_name ;
+  Ocaml_common.Location.input_name := input_name ;
   (* iterate until formatting stabilizes *)
   let rec print_check ~i ~(conf : Conf.t) t ~source =
     let format ~box_debug =
@@ -392,7 +392,7 @@ let parse_result fragment conf (opts : Conf.opts) ~source ~input_name =
   | parsed -> Ok parsed
 
 let parse_and_format fragment ?output_file ~input_name ~source conf opts =
-  Location.input_name := input_name ;
+  Ocaml_common.Location.input_name := input_name ;
   let open Result.Monad_infix in
   parse_result fragment conf opts ~source ~input_name
   >>= fun parsed ->

--- a/lib/dune
+++ b/lib/dune
@@ -17,4 +17,4 @@
   (:standard -open Base -open Import -open Compat))
  ;;INSERT_BISECT_HERE;;
  (libraries format_ import ocaml-migrate-parsetree odoc.model odoc.parser
-   parse_wyc re uuseg uuseg.string token_latest compat dune-build-info))
+   parse_wyc re uuseg uuseg.string token_latest compat dune-build-info ppxlib))

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -19,9 +19,9 @@ depends: [
   "fix"
   "fpath"
   "menhir"
-  "ocaml-migrate-parsetree" {>= "1.7.3" & < "2.0.0"}
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
+  "ppxlib" {>= "0.18.0"}
   "re"
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}

--- a/vendor/parse-wyc/lib/annot.ml
+++ b/vendor/parse-wyc/lib/annot.ml
@@ -1,50 +1,36 @@
 open Ast_helper
 open Migrate_ast.Parsetree
 
-module type Annotated = sig
-  type t
-
-  val mk : unit -> t
-
-  val is_generated : t -> bool
-end
-
 module Ext = struct
   let mk () = (Location.mkloc "merlin.hole" !default_loc, PStr [])
 
   let is_generated = function
-    | (({ txt = "merlin.hole"; _ }, PStr []) : extension) -> true
+    | (({ txt = "merlin.hole"; _ }, PStr []) : Ppxlib.extension) -> true
     | _ -> false
 end
 
 module Exp = struct
-  type t = expression
-
   let mk () = Exp.extension (Ext.mk ())
 
-  let is_generated e =
+  let is_generated (e : Ppxlib.expression) =
     match e.pexp_desc with
     | Pexp_extension ext when Ext.is_generated ext -> true
     | _ -> false
 end
 
 module Attr = struct
-  type t = attribute
-
   let mk () = Attr.mk { txt = "merlin.hole.gen"; loc = Location.none } (PStr [])
 
-  let is_generated a =
+  let is_generated (a : Ppxlib.attribute) =
     match (a.attr_name.txt, a.attr_payload) with
     | "merlin.hole.gen", PStr [] -> true
     | _ -> false
 end
 
 module Class_exp = struct
-  type t = class_expr
-
   let mk () = Cl.extension (Ext.mk ())
 
-  let is_generated e =
+  let is_generated (e : Ppxlib.class_expr) =
     match e.pcl_desc with
     | Pcl_extension ext when Ext.is_generated ext -> true
     | _ -> false

--- a/vendor/parse-wyc/lib/annot.mli
+++ b/vendor/parse-wyc/lib/annot.mli
@@ -1,15 +1,17 @@
-module type Annotated = sig
-  type t
+module Exp : sig
+  val mk : unit -> Migrate_ast.Parsetree.expression
 
-  val mk : unit -> t
-
-  val is_generated : t -> bool
+  val is_generated : Ppxlib.Parsetree.expression -> bool
 end
 
-open Migrate_ast.Parsetree
+module Attr : sig
+  val mk : unit -> Migrate_ast.Parsetree.attribute
 
-module Exp : Annotated with type t = expression
+  val is_generated : Ppxlib.Parsetree.attribute -> bool
+end
 
-module Attr : Annotated with type t = attribute
+module Class_exp : sig
+  val mk : unit -> Migrate_ast.Parsetree.class_expr
 
-module Class_exp : Annotated with type t = class_expr
+  val is_generated : Ppxlib.Parsetree.class_expr -> bool
+end

--- a/vendor/parse-wyc/lib/dune
+++ b/vendor/parse-wyc/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name parse_wyc)
- (libraries menhirLib ocaml-migrate-parsetree)
+ (libraries menhirLib ocaml-migrate-parsetree ppxlib)
  (modules_without_implementation let_binding))
 
 (ocamllex lexer)

--- a/vendor/parse-wyc/lib/migrate_ast.ml
+++ b/vendor/parse-wyc/lib/migrate_ast.ml
@@ -1,47 +1,36 @@
 module Selected_version = Migrate_parsetree.Ast_408
-module Ast_mapper = Selected_version.Ast_mapper
 module Parsetree = Selected_version.Parsetree
 module Asttypes = Selected_version.Asttypes
 
 module Mapper = struct
-  let structure = Selected_version.map_structure
+  type ('omp, 'ppxlib) fragment =
+    | Structure
+        : ( Selected_version.Parsetree.structure,
+            Ppxlib.Parsetree.structure )
+          fragment
+    | Signature
+        : ( Selected_version.Parsetree.signature,
+            Ppxlib.Parsetree.signature )
+          fragment
+    | Use_file
+        : ( Selected_version.Parsetree.toplevel_phrase list,
+            Ppxlib.Parsetree.toplevel_phrase list )
+          fragment
 
-  let signature = Selected_version.map_signature
+  let iter_ast (type o p) (fragment:(o, p) fragment) (m:Ppxlib.Ast_traverse.iter) (x:p) =
+    match fragment with
+    | Structure -> m#structure x
+    | Signature -> m#signature x
+    | Use_file -> List.iter m#toplevel_phrase x
 
-  (* Missing from ocaml_migrate_parsetree *)
-  let use_file (mapper : Ast_mapper.mapper) use_file =
-    let open Parsetree in
-    List.map
-      (fun toplevel_phrase ->
-        match (toplevel_phrase : toplevel_phrase) with
-        | Ptop_def structure ->
-            Ptop_def (mapper.Ast_mapper.structure mapper structure)
-        | Ptop_dir { pdir_name; pdir_arg; pdir_loc } ->
-            let pdir_arg =
-              match pdir_arg with
-              | None -> None
-              | Some a ->
-                  Some { a with pdira_loc = mapper.location mapper a.pdira_loc }
-            in
-            Ptop_dir
-              {
-                pdir_name =
-                  { pdir_name with loc = mapper.location mapper pdir_name.loc };
-                pdir_arg;
-                pdir_loc = mapper.location mapper pdir_loc;
-              })
-      use_file
 
-  type 'a fragment =
-    | Structure : Parsetree.structure fragment
-    | Signature : Parsetree.signature fragment
-    | Use_file : Parsetree.toplevel_phrase list fragment
-
-  let map_ast (type a) (x : a fragment) : Ast_mapper.mapper -> a -> a =
-    match x with
-    | Structure -> structure
-    | Signature -> signature
-    | Use_file -> use_file
+  let to_ppxlib (type o p) (f:(o, p) fragment) : o -> p =
+    let module Conv = Ppxlib_ast.Select_ast (Ppxlib_ast__.Versions.OCaml_408) in
+    let module To_ppxlib = Conv.Of_ocaml in
+    match f with
+    | Structure -> To_ppxlib.copy_structure
+    | Signature -> To_ppxlib.copy_signature
+    | Use_file -> List.map To_ppxlib.copy_toplevel_phrase
 end
 
 module Int = struct
@@ -55,15 +44,9 @@ module Position = struct
 end
 
 module Location = struct
-  include Selected_version.Location
+  include Ppxlib.Location
 
-  let compare_start x y = Position.compare x.loc_start y.loc_start
-
-  let compare_end x y = Position.compare x.loc_end y.loc_end
-
-  let compare x y =
-    let st = compare_start x y in
-    if st = 0 then compare_end x y else st
+  let curr = of_lexbuf
 
   let merge x y =
     if Position.compare x.loc_end y.loc_start >= 0 then

--- a/vendor/parse-wyc/lib/migrate_ast.mli
+++ b/vendor/parse-wyc/lib/migrate_ast.mli
@@ -1,21 +1,31 @@
 module Selected_version = Migrate_parsetree.Ast_408
-module Ast_mapper = Selected_version.Ast_mapper
 module Parsetree = Selected_version.Parsetree
 module Asttypes = Selected_version.Asttypes
 
-module Location : sig
-  include module type of Selected_version.Location
+module Mapper : sig
+  type ('omp, 'ppxlib) fragment =
+    | Structure
+        : ( Selected_version.Parsetree.structure,
+            Ppxlib.Parsetree.structure )
+          fragment
+    | Signature
+        : ( Selected_version.Parsetree.signature,
+            Ppxlib.Parsetree.signature )
+          fragment
+    | Use_file
+        : ( Selected_version.Parsetree.toplevel_phrase list,
+            Ppxlib.Parsetree.toplevel_phrase list )
+          fragment
 
-  val compare : t -> t -> int
+  val iter_ast : (_, 'ppxlib) fragment -> Ppxlib.Ast_traverse.iter -> 'ppxlib -> unit
 
-  val merge : t -> t -> t option
+  val to_ppxlib : ('omp, 'ppxlib) fragment -> 'omp -> 'ppxlib
 end
 
-module Mapper : sig
-  type 'a fragment =
-    | Structure : Parsetree.structure fragment
-    | Signature : Parsetree.signature fragment
-    | Use_file : Parsetree.toplevel_phrase list fragment
+module Location : sig
+  include module type of Ppxlib.Location
 
-  val map_ast : 'a fragment -> Ast_mapper.mapper -> 'a -> 'a
+  val curr : Lexing.lexbuf -> t
+
+  val merge : t -> t -> t option
 end

--- a/vendor/parse-wyc/lib/parse_wyc.ml
+++ b/vendor/parse-wyc/lib/parse_wyc.ml
@@ -90,7 +90,7 @@ module With_recovery : PARSE_INTF = struct
             | _ -> Intermediate parser ) )
 end
 
-let entrypoint (type a) : a Mapper.fragment -> _ -> a I.checkpoint =
+let entrypoint (type o p) : (o, p) Mapper.fragment -> _ -> o I.checkpoint =
   function
   | Mapper.Structure -> P.Incremental.implementation
   | Mapper.Signature -> P.Incremental.interface
@@ -136,49 +136,46 @@ let merge_adj merge l =
 let normalize_locs locs =
   List.sort_uniq Location.compare locs |> merge_adj Location.merge
 
-let invalid_locs fragment lexbuf =
-  let ast = parse_with_recovery fragment (lex_buf lexbuf) in
+let invalid_locs : type o p. (o, p) Mapper.fragment -> Lexing.lexbuf -> Warnings.loc list
+    =
+ fun fragment lexbuf ->
+  let ast_omp = lex_buf lexbuf |> parse_with_recovery fragment in
+  let ast = Mapper.to_ppxlib fragment ast_omp in
   let loc_stack = Stack.create () in
   let loc_list = ref [] in
-  let make_mapper () =
-    let open Parsetree in
-    let default = Ast_mapper.default_mapper in
-    let expr m e =
-      if Annot.Exp.is_generated e then
-        loc_list := Stack.top loc_stack :: !loc_list;
-      default.expr m e
-    in
-    let class_expr m x =
-      if Annot.Class_exp.is_generated x then
-        loc_list := Stack.top loc_stack :: !loc_list;
-      default.class_expr m x
-    in
-    let wrap mapper loc f x =
-      if Stack.is_empty loc_stack then (
-        Stack.push loc loc_stack;
-        let x = f mapper x in
-        ignore (Stack.pop loc_stack);
-        x )
-      else f mapper x
-    in
-    let structure_item m x = wrap m x.pstr_loc default.structure_item x in
-    let signature_item m x = wrap m x.psig_loc default.signature_item x in
-    let attribute m x =
-      if Annot.Attr.is_generated x then
-        loc_list := Stack.top loc_stack :: !loc_list;
-      default.attribute m x
-    in
-    {
-      Ast_mapper.default_mapper with
-      attribute;
-      expr;
-      class_expr;
-      structure_item;
-      signature_item;
-    }
+  let wrap loc f x =
+    if Stack.is_empty loc_stack then (
+      Stack.push loc loc_stack;
+      let x = f x in
+      ignore (Stack.pop loc_stack);
+      x )
+    else f x
   in
-  let mapper = make_mapper () in
-  ignore (Mapper.map_ast fragment mapper ast);
+  let iter =
+    object
+      inherit Ppxlib.Ast_traverse.iter as super
+
+      method! attribute x =
+        if Annot.Attr.is_generated x then
+          loc_list := Stack.top loc_stack :: !loc_list;
+        super#attribute x
+
+      method! expression e =
+        if Annot.Exp.is_generated e then
+          loc_list := Stack.top loc_stack :: !loc_list;
+        super#expression e
+
+      method! class_expr x =
+        if Annot.Class_exp.is_generated x then
+          loc_list := Stack.top loc_stack :: !loc_list;
+        super#class_expr x
+
+      method! structure_item x = wrap x.pstr_loc super#structure_item x
+
+      method! signature_item x = wrap x.psig_loc super#signature_item x
+    end
+  in
+  Mapper.iter_ast fragment iter ast;
   normalize_locs !loc_list
 
 let mk_parsable fragment source =

--- a/vendor/parse-wyc/lib/parser.mly
+++ b/vendor/parse-wyc/lib/parser.mly
@@ -17,7 +17,7 @@
 
 %{
 
-open Migrate_ast
+open Migrate_parsetree.Ast_408
 open Asttypes
 open Longident
 open Parsetree


### PR DESCRIPTION
Closes #1460

The most visible API change is that `Ast_mapper` (record-based) is replaced by `Ppxlib.Ast_traverse` (object-based). The port is mostly mechanical, replacing fields by methods and `default_mapper` by `super`. Ppxlib has more hooks so it is possible to override `location_stack` in one go for example.

OMP (like compiler-libs) provides two ways to print ASTs: `Pprintast` outputs concrete syntax (`let x = 1 in x`) and is provided by ppxlib. `Printast` outputs a form closer to the `Parsetree` representation (`Pexp_let (Ppat_var "x", Pexp_const 1, Pexp_var "x"`), but ppxlib does not provide that. It exposes a s-expression converter, so we use that instead. This is only used in debug messages.

`Location` is used for two different things: the type and relative functions are used by ocamlformat as a whole. In ppxlib, the API is slightly different, so there are minor changes. `Location.input_name` however is used by the parser, so we need to refer to the one in compiler libs as `Ocaml_common.Location.input_name`.

`parse-wyc` is a special case because it uses a 4.08 parser, so it produces a 4.08 AST. The library is split in two between the parser and associated modules that operate on the 4.08 and the rest that uses the ppxlib AST. The modified parser inserts generated nodes in places that would correspond to parse errors. For example, if it determines that some sequence of tokens can only form an expression (but it's missing some tokens to do so in a valid way), it will emit `[%merlin.hole]` as an expression. Later, an AST mapper walks the AST and needs to determine if an expression is generated or not. This is simple with OMP, but with ppxlib we use two different AST versions: the parser uses 4.08 (from OMP) and the mapper uses 4.11 (at the time; more generally, the one ppxlib uses). So in the Annot module, the mk functions return a 4.08 AST (they are called by the parser), but the is_generated functions expect a 4.11 one (they are called by a mapper after migration).