### PR TITLE
Add symbolic names when printing warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 
   + Option 'let-open' is now deprecated, concrete syntax will always be preserved starting from OCamlFormat v0.17.0, corresponding to the current 'let-open=preserve' behavior. (#1467, @gpetiot)
 
+  + Warnings printed by ocamlformat itself now use the 4.12 style with symbolic names (#1511, @emillon)
+
 #### Bug fixes
 
   + Fix break between keyword and expr with `if-then-else=keyword-first` (#1419, @gpetiot)

--- a/test/passing/error3.ml.ref
+++ b/test/passing/error3.ml.ref
@@ -1,6 +1,6 @@
 ocamlformat: ignoring "error3.ml" (misplaced documentation comments - warning 50)
 File "error3.ml", line 2, characters 0-13:
-Warning 50: ambiguous documentation comment
+Warning 50 [unexpected-docstring]: ambiguous documentation comment
 File "error3.ml", line 3, characters 8-16:
-Warning 50: unattached documentation comment (ignored)
+Warning 50 [unexpected-docstring]: unattached documentation comment (ignored)
 Hint: (Warning 50) This file contains a documentation comment (** ... *) that the OCaml compiler does not know how to attach to the AST. OCamlformat does not support these cases. You can find more information at: https://github.com/ocaml-ppx/ocamlformat#overview. If you'd like to disable this check and let ocamlformat make a choice (though it might not be consistent with the ocaml compilers and odoc), you can set the --no-comment-check option.

--- a/test/passing/option.ml.ref
+++ b/test/passing/option.ml.ref
@@ -1,17 +1,17 @@
 File "option.ml", line 63, characters 17-28:
-Warning 47: illegal payload for attribute 'ocamlformat'.
+Warning 47 [attribute-payload]: illegal payload for attribute 'ocamlformat'.
 margin not allowed here
 File "option.ml", line 13, characters 3-19:
-Warning 47: illegal payload for attribute 'ocamlformat.typo'.
+Warning 47 [attribute-payload]: illegal payload for attribute 'ocamlformat.typo'.
 Invalid format: Unknown suffix "typo"
 File "option.ml", line 21, characters 3-14:
-Warning 47: illegal payload for attribute 'ocamlformat'.
+Warning 47 [attribute-payload]: illegal payload for attribute 'ocamlformat'.
 Invalid format: String expected
 File "option.ml", line 28, characters 3-14:
-Warning 47: illegal payload for attribute 'ocamlformat'.
+Warning 47 [attribute-payload]: illegal payload for attribute 'ocamlformat'.
 For option "if-then-else": invalid value `bad', expected one of `compact', `fit-or-vertical', `keyword-first' or `k-r'
 File "option.ml", line 39, characters 14-25:
-Warning 47: illegal payload for attribute 'ocamlformat'.
+Warning 47 [attribute-payload]: illegal payload for attribute 'ocamlformat'.
 For option "if-then-else": invalid value `bad', expected one of `compact', `fit-or-vertical', `keyword-first' or `k-r'
 let _ =
   if b

--- a/vendor/compat/warning/ge_408.ml
+++ b/vendor/compat/warning/ge_408.ml
@@ -12,9 +12,32 @@ let with_warning_filter ~filter ~f =
     reset () ; x
   with e -> reset () ; raise e
 
+let add_warning_name s =
+  match int_of_string s with
+  | exception _ -> s
+  | n ->
+      begin
+        match Warning_name.warning_name n with
+        | Some s -> Printf.sprintf "%d [%s]" n s
+        | None -> s
+      end
+
+let map_kind_code ~f = function
+  | Location.Report_error -> Location.Report_error
+  | Report_warning s -> Report_warning (f s)
+  | Report_warning_as_error s -> Report_warning_as_error (f s)
+  | Report_alert s -> Report_alert (f s)
+  | Report_alert_as_error s -> Report_alert_as_error (f s)
+
+let map_report_code report ~f =
+  { report with Location.kind = map_kind_code ~f report.Location.kind
+  }
+
 let print_warning l w =
   match Location.default_warning_reporter l w with
-  | Some reporter -> Location.print_report Caml.Format.err_formatter reporter
+  | Some report ->
+      map_report_code report ~f:add_warning_name |>
+      Location.print_report Caml.Format.err_formatter
   | None -> ()
 
 let is_unexpected_docstring = function

--- a/vendor/compat/warning/lt_408.ml
+++ b/vendor/compat/warning/lt_408.ml
@@ -1,3 +1,5 @@
+open Base
+
 let with_warning_filter ~filter ~f =
   let warning_printer = !Location.warning_printer in
   (Location.warning_printer :=
@@ -9,8 +11,39 @@ let with_warning_filter ~filter ~f =
     reset () ; x
   with e -> reset () ; raise e
 
+let print_to_string f =
+  let buf = Buffer.create 0 in
+  let ppf = Caml.Format.formatter_of_buffer buf in
+  f ppf;
+  Caml.Format.pp_print_flush ppf ();
+  Buffer.contents buf
+
+let expand_names_on_line s =
+  let open Option in
+  let parsed_line =
+    String.index s ':' >>= fun colon_pos ->
+    let before_colon = String.subo s ~len:(colon_pos) in
+    String.chop_prefix before_colon ~prefix:"Warning " >>= fun n_str ->
+    Caml.int_of_string_opt n_str >>= fun n ->
+    Warning_name.warning_name n >>| fun name ->
+    let rest = String.subo s ~pos:colon_pos in
+    (n, name, rest)
+  in
+  match parsed_line with
+  | None -> s
+  | Some (n, name, rest) ->
+      Printf.sprintf "Warning %d [%s]%s" n name rest
+
+let expand_names s =
+  String.split_lines s
+  |> List.map ~f:expand_names_on_line
+  |> List.map ~f:(fun s -> s ^ "\n")
+  |> String.concat ~sep:""
+
 let print_warning l w =
-  !Location.warning_printer l Caml.Format.err_formatter w
+  print_to_string (fun ppf -> !Location.warning_printer l ppf w)
+  |> expand_names
+  |> Caml.Format.eprintf "%s"
 
 let is_unexpected_docstring = function
   | Warnings.Bad_docstring _ -> true

--- a/vendor/compat/warning_name.ml
+++ b/vendor/compat/warning_name.ml
@@ -1,0 +1,4 @@
+let warning_name = function
+  | 47 -> Some "attribute-payload"
+  | 50 -> Some "unexpected-docstring"
+  | _ -> None


### PR DESCRIPTION
This is the new behavior on 4.12. For 4.08 to 4.11 it is possible to map the string in the report value, but for 4.06 and 4.07 we need to parse the string that is being printed.

See #1508