### PR TITLE
Use dune instrumentation backend for bisect_ppx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /ocamlformat.install
 /test-extra/code
 /_opam
-/coverage
+/_coverage

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 #### Changes
 
++ Use dune instrumentation backend for bisect_ppx (#1550, @tmattio)
+
 #### New features
 
 ### 0.17.0 (2021-02-15)

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,12 @@ regtests:
 regtests-promote:
 	dune runtest --auto-promote
 
+coverage:
+	dune runtest --instrument-with bisect_ppx --force
+	bisect-ppx-report html
+	echo "Coverage report generated in _coverage/"
+	echo " => open _coverage/index.html"
+
 headers:
 	tools/update_headers.sh
 	dune build @fmt --auto-promote

--- a/bin/dune
+++ b/bin/dune
@@ -15,7 +15,8 @@
  (modules ocamlformat)
  (flags
   (:standard -open Base -open Import))
- ;;INSERT_BISECT_HERE;;
+ (instrumentation
+  (backend bisect_ppx))
  (libraries ocamlformat_lib))
 
 (rule

--- a/dune-project
+++ b/dune-project
@@ -58,6 +58,10 @@
   (ocaml-migrate-parsetree
    (>= 2.1.0))
   (ocp-indent :with-test)
+  (bisect_ppx
+   (and
+    :with-test
+    (>= 2.5.0)))
   (odoc
    (>= 1.4.2))
   (ppxlib

--- a/dune-project
+++ b/dune-project
@@ -32,7 +32,7 @@
  (name ocamlformat)
  (synopsis "Auto-formatter for OCaml code")
  (description
-   "OCamlFormat is a tool to automatically format OCaml code in a uniform style.")
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style.")
  (depends
   (ocaml
    (and

--- a/lib/dune
+++ b/lib/dune
@@ -15,6 +15,7 @@
  (name ocamlformat_lib)
  (flags
   (:standard -open Base -open Import -open Compat))
- ;;INSERT_BISECT_HERE;;
+ (instrumentation
+  (backend bisect_ppx))
  (libraries format_ import ocaml-version odoc.model odoc.parser parse_wyc re
    uuseg uuseg.string token_latest compat dune-build-info ppxlib))

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -24,6 +24,7 @@ depends: [
   "menhirSdk" {>= "20200624"}
   "ocaml-migrate-parsetree" {>= "2.1.0"}
   "ocp-indent" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc" {>= "1.4.2"}
   "ppxlib" {>= "0.22.0"}
   "re"

--- a/tools/bisect.sh
+++ b/tools/bisect.sh
@@ -18,23 +18,15 @@
 
 set -e
 
-if [[ ! -z "$1" ]]; then
+if [[ -n "$1" ]]; then
     branch="$1"
 else
     branch=$(git rev-parse HEAD)
 fi
 
-tmp=`mktemp -d`
+tmp=$(mktemp -d)
 git worktree add --detach "$tmp" "$branch"
 
-sed -i 's/;;INSERT_BISECT_HERE;;/(preprocess (pps bisect_ppx))/' "$tmp/bin/dune" "$tmp/lib/dune"
-
-# Run the tests
-make -C "$tmp" test
-
-dst="coverage"
-bisect-ppx-report -I "$tmp/_build/default" -html "$dst" `find "$tmp" -name 'bisect*.out'`
-echo "Coverage report generated in $dst/"
-echo " => open $dst/index.html"
+make -C "$tmp" coverage
 
 git worktree remove --force "$tmp"


### PR DESCRIPTION
This PR refactors the test coverage setup to use the newly introduced Dune's instrumentation stanza.

`bisect_ppx` can be used as a backend for Dune's instrumentation, but it is currently incompatible with ocamlformat, since it did not migrate to `ppxlib` yet. We can merge this once the migration of `bisect_ppx` to `ppxlib` is complete: https://github.com/aantron/bisect_ppx/pull/327