### PR TITLE
Cleaning ocamlformat.el again, due to feedback from melpa

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@
 
   + Indent attributes attached to included modules better (#1468, @gpetiot)
 
-  + Clean up `ocamlformat.el` for submission to MELPA (#1476, @bcc32)
+  + Clean up `ocamlformat.el` for submission to MELPA (#1476, #1495, @bcc32)
     - Added missing package metadata to `ocamlformat.el` (#1474, @bcc32)
     - Fix `ocamlformat.el` buffer replacement for MacOS Emacs (#1481, @juxd)
 

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -266,7 +266,7 @@ function."
           (widen)
           (write-region nil nil bufferfile)
           (if (zerop
-               (apply 'call-process
+               (apply #'call-process
                       ocamlformat-command nil (list :file errorfile) nil
                       (append margin-args enable-args extension-args
                               (list

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -1,6 +1,6 @@
 ;;; ocamlformat.el --- Utility functions to format ocaml code -*- lexical-binding: t; -*-
 
-;; Package-Requires: ((emacs "24.1"))
+;; Package-Requires: ((emacs "24.3"))
 ;; Version: 0.15.0
 ;; Keywords: languages, ocaml
 ;; URL: https://github.com/ocaml-ppx/ocamlformat
@@ -42,6 +42,8 @@
 ;;   (add-hook 'before-save-hook 'ocamlformat-before-save)
 
 ;;; Code:
+
+(require 'cl-lib)
 
 (defcustom ocamlformat-command "ocamlformat"
   "The 'ocamlformat' command."
@@ -158,14 +160,14 @@ function."
                 (forward-line len)
                 (let ((text (buffer-substring start (point))))
                   (with-current-buffer target-buffer
-                    (decf line-offset len)
+                    (cl-decf line-offset len)
                     (goto-char (point-min))
                     (forward-line (- from len line-offset))
                     (insert text)))))
              ((equal action "d")
               (with-current-buffer target-buffer
                 (ocamlformat--goto-line (- from line-offset))
-                (incf line-offset len)
+                (cl-incf line-offset len)
                 (ocamlformat--delete-whole-line len)))
              (t
               (error "Invalid rcs patch or internal error in ocamlformat--apply-rcs-patch")))))))))

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -185,14 +185,6 @@ function."
       (compilation-mode)
       (display-buffer errbuf))))
 
-(defun ocamlformat--kill-error-buffer (errbuf)
-  (let ((win (get-buffer-window errbuf)))
-    (if win
-        (quit-window t win)
-      (with-current-buffer errbuf
-        (erase-buffer))
-      (kill-buffer errbuf))))
-
 ;; replace-buffer-contents is broken in emacs-26.1
 ;; try to detect broken implementation.
 ;; https://bugzilla.redhat.com/show_bug.cgi?id=1597251

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -1,4 +1,4 @@
-;;; ocamlformat.el --- Utility functions to format ocaml code
+;;; ocamlformat.el --- Utility functions to format ocaml code -*- lexical-binding: t; -*-
 
 ;; Package-Requires: ((emacs "24.1"))
 ;; Version: 0.15.0

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -173,6 +173,10 @@ function."
               (error "Invalid rcs patch or internal error in ocamlformat--apply-rcs-patch")))))))))
 
 (defun ocamlformat--process-errors (filename tmpfile errorfile errbuf)
+  "Display ocamlformat errors in ERRBUF, a compilation buffer.
+
+Error messages are read from ERRORFILE, and occurrences of
+TMPFILE in the error messages are replaced with FILENAME."
   (with-current-buffer errbuf
     (if (eq ocamlformat-show-errors 'echo)
         (message "%s" (buffer-string))
@@ -205,10 +209,19 @@ function."
            ok))))
 
 (defun ocamlformat--replace-buffer-contents (outputfile)
+  "Replace the current buffer's contents with the contents of OUTPUTFILE.
+
+Uses `replace-buffer-contents'."
   (replace-buffer-contents (find-file-noselect outputfile))
   (kill-buffer (get-file-buffer outputfile)))
 
 (defun ocamlformat--patch-buffer (outputfile)
+  "Replace the current buffer's contents with the contents of OUTPUTFILE.
+
+Uses `ocamlformat--apply-rcs-patch' instead of
+`replace-buffer-contents'.  This function is used by
+`ocamlformat' when `ocamlformat--support-replace-buffer-contents'
+is nil."
   (let ((patchbuf (get-buffer-create "*OCamlFormat patch*")))
     (with-current-buffer patchbuf (erase-buffer))
     (call-process-region


### PR DESCRIPTION
Address feedback left in melpa/melpa#7151.  This PR makes a few more cleanups that will hopefully pass muster for inclusion in MELPA.