### PR TITLE
Using tokens instead of string manipulation when inspecting the original source

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@
 
   + Remove extension from executable name in error messages. On Windows, this means that messages now start with "ocamlformat: ..." instead of "ocamlformat.exe: ..." (#1531, @emillon)
 
+  + Using tokens instead of string manipulation when inspecting the original source (#1526)
+
 #### Bug fixes
 
   + Fix break between keyword and expr with `if-then-else=keyword-first` (#1419, @gpetiot)

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -215,7 +215,8 @@ end
 module Parser = Token_latest
 
 module Lexer = struct
-  let token lexbuf = Lexer.token lexbuf |> Token_latest.of_compiler_libs
+  let token lexbuf =
+    Lexer.token_with_comments lexbuf |> Token_latest.of_compiler_libs
 
   type error = Lexer.error
 

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -235,7 +235,11 @@ let is_long_functor_syntax (t : t) ~from = function
       else
         (* since 4.12 the functor keyword is just before the loc of the
            functor parameter *)
-        match find_token_before t ~filter:(fun _ -> true) from.loc_start with
+        match
+          find_token_before t
+            ~filter:(function COMMENT _ | DOCSTRING _ -> false | _ -> true)
+            from.loc_start
+        with
         | Some (Parser.FUNCTOR, _) -> true
         | _ -> false )
 

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -357,14 +357,14 @@ let locs_of_interval source loc =
          CONSTANT-DOTDOT-CONSTANT "
 
 let loc_of_constant t loc (cst : Parsetree.constant) =
-  let loc_of_tok filter =
-    match tokens_at t loc ~filter with [(_, loc)] -> loc | _ -> loc
+  let filter : Parser.token -> bool =
+    match cst with
+    | Pconst_string _ -> ( function STRING _ -> true | _ -> false )
+    | Pconst_char _ -> ( function CHAR _ -> true | _ -> false )
+    | Pconst_integer _ -> ( function INT _ -> true | _ -> false )
+    | Pconst_float _ -> ( function FLOAT _ -> true | _ -> false )
   in
-  match cst with
-  | Pconst_string _ -> loc_of_tok (function STRING _ -> true | _ -> false)
-  | Pconst_char _ -> loc_of_tok (function CHAR _ -> true | _ -> false)
-  | Pconst_integer _ -> loc_of_tok (function INT _ -> true | _ -> false)
-  | Pconst_float _ -> loc_of_tok (function FLOAT _ -> true | _ -> false)
+  match tokens_at t loc ~filter with [(_, loc)] -> loc | _ -> loc
 
 let loc_of_pat_constant t (p : Parsetree.pattern) =
   match p.ppat_desc with

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -19,6 +19,7 @@ let create text =
   let rec loop acc =
     match Lexer.token lexbuf with
     | Parser.EOF -> Array.of_list_rev acc
+    | Parser.EOL -> loop acc
     | tok -> loop ((tok, Location.of_lexbuf lexbuf) :: acc)
   in
   {text; tokens= loop []}

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -339,6 +339,4 @@ let kk = (* foo *) (module A : T)
 
 let kk = (module A : T) (* foo *)
 
-let kk = (* foo *) (module A : T)
-
-(* foo *)
+let kk = (* foo *) (module A : T) (* foo *)


### PR DESCRIPTION
Do less string manipulation, rely on the list of token instead.