### PR TITLE
Add `is_unexpected_docstring` to compat

### DIFF
--- a/lib/Parse_with_comments.ml
+++ b/lib/Parse_with_comments.ml
@@ -43,11 +43,10 @@ let parse fragment (conf : Conf.t) ~source =
   let t =
     with_warning_filter
       ~filter:(fun loc warn ->
-        match warn with
-        | Warnings.Bad_docstring _ when conf.comment_check ->
-            w50 := (loc, warn) :: !w50 ;
-            false
-        | _ -> not conf.quiet)
+        if is_unexpected_docstring warn && conf.comment_check then (
+          w50 := (loc, warn) :: !w50 ;
+          false )
+        else not conf.quiet)
       ~f:(fun () ->
         let ast = Migrate_ast.Parse.fragment fragment lexbuf in
         Warnings.check_fatal () ;

--- a/vendor/compat/gen/gen.ml
+++ b/vendor/compat/gen/gen.ml
@@ -2,4 +2,12 @@ let () =
   let ocaml_version =
     Scanf.sscanf Sys.ocaml_version "%u.%u" (fun a b -> (a, b))
   in
-  print_string (if ocaml_version < (4, 08) then "lt_408.ml" else "ge_408.ml")
+  let filename =
+    if ocaml_version >= (4, 12) then
+      "ge_412.ml"
+    else if ocaml_version >= (4, 8) then
+      "ge_408.ml"
+    else
+      "lt_408.ml"
+  in
+  print_string filename

--- a/vendor/compat/warning.mli
+++ b/vendor/compat/warning.mli
@@ -2,3 +2,5 @@ val with_warning_filter :
   filter:(Location.t -> Warnings.t -> bool) -> f:(unit -> 'a) -> 'a
 
 val print_warning : Location.t -> Warnings.t -> unit
+
+val is_unexpected_docstring : Warnings.t -> bool

--- a/vendor/compat/warning/ge_412.ml
+++ b/vendor/compat/warning/ge_412.ml
@@ -18,5 +18,5 @@ let print_warning l w =
   | None -> ()
 
 let is_unexpected_docstring = function
-  | Warnings.Bad_docstring _ -> true
+  | Warnings.Unexpected_docstring _ -> true
   | _ -> false

--- a/vendor/compat/warning/lt_408.ml
+++ b/vendor/compat/warning/lt_408.ml
@@ -11,3 +11,7 @@ let with_warning_filter ~filter ~f =
 
 let print_warning l w =
   !Location.warning_printer l Caml.Format.err_formatter w
+
+let is_unexpected_docstring = function
+  | Warnings.Bad_docstring _ -> true
+  | _ -> false

--- a/vendor/parse-wyc/lib/docstrings.ml
+++ b/vendor/parse-wyc/lib/docstrings.ml
@@ -43,24 +43,6 @@ type docstring =
 
 let docstrings : docstring list ref = ref []
 
-(* Warn for unused and ambiguous docstrings *)
-
-let warn_bad_docstrings () =
-  if Warnings.is_active (Warnings.Bad_docstring true) then begin
-    List.iter
-      (fun ds ->
-         match ds.ds_attached with
-         | Info -> ()
-         | Unattached ->
-           prerr_warning ds.ds_loc (Warnings.Bad_docstring true)
-         | Docs ->
-             match ds.ds_associated with
-             | Zero | One -> ()
-             | Many ->
-               prerr_warning ds.ds_loc (Warnings.Bad_docstring false))
-      (List.rev !docstrings)
-end
-
 (* Docstring constructors and destructors *)
 
 let docstring body loc =

--- a/vendor/parse-wyc/lib/docstrings.mli
+++ b/vendor/parse-wyc/lib/docstrings.mli
@@ -24,9 +24,6 @@ open Migrate_parsetree.Ast_408
 (** (Re)Initialise all docstring state *)
 val init : unit -> unit
 
-(** Emit warnings for unattached and ambiguous docstrings *)
-val warn_bad_docstrings : unit -> unit
-
 (** {2 Docstrings} *)
 
 (** Documentation comments *)


### PR DESCRIPTION
In 4.12, this warning has been renamed to `Unexpected_docstring`, so we add this to the compat layer.

The vendored `Docstrings` in pwyc refers to that in an unused function, so we can just remove it.

Part of #1505 