### PR TITLE
Add missing parentheses around a pattern matching that is the left-hand part of a sequence when an attribute is attached

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@
 
   + Added missing package metadata to `ocamlformat.el` (#1474, @bcc32)
 
+  + Add missing parentheses around a pattern matching that is the left-hand part of a sequence when an attribute is attached (#1483, @gpetiot)
+
 #### New features
 
 ### 0.15.0 (2020-08-06)

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2205,15 +2205,14 @@ end = struct
       | _ -> false
     in
     let exp_in_sequence lhs rhs exp =
-      match (lhs.pexp_desc, rhs, exp.pexp_attributes) with
-      | (Pexp_match _ | Pexp_try _), _, _ :: _ when lhs == exp -> true
-      | _, _, _ :: _ -> false
+      match (lhs.pexp_desc, exp.pexp_attributes) with
+      | (Pexp_match _ | Pexp_try _), _ :: _ when lhs == exp -> true
+      | _, _ :: _ -> false
       | ( Pexp_extension
             ( _
             , PStr
                 [ { pstr_desc= Pstr_eval ({pexp_desc= Pexp_sequence _; _}, [])
                   ; _ } ] )
-        , _
         , _ )
         when lhs == exp ->
           true

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2204,6 +2204,32 @@ end = struct
       | Pexp_let _ | Pexp_match _ | Pexp_try _ -> true
       | _ -> false
     in
+    let sequence ctx_pexp_desc exp =
+      match (ctx_pexp_desc, exp.pexp_attributes) with
+      | ( Pexp_sequence (({pexp_desc= Pexp_match _ | Pexp_try _; _} as e), _)
+        , _ :: _ )
+        when e == exp ->
+          true
+      | Pexp_sequence _, _ :: _ -> false
+      | ( Pexp_sequence
+            ( ( { pexp_desc=
+                    Pexp_extension
+                      ( _
+                      , PStr
+                          [ { pstr_desc=
+                                Pstr_eval
+                                  ({pexp_desc= Pexp_sequence _; _}, [])
+                            ; _ } ] )
+                ; _ } as lhs )
+            , _ )
+        , _ )
+        when lhs == exp ->
+          true
+      | Pexp_sequence (lhs, _), _ when lhs == exp ->
+          exposed_right_exp Let_match exp
+      | Pexp_sequence (_, rhs), _ when rhs == exp -> false
+      | _ -> assert false
+    in
     assert_check_exp xexp ;
     is_displaced_prefix_op xexp
     || is_displaced_infix_op xexp
@@ -2228,17 +2254,6 @@ end = struct
         false
     (* Object fields do not require parens, even with trailing attributes *)
     | Exp {pexp_desc= Pexp_object _; _}, _ -> false
-    | ( Exp
-          { pexp_desc=
-              Pexp_sequence
-                (({pexp_desc= Pexp_match _ | Pexp_try _; _} as e), _)
-          ; _ }
-      , {pexp_attributes= _ :: _; _} )
-      when e == exp ->
-        true
-    | Exp {pexp_desc= Pexp_sequence _; _}, {pexp_attributes= _ :: _; _} ->
-        false
-    | _, exp when Exp.has_trailing_attributes exp -> true
     | ( Exp {pexp_desc= Pexp_construct ({txt= id; _}, _); _}
       , {pexp_attributes= _ :: _; _} )
       when Longident.is_infix id ->
@@ -2340,22 +2355,9 @@ end = struct
         when e0 == exp ->
           false
       | Pexp_record (_, Some e0) when e0 == exp -> true
-      | Pexp_sequence
-          ( ( { pexp_desc=
-                  Pexp_extension
-                    ( _
-                    , PStr
-                        [ { pstr_desc=
-                              Pstr_eval ({pexp_desc= Pexp_sequence _; _}, [])
-                          ; _ } ] )
-              ; _ } as lhs )
-          , _ )
-        when lhs == exp ->
-          true
-      | Pexp_sequence (lhs, _) when lhs == exp ->
-          exposed_right_exp Let_match exp
-      | Pexp_sequence (_, rhs) when rhs == exp -> false
-      | _ -> parenze () )
+      | Pexp_sequence _ -> sequence pexp_desc exp
+      | _ -> Exp.has_trailing_attributes exp || parenze () )
+    | _, exp when Exp.has_trailing_attributes exp -> true
     | _ -> false
 
   (** [parenze_cl {ctx; ast}] holds when class expr [ast] should be

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2228,6 +2228,14 @@ end = struct
         false
     (* Object fields do not require parens, even with trailing attributes *)
     | Exp {pexp_desc= Pexp_object _; _}, _ -> false
+    | ( Exp
+          { pexp_desc=
+              Pexp_sequence
+                (({pexp_desc= Pexp_match _ | Pexp_try _; _} as e), _)
+          ; _ }
+      , {pexp_attributes= _ :: _; _} )
+      when e == exp ->
+        true
     | Exp {pexp_desc= Pexp_sequence _; _}, {pexp_attributes= _ :: _; _} ->
         false
     | _, exp when Exp.has_trailing_attributes exp -> true

--- a/test/passing/attributes.ml
+++ b/test/passing/attributes.ml
@@ -352,3 +352,11 @@ let (M.(A | B)[@attr]) = ()
 ;;
 {a____________________________________= b___________________________________}
 [@attr]
+
+let _ =
+  (match[@ocaml.warning "-4"] bar with _ -> ()) ;
+  foo
+
+let _ =
+  (try[@ocaml.warning "-4"] bar with _ -> ()) ;
+  foo

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -9634,7 +9634,7 @@ let tail3 = 0 :: ([] [@hello])
 let f ~l:(l[@foo]) = l
 let test x y = (( + ) [@foo]) x y
 let test x = (( ~- ) [@foo])x
-let test contents = { contents = (contents [@foo]) }
+let test contents = { contents = contents [@foo] }
 
 class type t = object (_[@foo]) end
 
@@ -9656,7 +9656,7 @@ function
 | { contents = (contents[@foo]) } -> ()
 
 ;;
-fun contents -> { contents = (contents [@foo]) }
+fun contents -> { contents = contents [@foo] }
 
 ;;
 ();

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -9634,7 +9634,7 @@ let tail3 = 0 :: ([] [@hello])
 let f ~l:(l[@foo]) = l
 let test x y = (( + ) [@foo]) x y
 let test x = (( ~- ) [@foo])x
-let test contents = { contents = (contents [@foo]) }
+let test contents = { contents = contents [@foo] }
 
 class type t = object (_[@foo]) end
 
@@ -9656,7 +9656,7 @@ function
 | { contents = (contents[@foo]) } -> ()
 
 ;;
-fun contents -> { contents = (contents [@foo]) }
+fun contents -> { contents = contents [@foo] }
 
 ;;
 ();

--- a/test/passing/source.ml
+++ b/test/passing/source.ml
@@ -7308,6 +7308,7 @@ let f = function ((`A|`B)[@bar]) | `C -> ();;
 let f = function _::(_::_ [@foo]) -> () | _ -> ();;
 function {contents=contents[@foo]} -> ();;
 fun contents -> {contents=contents[@foo]};;
+fun contents -> {contents=contents[@foo]; foo};;
 ((); (((); ())[@foo]));;
 
 (* https://github.com/LexiFi/gen_js_api/issues/61 *)

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -9178,6 +9178,9 @@ function {contents= (contents[@foo])} -> ()
 fun contents -> {contents= contents [@foo]}
 
 ;;
+fun contents -> {contents= contents [@foo]; foo}
+
+;;
 () ;
 (() ; ()) [@foo]
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -9159,7 +9159,7 @@ let test x y = (( + ) [@foo]) x y
 
 let test x = (( ~- ) [@foo])x
 
-let test contents = {contents= (contents [@foo])}
+let test contents = {contents= contents [@foo]}
 
 class type t = object (_[@foo]) end
 
@@ -9175,7 +9175,7 @@ let f = function _ :: ((_ :: _)[@foo]) -> () | _ -> ()
 function {contents= (contents[@foo])} -> ()
 
 ;;
-fun contents -> {contents= (contents [@foo])}
+fun contents -> {contents= contents [@foo]}
 
 ;;
 () ;


### PR DESCRIPTION
fix #1480 (allows to format lwt codebase, test/core/test_lwt.ml and src/unix/lwt_io.ml were unable to be formatted), no diff with test_branch.