### PR TITLE
Allow a break after `if%ext` but not after `if` with `if-then-else=keyword-first`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@
 
 #### Bug fixes
 
-  + Fix break between keyword and expr with `if-then-else=keyword-first` (#1419, @gpetiot)
+  + Fix break between keyword and expr with `if-then-else=keyword-first` (#1419, #1543, @gpetiot)
 
   + Fix parentheses around infix applications having attributes (#1464, @gpetiot)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@
 
 #### Bug fixes
 
-  + Fix break between keyword and expr with `if-then-else=keyword-first` (#1419, #1543, @gpetiot)
+  + Allow a break after `if%ext` with `if-then-else=keyword-first` (#1419, #1543, @gpetiot)
 
   + Fix parentheses around infix applications having attributes (#1464, @gpetiot)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2100,7 +2100,9 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                   Params.get_if_then_else c.conf ~first ~last ~parens
                     ~parens_bch ~parens_prev_bch:!parens_prev_bch ~xcond
                     ~expr_loc:pexp_loc ~bch_loc:xbch.ast.pexp_loc
-                    ~fmt_extension_suffix:(fmt_extension_suffix c ext)
+                    ~fmt_extension_suffix:
+                      (Option.map ext ~f:(fun _ ->
+                           fmt_extension_suffix c ext ) )
                     ~fmt_attributes:
                       (fmt_attributes c ~pre:Blank ~key:"@" pexp_attributes)
                     ~fmt_cond:(fmt_expression c) c.source

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -320,7 +320,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
               (if parens then 0 else 2)
               ( fmt_if (not first) "else "
               $ str "if"
-              $ fmt_if_k first fmt_extension_suffix
+              $ fmt_if_k first (fmt_opt fmt_extension_suffix)
               $ fmt_attributes $ fmt "@ " $ fmt_cond xcnd )
           $ fmt "@ then" )
     | None -> str "else"
@@ -389,9 +389,11 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
           opt xcond (fun xcnd ->
               hvbox 2
                 ( fmt_or_k first
-                    (str "if" $ fmt_extension_suffix)
+                    (str "if" $ fmt_opt fmt_extension_suffix)
                     (str "else if")
-                $ fmt_attributes $ fmt "@ " $ fmt_cond xcnd )
+                $ fmt_attributes
+                $ fmt_or (Option.is_some fmt_extension_suffix) "@ " " "
+                $ fmt_cond xcnd )
               $ fmt "@ " )
       ; box_keyword_and_expr=
           (fun k -> hvbox 2 (fmt_or (Option.is_some xcond) "then" "else" $ k))

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -100,7 +100,7 @@ val get_if_then_else :
   -> xcond:Migrate_ast.Parsetree.expression Ast.xt option
   -> expr_loc:Location.t
   -> bch_loc:Location.t
-  -> fmt_extension_suffix:Fmt.t
+  -> fmt_extension_suffix:Fmt.t option
   -> fmt_attributes:Fmt.t
   -> fmt_cond:(Migrate_ast.Parsetree.expression Ast.xt -> Fmt.t)
   -> Source.t

--- a/test/passing/ite-kw_first.ml.ref
+++ b/test/passing/ite-kw_first.ml.ref
@@ -45,9 +45,8 @@ f
 
 ;;
 f
-  ( if
-      and_ even
-        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  ( if and_ even
+         loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
   then ()
   else () )
 

--- a/test/passing/ite-kw_first_closing.ml.ref
+++ b/test/passing/ite-kw_first_closing.ml.ref
@@ -52,9 +52,8 @@ f
 
 ;;
 f
-  ( if
-      and_ even
-        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  ( if and_ even
+         loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
   then ()
   else ()
   )

--- a/test/passing/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/ite-kw_first_no_indicate.ml.ref
@@ -45,9 +45,8 @@ f
 
 ;;
 f
-  (if
-     and_ even
-       loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  (if and_ even
+        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
   then ()
   else ())
 


### PR DESCRIPTION
Reducing the diff introduced by #1419 

But it feels a bit like a regression to me as it produces an unnecessary indentation, for example:
```diff
     then (
diff --git a/lib/tyxml/tyxml_js.ml b/lib/tyxml/tyxml_js.ml
index d2a5a29ed..198ea3a9a 100644
--- a/lib/tyxml/tyxml_js.ml
+++ b/lib/tyxml/tyxml_js.ml
@@ -126,13 +126,12 @@ module Xml = struct
             else parse_int ~pos:1 ~base:10 e
           in
           Js.string_constr##fromCharCode i)
-        else if
-          string_fold e ~pos:0 ~init:true ~f:(fun acc x ->
-              (* This is not quite right according to
+        else if string_fold e ~pos:0 ~init:true ~f:(fun acc x ->
+                    (* This is not quite right according to
                        https://www.xml.com/axml/target.html#NT-Name.
                        but it seems to cover all html5 entities
                        https://dev.w3.org/html5/html-author/charref *)
-              acc && is_alpha_num x)
+                    acc && is_alpha_num x)
         then (
           match e with
           | "quot" -> Js.string "\""
```
but yeah it's a matter of vertical space VS horizontal space