### PR TITLE
Fix misalignment of cases in docked `function` match

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,8 @@
 
   + Fix invalid fragment delimiters of format-invalid-files recovery mode (#1485, @hhugo)
 
+  + Fix misalignment of cases in docked `function` match (#1498, @gpetiot)
+
 #### New features
 
 ### 0.15.0 (2020-08-06)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2015,12 +2015,15 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
   | Pexp_newtype _ | Pexp_fun _ ->
       let xargs, xbody = Sugar.fun_ c.cmts xexp in
       let fmt_cstr, xbody = type_constr_and_body c xbody in
+      let body_is_function =
+        match xbody.ast.pexp_desc with Pexp_function _ -> true | _ -> false
+      in
       let pre_body, body = fmt_body c ?ext xbody in
       let default_indent = if Option.is_none eol then 2 else 1 in
       let indent =
         Params.function_indent c.conf ~ctx ~default:default_indent
       in
-      hvbox_if box indent
+      hvbox_if (box || body_is_function) indent
         (Params.wrap_exp c.conf c.source ~loc:pexp_loc ~parens
            ~disambiguate:true ~fits_breaks:false
            ( hovbox 2

--- a/test/passing/source.ml
+++ b/test/passing/source.ml
@@ -7375,3 +7375,20 @@ let formula_base x =
   #&& ((Expr.int 0) #< x)
 
 let _ = call ~f:(fun pair -> (pair : a * b))
+
+;;
+f
+  (fun _ -> function
+    | true ->
+        let () = () in
+        () | false -> ())
+  ()
+
+;;
+f
+  (fun _ -> function
+    | true ->
+        let () = () in
+        ()
+        (* comment *) | false -> ())
+  ()

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -9252,3 +9252,22 @@ let formula_base x =
   #&& ((Expr.int 0) #< x)
 
 let _ = call ~f:(fun pair : (a * b) -> pair)
+
+;;
+f
+  (fun _ -> function
+    | true ->
+        let () = () in
+        ()
+    | false -> ())
+  ()
+
+;;
+f
+  (fun _ -> function
+    | true ->
+        let () = () in
+        ()
+    (* comment *)
+    | false -> ())
+  ()


### PR DESCRIPTION
Fix #1492, fix #1493 (didn't expect the comment issue to be related to the first one)

test_branch diff for conventional profile:
```diff
diff --git a/src/dune_engine/action.ml b/src/dune_engine/action.ml
index 3e1d07aaf..bbdac0d8e 100644
--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -139,8 +139,10 @@ module Unresolved = struct
       ~f_path:(fun ~dir:_ x -> x)
       ~f_target:(fun ~dir:_ x -> x)
       ~f_string:(fun ~dir:_ x -> x)
-      ~f_program:(fun ~dir:_ -> function This p -> Ok p
-        | Search (loc, s) -> Ok (f loc s))
+      ~f_program:
+        (fun ~dir:_ -> function
+          | This p -> Ok p
+          | Search (loc, s) -> Ok (f loc s))
 end
```

test_branch diff for janestreet profile:
```diff
diff --git a/src/dune_engine/action.ml b/src/dune_engine/action.ml
index 418ba68e7..dde8bb126 100644
--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -145,9 +145,10 @@ module Unresolved = struct
       ~f_path:(fun ~dir:_ x -> x)
       ~f_target:(fun ~dir:_ x -> x)
       ~f_string:(fun ~dir:_ x -> x)
-      ~f_program:(fun ~dir:_ -> function
-        | This p -> Ok p
-        | Search (loc, s) -> Ok (f loc s))
+      ~f_program:
+        (fun ~dir:_ -> function
+          | This p -> Ok p
+          | Search (loc, s) -> Ok (f loc s))
   ;;
 end
```