### PR TITLE
More tokens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
 
   + Remove extension from executable name in error messages. On Windows, this means that messages now start with "ocamlformat: ..." instead of "ocamlformat.exe: ..." (#1531, @emillon)
 
-  + Using tokens instead of string manipulation when inspecting the original source (#1526, @hhugo, #1532, @gpetiot, #1533 @hhugo)
+  + Using tokens instead of string manipulation when inspecting the original source (#1526, #1533, #1541 @hhugo) (#1532, @gpetiot)
 
 #### Bug fixes
 

--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -166,12 +166,13 @@ let fmt cmt src ~wrap:wrap_comments ~ocp_indent_compat ~fmt_code pos =
     | Error () -> fmt_non_code ~wrap_comments:false cmt
   in
   match cmt.txt with
-  | "*" -> (
-    (* "(**)" is not parsed as a docstring but as a regular comment
-       containing '*' and would be rewritten as "(***)" *)
-    match Source.sub src ~pos:cmt.loc.loc_start.pos_cnum ~len:4 with
-    | "(**)" -> str "(**)"
-    | _ -> str "(***)" )
+  | "*" ->
+      if
+        (* "(**)" is not parsed as a docstring but as a regular comment
+           containing '*' and would be rewritten as "(***)" *)
+        Location.width cmt.loc = 4
+      then str "(**)"
+      else str "(***)"
   | "" | "$" -> fmt_non_code cmt
   | str when Char.equal str.[0] '$' -> fmt_code cmt
   | _ -> fmt_non_code cmt

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -60,7 +60,9 @@ let is_adjacent src (l1 : Location.t) (l2 : Location.t) =
     case, comments attached to the following item should be kept after the
     infix symbol. *)
 let infix_symbol_before src (loc : Location.t) =
-  match Source.find_token_before src ~filter:(function _ -> true) loc with
+  match
+    Source.find_token_before src ~filter:(function _ -> true) loc.loc_start
+  with
   | Some
       ( ( SEMI | INFIXOP0 _ | INFIXOP1 _ | INFIXOP2 _ | INFIXOP3 _
         | INFIXOP4 _ | COLONCOLON | COLONEQUAL | BARBAR | LESSMINUS | EQUAL

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -60,9 +60,7 @@ let is_adjacent src (l1 : Location.t) (l2 : Location.t) =
     case, comments attached to the following item should be kept after the
     infix symbol. *)
 let infix_symbol_before src (loc : Location.t) =
-  match
-    Source.find_token_before src ~filter:(function _ -> true) loc.loc_start
-  with
+  match Source.find_token_before src ~filter:(function _ -> true) loc with
   | Some
       ( ( SEMI | INFIXOP0 _ | INFIXOP1 _ | INFIXOP2 _ | INFIXOP3 _
         | INFIXOP4 _ | COLONCOLON | COLONEQUAL | BARBAR | LESSMINUS | EQUAL

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -153,7 +153,7 @@ let maybe_disabled_k c (loc : Location.t) (l : attributes) f k =
   else
     let loc = Source.extend_loc_to_include_attributes c.source loc l in
     Cmts.drop_inside c.cmts loc ;
-    let s = Source.string_at c.source loc.loc_start loc.loc_end in
+    let s = Source.string_at c.source loc in
     let indent_of_first_line = Position.column loc.loc_start in
     let l = String.split ~on:'\n' s in
     let l =

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -16,12 +16,14 @@ open Fmt
 let parens_or_begin_end (c : Conf.t) source ~loc =
   match c.exp_grouping with
   | `Parens -> `Parens
-  | `Preserve ->
-      let str =
-        String.lstrip
-          (Source.string_at source loc.Location.loc_start loc.loc_end)
-      in
-      if String.is_prefix ~prefix:"begin" str then `Begin_end else `Parens
+  | `Preserve -> (
+    match
+      Source.find_token_after source
+        ~filter:(fun _ -> true)
+        loc.Location.loc_start
+    with
+    | Some (Token_latest.BEGIN, _) -> `Begin_end
+    | None | Some _ -> `Parens )
 
 let parens_if parens (c : Conf.t) ?(disambiguate = false) k =
   if disambiguate && c.Conf.disambiguate_non_breaking_match then

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -29,14 +29,10 @@ let string_between (t : t) (p1 : Lexing.position) (p2 : Lexing.position) =
   then None
   else Some (String.sub t.text ~pos ~len)
 
-let sub (t : t) ~pos ~len =
-  if String.length t.text < pos + len || pos < 0 || len < 0 then ""
-  else String.sub t.text ~pos ~len
-
 let string_at (t : t) loc_start loc_end =
   let pos = loc_start.Lexing.pos_cnum
   and len = Position.distance loc_start loc_end in
-  sub t ~pos ~len
+  String.sub t.text ~pos ~len
 
 let string_at_loc t (l : Location.t) = string_at t l.loc_start l.loc_end
 

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -29,12 +29,10 @@ let string_between (t : t) (p1 : Lexing.position) (p2 : Lexing.position) =
   then None
   else Some (String.sub t.text ~pos ~len)
 
-let string_at (t : t) loc_start loc_end =
-  let pos = loc_start.Lexing.pos_cnum
-  and len = Position.distance loc_start loc_end in
+let string_at t (l : Location.t) =
+  let pos = l.loc_start.Lexing.pos_cnum
+  and len = Position.distance l.loc_start l.loc_end in
   String.sub t.text ~pos ~len
-
-let string_at_loc t (l : Location.t) = string_at t l.loc_start l.loc_end
 
 let find_token t k pos =
   Array.binary_search t.tokens
@@ -70,8 +68,8 @@ let empty_line_between (t : t) p1 p2 =
 let tokens_at t ~filter (l : Location.t) : (Parser.token * Location.t) list =
   tokens_between t ~filter l.loc_start l.loc_end
 
-let find_token_before t ~filter (loc : Location.t) =
-  match find_token t `Last_strictly_less_than loc.loc_start with
+let find_token_before t ~filter pos =
+  match find_token t `Last_strictly_less_than pos with
   | None -> None
   | Some i ->
       let rec loop i =
@@ -82,8 +80,8 @@ let find_token_before t ~filter (loc : Location.t) =
       in
       loop i
 
-let find_token_after t ~filter (loc : Location.t) =
-  match find_token t `First_greater_than_or_equal_to loc.loc_end with
+let find_token_after t ~filter pos =
+  match find_token t `First_greater_than_or_equal_to pos with
   | None -> None
   | Some i ->
       let rec loop i =
@@ -95,7 +93,7 @@ let find_token_after t ~filter (loc : Location.t) =
       loop i
 
 let has_cmt_same_line_after t (loc : Location.t) =
-  match find_token_after t ~filter:(fun _ -> true) loc with
+  match find_token_after t ~filter:(fun _ -> true) loc.loc_end with
   | None -> false
   | Some ((COMMENT _ | DOCSTRING _), nloc) ->
       nloc.loc_start.pos_lnum = loc.loc_end.pos_lnum
@@ -159,7 +157,7 @@ let extend_loc_to_include_attributes (t : t) (loc : Location.t)
              |LBRACKETATAT | LBRACKETATATAT ->
                 Int.incr count ; false
             | _ -> false )
-          loc
+          loc.loc_end
       in
       match l with
       | None -> impossible "Invariant of the token stream"
@@ -190,7 +188,7 @@ let is_long_functor_syntax (t : t) ~from = function
         match
           find_token_before t
             ~filter:(function COMMENT _ | DOCSTRING _ -> false | _ -> true)
-            from
+            from.loc_start
         with
         | Some (Parser.FUNCTOR, _) -> true
         | _ -> false )
@@ -226,7 +224,7 @@ let string_literal t mode (l : Location.t) =
        | Parser.LBRACKETAT, _ )
        :: _ ->
       Option.value_exn ~message:"Parse error while reading string literal"
-        (Literal_lexer.string mode (string_at_loc t loc))
+        (Literal_lexer.string mode (string_at t loc))
   | _ -> impossible "Pconst_string is only produced by string literals"
 
 let char_literal t (l : Location.t) =
@@ -250,20 +248,20 @@ let char_literal t (l : Location.t) =
        | Parser.LBRACKETAT, _ )
        :: _ ->
       (Option.value_exn ~message:"Parse error while reading char literal")
-        (Literal_lexer.char (string_at_loc t loc))
+        (Literal_lexer.char (string_at t loc))
   | _ -> impossible "Pconst_char is only produced by char literals"
 
 let begins_line ?(ignore_spaces = true) t (l : Location.t) =
   if not ignore_spaces then Position.column l.loc_start = 0
   else
-    match find_token_before t ~filter:(fun _ -> true) l with
+    match find_token_before t ~filter:(fun _ -> true) l.loc_start with
     | None -> true
     | Some (_, prev) ->
         assert (Location.compare prev l < 0) ;
         prev.loc_end.pos_lnum < l.loc_start.pos_lnum
 
 let ends_line t (l : Location.t) =
-  match find_token_after t ~filter:(fun _ -> true) l with
+  match find_token_after t ~filter:(fun _ -> true) l.loc_end with
   | None -> true
   | Some (_, next) ->
       assert (Location.compare next l > 0) ;

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -32,8 +32,6 @@ val find_token_before :
   -> Location.t
   -> (Parser.token * Location.t) option
 
-val sub : t -> pos:int -> len:int -> string
-
 val string_literal : t -> [`Normalize | `Preserve] -> Location.t -> string
 
 val char_literal : t -> Location.t -> string

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -22,14 +22,20 @@ val empty_line_between : t -> Lexing.position -> Lexing.position -> bool
 
 val string_between : t -> Lexing.position -> Lexing.position -> string option
 
+val string_at : t -> Location.t -> string
+
 val has_cmt_same_line_after : t -> Location.t -> bool
 
-val string_at : t -> Lexing.position -> Lexing.position -> string
+val find_token_after :
+     t
+  -> filter:(Parser.token -> bool)
+  -> Lexing.position
+  -> (Parser.token * Location.t) option
 
 val find_token_before :
      t
   -> filter:(Parser.token -> bool)
-  -> Location.t
+  -> Lexing.position
   -> (Parser.token * Location.t) option
 
 val string_literal : t -> [`Normalize | `Preserve] -> Location.t -> string

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -29,7 +29,7 @@ val string_at : t -> Lexing.position -> Lexing.position -> string
 val find_token_before :
      t
   -> filter:(Parser.token -> bool)
-  -> Lexing.position
+  -> Location.t
   -> (Parser.token * Location.t) option
 
 val sub : t -> pos:int -> len:int -> string


### PR DESCRIPTION
based on #1533
- no longer expose Source.sub
- implement begins_line, ends_line by looking at tokens
- fix the detection of `begin` keywork