### PR TITLE
Ppxlib: replace some map uses by fold and iter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,7 +53,7 @@
 
 #### Internal
 
-  + Use ppxlib instead of ocaml-migrate-parsetree 1.x. (#1482, @emillon)
+  + Use ppxlib instead of ocaml-migrate-parsetree 1.x. (#1482, #1510, @emillon)
 
 ### 0.15.0 (2020-08-06)
 

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -322,7 +322,7 @@ let init fragment ~debug source asts comments_n_docstrings =
         super#expression x
     end
   in
-  Mapper.iter_ast fragment iter asts;
+  Traverse.iter fragment iter asts ;
   t
 
 let preserve fmt_x t =

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -305,9 +305,9 @@ let init fragment ~debug source asts comments_n_docstrings =
   let relocate_loc_stack loc stack =
     List.iter stack ~f:(fun src -> relocate t ~src ~before:loc ~after:loc)
   in
-  let mapper =
+  let iter =
     object
-      inherit Ppxlib.Ast_traverse.map as super
+      inherit Ppxlib.Ast_traverse.iter as super
 
       method! pattern x =
         relocate_loc_stack x.ppat_loc x.ppat_loc_stack ;
@@ -322,7 +322,7 @@ let init fragment ~debug source asts comments_n_docstrings =
         super#expression x
     end
   in
-  let _ = Mapper.map_ast fragment mapper asts in
+  Mapper.iter_ast fragment iter asts;
   t
 
 let preserve fmt_x t =

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -29,7 +29,7 @@ open Migrate_ast
 type t
 
 val init :
-  'a Mapper.fragment -> debug:bool -> Source.t -> 'a -> Cmt.t list -> t
+  'a Traverse.fragment -> debug:bool -> Source.t -> 'a -> Cmt.t list -> t
 (** [init fragment source x comments] associates each comment in [comments]
     with a source location appearing in [x]. It uses [Source] to help resolve
     ambiguities. Initializes the state used by the [fmt] functions. *)

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1276,7 +1276,7 @@ let inputs =
   mk ~default
     Arg.(value & pos_all file_or_dash default & info [] ~doc ~docv ~docs)
 
-type kind = Kind : _ list Migrate_ast.Mapper.fragment -> kind
+type kind = Kind : _ list Migrate_ast.Traverse.fragment -> kind
 
 let kind : kind option ref =
   let doc = "Parse file with unrecognized extension as an implementation." in

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -85,7 +85,7 @@ type t =
 
 type file = Stdin | File of string
 
-type kind = Kind : _ list Migrate_ast.Mapper.fragment -> kind
+type kind = Kind : _ list Migrate_ast.Traverse.fragment -> kind
 
 type input = {kind: kind; name: string; file: file; conf: t}
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4509,13 +4509,13 @@ let fmt_toplevel c ctx itms =
 (** Entry points *)
 
 let fmt_file (type a) ~ctx ~fmt_code ~debug
-    (fragment : a list Mapper.fragment) source cmts conf (itms : a list) =
+    (fragment : a list Traverse.fragment) source cmts conf (itms : a list) =
   let c = {source; cmts; conf; debug; fmt_code} in
   match (fragment, itms) with
   | _, [] -> Cmts.fmt_after ~pro:noop c Location.none
-  | Mapper.Structure, l -> fmt_structure c ctx l
-  | Mapper.Signature, l -> fmt_signature c ctx l
-  | Mapper.Use_file, l -> fmt_toplevel c ctx l
+  | Traverse.Structure, l -> fmt_structure c ctx l
+  | Traverse.Signature, l -> fmt_signature c ctx l
+  | Traverse.Use_file, l -> fmt_toplevel c ctx l
 
 let fmt_code ~debug =
   let rec fmt_code conf s =
@@ -4524,9 +4524,7 @@ let fmt_code ~debug =
         let source = Source.create s in
         let cmts = Cmts.init Structure ~debug source ast comments in
         let ctx = Pld (PStr ast) in
-        Ok
-          (fmt_file ~ctx ~debug Mapper.Structure source cmts conf ast
-             ~fmt_code)
+        Ok (fmt_file ~ctx ~debug Structure source cmts conf ast ~fmt_code)
     | exception _ -> Error ()
   in
   fmt_code

--- a/lib/Fmt_ast.mli
+++ b/lib/Fmt_ast.mli
@@ -12,7 +12,7 @@
 (** Format OCaml Ast *)
 
 val fmt_fragment :
-     'a list Migrate_ast.Mapper.fragment
+     'a list Migrate_ast.Traverse.fragment
   -> debug:bool
   -> Source.t
   -> Cmts.t

--- a/lib/Loc_tree.ml
+++ b/lib/Loc_tree.ml
@@ -48,5 +48,5 @@ let fold src =
 
 (** Use Ast_mapper to collect all locs in ast, and create tree of them. *)
 let of_ast fragment ast src =
-  let locs = Mapper.fold_ast fragment (fold src) ast [] in
+  let locs = Traverse.fold fragment (fold src) ast [] in
   (of_list locs, locs)

--- a/lib/Loc_tree.mli
+++ b/lib/Loc_tree.mli
@@ -13,5 +13,5 @@ open Migrate_ast
 
 include Non_overlapping_interval_tree.S with type itv = Location.t
 
-val of_ast : 'a Mapper.fragment -> 'a -> Source.t -> t * Location.t list
+val of_ast : 'a Traverse.fragment -> 'a -> Source.t -> t * Location.t list
 (** Use Ast_mapper to collect all locs in ast, and create a tree of them. *)

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -36,7 +36,7 @@ module Asttypes = struct
   let is_mutable = function Mutable -> true | Immutable -> false
 end
 
-module Mapper = struct
+module Traverse = struct
   type 'a fragment =
     | Structure : Parsetree.structure fragment
     | Signature : Parsetree.signature fragment
@@ -48,22 +48,21 @@ module Mapper = struct
     | Signature -> Parsetree.equal_signature
     | Use_file -> List.equal Parsetree.equal_toplevel_phrase
 
-  let map_ast (type a) (x : a fragment) (m : Ppxlib.Ast_traverse.map) :
-      a -> a =
+  let map (type a) (x : a fragment) (m : Ppxlib.Ast_traverse.map) : a -> a =
     match x with
     | Structure -> m#structure
     | Signature -> m#signature
     | Use_file -> m#list m#toplevel_phrase
 
-  let iter_ast (type a) (fragment : a fragment)
-      (i : Ppxlib.Ast_traverse.iter) : a -> unit =
+  let iter (type a) (fragment : a fragment) (i : Ppxlib.Ast_traverse.iter) :
+      a -> unit =
     match fragment with
     | Structure -> i#structure
     | Signature -> i#signature
     | Use_file -> i#list i#toplevel_phrase
 
-  let fold_ast (type a) (fragment : a fragment)
-      (f : _ Ppxlib.Ast_traverse.fold) : a -> _ =
+  let fold (type a) (fragment : a fragment) (f : _ Ppxlib.Ast_traverse.fold)
+      : a -> _ =
     match fragment with
     | Structure -> f#structure
     | Signature -> f#signature
@@ -82,11 +81,11 @@ module Parse = struct
         | Ptop_def [] -> false
         | Ptop_def (_ :: _) | Ptop_dir _ -> true)
 
-  let fragment (type a) (fragment : a Mapper.fragment) lexbuf : a =
+  let fragment (type a) (fragment : a Traverse.fragment) lexbuf : a =
     match fragment with
-    | Mapper.Structure -> implementation lexbuf
-    | Mapper.Signature -> interface lexbuf
-    | Mapper.Use_file -> use_file lexbuf
+    | Traverse.Structure -> implementation lexbuf
+    | Traverse.Signature -> interface lexbuf
+    | Traverse.Use_file -> use_file lexbuf
 end
 
 module Printast = struct
@@ -104,10 +103,10 @@ module Printast = struct
 
   let use_file ppf x = pp_sexp ppf (List.sexp_of_t sexp_of#toplevel_phrase x)
 
-  let fragment (type a) : a Mapper.fragment -> _ -> a -> _ = function
-    | Mapper.Structure -> implementation
-    | Mapper.Signature -> interface
-    | Mapper.Use_file -> use_file
+  let fragment (type a) : a Traverse.fragment -> _ -> a -> _ = function
+    | Traverse.Structure -> implementation
+    | Traverse.Signature -> interface
+    | Traverse.Use_file -> use_file
 end
 
 module Pprintast = Ppxlib.Pprintast

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -54,6 +54,20 @@ module Mapper = struct
     | Structure -> m#structure
     | Signature -> m#signature
     | Use_file -> m#list m#toplevel_phrase
+
+  let iter_ast (type a) (fragment : a fragment)
+      (i : Ppxlib.Ast_traverse.iter) : a -> unit =
+    match fragment with
+    | Structure -> i#structure
+    | Signature -> i#signature
+    | Use_file -> i#list i#toplevel_phrase
+
+  let fold_ast (type a) (fragment : a fragment)
+      (f : _ Ppxlib.Ast_traverse.fold) : a -> _ =
+    match fragment with
+    | Structure -> f#structure
+    | Signature -> f#signature
+    | Use_file -> f#list f#toplevel_phrase
 end
 
 module Parse = struct

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -93,6 +93,10 @@ module Mapper : sig
   val equal : 'a fragment -> 'a -> 'a -> bool
 
   val map_ast : 'a fragment -> Ppxlib.Ast_traverse.map -> 'a -> 'a
+
+  val iter_ast : 'a fragment -> Ppxlib.Ast_traverse.iter -> 'a -> unit
+
+  val fold_ast : 'a fragment -> 'r Ppxlib.Ast_traverse.fold -> 'a -> 'r -> 'r
 end
 
 module Parse : sig

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -84,7 +84,7 @@ module Location : sig
   val is_single_line : t -> int -> bool
 end
 
-module Mapper : sig
+module Traverse : sig
   type 'a fragment =
     | Structure : Parsetree.structure fragment
     | Signature : Parsetree.signature fragment
@@ -92,15 +92,15 @@ module Mapper : sig
 
   val equal : 'a fragment -> 'a -> 'a -> bool
 
-  val map_ast : 'a fragment -> Ppxlib.Ast_traverse.map -> 'a -> 'a
+  val map : 'a fragment -> Ppxlib.Ast_traverse.map -> 'a -> 'a
 
-  val iter_ast : 'a fragment -> Ppxlib.Ast_traverse.iter -> 'a -> unit
+  val iter : 'a fragment -> Ppxlib.Ast_traverse.iter -> 'a -> unit
 
-  val fold_ast : 'a fragment -> 'r Ppxlib.Ast_traverse.fold -> 'a -> 'r -> 'r
+  val fold : 'a fragment -> 'r Ppxlib.Ast_traverse.fold -> 'a -> 'r -> 'r
 end
 
 module Parse : sig
-  val fragment : 'a Mapper.fragment -> Lexing.lexbuf -> 'a
+  val fragment : 'a Traverse.fragment -> Lexing.lexbuf -> 'a
 end
 
 module Printast : sig
@@ -114,7 +114,7 @@ module Printast : sig
 
   val use_file : Format.formatter -> Parsetree.toplevel_phrase list -> unit
 
-  val fragment : 'a Mapper.fragment -> Format.formatter -> 'a -> unit
+  val fragment : 'a Traverse.fragment -> Format.formatter -> 'a -> unit
 end
 
 module Pprintast = Ppxlib.Pprintast

--- a/lib/Normalize.ml
+++ b/lib/Normalize.ml
@@ -46,7 +46,7 @@ let dedup_cmts fragment ast comments =
           | _ -> super#attribute atr docs
       end
     in
-    Mapper.fold_ast fragment iter ast (Set.empty (module Cmt))
+    Traverse.fold fragment iter ast (Set.empty (module Cmt))
   in
   Set.(to_list (diff (of_list (module Cmt) comments) (of_ast ast)))
 
@@ -107,7 +107,7 @@ let rec odoc_nestable_block_element c fmt = function
           let ({ast; comments; _} : _ Parse_with_comments.with_comments) =
             Parse_with_comments.parse Structure c.conf ~source:txt
           in
-          let comments = dedup_cmts Mapper.Structure ast comments in
+          let comments = dedup_cmts Traverse.Structure ast comments in
           let print_comments fmt (l : Cmt.t list) =
             List.sort l ~compare:(fun {Cmt.loc= a; _} {Cmt.loc= b; _} ->
                 Location.compare a b)
@@ -358,11 +358,11 @@ let make_mapper conf ~ignore_doc_comments =
   end
 
 let normalize fragment c =
-  Mapper.map_ast fragment (make_mapper c ~ignore_doc_comments:false)
+  Traverse.map fragment (make_mapper c ~ignore_doc_comments:false)
 
 let equal fragment ~ignore_doc_comments c ast1 ast2 =
-  let map = Mapper.map_ast fragment (make_mapper c ~ignore_doc_comments) in
-  Mapper.equal fragment (map ast1) (map ast2)
+  let map = Traverse.map fragment (make_mapper c ~ignore_doc_comments) in
+  Traverse.equal fragment (map ast1) (map ast2)
 
 let fold_docstrings =
   let doc_attribute = function
@@ -391,8 +391,8 @@ let fold_docstrings =
       super#attributes (sort_attributes atrs)
   end
 
-let docstrings (type a) (fragment : a Mapper.fragment) s =
-  Mapper.fold_ast fragment fold_docstrings s []
+let docstrings (type a) (fragment : a Traverse.fragment) s =
+  Traverse.fold fragment fold_docstrings s []
 
 type docstring_error =
   | Moved of Location.t * Location.t * string

--- a/lib/Normalize.ml
+++ b/lib/Normalize.ml
@@ -24,12 +24,11 @@ type conf =
 (** Remove comments that duplicate docstrings (or other comments). *)
 let dedup_cmts fragment ast comments =
   let of_ast ast =
-    let docs = ref (Set.empty (module Cmt)) in
-    let mapper =
+    let iter =
       object
-        inherit Ppxlib.Ast_traverse.map as super
+        inherit [Set.M(Cmt).t] Ppxlib.Ast_traverse.fold as super
 
-        method! attribute atr =
+        method! attribute atr docs =
           match atr with
           | { attr_name= {txt= "ocaml.doc" | "ocaml.text"; _}
             ; attr_payload=
@@ -43,13 +42,11 @@ let dedup_cmts fragment ast comments =
                           , [] )
                     ; _ } ]
             ; _ } ->
-              docs := Set.add !docs (Cmt.create ("*" ^ doc) pexp_loc) ;
-              atr
-          | _ -> super#attribute atr
+              Set.add docs (Cmt.create ("*" ^ doc) pexp_loc)
+          | _ -> super#attribute atr docs
       end
     in
-    Mapper.map_ast fragment mapper ast |> ignore ;
-    !docs
+    Mapper.fold_ast fragment iter ast (Set.empty (module Cmt))
   in
   Set.(to_list (diff (of_list (module Cmt) comments) (of_ast ast)))
 
@@ -367,57 +364,35 @@ let equal fragment ~ignore_doc_comments c ast1 ast2 =
   let map = Mapper.map_ast fragment (make_mapper c ~ignore_doc_comments) in
   Mapper.equal fragment (map ast1) (map ast2)
 
-let make_docstring_mapper c docstrings =
+let fold_docstrings =
   let doc_attribute = function
     | {attr_name= {txt= "ocaml.doc" | "ocaml.text"; _}; _} -> true
     | _ -> false
   in
   object
-    inherit Ppxlib.Ast_traverse.map as super
+    inherit [(Location.t * string) list] Ppxlib.Ast_traverse.fold as super
 
-    method! attribute attr =
+    method! attribute attr docstrings =
       match (attr.attr_name, attr.attr_payload) with
-      | ( {txt= ("ocaml.doc" | "ocaml.text") as txt; loc}
+      | ( {txt= "ocaml.doc" | "ocaml.text"; loc}
         , PStr
             [ { pstr_desc=
                   Pstr_eval
                     ( { pexp_desc=
-                          Pexp_constant (Pconst_string (doc, str_loc, None))
-                      ; pexp_loc
-                      ; pexp_attributes
+                          Pexp_constant (Pconst_string (doc, _, None))
                       ; _ }
                     , [] )
-              ; pstr_loc } ] ) ->
-          let doc' = docstring c doc in
-          docstrings := (loc, doc) :: !docstrings ;
-          { attr_name= {txt; loc}
-          ; attr_payload=
-              super#payload
-                (PStr
-                   [ { pstr_desc=
-                         Pstr_eval
-                           ( { pexp_desc=
-                                 Pexp_constant
-                                   (Pconst_string (doc', str_loc, None))
-                             ; pexp_loc
-                             ; pexp_attributes
-                             ; pexp_loc_stack= [] }
-                           , [] )
-                     ; pstr_loc } ])
-          ; attr_loc= attr.attr_loc }
-      | _ -> super#attribute attr
+              ; _ } ] ) ->
+          (loc, doc) :: docstrings
+      | _ -> super#attribute attr docstrings
 
     method! attributes atrs =
       let atrs = List.filter atrs ~f:doc_attribute in
       super#attributes (sort_attributes atrs)
   end
 
-let docstrings (type a) (fragment : a Mapper.fragment) c s =
-  let docstrings = ref [] in
-  let (_ : a) =
-    Mapper.map_ast fragment (make_docstring_mapper c docstrings) s
-  in
-  !docstrings
+let docstrings (type a) (fragment : a Mapper.fragment) s =
+  Mapper.fold_ast fragment fold_docstrings s []
 
 type docstring_error =
   | Moved of Location.t * Location.t * string
@@ -425,8 +400,8 @@ type docstring_error =
 
 let moved_docstrings fragment c s1 s2 =
   let c = {conf= c; normalize_code= normalize Structure c} in
-  let d1 = docstrings fragment c s1 in
-  let d2 = docstrings fragment c s2 in
+  let d1 = docstrings fragment s1 in
+  let d2 = docstrings fragment s2 in
   let equal (_, x) (_, y) =
     let b = String.equal (docstring c x) (docstring c y) in
     Caml.Printf.printf "Docstring equal? %b,\n%s\n%s\n" b (docstring c x)

--- a/lib/Normalize.mli
+++ b/lib/Normalize.mli
@@ -13,7 +13,7 @@
 
 open Migrate_ast
 
-val dedup_cmts : 'a Mapper.fragment -> 'a -> Cmt.t list -> Cmt.t list
+val dedup_cmts : 'a Traverse.fragment -> 'a -> Cmt.t list -> Cmt.t list
 
 val comment : string -> string
 (** Normalize a comment. *)
@@ -21,11 +21,11 @@ val comment : string -> string
 val docstring : Conf.t -> string -> string
 (** Normalize a docstring. *)
 
-val normalize : 'a Mapper.fragment -> Conf.t -> 'a -> 'a
+val normalize : 'a Traverse.fragment -> Conf.t -> 'a -> 'a
 (** Normalize an AST fragment. *)
 
 val equal :
-     'a Mapper.fragment
+     'a Traverse.fragment
   -> ignore_doc_comments:bool
   -> Conf.t
   -> 'a
@@ -38,4 +38,4 @@ type docstring_error =
   | Unstable of Location.t * string
 
 val moved_docstrings :
-  'a Mapper.fragment -> Conf.t -> 'a -> 'a -> docstring_error list
+  'a Traverse.fragment -> Conf.t -> 'a -> 'a -> docstring_error list

--- a/lib/Parse_with_comments.mli
+++ b/lib/Parse_with_comments.mli
@@ -26,7 +26,7 @@ end
 exception Warning50 of (Location.t * Warnings.t) list
 
 val parse :
-     'a Migrate_ast.Mapper.fragment
+     'a Migrate_ast.Traverse.fragment
   -> Conf.t
   -> source:string
   -> 'a with_comments

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -228,10 +228,10 @@ let equal fragment ~ignore_doc_comments c a b =
 let normalize fragment c {Parse_with_comments.ast; _} =
   Normalize.normalize fragment c ast
 
-let recover (type a) : a Mapper.fragment -> _ = function
-  | Mapper.Structure -> Parse_wyc.Make_parsable.structure
-  | Mapper.Signature -> Parse_wyc.Make_parsable.signature
-  | Mapper.Use_file -> Parse_wyc.Make_parsable.use_file
+let recover (type a) : a Traverse.fragment -> _ = function
+  | Traverse.Structure -> Parse_wyc.Make_parsable.structure
+  | Traverse.Signature -> Parse_wyc.Make_parsable.signature
+  | Traverse.Use_file -> Parse_wyc.Make_parsable.use_file
 
 let format fragment ?output_file ~input_name ~source ~parsed conf opts =
   let open Result.Monad_infix in

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -12,7 +12,7 @@
 type error
 
 val parse_and_format :
-     _ list Migrate_ast.Mapper.fragment
+     _ list Migrate_ast.Traverse.fragment
   -> ?output_file:string
   -> input_name:string
   -> source:string

--- a/vendor/parse-wyc/lib/migrate_ast.ml
+++ b/vendor/parse-wyc/lib/migrate_ast.ml
@@ -17,12 +17,12 @@ module Mapper = struct
             Ppxlib.Parsetree.toplevel_phrase list )
           fragment
 
-  let iter_ast (type o p) (fragment:(o, p) fragment) (m:Ppxlib.Ast_traverse.iter) (x:p) =
+  let fold_ast (type o p) (fragment:(o, p) fragment)
+        (m:_ Ppxlib.Ast_traverse.fold) init (x:p) =
     match fragment with
-    | Structure -> m#structure x
-    | Signature -> m#signature x
-    | Use_file -> List.iter m#toplevel_phrase x
-
+    | Structure -> m#structure x init
+    | Signature -> m#signature x init
+    | Use_file -> List.fold_left (fun acc tlp -> m#toplevel_phrase tlp acc) init x
 
   let to_ppxlib (type o p) (f:(o, p) fragment) : o -> p =
     let module Conv = Ppxlib_ast.Select_ast (Ppxlib_ast__.Versions.OCaml_408) in

--- a/vendor/parse-wyc/lib/migrate_ast.mli
+++ b/vendor/parse-wyc/lib/migrate_ast.mli
@@ -17,7 +17,7 @@ module Mapper : sig
             Ppxlib.Parsetree.toplevel_phrase list )
           fragment
 
-  val iter_ast : (_, 'ppxlib) fragment -> Ppxlib.Ast_traverse.iter -> 'ppxlib -> unit
+  val fold_ast : (_, 'ppxlib) fragment -> 'a Ppxlib.Ast_traverse.fold -> 'a -> 'ppxlib -> 'a
 
   val to_ppxlib : ('omp, 'ppxlib) fragment -> 'omp -> 'ppxlib
 end


### PR DESCRIPTION
In most places, we are not interested by the return value and just using `map` for the side effects. These cases can be adapted to use `iter` instead.

In some places, this removes a good chunk of code that was used only to build tree fragments that were only ignored later.

Going further, most places only use side effects to build a list or a map. These can be adapted to use `fold`. This makes state management more explicit in parse-wyc.