### PR TITLE
Add missing parentheses around infix operator used to build a function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@
 
   + Add missing parentheses around a pattern matching that is the left-hand part of a sequence when an attribute is attached (#1483, @gpetiot)
 
+  + Add missing parentheses around infix operator used to build a function (#1486, @gpetiot)
+
 #### New features
 
 ### 0.15.0 (2020-08-06)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1776,6 +1776,9 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let inner_wrap = parens || has_attr in
       let outer_wrap =
         match ctx0 with
+        (* infix operator used to build a function *)
+        | Exp {pexp_desc= Pexp_apply (f, _); _} when phys_equal f exp ->
+            has_attr && parens
         | Exp
             { pexp_desc=
                 Pexp_apply ({pexp_desc= Pexp_ident {txt= id; loc= _}; _}, _)

--- a/test/passing/apply.ml
+++ b/test/passing/apply.ml
@@ -64,3 +64,9 @@ let whatever_labelled a_function_name long_list_one some_other_thing =
   ListLabels.map long_list_one ~f:(fun long_list_one_elt ->
       do_something_with_a_function_and_some_things a_function_name
         long_list_one_elt some_other_thing)
+
+;;
+(a - b) ()
+
+;;
+((a - b) [@foo]) ()


### PR DESCRIPTION
fix #1355, no diff with test_branch.

Future improvement: the parenze functions from Ast.ml should be rewritten to return something like `{internal: bool: external: bool}` to take into account the parens including and excluding the attributes