### PR TITLE
fix invalid source handling .. (quick fix, invalid locations in warnings)

### DIFF
--- a/test/passing/format_invalid_files.ml.ref
+++ b/test/passing/format_invalid_files.ml.ref
@@ -11,7 +11,9 @@ module K = struct
 begin
   let x = in
   ()
+;;
 
 let foooooo = fooooo foooooooo
 
 let k =
+;;

--- a/test/passing/partial.ml.ref
+++ b/test/passing/partial.ml.ref
@@ -14,3 +14,4 @@ else (d, m)
     let rem n k = snd (quot_rem n k) in
 
 quot, rem
+;;

--- a/test/passing/partial_double_quotes.ml.ref
+++ b/test/passing/partial_double_quotes.ml.ref
@@ -1,3 +1,4 @@
 Warning: partial_double_quotes.ml is invalid, recovering.
 Warning: partial_double_quotes.ml is invalid, recovering.
 let x = "123" +
+;;

--- a/vendor/parse-wyc/lib/parse_wyc.ml
+++ b/vendor/parse-wyc/lib/parse_wyc.ml
@@ -214,7 +214,7 @@ let mk_parsable fragment source =
       let delim = "_i_n_v_a_l_i_d_" in
       let extension_name = "%%invalid.ast.node" in
       let wrapper_opn, wrapper_cls =
-        (Printf.sprintf "[%s {%s|" extension_name delim, Printf.sprintf "|%s}]" delim)
+        (Printf.sprintf "[%s {%s|" extension_name delim, Printf.sprintf "\n;;|%s}]" delim)
       in
       let wrapper_len = String.length wrapper_opn + String.length wrapper_cls in
       let source_len = String.length source in


### PR DESCRIPTION
This is a quick fix for #1534 

- The addition of the `;;` should only be done if present in the original source
- This gives bad location for warnings