### PR TITLE
Cleanup string and char escapes

### DIFF
--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -245,8 +245,8 @@ let string_literal t mode (l : Location.t) =
        | Parser.LBRACKETATAT, _
        | Parser.LBRACKETAT, _ )
        :: _ ->
-      Some (Literal_lexer.string mode (lexbuf_from_loc t loc))
-  | _ -> None
+      Literal_lexer.string mode (lexbuf_from_loc t loc)
+  | _ -> impossible "Pconst_string is only produced by string literals"
 
 let char_literal t (l : Location.t) =
   (* the location of a [char] might include surrounding comments and
@@ -268,8 +268,8 @@ let char_literal t (l : Location.t) =
        | Parser.LBRACKETATAT, _
        | Parser.LBRACKETAT, _ )
        :: _ ->
-      Some (Literal_lexer.char (lexbuf_from_loc t loc))
-  | _ -> None
+      Literal_lexer.char (lexbuf_from_loc t loc)
+  | _ -> impossible "Pconst_char is only produced by char literals"
 
 let begins_line ?(ignore_spaces = true) t (l : Location.t) =
   let rec begins_line_ cnum =

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -28,10 +28,9 @@ val string_at : t -> Lexing.position -> Lexing.position -> string
 
 val sub : t -> pos:int -> len:int -> string
 
-val string_literal :
-  t -> [`Normalize | `Preserve] -> Location.t -> string option
+val string_literal : t -> [`Normalize | `Preserve] -> Location.t -> string
 
-val char_literal : t -> Location.t -> string option
+val char_literal : t -> Location.t -> string
 
 val position_before : t -> Lexing.position -> Lexing.position option
 (** [position_before s pos] returns the starting position of the token


### PR DESCRIPTION
OCamlformat has to deal with escaping in strings in two cases

- when `escape-strings` is set to anything other than `preserve` (this has been removed in #1462)
- when `Source.string_literal` cannot recover the original string in the source code. In that case, a decimal escape is used.

This PR is based on the observation that the latter case is never used. It seems to never actually be the case (in the test suite and on `test_branch`, including with older compilers, ). So we can make `Source.string_literal` total and delete the corresponding dead code.

In technical terms, the new assumption is that the tokens found in `Pconst_string(_, _, None)` (double quoted strings) start by a `STRING` token.

Once we require a OCaml >= 4.11 parser we can use the payload loc directly.

The char situation is similar but with less dead code associated.