### PR TITLE
opam metadata: bump the bound to < 4.13

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,6 +37,10 @@
   (ocaml
    (and
     (>= 4.06)
+    (< 4.13)))
+  (ocaml
+   (and
+    :with-test
     (< 4.12)))
   (alcotest :with-test)
   (base

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -10,7 +10,8 @@ homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.06" & < "4.12"}
+  "ocaml" {>= "4.06" & < "4.13"}
+  "ocaml" {with-test & < "4.12"}
   "alcotest" {with-test}
   "base" {>= "v0.12.0" & < "v0.15"}
   "base-unix"


### PR DESCRIPTION
The tests do not pass for now but ocamlformat can be built.

This will also make sure OCaml health check knows about 4.12
compatibility in master.