### PR TITLE
Fix the disabled structure items with attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
   + Fix extraneous parenthesis after 'let open' with 'closing-on-separate-line' (#1612, @Julow)
 
+  + Fix the disabled structure items with attributes (#1551, @gpetiot)
+
 #### Changes
 
   + Use dune instrumentation backend for bisect_ppx (#1550, @tmattio)

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -447,6 +447,32 @@ module Tyd = struct
 end
 
 module Structure_item = struct
+  let attributes itm =
+    match itm.pstr_desc with
+    | Pstr_attribute attr -> [attr]
+    | Pstr_eval (_, attrs) -> attrs
+    | Pstr_value (_, vb) -> List.concat_map vb ~f:(fun x -> x.pvb_attributes)
+    | Pstr_primitive {pval_attributes= attrs; _} -> attrs
+    | Pstr_type (_, t) -> List.concat_map t ~f:(fun x -> x.ptype_attributes)
+    | Pstr_typext {ptyext_attributes= attrs; _} -> attrs
+    | Pstr_recmodule m ->
+        List.concat_map m ~f:(fun x -> x.pmb_expr.pmod_attributes)
+    | Pstr_modtype {pmtd_attributes= attrs; _} -> attrs
+    | Pstr_open {popen_attributes= attrs; _} -> attrs
+    | Pstr_extension (_, attrs) -> attrs
+    | Pstr_class_type ct -> List.concat_map ct ~f:(fun x -> x.pci_attributes)
+    | Pstr_class c -> List.concat_map c ~f:(fun x -> x.pci_attributes)
+    | Pstr_include
+        {pincl_mod= {pmod_attributes= attrs1; _}; pincl_attributes= attrs2; _}
+     |Pstr_exception
+        { ptyexn_attributes= attrs1
+        ; ptyexn_constructor= {pext_attributes= attrs2; _}
+        ; _ }
+     |Pstr_module
+        {pmb_attributes= attrs1; pmb_expr= {pmod_attributes= attrs2; _}; _}
+      ->
+        List.append attrs1 attrs2
+
   let has_doc itm =
     match itm.pstr_desc with
     | Pstr_attribute atr -> Option.is_some (fst (doc_atrs [atr]))

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -120,6 +120,10 @@ module Pat : sig
   val is_simple : pattern -> bool
 end
 
+module Structure_item : sig
+  val attributes : structure_item -> attributes
+end
+
 module Mod : sig
   val is_simple : module_expr -> bool
 end

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4534,7 +4534,7 @@ let fmt_toplevel c ctx itms =
   let break_struct = c.conf.break_struct || is_top ctx in
   let fmt_item c ~last = function
     | `Item i ->
-        maybe_disabled c i.pstr_loc []
+        maybe_disabled c i.pstr_loc (Ast.Structure_item.attributes i)
         @@ fun c -> fmt_structure_item c ~last (sub_str ~ctx i)
     | `Directive d -> fmt_toplevel_directive c d
   in

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -106,13 +106,21 @@ let has_cmt_same_line_after t (loc : Location.t) =
   | Some _ -> false
 
 let extend_loc_to_include_attributes (loc : Location.t) (l : attributes) =
+  let loc_start =
+    List.fold l ~init:loc
+      ~f:(fun acc ({attr_loc; _} : Parsetree.attribute) ->
+        if Location.compare_start attr_loc acc >= 0 then acc else attr_loc )
+  in
   let loc_end =
     List.fold l ~init:loc ~f:(fun acc ({attr_loc; _} : attribute) ->
         if Location.compare_end attr_loc acc <= 0 then acc else attr_loc )
   in
-  if phys_equal loc_end loc then loc
+  if phys_equal loc_end loc && phys_equal loc_start loc then loc
   else
-    {loc with loc_end= {loc.loc_end with pos_cnum= loc_end.loc_end.pos_cnum}}
+    { loc with
+      loc_end= {loc.loc_end with pos_cnum= loc_end.loc_end.pos_cnum}
+    ; loc_start= {loc.loc_start with pos_cnum= loc_start.loc_start.pos_cnum}
+    }
 
 let contains_token_between t ~(from : Location.t) ~(upto : Location.t) tok =
   let filter = Poly.( = ) tok in

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -107,8 +107,7 @@ let has_cmt_same_line_after t (loc : Location.t) =
 
 let extend_loc_to_include_attributes (loc : Location.t) (l : attributes) =
   let loc_start =
-    List.fold l ~init:loc
-      ~f:(fun acc ({attr_loc; _} : Parsetree.attribute) ->
+    List.fold l ~init:loc ~f:(fun acc ({attr_loc; _} : attribute) ->
         if Location.compare_start attr_loc acc >= 0 then acc else attr_loc )
   in
   let loc_end =

--- a/test/passing/disabled_attr.ml
+++ b/test/passing/disabled_attr.ml
@@ -1,0 +1,4 @@
+[@@@ocamlformat "disable"]
+
+(** hello *)
+let foo = 42

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -604,6 +604,16 @@
 (rule
  (deps .ocamlformat )
  (action
+   (with-outputs-to disabled_attr.ml.output
+     (run %{bin:ocamlformat} %{dep:disabled_attr.ml}))))
+
+(rule
+ (alias runtest)
+ (action (diff disabled_attr.ml disabled_attr.ml.output)))
+
+(rule
+ (deps .ocamlformat )
+ (action
    (with-outputs-to disambiguate.ml.output
      (run %{bin:ocamlformat} %{dep:disambiguate.ml}))))
 


### PR DESCRIPTION
fix #1545, no diff with test_branch.sh (alright just working for 4.11+ apparently)

`Source.extend_loc_to_include_attributes` had to also extend the location when the attributes precede the item, and we need to fetch the attributes of structure_item as we will rely on the item's location to write it verbatim when disabled.

I'm not really a fan of having some `[@@@ocamlformat "disable"]` attribute anywhere, personally I would rather only allow to disable the formatting of whole files with .ocamlformat-ignore and that's it, so we can remove this trick and the `maybe_disable` functions everywhere. It looks to me that most usage of this feature is to put the disable attribute at the beginning of file anyway. Any thoughts? (for 1.0 maybe)