### PR TITLE
Comments of type constrained label in record pattern have to be relocated in 4.12

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,8 @@
 
   + Do not change the spaces within the code spans in docstrings (#1499, @gpetiot)
 
+  + Comments of type constrained label in record pattern have to be relocated in 4.12 (#1517, @gpetiot)
+
 #### New features
 
 #### Internal

--- a/dune-project
+++ b/dune-project
@@ -42,6 +42,7 @@
    (and
     :with-test
     (< 4.12)))
+  ocaml-version
   (alcotest :with-test)
   (base
    (and

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1030,6 +1030,12 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
           | Ppat_constraint ({ppat_desc= Ppat_var {txt; _}; ppat_loc; _}, t)
             when field_alias ~field:lid1.txt (Longident.lident txt)
                  && List.is_empty ppat_attributes ->
+              if
+                Ocaml_version.(compare Parse.parser_version Releases.v4_12)
+                >= 0
+              then
+                Cmts.relocate c.cmts ~src:ppat_loc ~before:lid1.loc
+                  ~after:lid1.loc ;
               let typ = sub_typ ~ctx:(Pat pat) t in
               Cmts.fmt c ppat_loc @@ fmt_record_field c ~typ lid1
           | Ppat_constraint ({ppat_desc= Ppat_unpack _; ppat_loc; _}, _) ->

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1039,7 +1039,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
               let typ = sub_typ ~ctx:(Pat pat) t
               and rhs = fmt_rhs ~ctx:(Pat pat) p in
               let type_first =
-                Poly.(`Type_first = Source.typed_pattern t p)
+                Source.type_constraint_is_first t p.ppat_loc
               in
               Cmts.fmt c p.ppat_loc
               @@ fmt_record_field c ~typ ~rhs ~type_first lid1
@@ -2338,7 +2338,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
               @@ fmt_record_field c ~rhs:(fmt_rhs f) lid1
           | Pexp_constraint (e, t) when List.is_empty f.pexp_attributes ->
               let type_first =
-                Poly.(`Type_first = Source.typed_expression t e)
+                Source.type_constraint_is_first t e.pexp_loc
               in
               Cmts.fmt c f.pexp_loc
               @@ fmt_record_field c ~typ:(sub_typ ~ctx t) ~rhs:(fmt_rhs e)
@@ -4369,7 +4369,7 @@ and fmt_value_binding c let_op ~rec_flag ?ext ?in_ ?epi ctx ~attributes ~loc
                   , ( {ptyp_desc= Ptyp_package _; ptyp_attributes= []; _} as
                     typ ) )
               , _ )
-              when Poly.(Source.typed_expression typ exp = `Type_first) ->
+              when Source.type_constraint_is_first typ exp.pexp_loc ->
                 Cmts.relocate c.cmts ~src:body.pexp_loc ~before:exp.pexp_loc
                   ~after:exp.pexp_loc ;
                 fmt_cstr_and_xbody typ exp
@@ -4380,7 +4380,7 @@ and fmt_value_binding c let_op ~rec_flag ?ext ?in_ ?epi ctx ~attributes ~loc
              |Pexp_constraint _, Ppat_constraint _ ->
                 (None, xbody)
             | Pexp_constraint (exp, typ), _
-              when Poly.(Source.typed_expression typ exp = `Type_first) ->
+              when Source.type_constraint_is_first typ exp.pexp_loc ->
                 Cmts.relocate c.cmts ~src:body.pexp_loc ~before:exp.pexp_loc
                   ~after:exp.pexp_loc ;
                 fmt_cstr_and_xbody typ exp

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -86,6 +86,8 @@ module Parse = struct
     | Traverse.Structure -> implementation lexbuf
     | Traverse.Signature -> interface lexbuf
     | Traverse.Use_file -> use_file lexbuf
+
+  let parser_version = Ocaml_version.of_string_exn Sys.ocaml_version
 end
 
 module Printast = struct

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -87,7 +87,7 @@ module Parse = struct
     | Traverse.Signature -> interface lexbuf
     | Traverse.Use_file -> use_file lexbuf
 
-  let parser_version = Ocaml_version.of_string_exn Sys.ocaml_version
+  let parser_version = Ocaml_version.sys_version
 end
 
 module Printast = struct

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -101,6 +101,8 @@ end
 
 module Parse : sig
   val fragment : 'a Traverse.fragment -> Lexing.lexbuf -> 'a
+
+  val parser_version : Ocaml_version.t
 end
 
 module Printast : sig

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -300,14 +300,8 @@ let extension_using_sugar ~(name : string Location.loc)
     ~(payload : Location.t) =
   Source_code_position.ascending name.loc.loc_start payload.loc_start > 0
 
-let typed_expression (typ : Parsetree.core_type)
-    (expr : Parsetree.expression) =
-  if Location.compare_start typ.ptyp_loc expr.pexp_loc < 0 then `Type_first
-  else `Expr_first
-
-let typed_pattern (typ : Parsetree.core_type) (pat : Parsetree.pattern) =
-  if Location.compare_start typ.ptyp_loc pat.ppat_loc < 0 then `Type_first
-  else `Pat_first
+let type_constraint_is_first typ loc =
+  Location.compare_start typ.Parsetree.ptyp_loc loc < 0
 
 let loc_of_underscore t flds (ppat_loc : Location.t) =
   let end_last_field =

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -60,11 +60,7 @@ val extension_using_sugar :
 val extend_loc_to_include_attributes :
   t -> Location.t -> Parsetree.attributes -> Location.t
 
-val typed_expression :
-  Parsetree.core_type -> Parsetree.expression -> [`Type_first | `Expr_first]
-
-val typed_pattern :
-  Parsetree.core_type -> Parsetree.pattern -> [`Type_first | `Pat_first]
+val type_constraint_is_first : Parsetree.core_type -> Location.t -> bool
 
 val loc_of_underscore :
   t -> ('a * Parsetree.pattern) list -> Location.t -> Location.t option

--- a/lib/dune
+++ b/lib/dune
@@ -16,5 +16,6 @@
  (flags
   (:standard -open Base -open Import -open Compat))
  ;;INSERT_BISECT_HERE;;
- (libraries format_ import ocaml-migrate-parsetree odoc.model odoc.parser
-   parse_wyc re uuseg uuseg.string token_latest compat dune-build-info ppxlib))
+ (libraries format_ import ocaml-migrate-parsetree ocaml-version odoc.model
+   odoc.parser parse_wyc re uuseg uuseg.string token_latest compat
+   dune-build-info ppxlib))

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -12,6 +12,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.06" & < "4.13"}
   "ocaml" {with-test & < "4.12"}
+  "ocaml-version"
   "alcotest" {with-test}
   "base" {>= "v0.12.0" & < "v0.15"}
   "base-unix"

--- a/test/passing/record-loose.ml.ref
+++ b/test/passing/record-loose.ml.ref
@@ -116,3 +116,7 @@ type t = {a : (module S); b : (module S)}
 let _ = {a = (module M : S); b = (module M : S)}
 
 let to_string {x; _ (* we should print y *)} = string_of_int x
+
+let {x (*b*) : z} = e
+
+let {(* a *) x (*b*) : (* c *) z (* d *)} = e

--- a/test/passing/record-tight_decl.ml.ref
+++ b/test/passing/record-tight_decl.ml.ref
@@ -116,3 +116,7 @@ type t = {a: (module S); b: (module S)}
 let _ = {a = (module M : S); b = (module M : S)}
 
 let to_string {x; _ (* we should print y *)} = string_of_int x
+
+let {x (*b*) : z} = e
+
+let {(* a *) x (*b*) : (* c *) z (* d *)} = e

--- a/test/passing/record.ml
+++ b/test/passing/record.ml
@@ -121,3 +121,7 @@ type t = { a : (module S); b : (module S) }
 let _ = { a = (module M : S); b = (module M : S) }
 
 let to_string {x; _ (* we should print y *)} = string_of_int x
+
+let { x (*b*) : z } = e
+
+let { (* a *) x (*b*) : (* c *) z (* d *) } = e

--- a/test/passing/record.ml.ref
+++ b/test/passing/record.ml.ref
@@ -116,3 +116,7 @@ type t = {a: (module S); b: (module S)}
 let _ = {a= (module M : S); b= (module M : S)}
 
 let to_string {x; _ (* we should print y *)} = string_of_int x
+
+let {x (*b*): z} = e
+
+let {(* a *) x (*b*): (* c *) z (* d *)} = e


### PR DESCRIPTION
Fix #1513 no change are required when the pattern is more complicated (other pattern matching cases of fmt_pattern) and same for expressions

The changes of `type_constraint_is_first` are not related to the bugfix but it makes the code easier to read.