### PR TITLE
Use tokens_between instead of string_between

### DIFF
--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -48,8 +48,7 @@ let find_at_position t loc pos =
 let is_adjacent src (l1 : Location.t) (l2 : Location.t) =
   match
     Source.tokens_between src l1.loc_end l2.loc_start ~filter:(function
-      | Token_latest.(COMMENT _ | DOCSTRING _) -> false
-      | _ -> true )
+        | _ -> true )
   with
   | [] -> true
   | [(Token_latest.BAR, _)] ->

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -46,14 +46,16 @@ let find_at_position t loc pos =
     [|] character and the first location begins a line and the start column
     of the first location is lower than that of the second location. *)
 let is_adjacent src (l1 : Location.t) (l2 : Location.t) =
-  Option.value_map (Source.string_between src l1.loc_end l2.loc_start)
-    ~default:false ~f:(fun btw ->
-      match String.strip btw with
-      | "" -> true
-      | "|" ->
-          Source.begins_line src l1
-          && Position.column l1.loc_start < Position.column l2.loc_start
-      | _ -> false )
+  match
+    Source.tokens_between src l1.loc_end l2.loc_start ~filter:(function
+      | Token_latest.(COMMENT _ | DOCSTRING _) -> false
+      | _ -> true )
+  with
+  | [] -> true
+  | [(Token_latest.BAR, _)] ->
+      Source.begins_line src l1
+      && Position.column l1.loc_start < Position.column l2.loc_start
+  | _ -> false
 
 (** Whether the symbol preceding location [loc] is an infix symbol
     (corresponding to [Ast.String_id.is_infix]) or a semicolon. If it is the
@@ -378,8 +380,9 @@ let break_comment_group source margin {Cmt.loc= a; _} {Cmt.loc= b; _} =
   in
   let horizontal_align =
     line_dist a b = 0
-    && Option.value_map (Source.string_between source a.loc_end b.loc_start)
-         ~default:true ~f:(fun x -> String.(strip x |> is_empty))
+    && List.is_empty
+         (Source.tokens_between source a.loc_end b.loc_start
+              ~filter:(function _ -> true) )
   in
   not
     ( (Location.is_single_line a margin && Location.is_single_line b margin)

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -22,6 +22,13 @@ val empty_line_between : t -> Lexing.position -> Lexing.position -> bool
 
 val string_between : t -> Lexing.position -> Lexing.position -> string option
 
+val tokens_between :
+     t
+  -> filter:(Parser.token -> bool)
+  -> Lexing.position
+  -> Lexing.position
+  -> (Parser.token * Location.t) list
+
 val string_at : t -> Location.t -> string
 
 val has_cmt_same_line_after : t -> Location.t -> bool


### PR DESCRIPTION
Some follow-up on recent work on using tokens in `Source.ml`

There remains 1 use of `Source.string_between` in `Cmts.add_cmts`, but it's to display the string between 2 positions so it makes sense to keep it (I tried to use `ppx_sexp_conv` to have some formatting functions for the tokens but it doesn't seem to be compatible with the current version of `ppxlib` anyway) (on the other hand it's something that is printed in debug mode only, and honestly I've never found that useful to me)