### PR TITLE
Remove extension from executable in error messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
 
   + Warnings printed by ocamlformat itself now use the 4.12 style with symbolic names (#1511, #1518, @emillon)
 
+  + Remove extension from executable name in error messages. On Windows, this means that messages now start with "ocamlformat: ..." instead of "ocamlformat.exe: ..." (#1531, @emillon)
+
 #### Bug fixes
 
   + Fix break between keyword and expr with `if-then-else=keyword-first` (#1419, @gpetiot)

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -35,8 +35,9 @@ let source_from_file = function
   | File f -> In_channel.with_file f ~f:In_channel.input_all
 
 let print_error conf opts ~input_name e =
-  Translation_unit.print_error ~debug:opts.Conf.debug ~quiet:conf.Conf.quiet
-    ~input_name e
+  let exe = Filename.basename Caml.Sys.argv.(0) in
+  Translation_unit.print_error ~exe ~debug:opts.Conf.debug
+    ~quiet:conf.Conf.quiet ~input_name e
 
 let run_action action opts =
   match action with

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -34,8 +34,13 @@ let source_from_file = function
   | Conf.Stdin -> In_channel.input_all In_channel.stdin
   | File f -> In_channel.with_file f ~f:In_channel.input_all
 
+let chop_any_extension s =
+  match Filename.chop_extension s with
+  | r -> r
+  | exception Invalid_argument _ -> s
+
 let print_error conf opts ~input_name e =
-  let exe = Filename.basename Caml.Sys.argv.(0) in
+  let exe = chop_any_extension (Filename.basename Caml.Sys.argv.(0)) in
   Translation_unit.print_error ~exe ~debug:opts.Conf.debug
     ~quiet:conf.Conf.quiet ~input_name e
 

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -41,8 +41,8 @@ let chop_any_extension s =
 
 let print_error conf opts ~input_name e =
   let exe = chop_any_extension (Filename.basename Caml.Sys.argv.(0)) in
-  Translation_unit.print_error ~exe ~debug:opts.Conf.debug
-    ~quiet:conf.Conf.quiet ~input_name e
+  Translation_unit.print_error ~fmt:Format.err_formatter ~exe
+    ~debug:opts.Conf.debug ~quiet:conf.Conf.quiet ~input_name e
 
 let run_action action opts =
   match action with

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -61,9 +61,8 @@ let dump_formatted ~input_name ?output_file ~suffix fmted =
   with_file input_name output_file suffix ext (fun oc ->
       Out_channel.output_string oc fmted )
 
-let print_error ?(fmt = Format.err_formatter) ~debug ~quiet ~input_name error
-    =
-  let exe = Filename.basename Caml.Sys.argv.(0) in
+let print_error ?(fmt = Format.err_formatter) ~exe ~debug ~quiet ~input_name
+    error =
   match error with
   | Invalid_source _ when quiet -> ()
   | Invalid_source {exn} -> (

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -61,8 +61,7 @@ let dump_formatted ~input_name ?output_file ~suffix fmted =
   with_file input_name output_file suffix ext (fun oc ->
       Out_channel.output_string oc fmted )
 
-let print_error ?(fmt = Format.err_formatter) ~exe ~debug ~quiet ~input_name
-    error =
+let print_error ~fmt ~exe ~debug ~quiet ~input_name error =
   match error with
   | Invalid_source _ when quiet -> ()
   | Invalid_source {exn} -> (

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -24,6 +24,7 @@ val parse_and_format :
 
 val print_error :
      ?fmt:Format.formatter
+  -> exe:string
   -> debug:bool
   -> quiet:bool
   -> input_name:string

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -23,7 +23,7 @@ val parse_and_format :
     formats [source] as a list of fragments. *)
 
 val print_error :
-     ?fmt:Format.formatter
+     fmt:Format.formatter
   -> exe:string
   -> debug:bool
   -> quiet:bool


### PR DESCRIPTION
This ensures that on Windows the messages start with "ocamlformat: ..." and not "ocamlformat.exe: ..." (these appear in tests for example).