### PR TITLE
Lower bound on menhir version

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -53,7 +53,8 @@
   dune-build-info
   fix
   fpath
-  menhir
+  (menhir
+   (>= 20180528))
   (ocp-indent :with-test)
   (odoc
    (>= 1.4.2))

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -20,7 +20,7 @@ depends: [
   "dune-build-info"
   "fix"
   "fpath"
-  "menhir"
+  "menhir" {>= "20180528"}
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
   "ppxlib" {>= "0.18.0"}


### PR DESCRIPTION
Hi ! This is really a small thing but :
Minimum version for menhir is 20180528. It's when --infer-write-query was added.

For some reason, esy resolved menhir 2017xxx and ocamlformat would not compile..