### PR TITLE
Fix invalid source handling (with correct locations)

### DIFF
--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -489,6 +489,7 @@ let diff (conf : Conf.t) x y =
             let str = String.sub ~pos:1 ~len str in
             try
               Migrate_ast.Parse.fragment Structure (Lexing.from_string str)
+                Lexer.token
               |> Normalize.normalize Structure conf
               |> Caml.Format.asprintf "%a" Printast.implementation
             with _ -> norm_non_code z

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4547,7 +4547,7 @@ let fmt_file (type a) ~ctx ~fmt_code ~debug
 
 let fmt_code ~debug =
   let rec fmt_code conf s =
-    match Parse_with_comments.parse Structure conf ~source:s with
+    match Parse_with_comments.parse Structure conf ~source:s ~invalid:[] with
     | {ast; comments; _} ->
         let source = Source.create s in
         let cmts = Cmts.init Structure ~debug source ast comments in

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -70,22 +70,88 @@ module Traverse = struct
 end
 
 module Parse = struct
-  let implementation = Ppxlib_ast.Parse.implementation
+  let wrap parsing_fun lexbuf =
+    let open Ocaml_common in
+    try
+      Docstrings.init () ;
+      Lexer.init () ;
+      let ast = parsing_fun lexbuf in
+      Stdlib.Parsing.clear_parser () ;
+      Docstrings.warn_bad_docstrings () ;
+      ast
+    with Stdlib.Parsing.Parse_error | Syntaxerr.Escape_error ->
+      let loc = Location.curr lexbuf in
+      raise (Syntaxerr.Error (Syntaxerr.Other loc))
 
-  let interface = Ppxlib_ast.Parse.interface
+  let rec loop token lexbuf in_error checkpoint =
+    let module I = Parser.MenhirInterpreter in
+    match checkpoint with
+    | I.InputNeeded _env ->
+        let triple =
+          if in_error then
+            (* The parser detected an error. At this point we don't want to
+               consume input anymore. In the top-level, it would translate
+               into waiting for the user to type something, just to raise an
+               error at some earlier position, rather than just raising the
+               error immediately.
 
-  let use_file lexbuf =
-    List.filter (Ppxlib_ast.Parse.use_file lexbuf)
+               This worked before with yacc because, AFAICT (@let-def): -
+               yacc eagerly reduces "default reduction" (when the next action
+               is to reduce the same production no matter what token is read,
+               yacc reduces it immediately rather than waiting for that token
+               to be read) - error productions in OCaml grammar are always in
+               a position that allows default reduction ("error" symbol is
+               the last producer, and the lookahead token will not be used to
+               disambiguate between two possible error rules) This solution
+               is fragile because it relies on an optimization (default
+               reduction), that changes the semantics of the parser the way
+               it is implemented in Yacc (an optimization that changes
+               semantics? hmmmm).
+
+               Rather than relying on implementation details of the parser,
+               when an error is detected in this loop we stop looking at the
+               input and fill the parser with EOF tokens. The skip_phrase
+               logic will resynchronize the input stream by looking for the
+               next ';;'. *)
+            (Parser.EOF, lexbuf.Lexing.lex_curr_p, lexbuf.Lexing.lex_curr_p)
+          else
+            let token = token lexbuf in
+            (token, lexbuf.Lexing.lex_start_p, lexbuf.Lexing.lex_curr_p)
+        in
+        let checkpoint = I.offer checkpoint triple in
+        loop token lexbuf in_error checkpoint
+    | I.Shifting _ | I.AboutToReduce _ ->
+        loop token lexbuf in_error (I.resume checkpoint)
+    | I.Accepted v -> v
+    | I.Rejected -> raise Parser.Error
+    | I.HandlingError _ -> loop token lexbuf true (I.resume checkpoint)
+
+  let wrap_menhir entry lexbuf token =
+    let initial = entry lexbuf.Lexing.lex_curr_p in
+    wrap (fun lexbuf -> loop token lexbuf false initial) lexbuf
+
+  let implementation = wrap_menhir Parser.Incremental.implementation
+
+  and interface = wrap_menhir Parser.Incremental.interface
+
+  and use_file = wrap_menhir Parser.Incremental.use_file
+
+  module Of_ocaml = Ppxlib_ast.Import_for_core.Parse.Of_ocaml
+
+  let use_file lexbuf token =
+    List.filter (use_file lexbuf token)
       ~f:(fun (p : Parsetree.toplevel_phrase) ->
         match p with
         | Ptop_def [] -> false
         | Ptop_def (_ :: _) | Ptop_dir _ -> true )
 
-  let fragment (type a) (fragment : a Traverse.fragment) lexbuf : a =
+  let fragment (type a) (fragment : a Traverse.fragment) lexbuf token : a =
     match fragment with
-    | Traverse.Structure -> implementation lexbuf
-    | Traverse.Signature -> interface lexbuf
-    | Traverse.Use_file -> use_file lexbuf
+    | Traverse.Structure ->
+        implementation lexbuf token |> Of_ocaml.copy_structure
+    | Traverse.Signature -> interface lexbuf token |> Of_ocaml.copy_signature
+    | Traverse.Use_file ->
+        use_file lexbuf token |> List.map ~f:Of_ocaml.copy_toplevel_phrase
 
   let parser_version = Ocaml_version.sys_version
 end

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -84,6 +84,8 @@ module Location : sig
   val width : t -> int
 
   val is_single_line : t -> int -> bool
+
+  val to_string : t -> string
 end
 
 module Traverse : sig
@@ -102,7 +104,11 @@ module Traverse : sig
 end
 
 module Parse : sig
-  val fragment : 'a Traverse.fragment -> Lexing.lexbuf -> 'a
+  val fragment :
+       'a Traverse.fragment
+    -> Lexing.lexbuf
+    -> (Lexing.lexbuf -> Parser.token)
+    -> 'a
 
   val parser_version : Ocaml_version.t
 end

--- a/lib/Normalize.ml
+++ b/lib/Normalize.ml
@@ -106,6 +106,7 @@ let rec odoc_nestable_block_element c fmt = function
         try
           let ({ast; comments; _} : _ Parse_with_comments.with_comments) =
             Parse_with_comments.parse Structure c.conf ~source:txt
+              ~invalid:[]
           in
           let comments = dedup_cmts Traverse.Structure ast comments in
           let print_comments fmt (l : Cmt.t list) =

--- a/lib/Parse_with_comments.ml
+++ b/lib/Parse_with_comments.ml
@@ -26,7 +26,76 @@ end
 
 exception Warning50 of (Location.t * Warnings.t) list
 
-let parse fragment (conf : Conf.t) ~source =
+type pending =
+  | No
+  | Pending of {tokens: Parser.token list; invalid_loc: Location.t}
+
+let wrap_token source invalid =
+  match invalid with
+  | [] -> Lexer.token
+  | _ -> (
+      let invalid = ref invalid in
+      let pending = ref No in
+      let maybe_emit lexbuf pending =
+        match !pending with
+        | No -> None
+        | Pending {tokens= []; invalid_loc= _} -> assert false
+        | Pending {tokens= x :: xs; invalid_loc} ->
+            lexbuf.Lexing.lex_start_p <- invalid_loc.Location.loc_start ;
+            lexbuf.Lexing.lex_curr_p <- invalid_loc.Location.loc_end ;
+            (pending :=
+               match xs with
+               | [] ->
+                   lexbuf.Lexing.lex_curr_pos <-
+                     invalid_loc.Location.loc_end.pos_cnum ;
+                   lexbuf.Lexing.lex_start_pos <-
+                     invalid_loc.Location.loc_start.pos_cnum ;
+                   No
+               | tokens -> Pending {tokens; invalid_loc} ) ;
+            Some x
+      in
+      fun lexbuf ->
+        match maybe_emit lexbuf pending with
+        | Some x -> x
+        | None -> (
+            let tok = Lexer.token lexbuf in
+            match !invalid with
+            | [] -> tok
+            | first_invalid :: rest_invalid ->
+                if
+                  first_invalid.Location.loc_start.pos_cnum
+                  <> lexbuf.Lexing.lex_start_p.pos_cnum
+                then tok
+                else (
+                  invalid := rest_invalid ;
+                  let source =
+                    String.sub source
+                      ~pos:first_invalid.Location.loc_start.pos_cnum
+                      ~len:
+                        ( first_invalid.Location.loc_end.pos_cnum
+                        - first_invalid.Location.loc_start.pos_cnum )
+                  in
+                  pending :=
+                    Pending
+                      { invalid_loc= first_invalid
+                      ; tokens=
+                          List.concat
+                            [ [ Parser.LBRACKETPERCENTPERCENT
+                              ; LIDENT "invalid"
+                              ; DOT
+                              ; LIDENT "ast"
+                              ; DOT
+                              ; LIDENT "node" ]
+                            ; [ STRING
+                                  ( source ^ "\n;;"
+                                  , Location.none
+                                  , Some "_i_n_v_a_l_i_d_" ) ]
+                            ; [RBRACKET] ] } ;
+                  match maybe_emit lexbuf pending with
+                  | None -> assert false
+                  | Some x -> x ) ) )
+
+let parse fragment (conf : Conf.t) ~source ~invalid =
   let lexbuf = Lexing.from_string source in
   let warnings =
     W.enable 50
@@ -40,6 +109,7 @@ let parse fragment (conf : Conf.t) ~source =
   in
   Location.init lexbuf !Location.input_name ;
   let w50 = ref [] in
+  let token = wrap_token source invalid in
   let t =
     with_warning_filter
       ~filter:(fun loc warn ->
@@ -48,7 +118,7 @@ let parse fragment (conf : Conf.t) ~source =
           false )
         else not conf.quiet )
       ~f:(fun () ->
-        let ast = Migrate_ast.Parse.fragment fragment lexbuf in
+        let ast = Migrate_ast.Parse.fragment fragment lexbuf token in
         Warnings.check_fatal () ;
         let comments =
           List.map

--- a/lib/Parse_with_comments.mli
+++ b/lib/Parse_with_comments.mli
@@ -29,4 +29,5 @@ val parse :
      'a Migrate_ast.Traverse.fragment
   -> Conf.t
   -> source:string
+  -> invalid:Location.t list
   -> 'a with_comments

--- a/lib/dune
+++ b/lib/dune
@@ -18,4 +18,4 @@
  ;;INSERT_BISECT_HERE;;
  (libraries format_ import ocaml-migrate-parsetree ocaml-version odoc.model
    odoc.parser parse_wyc re uuseg uuseg.string token_latest compat
-   dune-build-info ppxlib))
+   dune-build-info ppxlib ppxlib.ast))

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -961,6 +961,16 @@
 (rule
  (deps .ocamlformat )
  (action
+   (with-outputs-to format_invalid_files_with_proper_locations.ml.output
+     (run %{bin:ocamlformat} --format-invalid-files=auto %{dep:format_invalid_files_with_proper_locations.ml}))))
+
+(rule
+ (alias runtest)
+ (action (diff format_invalid_files_with_proper_locations.ml.ref format_invalid_files_with_proper_locations.ml.output)))
+
+(rule
+ (deps .ocamlformat )
+ (action
    (with-outputs-to fun_decl.ml.output
      (run %{bin:ocamlformat} %{dep:fun_decl.ml}))))
 

--- a/test/passing/format_invalid_files.ml.ref
+++ b/test/passing/format_invalid_files.ml.ref
@@ -11,7 +11,9 @@ module K = struct
 begin
   let x = in
   ()
+;;
 
 let foooooo = fooooo foooooooo
 
 let k =
+;;

--- a/test/passing/format_invalid_files_with_proper_locations.ml
+++ b/test/passing/format_invalid_files_with_proper_locations.ml
@@ -1,0 +1,11 @@
+let x = 1 +;;
+
+
+
+
+
+let x =    "\064"
+let x =    "@"
+
+(** parse [ docstring *)
+let x = 0

--- a/test/passing/format_invalid_files_with_proper_locations.ml.opts
+++ b/test/passing/format_invalid_files_with_proper_locations.ml.opts
@@ -1,0 +1,1 @@
+--format-invalid-files=auto

--- a/test/passing/format_invalid_files_with_proper_locations.ml.ref
+++ b/test/passing/format_invalid_files_with_proper_locations.ml.ref
@@ -1,0 +1,14 @@
+Warning: format_invalid_files_with_proper_locations.ml is invalid, recovering.
+Warning: Invalid documentation comment:
+File "", line 10, characters 22-22:
+End of text is not allowed in '[...]' (code).
+Warning: format_invalid_files_with_proper_locations.ml is invalid, recovering.
+let x = 1 +
+;;
+
+let x = "\064"
+
+let x = "@"
+
+(** parse [ docstring *)
+let x = 0

--- a/test/passing/partial.ml.ref
+++ b/test/passing/partial.ml.ref
@@ -14,3 +14,4 @@ else (d, m)
     let rem n k = snd (quot_rem n k) in
 
 quot, rem
+;;

--- a/test/passing/partial_double_quotes.ml.ref
+++ b/test/passing/partial_double_quotes.ml.ref
@@ -1,3 +1,4 @@
 Warning: partial_double_quotes.ml is invalid, recovering.
 Warning: partial_double_quotes.ml is invalid, recovering.
 let x = "123" +
+;;

--- a/vendor/parse-wyc/lib/parse_wyc.ml
+++ b/vendor/parse-wyc/lib/parse_wyc.ml
@@ -214,7 +214,7 @@ let mk_parsable fragment source =
       let delim = "_i_n_v_a_l_i_d_" in
       let extension_name = "%%invalid.ast.node" in
       let wrapper_opn, wrapper_cls =
-        (Printf.sprintf "[%s {%s|" extension_name delim, Printf.sprintf "|%s}]" delim)
+        (Printf.sprintf "[%s {%s|" extension_name delim, Printf.sprintf "\n;;|%s}]" delim)
       in
       let wrapper_len = String.length wrapper_opn + String.length wrapper_cls in
       let source_len = String.length source in


### PR DESCRIPTION
Alternative to #1535, as proposed in #1534 

It works by wrapping the lexer and emitting alternative tokens for invalid items
It rely on some ppxlib internals and compiler-libs, so it cannot be merged as is.

Consider this PR as a PoC. I'll let other developers  decide what to do with this.
