### PR TITLE
Preserve short-form extensions for structure item extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,7 @@
   + Fix misalignment of cases in docked `function` match (#1498, @gpetiot)
 
   + Preserve short-form extensions for structure item extensions (#1502, @gpetiot)
+    For example `open%ext M` will not get rewritten to `[%%ext open M]`.
 
 #### New features
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,8 @@
 
   + Fix misalignment of cases in docked `function` match (#1498, @gpetiot)
 
+  + Preserve short-form extensions for structure item extensions (#1502, @gpetiot)
+
 #### New features
 
 ### 0.15.0 (2020-08-06)

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -258,7 +258,7 @@ module Exp = struct
             [ { pstr_desc=
                   Pstr_eval (({pexp_desc= Pexp_sequence _; _} as e), [])
               ; _ } ] )
-      when Source.extension_using_sugar ~name:ext ~payload:e ->
+      when Source.extension_using_sugar ~name:ext ~payload:e.pexp_loc ->
         true
     | _ -> false
 
@@ -1758,7 +1758,7 @@ end = struct
                       , _ )
                 ; _ } ] )
         when Poly.(!extension_sugar = `Always)
-             || Source.extension_using_sugar ~name:ext ~payload:e ->
+             || Source.extension_using_sugar ~name:ext ~payload:e.pexp_loc ->
           Some Apply
       | Pexp_extension
           ( ext
@@ -1767,7 +1767,7 @@ end = struct
                     Pstr_eval (({pexp_desc= Pexp_sequence _; _} as e), _)
                 ; _ } ] )
         when Poly.(!extension_sugar = `Always)
-             || Source.extension_using_sugar ~name:ext ~payload:e ->
+             || Source.extension_using_sugar ~name:ext ~payload:e.pexp_loc ->
           Some Semi
       | Pexp_setfield _ -> Some LessMinus
       | Pexp_setinstvar _ -> Some LessMinus
@@ -2060,7 +2060,7 @@ end = struct
                             ; _ } as e )
                         , _ )
                   ; _ } ] )
-          when Source.extension_using_sugar ~name:ext ~payload:e ->
+          when Source.extension_using_sugar ~name:ext ~payload:e.pexp_loc ->
             continue e
         | Pexp_let (_, _, e)
          |Pexp_letop {body= e; _}
@@ -2136,7 +2136,7 @@ end = struct
        |Pexp_letmodule (_, _, e) ->
           continue e
       | Pexp_extension (ext, PStr [{pstr_desc= Pstr_eval (e, _); _}])
-        when Source.extension_using_sugar ~name:ext ~payload:e -> (
+        when Source.extension_using_sugar ~name:ext ~payload:e.pexp_loc -> (
         match e.pexp_desc with
         | Pexp_function cases | Pexp_match (_, cases) | Pexp_try (_, cases)
           ->
@@ -2199,7 +2199,7 @@ end = struct
     let rec ifthenelse pexp_desc =
       match pexp_desc with
       | Pexp_extension (ext, PStr [{pstr_desc= Pstr_eval (e, _); _}])
-        when Source.extension_using_sugar ~name:ext ~payload:e ->
+        when Source.extension_using_sugar ~name:ext ~payload:e.pexp_loc ->
           ifthenelse e.pexp_desc
       | Pexp_let _ | Pexp_match _ | Pexp_try _ -> true
       | _ -> false

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -506,7 +506,7 @@ let rec fmt_extension c ctx key (ext, pld) =
                 ( Pstr_value _ | Pstr_type _ | Pstr_exception _
                 | Pstr_open {popen_override= Fresh; _}
                 | Pstr_include _ | Pstr_module _ | Pstr_recmodule _
-                | Pstr_modtype _ | Pstr_class_type _ )
+                | Pstr_modtype _ | Pstr_class_type _ | Pstr_class _ )
             ; _ } as si ) ]
     , (Pld _ | Str _ | Top) ) ->
       fmt_structure_item c ~last:true ~ext (sub_str ~ctx si)
@@ -3619,7 +3619,7 @@ and fmt_class_types ?ext c ctx ~pre ~sep (cls : class_type class_infos list)
       $ hovbox 0
         @@ Cmts.fmt c cl.pci_loc (doc_before $ class_types $ doc_after))
 
-and fmt_class_exprs c ctx (cls : class_expr class_infos list) =
+and fmt_class_exprs ?ext c ctx (cls : class_expr class_infos list) =
   list_fl cls (fun ~first ~last:_ cl ->
       update_config_maybe_disabled c cl.pci_loc cl.pci_attributes
       @@ fun c ->
@@ -3645,6 +3645,7 @@ and fmt_class_exprs c ctx (cls : class_expr class_infos list) =
               ( box_fun_decl_args c 2
                   ( hovbox 2
                       ( str (if first then "class" else "and")
+                      $ fmt_if_k first (fmt_extension_suffix c ext)
                       $ fmt_virtual_flag cl.pci_virt
                       $ fmt "@ "
                       $ fmt_class_params c ctx cl.pci_params
@@ -4217,7 +4218,7 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
         $ doc_after )
   | Pstr_class_type cl ->
       fmt_class_types ?ext c ctx ~pre:"class type" ~sep:"=" cl
-  | Pstr_class cls -> fmt_class_exprs c ctx cls
+  | Pstr_class cls -> fmt_class_exprs ?ext c ctx cls
 
 and fmt_let c ctx ~ext ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr ~loc
     ~body_loc ~attributes ~indent_after_in =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -505,7 +505,8 @@ let rec fmt_extension c ctx key (ext, pld) =
         [ ( { pstr_desc=
                 ( Pstr_value _ | Pstr_type _ | Pstr_exception _
                 | Pstr_open {popen_override= Fresh; _}
-                | Pstr_include _ | Pstr_module _ | Pstr_recmodule _ )
+                | Pstr_include _ | Pstr_module _ | Pstr_recmodule _
+                | Pstr_modtype _ )
             ; _ } as si ) ]
     , (Pld _ | Str _ | Top) ) ->
       fmt_structure_item c ~last:true ~ext (sub_str ~ctx si)
@@ -3788,12 +3789,12 @@ and fmt_module_substitution c ctx pms =
     (fmt_module c "module" ~eqty:":=" pms_name [] None (Some xmty)
        pms_attributes ~rec_flag:false)
 
-and fmt_module_type_declaration c ctx pmtd =
+and fmt_module_type_declaration ?ext c ctx pmtd =
   let {pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc} = pmtd in
   update_config_maybe_disabled c pmtd_loc pmtd_attributes
   @@ fun c ->
   let pmtd_name = {pmtd_name with txt= Some pmtd_name.txt} in
-  fmt_module c "module type" pmtd_name [] None ~rec_flag:false
+  fmt_module ?ext c "module type" pmtd_name [] None ~rec_flag:false
     (Option.map pmtd_type ~f:(sub_mty ~ctx))
     pmtd_attributes
 
@@ -4199,7 +4200,7 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
       hvbox 0 ~name:"value"
         (list_fl grps (fun ~first ~last grp ->
              fmt_grp ~first ~last grp $ fmt_if (not last) "\n@;<1000 0>"))
-  | Pstr_modtype mtd -> fmt_module_type_declaration c ctx mtd
+  | Pstr_modtype mtd -> fmt_module_type_declaration ?ext c ctx mtd
   | Pstr_extension (ext, atrs) ->
       let doc_before, doc_after, atrs = fmt_docstring_around_item c atrs in
       let box =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -507,7 +507,7 @@ let rec fmt_extension c ctx key (ext, pld) =
                 | Pstr_open {popen_override= Fresh; _}
                 | Pstr_include _ | Pstr_module _ | Pstr_recmodule _
                 | Pstr_modtype _ | Pstr_class_type _ | Pstr_class _
-                | Pstr_typext _ )
+                | Pstr_typext _ | Pstr_primitive _ )
             ; _ } as si ) ]
     , (Pld _ | Str _ | Top) ) ->
       fmt_structure_item c ~last:true ~ext (sub_str ~ctx si)
@@ -3024,7 +3024,7 @@ and fmt_case c ctx ~first ~last ~padding case =
               | `No -> "@,)"
               | `Closing_on_separate_line -> "@;<1000 -2>)" ) ) )
 
-and fmt_value_description c ctx vd =
+and fmt_value_description ?ext c ctx vd =
   let {pval_name= {txt; loc}; pval_type; pval_prim; pval_attributes; pval_loc}
       =
     vd
@@ -3043,7 +3043,9 @@ and fmt_value_description c ctx vd =
   hvbox 0
     ( doc_before
     $ box_fun_sig_args c 2
-        ( str pre $ str " "
+        ( str pre
+        $ fmt_extension_suffix c ext
+        $ str " "
         $ Cmts.fmt c loc
             (wrap_if (String_id.is_symbol txt) "( " " )" (str txt))
         $ fmt_core_type c ~pro:":"
@@ -4160,7 +4162,7 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
         $ fmt "@ "
       in
       fmt_module_statement c ~attributes ~keyword (sub_mod ~ctx popen_expr)
-  | Pstr_primitive vd -> fmt_value_description c ctx vd
+  | Pstr_primitive vd -> fmt_value_description ?ext c ctx vd
   | Pstr_recmodule bindings ->
       fmt_recmodule c ctx bindings (fmt_module_binding ?ext) (fun x ->
           Mod x.pmb_expr)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -508,8 +508,11 @@ let rec fmt_extension c ctx key (ext, pld) =
                 | Pstr_include _ | Pstr_module _ | Pstr_recmodule _
                 | Pstr_modtype _ | Pstr_class_type _ | Pstr_class _
                 | Pstr_typext _ | Pstr_primitive _ )
+            ; pstr_loc
             ; _ } as si ) ]
-    , (Pld _ | Str _ | Top) ) ->
+    , (Pld _ | Str _ | Top) )
+    when Poly.(c.conf.extension_sugar = `Always)
+         || Source.extension_using_sugar ~name:ext ~payload:pstr_loc ->
       fmt_structure_item c ~last:true ~ext (sub_str ~ctx si)
   | _, _, PSig [({psig_desc= Psig_type _; _} as si)], (Pld _ | Sig _ | Top)
     ->
@@ -2364,7 +2367,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             ; pstr_loc= _ } ] )
     when List.is_empty pexp_attributes
          && ( Poly.(c.conf.extension_sugar = `Always)
-            || Source.extension_using_sugar ~name:ext ~payload:e1
+            || Source.extension_using_sugar ~name:ext ~payload:e1.pexp_loc
                && List.length (Sugar.sequence c.conf c.cmts xexp) > 1 ) ->
       fmt_sequence ~has_attr c parens (expression_width c) xexp pexp_loc
         fmt_atrs ~ext
@@ -2423,7 +2426,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
               ; pstr_loc= _ } as str ) ] )
     when List.is_empty pexp_attributes
          && ( Poly.(c.conf.extension_sugar = `Always)
-            || Source.extension_using_sugar ~name:ext ~payload:e1 ) ->
+            || Source.extension_using_sugar ~name:ext ~payload:e1.pexp_loc )
+    ->
       hvbox 0
         ( fmt_expression c ~box ?eol ~parens ~ext (sub_exp ~ctx:(Str str) e1)
         $ fmt_atrs )

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2591,7 +2591,7 @@ and fmt_class_structure c ~ctx ?ext self_ fields =
           str "\n"
       | _ -> noop )
     $ fmt_if (not (List.is_empty fields)) "@;<1000 0>"
-    $ hvbox 0 (list fields "\n@\n" fmt_field) )
+    $ hvbox 0 (list fields "\n@;<1000 0>" fmt_field) )
   $ fmt_or (List.is_empty fields) "@ " "@\n"
   $ str "end"
 
@@ -2632,7 +2632,7 @@ and fmt_class_signature c ~ctx ~parens ?ext self_ fields =
                  str "\n"
              | _ -> noop )
            $ fmt_if (not (List.is_empty fields)) "@;<1000 0>"
-           $ hvbox 0 (list fields "\n@\n" fmt_field) )
+           $ hvbox 0 (list fields "\n@;<1000 0>" fmt_field) )
        $ fmt_or (List.is_empty fields) "@ " "@\n"
        $ str "end" ))
 
@@ -3624,52 +3624,53 @@ and fmt_class_types ?ext c ctx ~pre ~sep (cls : class_type class_infos list)
           $ fmt_class_type c (sub_cty ~ctx cl.pci_expr)
           $ fmt_attributes c ~pre:(Break (1, 0)) ~key:"@@" atrs )
       in
-      fmt_if (not first) "\n@\n"
+      fmt_if (not first) "\n@;<1000 0>"
       $ hovbox 0
         @@ Cmts.fmt c cl.pci_loc (doc_before $ class_types $ doc_after))
 
 and fmt_class_exprs ?ext c ctx (cls : class_expr class_infos list) =
-  list_fl cls (fun ~first ~last:_ cl ->
-      update_config_maybe_disabled c cl.pci_loc cl.pci_attributes
-      @@ fun c ->
-      let xargs, xbody =
-        match cl.pci_expr.pcl_attributes with
-        | [] ->
-            Sugar.cl_fun c.cmts ~will_keep_first_ast_node:false
-              (sub_cl ~ctx cl.pci_expr)
-        | _ -> ([], sub_cl ~ctx cl.pci_expr)
-      in
-      let ty, e =
-        match xbody.ast with
-        | {pcl_desc= Pcl_constraint (e, t); _} -> (Some t, sub_cl ~ctx e)
-        | _ -> (None, xbody)
-      in
-      let doc_before, doc_after, atrs =
-        let force_before = not (Cl.is_simple cl.pci_expr) in
-        fmt_docstring_around_item ~force_before c cl.pci_attributes
-      in
-      let class_exprs =
-        hovbox 2
-          ( hovbox 2
-              ( box_fun_decl_args c 2
-                  ( hovbox 2
-                      ( str (if first then "class" else "and")
-                      $ fmt_if_k first (fmt_extension_suffix c ext)
-                      $ fmt_virtual_flag cl.pci_virt
-                      $ fmt "@ "
-                      $ fmt_class_params c ctx cl.pci_params
-                      $ fmt_str_loc c cl.pci_name )
-                  $ fmt_if (not (List.is_empty xargs)) "@ "
-                  $ wrap_fun_decl_args c (fmt_fun_args c xargs) )
-              $ opt ty (fun t ->
-                    fmt " :@ " $ fmt_class_type c (sub_cty ~ctx t))
-              $ fmt "@ =" )
-          $ fmt "@;" $ fmt_class_expr c e )
-        $ fmt_attributes c ~pre:(Break (1, 0)) ~key:"@@" atrs
-      in
-      fmt_if (not first) "\n@\n"
-      $ hovbox 0
-        @@ Cmts.fmt c cl.pci_loc (doc_before $ class_exprs $ doc_after))
+  hvbox 0
+  @@ list_fl cls (fun ~first ~last:_ cl ->
+         update_config_maybe_disabled c cl.pci_loc cl.pci_attributes
+         @@ fun c ->
+         let xargs, xbody =
+           match cl.pci_expr.pcl_attributes with
+           | [] ->
+               Sugar.cl_fun c.cmts ~will_keep_first_ast_node:false
+                 (sub_cl ~ctx cl.pci_expr)
+           | _ -> ([], sub_cl ~ctx cl.pci_expr)
+         in
+         let ty, e =
+           match xbody.ast with
+           | {pcl_desc= Pcl_constraint (e, t); _} -> (Some t, sub_cl ~ctx e)
+           | _ -> (None, xbody)
+         in
+         let doc_before, doc_after, atrs =
+           let force_before = not (Cl.is_simple cl.pci_expr) in
+           fmt_docstring_around_item ~force_before c cl.pci_attributes
+         in
+         let class_exprs =
+           hovbox 2
+             ( hovbox 2
+                 ( box_fun_decl_args c 2
+                     ( hovbox 2
+                         ( str (if first then "class" else "and")
+                         $ fmt_if_k first (fmt_extension_suffix c ext)
+                         $ fmt_virtual_flag cl.pci_virt
+                         $ fmt "@ "
+                         $ fmt_class_params c ctx cl.pci_params
+                         $ fmt_str_loc c cl.pci_name )
+                     $ fmt_if (not (List.is_empty xargs)) "@ "
+                     $ wrap_fun_decl_args c (fmt_fun_args c xargs) )
+                 $ opt ty (fun t ->
+                       fmt " :@ " $ fmt_class_type c (sub_cty ~ctx t))
+                 $ fmt "@ =" )
+             $ fmt "@;" $ fmt_class_expr c e )
+           $ fmt_attributes c ~pre:(Break (1, 0)) ~key:"@@" atrs
+         in
+         fmt_if (not first) "\n@;<1000 0>"
+         $ hovbox 0
+           @@ Cmts.fmt c cl.pci_loc (doc_before $ class_exprs $ doc_after))
 
 and fmt_module c ?ext ?epi ?(can_sparse = false) keyword ?(eqty = "=") name
     xargs xbody xmty attributes ~rec_flag =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -506,7 +506,7 @@ let rec fmt_extension c ctx key (ext, pld) =
                 ( Pstr_value _ | Pstr_type _ | Pstr_exception _
                 | Pstr_open {popen_override= Fresh; _}
                 | Pstr_include _ | Pstr_module _ | Pstr_recmodule _
-                | Pstr_modtype _ )
+                | Pstr_modtype _ | Pstr_class_type _ )
             ; _ } as si ) ]
     , (Pld _ | Str _ | Top) ) ->
       fmt_structure_item c ~last:true ~ext (sub_str ~ctx si)
@@ -3593,7 +3593,8 @@ and fmt_signature_item c ?ext {ast= si; _} =
   | Psig_class_type cl -> fmt_class_types c ctx ~pre:"class type" ~sep:"=" cl
   | Psig_typesubst decls -> fmt_type c ?ext ~eq:":=" Recursive decls ctx
 
-and fmt_class_types c ctx ~pre ~sep (cls : class_type class_infos list) =
+and fmt_class_types ?ext c ctx ~pre ~sep (cls : class_type class_infos list)
+    =
   list_fl cls (fun ~first ~last:_ cl ->
       update_config_maybe_disabled c cl.pci_loc cl.pci_attributes
       @@ fun c ->
@@ -3605,6 +3606,7 @@ and fmt_class_types c ctx ~pre ~sep (cls : class_type class_infos list) =
         hovbox 2
           ( hvbox 2
               ( str (if first then pre else "and")
+              $ fmt_if_k first (fmt_extension_suffix c ext)
               $ fmt_virtual_flag cl.pci_virt
               $ fmt "@ "
               $ fmt_class_params c ctx cl.pci_params
@@ -4213,7 +4215,8 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
         $ hvbox_if (not box) 0 ~name:"ext2" (fmt_extension c ctx "%%" ext)
         $ fmt_attributes c ~pre:Space ~key:"@@" atrs
         $ doc_after )
-  | Pstr_class_type cl -> fmt_class_types c ctx ~pre:"class type" ~sep:"=" cl
+  | Pstr_class_type cl ->
+      fmt_class_types ?ext c ctx ~pre:"class type" ~sep:"=" cl
   | Pstr_class cls -> fmt_class_exprs c ctx cls
 
 and fmt_let c ctx ~ext ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr ~loc

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -503,8 +503,7 @@ let rec fmt_extension c ctx key (ext, pld) =
     , _
     , PStr
         [ ( { pstr_desc=
-                ( Pstr_value _ | Pstr_type _ | Pstr_exception _
-                | Pstr_open {popen_override= Fresh; _}
+                ( Pstr_value _ | Pstr_type _ | Pstr_exception _ | Pstr_open _
                 | Pstr_include _ | Pstr_module _ | Pstr_recmodule _
                 | Pstr_modtype _ | Pstr_class_type _ | Pstr_class _
                 | Pstr_typext _ | Pstr_primitive _ )
@@ -2225,6 +2224,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                              $ Cmts.fmt_before c popen_loc
                              $ fits_breaks ?force ~level:4 ""
                                  (if override then "open!" else "open")
+                             $ opt ext (fun _ -> fmt_if override " ")
                              $ fmt_extension_suffix c ext )
                          $ fits_breaks ?force ~level:3 "" ~hint:(1, 0) "" )
                        (sub_mod ~ctx popen_expr)
@@ -2419,7 +2419,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                             | Pexp_try _ | Pexp_let _ | Pexp_ifthenelse _
                             | Pexp_new _ | Pexp_letmodule _ | Pexp_object _
                             | Pexp_function _ | Pexp_letexception _
-                            | Pexp_open ({popen_override= Fresh; _}, _) )
+                            | Pexp_open _ )
                         ; pexp_attributes= []
                         ; _ } as e1 )
                     , _ )
@@ -4162,7 +4162,8 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
       let keyword =
         fmt_or_k
           (is_override popen_override)
-          (str "open!")
+          ( str "open!"
+          $ opt ext (fun _ -> str " " $ fmt_extension_suffix c ext) )
           (str "open" $ fmt_extension_suffix c ext)
         $ fmt "@ "
       in

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -506,7 +506,8 @@ let rec fmt_extension c ctx key (ext, pld) =
                 ( Pstr_value _ | Pstr_type _ | Pstr_exception _
                 | Pstr_open {popen_override= Fresh; _}
                 | Pstr_include _ | Pstr_module _ | Pstr_recmodule _
-                | Pstr_modtype _ | Pstr_class_type _ | Pstr_class _ )
+                | Pstr_modtype _ | Pstr_class_type _ | Pstr_class _
+                | Pstr_typext _ )
             ; _ } as si ) ]
     , (Pld _ | Str _ | Top) ) ->
       fmt_structure_item c ~last:true ~ext (sub_str ~ctx si)
@@ -3301,7 +3302,7 @@ and fmt_constructor_arguments_result c ctx args res =
   in
   fmt_constructor_arguments c ctx ~pre args $ opt res fmt_type
 
-and fmt_type_extension c ctx
+and fmt_type_extension ?ext c ctx
     { ptyext_attributes
     ; ptyext_params
     ; ptyext_path
@@ -3322,7 +3323,9 @@ and fmt_type_extension c ctx
   @@ hvbox 2
        ( fmt_docstring c ~epi:(fmt "@,") doc
        $ hvbox c.conf.type_decl_indent
-           ( str "type "
+           ( str "type"
+           $ fmt_extension_suffix c ext
+           $ str " "
            $ hvbox_if
                (not (List.is_empty ptyext_params))
                0
@@ -4162,7 +4165,7 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
       fmt_recmodule c ctx bindings (fmt_module_binding ?ext) (fun x ->
           Mod x.pmb_expr)
   | Pstr_type (rec_flag, decls) -> fmt_type c ?ext rec_flag decls ctx
-  | Pstr_typext te -> fmt_type_extension c ctx te
+  | Pstr_typext te -> fmt_type_extension ?ext c ctx te
   | Pstr_value (rec_flag, bindings) ->
       let with_conf c b =
         let c = update_config ~quiet:true c b.pvb_attributes in

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -297,10 +297,8 @@ let ends_line t (l : Location.t) =
   else ends_line_ l.loc_end.pos_cnum
 
 let extension_using_sugar ~(name : string Location.loc)
-    ~(payload : Parsetree.expression) =
-  Source_code_position.ascending name.loc.loc_start
-    payload.pexp_loc.loc_start
-  > 0
+    ~(payload : Location.t) =
+  Source_code_position.ascending name.loc.loc_start payload.loc_start > 0
 
 let typed_expression (typ : Parsetree.core_type)
     (expr : Parsetree.expression) =

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -55,7 +55,7 @@ val begins_line : ?ignore_spaces:bool -> t -> Location.t -> bool
 val ends_line : t -> Location.t -> bool
 
 val extension_using_sugar :
-  name:string Location.loc -> payload:Parsetree.expression -> bool
+  name:string Location.loc -> payload:Location.t -> bool
 
 val extend_loc_to_include_attributes :
   t -> Location.t -> Parsetree.attributes -> Location.t

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -257,7 +257,8 @@ let sequence (conf : Conf.t) cmts xexp =
               ; pstr_loc= _ } ] )
       when List.is_empty pexp_attributes
            && ( Poly.(conf.extension_sugar = `Always)
-              || Source.extension_using_sugar ~name:ext ~payload:e1 ) ->
+              || Source.extension_using_sugar ~name:ext ~payload:e1.pexp_loc
+              ) ->
         let ctx = Exp exp in
         Cmts.relocate cmts ~src:pexp_loc ~before:e1.pexp_loc
           ~after:e2.pexp_loc ;

--- a/test/passing/extensions-indent.ml.ref
+++ b/test/passing/extensions-indent.ml.ref
@@ -277,11 +277,12 @@ class%ext x = y
 
 class%ext x = y
 
-   and y = z
+and y = z
 
-[%%ext class x = y
+[%%ext
+   class x = y
 
-       and y = z]
+   and y = z]
 
 class type%ext x = y
 
@@ -291,6 +292,7 @@ class type%ext x = y
 
    and y = z
 
-[%%ext class type x = y
+[%%ext
+   class type x = y
 
-       and y = z]
+   and y = z]

--- a/test/passing/extensions-indent.ml.ref
+++ b/test/passing/extensions-indent.ml.ref
@@ -265,3 +265,7 @@ let _ =
   [%ext
        let module E = P in
        x]
+
+module type%ext E = P
+
+module type%ext E = P

--- a/test/passing/extensions-indent.ml.ref
+++ b/test/passing/extensions-indent.ml.ref
@@ -246,3 +246,22 @@ let _ =
   [%ext
        let exception E in
        x]
+
+module%ext E = P
+
+module%ext E = P
+
+module%ext rec K = A
+and L = A
+
+module%ext rec K = A
+and L = A
+
+let _ =
+  let module%ext E = P in
+  x
+
+let _ =
+  [%ext
+       let module E = P in
+       x]

--- a/test/passing/extensions-indent.ml.ref
+++ b/test/passing/extensions-indent.ml.ref
@@ -212,13 +212,13 @@ let () =
 
 open%ext M
 
-open%ext M
+[%%ext open M]
 
 [%%ext open! M]
 
 include%ext M
 
-include%ext M
+[%%ext include M]
 
 let x =
   let open%ext M in
@@ -236,7 +236,7 @@ let x =
 
 exception%ext E
 
-exception%ext E
+[%%ext exception E]
 
 let _ =
   let exception%ext E in
@@ -249,13 +249,14 @@ let _ =
 
 module%ext E = P
 
-module%ext E = P
+[%%ext module E = P]
 
 module%ext rec K = A
 and L = A
 
-module%ext rec K = A
-and L = A
+[%%ext
+   module rec K = A
+   and L = A]
 
 let _ =
   let module%ext E = P in
@@ -268,28 +269,28 @@ let _ =
 
 module type%ext E = P
 
-module type%ext E = P
+[%%ext module type E = P]
 
 class%ext x = y
 
-class%ext x = y
-
-class%ext x = y
-
-   and y = z
+[%%ext class x = y]
 
 class%ext x = y
 
    and y = z
 
-class type%ext x = y
+[%%ext class x = y
+
+       and y = z]
 
 class type%ext x = y
+
+[%%ext class type x = y]
 
 class type%ext x = y
 
    and y = z
 
-class type%ext x = y
+[%%ext class type x = y
 
-   and y = z
+       and y = z]

--- a/test/passing/extensions-indent.ml.ref
+++ b/test/passing/extensions-indent.ml.ref
@@ -209,3 +209,40 @@ let () =
        (* 2 *)
        [@foo "bar"]
        (* 3 *)]
+
+open%ext M
+
+open%ext M
+
+[%%ext open! M]
+
+include%ext M
+
+include%ext M
+
+let x =
+  let open%ext M in
+  x
+
+let x =
+  [%ext
+       let open M in
+       x]
+
+let x =
+  [%ext
+       let open! M in
+       x]
+
+exception%ext E
+
+exception%ext E
+
+let _ =
+  let exception%ext E in
+  x
+
+let _ =
+  [%ext
+       let exception E in
+       x]

--- a/test/passing/extensions-indent.ml.ref
+++ b/test/passing/extensions-indent.ml.ref
@@ -214,6 +214,8 @@ open%ext M
 
 [%%ext open M]
 
+open! %ext M
+
 [%%ext open! M]
 
 include%ext M
@@ -228,6 +230,10 @@ let x =
   [%ext
        let open M in
        x]
+
+let x =
+  let open! %ext M in
+  x
 
 let x =
   [%ext

--- a/test/passing/extensions-indent.ml.ref
+++ b/test/passing/extensions-indent.ml.ref
@@ -270,6 +270,18 @@ module type%ext E = P
 
 module type%ext E = P
 
+class%ext x = y
+
+class%ext x = y
+
+class%ext x = y
+
+   and y = z
+
+class%ext x = y
+
+   and y = z
+
 class type%ext x = y
 
 class type%ext x = y

--- a/test/passing/extensions-indent.ml.ref
+++ b/test/passing/extensions-indent.ml.ref
@@ -269,3 +269,15 @@ let _ =
 module type%ext E = P
 
 module type%ext E = P
+
+class type%ext x = y
+
+class type%ext x = y
+
+class type%ext x = y
+
+   and y = z
+
+class type%ext x = y
+
+   and y = z

--- a/test/passing/extensions-sugar_always.ml.ref
+++ b/test/passing/extensions-sugar_always.ml.ref
@@ -209,7 +209,9 @@ open%ext M
 
 open%ext M
 
-[%%ext open! M]
+open! %ext M
+
+open! %ext M
 
 include%ext M
 
@@ -224,9 +226,12 @@ let x =
   x
 
 let x =
-  [%ext
-    let open! M in
-    x]
+  let open! %ext M in
+  x
+
+let x =
+  let open! %ext M in
+  x
 
 exception%ext E
 

--- a/test/passing/extensions-sugar_always.ml.ref
+++ b/test/passing/extensions-sugar_always.ml.ref
@@ -262,6 +262,18 @@ module type%ext E = P
 
 module type%ext E = P
 
+class%ext x = y
+
+class%ext x = y
+
+class%ext x = y
+
+and y = z
+
+class%ext x = y
+
+and y = z
+
 class type%ext x = y
 
 class type%ext x = y

--- a/test/passing/extensions-sugar_always.ml.ref
+++ b/test/passing/extensions-sugar_always.ml.ref
@@ -261,3 +261,15 @@ let _ =
 module type%ext E = P
 
 module type%ext E = P
+
+class type%ext x = y
+
+class type%ext x = y
+
+class type%ext x = y
+
+and y = z
+
+class type%ext x = y
+
+and y = z

--- a/test/passing/extensions-sugar_always.ml.ref
+++ b/test/passing/extensions-sugar_always.ml.ref
@@ -239,3 +239,21 @@ let _ =
 let _ =
   let exception%ext E in
   x
+
+module%ext E = P
+
+module%ext E = P
+
+module%ext rec K = A
+and L = A
+
+module%ext rec K = A
+and L = A
+
+let _ =
+  let module%ext E = P in
+  x
+
+let _ =
+  let module%ext E = P in
+  x

--- a/test/passing/extensions-sugar_always.ml.ref
+++ b/test/passing/extensions-sugar_always.ml.ref
@@ -257,3 +257,7 @@ let _ =
 let _ =
   let module%ext E = P in
   x
+
+module type%ext E = P
+
+module type%ext E = P

--- a/test/passing/extensions-sugar_always.ml.ref
+++ b/test/passing/extensions-sugar_always.ml.ref
@@ -204,3 +204,38 @@ let () =
     (* 2 *)
     [@foo "bar"]
     (* 3 *)]
+
+open%ext M
+
+open%ext M
+
+[%%ext open! M]
+
+include%ext M
+
+include%ext M
+
+let x =
+  let open%ext M in
+  x
+
+let x =
+  let open%ext M in
+  x
+
+let x =
+  [%ext
+    let open! M in
+    x]
+
+exception%ext E
+
+exception%ext E
+
+let _ =
+  let exception%ext E in
+  x
+
+let _ =
+  let exception%ext E in
+  x

--- a/test/passing/extensions.ml
+++ b/test/passing/extensions.ml
@@ -242,3 +242,21 @@ let _ =
   [%ext
     let exception E in
     x]
+
+module%ext E = P
+[%%ext module E = P]
+
+module%ext rec K =A
+and L = A
+
+[%%ext module rec K =A
+and L = A]
+
+let _ =
+  let module%ext E = P in
+  x
+
+let _ =
+  [%ext
+    let module E = P in
+    x]

--- a/test/passing/extensions.ml
+++ b/test/passing/extensions.ml
@@ -210,3 +210,35 @@ ___________________________________________________________
 
 let () =
   (* -1 *) begin (* 0 *) % (* 0.5 *) test (* 1 *) [@foo (* 2 *) "bar"] (* 3 *) end
+
+open%ext M
+[%%ext open M]
+[%%ext open! M]
+include%ext M
+[%%ext include M]
+
+let x =
+  let open%ext M in
+  x
+
+let x =
+  [%ext
+    let open M in
+    x]
+
+let x =
+  [%ext
+    let open! M in
+    x]
+
+exception%ext E
+[%%ext exception E]
+
+let _ =
+  let exception%ext E in
+  x
+
+let _ =
+  [%ext
+    let exception E in
+    x]

--- a/test/passing/extensions.ml
+++ b/test/passing/extensions.ml
@@ -264,6 +264,16 @@ let _ =
 module type%ext E = P
 [%%ext module type E = P]
 
+class%ext x = y
+[%%ext class x = y]
+
+class%ext x = y
+and y = z
+
+[%%ext
+  class x = y
+  and y = z]
+
 class type%ext x = y
 [%%ext class type x = y]
 

--- a/test/passing/extensions.ml
+++ b/test/passing/extensions.ml
@@ -213,6 +213,7 @@ let () =
 
 open%ext M
 [%%ext open M]
+open! %ext M
 [%%ext open! M]
 include%ext M
 [%%ext include M]
@@ -225,6 +226,10 @@ let x =
   [%ext
     let open M in
     x]
+
+let x =
+  let open! %ext M in
+  x
 
 let x =
   [%ext

--- a/test/passing/extensions.ml
+++ b/test/passing/extensions.ml
@@ -263,3 +263,12 @@ let _ =
 
 module type%ext E = P
 [%%ext module type E = P]
+
+class type%ext x = y
+[%%ext class type x = y]
+
+class type%ext x = y
+and y = z
+
+[%%ext class type x = y
+and y = z]

--- a/test/passing/extensions.ml
+++ b/test/passing/extensions.ml
@@ -260,3 +260,6 @@ let _ =
   [%ext
     let module E = P in
     x]
+
+module type%ext E = P
+[%%ext module type E = P]

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -214,6 +214,8 @@ open%ext M
 
 [%%ext open M]
 
+open! %ext M
+
 [%%ext open! M]
 
 include%ext M
@@ -228,6 +230,10 @@ let x =
   [%ext
     let open M in
     x]
+
+let x =
+  let open! %ext M in
+  x
 
 let x =
   [%ext

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -246,3 +246,22 @@ let _ =
   [%ext
     let exception E in
     x]
+
+module%ext E = P
+
+module%ext E = P
+
+module%ext rec K = A
+and L = A
+
+module%ext rec K = A
+and L = A
+
+let _ =
+  let module%ext E = P in
+  x
+
+let _ =
+  [%ext
+    let module E = P in
+    x]

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -269,3 +269,15 @@ let _ =
 module type%ext E = P
 
 module type%ext E = P
+
+class type%ext x = y
+
+class type%ext x = y
+
+class type%ext x = y
+
+and y = z
+
+class type%ext x = y
+
+and y = z

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -212,13 +212,13 @@ let () =
 
 open%ext M
 
-open%ext M
+[%%ext open M]
 
 [%%ext open! M]
 
 include%ext M
 
-include%ext M
+[%%ext include M]
 
 let x =
   let open%ext M in
@@ -236,7 +236,7 @@ let x =
 
 exception%ext E
 
-exception%ext E
+[%%ext exception E]
 
 let _ =
   let exception%ext E in
@@ -249,13 +249,14 @@ let _ =
 
 module%ext E = P
 
-module%ext E = P
+[%%ext module E = P]
 
 module%ext rec K = A
 and L = A
 
-module%ext rec K = A
-and L = A
+[%%ext
+module rec K = A
+and L = A]
 
 let _ =
   let module%ext E = P in
@@ -268,28 +269,28 @@ let _ =
 
 module type%ext E = P
 
-module type%ext E = P
+[%%ext module type E = P]
 
 class%ext x = y
 
-class%ext x = y
-
-class%ext x = y
-
-and y = z
+[%%ext class x = y]
 
 class%ext x = y
 
 and y = z
 
-class type%ext x = y
+[%%ext class x = y
+
+       and y = z]
 
 class type%ext x = y
+
+[%%ext class type x = y]
 
 class type%ext x = y
 
 and y = z
 
-class type%ext x = y
+[%%ext class type x = y
 
-and y = z
+       and y = z]

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -279,9 +279,10 @@ class%ext x = y
 
 and y = z
 
-[%%ext class x = y
+[%%ext
+class x = y
 
-       and y = z]
+and y = z]
 
 class type%ext x = y
 
@@ -291,6 +292,7 @@ class type%ext x = y
 
 and y = z
 
-[%%ext class type x = y
+[%%ext
+class type x = y
 
-       and y = z]
+and y = z]

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -209,3 +209,40 @@ let () =
     (* 2 *)
     [@foo "bar"]
     (* 3 *)]
+
+open%ext M
+
+open%ext M
+
+[%%ext open! M]
+
+include%ext M
+
+include%ext M
+
+let x =
+  let open%ext M in
+  x
+
+let x =
+  [%ext
+    let open M in
+    x]
+
+let x =
+  [%ext
+    let open! M in
+    x]
+
+exception%ext E
+
+exception%ext E
+
+let _ =
+  let exception%ext E in
+  x
+
+let _ =
+  [%ext
+    let exception E in
+    x]

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -270,6 +270,18 @@ module type%ext E = P
 
 module type%ext E = P
 
+class%ext x = y
+
+class%ext x = y
+
+class%ext x = y
+
+and y = z
+
+class%ext x = y
+
+and y = z
+
 class type%ext x = y
 
 class type%ext x = y

--- a/test/passing/extensions.ml.ref
+++ b/test/passing/extensions.ml.ref
@@ -265,3 +265,7 @@ let _ =
   [%ext
     let module E = P in
     x]
+
+module type%ext E = P
+
+module type%ext E = P

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -38,7 +38,7 @@ type var =
 
 let ([%foo 2 + 1] : [%foo bar.baz]) = [%foo "foo"]
 
-[%%foo module M = [%bar]]
+module%foo M = [%bar]
 
 let ([%foo let () = ()] : [%foo type t = t]) = [%foo class c = object end]
 
@@ -190,12 +190,11 @@ and t = int [@@foo]
 [%%foo class x = x [@@foo]]
 [%%foo class type x = x [@@foo]]
 [%%foo external x : _ = "" [@@foo]]
-[%%foo exception X [@foo]]
-[%%foo module M = M [@@foo]]
+exception%foo X [@foo]
+module%foo M = M [@@foo]
 
-[%%foo
-  module rec M : S = M [@@foo]
-  and M : S = M [@@foo]]
+module%foo rec M : S = M [@@foo]
+and M : S = M [@@foo]
 
 [%%foo module type S = S [@@foo]]
 include%foo M [@@foo]

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -196,7 +196,7 @@ module%foo M = M [@@foo]
 module%foo rec M : S = M [@@foo]
 and M : S = M [@@foo]
 
-[%%foo module type S = S [@@foo]]
+module type%foo S = S [@@foo]
 include%foo M [@@foo]
 open%foo M [@@foo]
 

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -189,7 +189,7 @@ and t = int [@@foo]
 type%foo t += T [@@foo]
 class%foo x = x [@@foo]
 class type%foo x = x [@@foo]
-[%%foo external x : _ = "" [@@foo]]
+external%foo x : _ = "" [@@foo]
 exception%foo X [@foo]
 module%foo M = M [@@foo]
 

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -187,7 +187,7 @@ type%foo t = int [@@foo]
 and t = int [@@foo]
 
 [%%foo type t += T [@@foo]]
-[%%foo class x = x [@@foo]]
+class%foo x = x [@@foo]
 class type%foo x = x [@@foo]
 [%%foo external x : _ = "" [@@foo]]
 exception%foo X [@foo]

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -198,8 +198,8 @@ and t = int [@@foo]
   and M : S = M [@@foo]]
 
 [%%foo module type S = S [@@foo]]
-[%%foo include M [@@foo]]
-[%%foo open M [@@foo]]
+include%foo M [@@foo]
+open%foo M [@@foo]
 
 (* Signature items *)
 module type S = sig

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -188,7 +188,7 @@ and t = int [@@foo]
 
 [%%foo type t += T [@@foo]]
 [%%foo class x = x [@@foo]]
-[%%foo class type x = x [@@foo]]
+class type%foo x = x [@@foo]
 [%%foo external x : _ = "" [@@foo]]
 exception%foo X [@foo]
 module%foo M = M [@@foo]

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -186,7 +186,7 @@ type%foo t = int [@@foo]
 
 and t = int [@@foo]
 
-[%%foo type t += T [@@foo]]
+type%foo t += T [@@foo]
 class%foo x = x [@@foo]
 class type%foo x = x [@@foo]
 [%%foo external x : _ = "" [@@foo]]

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -38,7 +38,7 @@ type var =
 
 let ([%foo 2 + 1] : [%foo bar.baz]) = [%foo "foo"]
 
-module%foo M = [%bar]
+[%%foo module M = [%bar]]
 
 let ([%foo let () = ()] : [%foo type t = t]) = [%foo class c = object end]
 

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -38,7 +38,7 @@ x]
 
 let ([%foo 2 + 1] : [%foo bar.baz]) = [%foo "foo"]
 
-module%foo M = [%bar]
+[%%foo module M = [%bar]]
 
 let ([%foo let () = ()] : [%foo type t = t]) = [%foo class c = object end]
 

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -190,7 +190,7 @@ and t = int [@@foo]
 [%%foo class x = x [@@foo]]
 [%%foo class type x = x [@@foo]]
 [%%foo external x : _ = "" [@@foo]]
-[%%foo exception X [@foo]]
+exception%foo X [@foo]
 [%%foo module M = M [@@foo]]
 
 [%%foo
@@ -198,8 +198,8 @@ module rec M : S = M [@@foo]
 and M : S = M [@@foo]]
 
 [%%foo module type S = S [@@foo]]
-[%%foo include M [@@foo]]
-[%%foo open M [@@foo]]
+include%foo M [@@foo]
+open%foo M [@@foo]
 
 (* Signature items *)
 module type S = sig

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -38,7 +38,7 @@ x]
 
 let ([%foo 2 + 1] : [%foo bar.baz]) = [%foo "foo"]
 
-[%%foo module M = [%bar]]
+module%foo M = [%bar]
 
 let ([%foo let () = ()] : [%foo type t = t]) = [%foo class c = object end]
 
@@ -191,11 +191,10 @@ and t = int [@@foo]
 [%%foo class type x = x [@@foo]]
 [%%foo external x : _ = "" [@@foo]]
 exception%foo X [@foo]
-[%%foo module M = M [@@foo]]
+module%foo M = M [@@foo]
 
-[%%foo
-module rec M : S = M [@@foo]
-and M : S = M [@@foo]]
+module%foo rec M : S = M [@@foo]
+and M : S = M [@@foo]
 
 [%%foo module type S = S [@@foo]]
 include%foo M [@@foo]

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -196,7 +196,7 @@ module%foo M = M [@@foo]
 module%foo rec M : S = M [@@foo]
 and M : S = M [@@foo]
 
-[%%foo module type S = S [@@foo]]
+module type%foo S = S [@@foo]
 include%foo M [@@foo]
 open%foo M [@@foo]
 

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -189,7 +189,7 @@ and t = int [@@foo]
 type%foo t += T [@@foo]
 class%foo x = x [@@foo]
 class type%foo x = x [@@foo]
-[%%foo external x : _ = "" [@@foo]]
+external%foo x : _ = "" [@@foo]
 exception%foo X [@foo]
 module%foo M = M [@@foo]
 

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -187,7 +187,7 @@ type%foo t = int [@@foo]
 and t = int [@@foo]
 
 [%%foo type t += T [@@foo]]
-[%%foo class x = x [@@foo]]
+class%foo x = x [@@foo]
 class type%foo x = x [@@foo]
 [%%foo external x : _ = "" [@@foo]]
 exception%foo X [@foo]

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -188,7 +188,7 @@ and t = int [@@foo]
 
 [%%foo type t += T [@@foo]]
 [%%foo class x = x [@@foo]]
-[%%foo class type x = x [@@foo]]
+class type%foo x = x [@@foo]
 [%%foo external x : _ = "" [@@foo]]
 exception%foo X [@foo]
 module%foo M = M [@@foo]

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -186,7 +186,7 @@ type%foo t = int [@@foo]
 
 and t = int [@@foo]
 
-[%%foo type t += T [@@foo]]
+type%foo t += T [@@foo]
 class%foo x = x [@@foo]
 class type%foo x = x [@@foo]
 [%%foo external x : _ = "" [@@foo]]

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -108,7 +108,7 @@ and t = int [@@foo]
 
 [%%foo external x : _ = "" [@@foo]]
 
-[%%foo exception X [@@foo]]
+exception%foo X [@@foo]
 
 [%%foo module M = M [@@foo]]
 
@@ -118,9 +118,9 @@ and M : S = M [@@foo]]
 
 [%%foo module type S = S [@@foo]]
 
-[%%foo include M [@@foo]]
+include%foo M [@@foo]
 
-[%%foo open M [@@foo]]
+open%foo M [@@foo]
 
 (* Signature items *)
 module type S = sig

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -110,11 +110,10 @@ and t = int [@@foo]
 
 exception%foo X [@@foo]
 
-[%%foo module M = M [@@foo]]
+module%foo M = M [@@foo]
 
-[%%foo
-module rec M : S = M [@@foo]
-and M : S = M [@@foo]]
+module%foo rec M : S = M [@@foo]
+and M : S = M [@@foo]
 
 [%%foo module type S = S [@@foo]]
 

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -104,7 +104,7 @@ and t = int [@@foo]
 
 [%%foo class x = x [@@foo]]
 
-[%%foo class type x = x [@@foo]]
+class type%foo x = x [@@foo]
 
 [%%foo external x : _ = "" [@@foo]]
 

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -102,7 +102,7 @@ and t = int [@@foo]
 
 [%%foo type t += T [@@foo]]
 
-[%%foo class x = x [@@foo]]
+class%foo x = x [@@foo]
 
 class type%foo x = x [@@foo]
 

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -106,7 +106,7 @@ class%foo x = x [@@foo]
 
 class type%foo x = x [@@foo]
 
-[%%foo external x : _ = "" [@@foo]]
+external%foo x : _ = "" [@@foo]
 
 exception%foo X [@@foo]
 

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -100,7 +100,7 @@ type%foo t = int [@@foo]
 
 and t = int [@@foo]
 
-[%%foo type t += T [@@foo]]
+type%foo t += T [@@foo]
 
 class%foo x = x [@@foo]
 

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -115,7 +115,7 @@ module%foo M = M [@@foo]
 module%foo rec M : S = M [@@foo]
 and M : S = M [@@foo]
 
-[%%foo module type S = S [@@foo]]
+module type%foo S = S [@@foo]
 
 include%foo M [@@foo]
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -226,7 +226,7 @@ and t = int [@@foo]
 
 [%%foo external x : _ = "" [@@foo]]
 
-[%%foo exception X [@foo]]
+exception%foo X [@foo]
 
 [%%foo module M = M [@@foo]]
 
@@ -236,9 +236,9 @@ and M : S = M [@@foo]]
 
 [%%foo module type S = S [@@foo]]
 
-[%%foo include M [@@foo]]
+include%foo M [@@foo]
 
-[%%foo open M [@@foo]]
+open%foo M [@@foo]
 
 (* Signature items *)
 module type S = sig

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -42,7 +42,7 @@ x]
 
 let ([%foo 2 + 1] : [%foo bar.baz]) = [%foo "foo"]
 
-module%foo M = [%bar]
+[%%foo module M = [%bar]]
 
 let ([%foo let () = ()] : [%foo type t = t]) = [%foo class c = object end]
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -218,7 +218,7 @@ type%foo t = int [@@foo]
 
 and t = int [@@foo]
 
-[%%foo type t += T [@@foo]]
+type%foo t += T [@@foo]
 
 class%foo x = x [@@foo]
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -42,7 +42,7 @@ x]
 
 let ([%foo 2 + 1] : [%foo bar.baz]) = [%foo "foo"]
 
-[%%foo module M = [%bar]]
+module%foo M = [%bar]
 
 let ([%foo let () = ()] : [%foo type t = t]) = [%foo class c = object end]
 
@@ -228,11 +228,10 @@ and t = int [@@foo]
 
 exception%foo X [@foo]
 
-[%%foo module M = M [@@foo]]
+module%foo M = M [@@foo]
 
-[%%foo
-module rec M : S = M [@@foo]
-and M : S = M [@@foo]]
+module%foo rec M : S = M [@@foo]
+and M : S = M [@@foo]
 
 [%%foo module type S = S [@@foo]]
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -222,7 +222,7 @@ and t = int [@@foo]
 
 [%%foo class x = x [@@foo]]
 
-[%%foo class type x = x [@@foo]]
+class type%foo x = x [@@foo]
 
 [%%foo external x : _ = "" [@@foo]]
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -220,7 +220,7 @@ and t = int [@@foo]
 
 [%%foo type t += T [@@foo]]
 
-[%%foo class x = x [@@foo]]
+class%foo x = x [@@foo]
 
 class type%foo x = x [@@foo]
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -233,7 +233,7 @@ module%foo M = M [@@foo]
 module%foo rec M : S = M [@@foo]
 and M : S = M [@@foo]
 
-[%%foo module type S = S [@@foo]]
+module type%foo S = S [@@foo]
 
 include%foo M [@@foo]
 

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -224,7 +224,7 @@ class%foo x = x [@@foo]
 
 class type%foo x = x [@@foo]
 
-[%%foo external x : _ = "" [@@foo]]
+external%foo x : _ = "" [@@foo]
 
 exception%foo X [@foo]
 

--- a/test/passing/string.ml.ref
+++ b/test/passing/string.ml.ref
@@ -31,12 +31,11 @@ let f ("test"[@test "test"]) = 2
 \ xxxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxx \
  xxxxxxxx xxxxxxxxxxx"
 
-[%%c
-external print : str:string -> d:int -> void
+external%c print : str:string -> d:int -> void
   = {|
   printf("%s (%d)\n",$str,$d);
   fflush(stdout);
 |} {|
   printf("%s (%d)\n",$str,$d);
   fflush(stdout);
-|}]
+|}


### PR DESCRIPTION
Fix #1501 (since this issue focuses on structure items)

it seems that the deprecated `extension-sugar` extension is taken into account only for expressions, for structure items we always use the sugared syntax, and never for signature items.
The option is now taken into account for structure items.

No diff with test_branch.