### PR TITLE
Implement the Fmt module on top of a small kernel

### DIFF
--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -37,6 +37,9 @@ val ( $ ) : t -> t -> t
 val ( >$ ) : t -> ('b -> t) -> 'b -> t
 (** Pre-compose a format thunk onto a function returning a format thunk. *)
 
+val lazy_ : (unit -> t) -> t
+(** Defer the evaluation of some side effects until formatting happens. *)
+
 val set_margin : int -> t
 (** Set the margin. *)
 

--- a/test/unit/test_fmt.ml
+++ b/test/unit/test_fmt.ml
@@ -8,42 +8,39 @@ let eval_fmt term =
   Format_.pp_print_flush ppf () ;
   Buffer.contents buffer
 
-let join l = List.fold_left l ~init:Fmt.noop ~f:Fmt.( $ )
-
-let map_string s ~f = String.to_list s |> List.map ~f |> join
-
 let tests_lazy =
-  let test name term ~expected =
-    ( "lazy_: " ^ name
+  [ ( "lazy_: not using lazy"
     , `Quick
     , fun () ->
+        let r = ref None in
+        let pp s =
+          r := Some s ;
+          Fmt.str s
+        in
+        let term = Fmt.fmt_if_k false (pp "hello") in
+        let expected = "" in
+        let expected_r = Some "hello" in
         let got = eval_fmt term in
-        Alcotest.check Alcotest.(string) Caml.__LOC__ expected got )
-  in
-  let is_vowel = function
-    | 'a' | 'e' | 'i' | 'o' | 'u' | 'y' -> true
-    | _ -> false
-  in
-  [ test "not using lazy"
-      (let i = ref 0 in
-       let pp_letter c =
-         let open Fmt in
-         Int.incr i ;
-         str (Int.to_string !i) $ char c
-       in
-       let pp_if_vowel c = Fmt.fmt_if_k (is_vowel c) (pp_letter c) in
-       map_string "hello" ~f:pp_if_vowel)
-      ~expected:"2e5o"
-  ; test "using lazy"
-      (let i = ref 0 in
-       let pp_letter c =
-         let open Fmt in
-         lazy_ (fun () ->
-             Int.incr i ;
-             str (Int.to_string !i) $ char c)
-       in
-       let pp_if_vowel c = Fmt.fmt_if_k (is_vowel c) (pp_letter c) in
-       map_string "hello" ~f:pp_if_vowel)
-      ~expected:"1e2o" ]
+        let got_r = !r in
+        Alcotest.check Alcotest.(string) Caml.__LOC__ expected got ;
+        Alcotest.check Alcotest.(option string) Caml.__LOC__ expected_r got_r
+    )
+  ; ( "lazy_: using lazy"
+    , `Quick
+    , fun () ->
+        let r = ref None in
+        let pp s =
+          Fmt.lazy_ (fun () ->
+              r := Some s ;
+              Fmt.str s)
+        in
+        let term = Fmt.fmt_if_k false (pp "hello") in
+        let expected = "" in
+        let expected_r = None in
+        let got = eval_fmt term in
+        let got_r = !r in
+        Alcotest.check Alcotest.(string) Caml.__LOC__ expected got ;
+        Alcotest.check Alcotest.(option string) Caml.__LOC__ expected_r got_r
+    ) ]
 
 let tests = tests_lazy

--- a/test/unit/test_fmt.ml
+++ b/test/unit/test_fmt.ml
@@ -1,0 +1,49 @@
+open Base
+open Ocamlformat_lib
+
+let eval_fmt term =
+  let buffer = Buffer.create 0 in
+  let ppf = Format_.formatter_of_buffer buffer in
+  Fmt.eval ppf term ;
+  Format_.pp_print_flush ppf () ;
+  Buffer.contents buffer
+
+let join l = List.fold_left l ~init:Fmt.noop ~f:Fmt.( $ )
+
+let map_string s ~f = String.to_list s |> List.map ~f |> join
+
+let tests_lazy =
+  let test name term ~expected =
+    ( "lazy_: " ^ name
+    , `Quick
+    , fun () ->
+        let got = eval_fmt term in
+        Alcotest.check Alcotest.(string) Caml.__LOC__ expected got )
+  in
+  let is_vowel = function
+    | 'a' | 'e' | 'i' | 'o' | 'u' | 'y' -> true
+    | _ -> false
+  in
+  [ test "not using lazy"
+      (let i = ref 0 in
+       let pp_letter c =
+         let open Fmt in
+         Int.incr i ;
+         str (Int.to_string !i) $ char c
+       in
+       let pp_if_vowel c = Fmt.fmt_if_k (is_vowel c) (pp_letter c) in
+       map_string "hello" ~f:pp_if_vowel)
+      ~expected:"2e5o"
+  ; test "using lazy"
+      (let i = ref 0 in
+       let pp_letter c =
+         let open Fmt in
+         lazy_ (fun () ->
+             Int.incr i ;
+             str (Int.to_string !i) $ char c)
+       in
+       let pp_if_vowel c = Fmt.fmt_if_k (is_vowel c) (pp_letter c) in
+       map_string "hello" ~f:pp_if_vowel)
+      ~expected:"1e2o" ]
+
+let tests = tests_lazy

--- a/test/unit/test_fmt.mli
+++ b/test/unit/test_fmt.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test_case list

--- a/test/unit/test_unit.ml
+++ b/test/unit/test_unit.ml
@@ -114,6 +114,7 @@ let tests =
   [ ("Location", Test_location.tests)
   ; ("non overlapping interval tree", Test_noit.tests)
   ; ("Ast", Test_ast.tests)
-  ; ("Literal_lexer", Test_literal_lexer.tests) ]
+  ; ("Literal_lexer", Test_literal_lexer.tests)
+  ; ("Fmt", Test_fmt.tests) ]
 
 let () = Alcotest.run "ocamlformat" tests


### PR DESCRIPTION
Fmt is a lightweight abstraction on top of `Format` boxes (or rather `Format_` boxes). In its current implementation, we have `type t = Format.formatter -> unit`, and most of the module relies on that. It makes the current abstraction pretty leaky (even if it's just within the module), and hard to experiment with.

This PR defines a small kernel of functions that need to rely on the formatter abstraction, and implements the rest of the module on top of that, for example `list_pn`.

One pattern that has emerged is the need for a `lazy_` combinator, that defers side effects until corresponding bit is actually laid out. A test is added as an example. This missing combinator the part that was blocking previous attempts at modifying this module.

Inside of the module, this uses `Staged.t` in order to make staging explicit, which should make the move to another representation easier, but technically it's not required.