### PR TITLE
Add tests for Literal_lexer

### DIFF
--- a/lib/Literal_lexer.mli
+++ b/lib/Literal_lexer.mli
@@ -9,6 +9,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val string : [`Normalize | `Preserve] -> Caml.Lexing.lexbuf -> string
+val string : [`Normalize | `Preserve] -> string -> string option
 
-val char : Caml.Lexing.lexbuf -> string
+val char : string -> string option

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -221,9 +221,7 @@ let is_long_pmty_functor source Parsetree.{pmty_desc; pmty_loc= from; _} =
       contains_token_between source ~from ~upto Parser.FUNCTOR
   | _ -> false
 
-let lexbuf_from_loc t (l : Location.t) =
-  let s = string_at t l.loc_start l.loc_end in
-  Lexing.from_string s
+let string_at_loc t (l : Location.t) = string_at t l.loc_start l.loc_end
 
 let string_literal t mode (l : Location.t) =
   (* the location of a [string] might include surrounding comments and
@@ -245,7 +243,8 @@ let string_literal t mode (l : Location.t) =
        | Parser.LBRACKETATAT, _
        | Parser.LBRACKETAT, _ )
        :: _ ->
-      Literal_lexer.string mode (lexbuf_from_loc t loc)
+      Option.value_exn ~message:"Parse error while reading string literal"
+        (Literal_lexer.string mode (string_at_loc t loc))
   | _ -> impossible "Pconst_string is only produced by string literals"
 
 let char_literal t (l : Location.t) =
@@ -268,7 +267,8 @@ let char_literal t (l : Location.t) =
        | Parser.LBRACKETATAT, _
        | Parser.LBRACKETAT, _ )
        :: _ ->
-      Literal_lexer.char (lexbuf_from_loc t loc)
+      (Option.value_exn ~message:"Parse error while reading char literal")
+        (Literal_lexer.char (string_at_loc t loc))
   | _ -> impossible "Pconst_char is only produced by char literals"
 
 let begins_line ?(ignore_spaces = true) t (l : Location.t) =

--- a/test/unit/test_literal_lexer.ml
+++ b/test/unit/test_literal_lexer.ml
@@ -1,0 +1,80 @@
+open Base
+open Ocamlformat_lib
+
+let single_quote = '\''
+
+let double_quote = '"'
+
+let backslash = '\\'
+
+let space = ' '
+
+let tab = '\t'
+
+let newline = '\n'
+
+let tests_string =
+  let test_opt name s mode ~expected =
+    ( "string: " ^ name
+    , `Quick
+    , fun () ->
+        let got = Literal_lexer.string mode s in
+        Alcotest.check Alcotest.(option string) Caml.__LOC__ expected got )
+  in
+  let test_one name s mode ~expected =
+    test_opt name s mode ~expected:(Some expected)
+  in
+  let test name s ~expected_preserve ~expected_normalize =
+    [ test_one (name ^ " (preserve)") s `Preserve ~expected:expected_preserve
+    ; test_one (name ^ " (normalize)") s `Normalize
+        ~expected:expected_normalize ]
+  in
+  List.concat
+    [ [test_opt "string: not a string" {|hello|} `Preserve ~expected:None]
+    ; test "simple" {|"hello"|} ~expected_preserve:"hello"
+        ~expected_normalize:"hello"
+    ; test "numeric escapes" {|"\123 \xff \o234"|}
+        ~expected_preserve:{|\123 \xff \o234|}
+        ~expected_normalize:{|\123 \xff \o234|}
+    ; test "raw tab"
+        (String.of_char_list [double_quote; tab; double_quote])
+        ~expected_preserve:(String.of_char_list [tab])
+        ~expected_normalize:(String.of_char_list [backslash; 't'])
+    ; test "backslash space"
+        (String.of_char_list [double_quote; backslash; space; double_quote])
+        ~expected_preserve:(String.of_char_list [backslash; space])
+        ~expected_normalize:(String.of_char_list [space])
+    ; test "backslash n"
+        (String.of_char_list [double_quote; backslash; 'n'; double_quote])
+        ~expected_preserve:(String.of_char_list [backslash; 'n'])
+        ~expected_normalize:(String.of_char_list [newline]) ]
+
+let tests_char =
+  let test_opt name s ~expected =
+    ( "char: " ^ name
+    , `Quick
+    , fun () ->
+        let got = Literal_lexer.char s in
+        Alcotest.check
+          (Alcotest.option Alcotest.string)
+          Caml.__LOC__ expected got )
+  in
+  let test name s ~expected = test_opt name s ~expected:(Some expected) in
+  [ test_opt "not a character literal" {|c|} ~expected:None
+  ; test "escaped newline"
+      (String.of_char_list [single_quote; newline; single_quote])
+      ~expected:(String.of_char_list [backslash; 'n'])
+  ; test "letter" {|'c'|} ~expected:"c"
+  ; test "escaped backslash" {|'\\'|} ~expected:{|\\|}
+  ; test "escaped single quote" {|'\''|} ~expected:{|\'|}
+  ; test "escaped double quote" {|'\"'|} ~expected:{|\"|}
+  ; test "backslash n" {|'\n'|} ~expected:{|\n|}
+  ; test "backslash t" {|'\t'|} ~expected:{|\t|}
+  ; test "backslash b" {|'\b'|} ~expected:{|\b|}
+  ; test "backslash r" {|'\r'|} ~expected:{|\r|}
+  ; test "backslash space" {|'\ '|} ~expected:{|\ |}
+  ; test "decimal escape" {|'\123'|} ~expected:{|\123|}
+  ; test "octal escape" {|'\o356'|} ~expected:{|\o356|}
+  ; test "hex escape" {|'\xde'|} ~expected:{|\xde|} ]
+
+let tests = tests_string @ tests_char

--- a/test/unit/test_literal_lexer.mli
+++ b/test/unit/test_literal_lexer.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test_case list

--- a/test/unit/test_unit.ml
+++ b/test/unit/test_unit.ml
@@ -113,6 +113,7 @@ end
 let tests =
   [ ("Location", Test_location.tests)
   ; ("non overlapping interval tree", Test_noit.tests)
-  ; ("Ast", Test_ast.tests) ]
+  ; ("Ast", Test_ast.tests)
+  ; ("Literal_lexer", Test_literal_lexer.tests) ]
 
 let () = Alcotest.run "ocamlformat" tests


### PR DESCRIPTION
I was not too sure what the "mode" parameter was used for, so I added some tests. The tests make it explicit, but the behavior for "normalize" is that:

- hard tabs are converted to escapes
- escaped newlines are converted to hard newlines
- escaped spaces are converted to spaces

This mechanism is used for `break_string_literals` only.