### PR TITLE
Preserve spacing of toplevel comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
 
   + Fix the vertical alignment test to break down comment groups (#1575, @gpetiot)
 
+  + Preserve spacing of toplevel comments (#1554, @gpetiot)
+
 #### Changes
 
   + Add buffer filename in the logs when applying ocamlformat (#1557, @dannywillems)

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -82,6 +82,26 @@ val fmt_within :
 (** [fmt_within loc] formats the comments associated with [loc] that appear
     within [loc]. *)
 
+module Toplevel : sig
+  val fmt_before :
+       t
+    -> Conf.t
+    -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
+    -> Location.t
+    -> Fmt.t
+  (** [fmt_before loc] formats the comments associated with [loc] that appear
+      before [loc]. *)
+
+  val fmt_after :
+       t
+    -> Conf.t
+    -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
+    -> Location.t
+    -> Fmt.t
+  (** [fmt_after loc] formats the comments associated with [loc] that appear
+      after [loc]. *)
+end
+
 val drop_inside : t -> Location.t -> unit
 
 val drop_before : t -> Location.t -> t

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -180,6 +180,8 @@ module Location = struct
 
   let compare_end_col x y = Position.compare_col x.loc_end y.loc_end
 
+  let line_difference fst snd = snd.loc_start.pos_lnum - fst.loc_end.pos_lnum
+
   let contains l1 l2 = compare_start l1 l2 <= 0 && compare_end l1 l2 >= 0
 
   let width x = Position.distance x.loc_start x.loc_end

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -77,6 +77,8 @@ module Location : sig
 
   val compare_end_col : t -> t -> int
 
+  val line_difference : t -> t -> int
+
   val fmt : Format.formatter -> t -> unit
 
   val smallest : t -> t list -> t

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -78,6 +78,9 @@ module Location : sig
   val compare_end_col : t -> t -> int
 
   val line_difference : t -> t -> int
+  (** [line_difference x y] returns the difference between the line at the
+      start of [y] and at the end of [x]. [x] must precede [y], undefined
+      behavior otherwise, or if one location includes the other. *)
 
   val fmt : Format.formatter -> t -> unit
 

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -219,6 +219,16 @@ let ends_line t (l : Location.t) =
       assert (Location.compare next l > 0) ;
       next.loc_start.pos_lnum > l.loc_end.pos_lnum
 
+let empty_line_before t (loc : Location.t) =
+  match find_token_before t ~filter:(fun _ -> true) loc.loc_start with
+  | Some (_, before) -> Location.line_difference before loc > 1
+  | None -> false
+
+let empty_line_after t (loc : Location.t) =
+  match find_token_after t ~filter:(fun _ -> true) loc.loc_end with
+  | Some (_, after) -> Location.line_difference loc after > 1
+  | None -> false
+
 let extension_using_sugar ~(name : string Location.loc)
     ~(payload : Location.t) =
   Source_code_position.ascending name.loc.loc_start payload.loc_start > 0

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -20,6 +20,10 @@ val empty_line_between : t -> Lexing.position -> Lexing.position -> bool
     [p1] and [p2]. The lines containing [p1] and [p2] are not considered
     empty. *)
 
+val empty_line_before : t -> Location.t -> bool
+
+val empty_line_after : t -> Location.t -> bool
+
 val string_between : t -> Lexing.position -> Lexing.position -> string option
 
 val tokens_between :

--- a/test/passing/comments.ml
+++ b/test/passing/comments.ml
@@ -254,3 +254,8 @@ let kk = ((* foo *) (module A : T))
 let kk = ((module A : T) (* foo *))
 
 let kk = ((* foo *) (module A : T) (* foo *))
+
+let _ = assert (foo (bar + baz <= quux))
+(* this comment should stay attached to the preceding item *)
+
+let _ = foo

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -37,19 +37,15 @@ let foo = function Blah, (x, (* old *) y) -> ()
 let foo = function (x, y) (* old *), z -> ()
 
 let _ = if (* a0 *) b (* c0 *) then (* d0 *) e (* f0 *) else (* g0 *) h
-
 (* i0 *)
 
 let _ = if (* a1 *) b (* c1 *) then (* d1 *) e (* f1 *) else (* g1 *) h
-
 (* i1 *)
 
 let _ = if (* a2 *) B (* c2 *) then (* d2 *) E (* f2 *) else (* g2 *) H
-
 (* i2 *)
 
 let _ = if (* a3 *) B (* c3 *) then (* d3 *) E (* f3 *) else (* g3 *) H
-
 (* i3 *)
 
 ;;
@@ -194,7 +190,6 @@ type t =
      tempor incididunt ut labore et dolore magna aliqua. *)
   | Bbbbbbbbbb (* foo *)
   | Bbbbbbbbbb
-
 (* foo *)
 
 let () =
@@ -347,3 +342,8 @@ let kk = (* foo *) (module A : T)
 let kk = (module A : T) (* foo *)
 
 let kk = (* foo *) (module A : T) (* foo *)
+
+let _ = assert (foo (bar + baz <= quux))
+(* this comment should stay attached to the preceding item *)
+
+let _ = foo

--- a/test/passing/extensions-indent.ml.ref
+++ b/test/passing/extensions-indent.ml.ref
@@ -292,7 +292,7 @@ class type%ext x = y
 
 class type%ext x = y
 
-   and y = z
+and y = z
 
 [%%ext
    class type x = y

--- a/test/passing/js_args.ml.ref
+++ b/test/passing/js_args.ml.ref
@@ -58,7 +58,6 @@ let () =
    the left margin in a few special cases: *)
 let _ = foo (bar (fun x -> (* special: "fun _ ->" at EOL *)
                            baz ))
-
 (* assume no more arguments to "bar" *)
 
 let _ = foo ~a_long_field_name:(check (fun bar -> baz))
@@ -71,7 +70,6 @@ let _ = foo (bar (quux (fnord (fun x -> (* any depth *)
 (* We also wanted to tweak the operator indentation, making operators like <=
    not special cases in contexts like this: *)
 let _ = assert (foo (bar + baz <= quux))
-
 (* lined up under left argument to op, sim. to ^ above *)
 
 (* Sim. indentation of if conditions: *)

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -496,11 +496,9 @@ type 'a foo2 += D = A | E = B | F = C
 type +'a foo = ..
 type 'a foo += A of (int -> 'a)
 type 'a foo += B of ('a -> int)
-
 (* ERROR: Parameter variances are not satisfied *)
 
 type _ foo += C : ('a -> int) -> 'a foo
-
 (* ERROR: Parameter variances are not satisfied *)
 
 type 'a bar = ..
@@ -2465,8 +2463,7 @@ type tag =
 type 'a poly =
   | AandBTags : [< `TagA of int | `TagB ] poly
   | ATag : [< `TagA of int ] poly
-
-(* constraint 'a = [< `TagA of int | `TagB] *)
+  (* constraint 'a = [< `TagA of int | `TagB] *)
 
 let intA = function
   | `TagA i -> i
@@ -2914,7 +2911,6 @@ let rec pre_subst f = function
 ;;
 
 let comp_subst f g (x : 'a fin) = pre_subst f (g x)
-
 (*  val comp_subst :
     ('b fin -> 'c term) -> ('a fin -> 'b term) -> 'a fin -> 'c term *)
 
@@ -2967,7 +2963,6 @@ let subst_var x t' y =
 (* val subst_var : 'a succ fin -> 'a term -> 'a succ fin -> 'a term *)
 
 let subst x t' = pre_subst (subst_var x t')
-
 (* val subst : 'a succ fin -> 'a term -> 'a succ term -> 'a term *)
 
 (* 5 A Refinement of Substitution *)
@@ -3012,7 +3007,6 @@ let rec sub' : type m. m ealist -> m fin -> m term = function
 ;;
 
 let subst' d = pre_subst (sub' d)
-
 (*  val subst' : 'a ealist -> 'a term -> 'a term *)
 
 (* 6 First-Order Unification *)
@@ -3026,7 +3020,6 @@ let flex_flex x y =
 (* val flex_flex : 'a succ fin -> 'a succ fin -> 'a succ ealist *)
 
 let flex_rigid x t = bind (check x t) (fun t' -> Some (asnoc Anil t' x))
-
 (* val flex_rigid : 'a succ fin -> 'a succ term -> 'a succ ealist option *)
 
 let rec amgu : type m. m term -> m term -> m ealist -> m ealist option =
@@ -3052,7 +3045,6 @@ let rec amgu : type m. m term -> m term -> m ealist -> m ealist option =
 ;;
 
 let mgu s t = amgu s t (EAlist Anil)
-
 (* val mgu : 'a term -> 'a term -> 'a ealist option *)
 
 let s = Fork (Var FZ, Fork (Var (FS (FS FZ)), Leaf))
@@ -5090,7 +5082,6 @@ module Bazoinks = struct
 end
 
 module Bug = Foo (Bazoinks) (Bazoinks)
-
 (* PR#6992, reported by Stephen Dolan *)
 
 type (_, _) eq = Eq : ('a, 'a) eq
@@ -5295,7 +5286,6 @@ module rec M : sig
 end = struct
   external f : int -> int = "%identity"
 end
-
 (* with module *)
 
 module type S = sig
@@ -6639,7 +6629,6 @@ module M : sig
 end = struct
   type refer = { poly : 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) }
 end
-
 (*
   ocamlc -c pr3918a.mli pr3918b.mli
   rm -f pr3918a.cmi
@@ -6687,7 +6676,6 @@ module Make' (Unit : sig end) : Priv' = struct
 end
 
 module A' = Make' ()
-
 (* PR5057 *)
 
 module TT = struct
@@ -7334,7 +7322,6 @@ module Bootstrap2 (MakeDiet : functor (X : ORD) ->
 
   let iter f = Diet.iter (Elt.iter f)
 end
-
 (* PR 4470: simplified from OMake's sources *)
 
 module rec DirElt : sig
@@ -7358,7 +7345,6 @@ and DirHash : sig
 end = struct
   type t = DirCompare.t list
 end
-
 (* PR 4758, PR 4266 *)
 
 module PR_4758 = struct
@@ -7445,7 +7431,6 @@ module F (X : Set.OrderedType) = struct
 
   and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
 end
-
 (* Tests for recursive modules *)
 
 let test number result expected =
@@ -8375,7 +8360,6 @@ module type CORE0 = sig
   module V : VALUE
 
   val setglobal : V.state -> string -> V.value -> unit
-
   (* five more functions common to core and evaluator *)
 end
 
@@ -8383,7 +8367,6 @@ module type CORE = sig
   include CORE0
 
   val apply : V.value -> V.state -> V.value list -> V.value
-
   (* apply function f in state s to list of args *)
 end
 
@@ -9105,7 +9088,6 @@ module OK = struct
     match r with
     | { x; y } -> y + y
   ;;
-
   (* ok *)
 end
 
@@ -9571,7 +9553,6 @@ let () = proj1 (inj2 42)
 let _ = ~-1
 
 class id = [%exp]
-
 (* checkpoint *)
 
 (* Subtyping is "syntactic" *)

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -496,11 +496,9 @@ type 'a foo2 += D = A | E = B | F = C
 type +'a foo = ..
 type 'a foo += A of (int -> 'a)
 type 'a foo += B of ('a -> int)
-
 (* ERROR: Parameter variances are not satisfied *)
 
 type _ foo += C : ('a -> int) -> 'a foo
-
 (* ERROR: Parameter variances are not satisfied *)
 
 type 'a bar = ..
@@ -2465,7 +2463,6 @@ type tag =
 type 'a poly =
   | AandBTags : [< `TagA of int | `TagB ] poly
   | ATag : [< `TagA of int ] poly
-
 (* constraint 'a = [< `TagA of int | `TagB] *)
 
 let intA = function
@@ -2914,7 +2911,6 @@ let rec pre_subst f = function
 ;;
 
 let comp_subst f g (x : 'a fin) = pre_subst f (g x)
-
 (*  val comp_subst :
     ('b fin -> 'c term) -> ('a fin -> 'b term) -> 'a fin -> 'c term *)
 
@@ -2967,7 +2963,6 @@ let subst_var x t' y =
 (* val subst_var : 'a succ fin -> 'a term -> 'a succ fin -> 'a term *)
 
 let subst x t' = pre_subst (subst_var x t')
-
 (* val subst : 'a succ fin -> 'a term -> 'a succ term -> 'a term *)
 
 (* 5 A Refinement of Substitution *)
@@ -3012,7 +3007,6 @@ let rec sub' : type m. m ealist -> m fin -> m term = function
 ;;
 
 let subst' d = pre_subst (sub' d)
-
 (*  val subst' : 'a ealist -> 'a term -> 'a term *)
 
 (* 6 First-Order Unification *)
@@ -3026,7 +3020,6 @@ let flex_flex x y =
 (* val flex_flex : 'a succ fin -> 'a succ fin -> 'a succ ealist *)
 
 let flex_rigid x t = bind (check x t) (fun t' -> Some (asnoc Anil t' x))
-
 (* val flex_rigid : 'a succ fin -> 'a succ term -> 'a succ ealist option *)
 
 let rec amgu : type m. m term -> m term -> m ealist -> m ealist option =
@@ -3052,7 +3045,6 @@ let rec amgu : type m. m term -> m term -> m ealist -> m ealist option =
 ;;
 
 let mgu s t = amgu s t (EAlist Anil)
-
 (* val mgu : 'a term -> 'a term -> 'a ealist option *)
 
 let s = Fork (Var FZ, Fork (Var (FS (FS FZ)), Leaf))
@@ -5090,7 +5082,6 @@ module Bazoinks = struct
 end
 
 module Bug = Foo (Bazoinks) (Bazoinks)
-
 (* PR#6992, reported by Stephen Dolan *)
 
 type (_, _) eq = Eq : ('a, 'a) eq
@@ -5295,7 +5286,6 @@ module rec M : sig
 end = struct
   external f : int -> int = "%identity"
 end
-
 (* with module *)
 
 module type S = sig
@@ -6639,7 +6629,6 @@ module M : sig
 end = struct
   type refer = { poly : 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) }
 end
-
 (*
   ocamlc -c pr3918a.mli pr3918b.mli
   rm -f pr3918a.cmi
@@ -6687,7 +6676,6 @@ module Make' (Unit : sig end) : Priv' = struct
 end
 
 module A' = Make' ()
-
 (* PR5057 *)
 
 module TT = struct
@@ -7334,7 +7322,6 @@ module Bootstrap2 (MakeDiet : functor (X : ORD) ->
 
   let iter f = Diet.iter (Elt.iter f)
 end
-
 (* PR 4470: simplified from OMake's sources *)
 
 module rec DirElt : sig
@@ -7358,7 +7345,6 @@ and DirHash : sig
 end = struct
   type t = DirCompare.t list
 end
-
 (* PR 4758, PR 4266 *)
 
 module PR_4758 = struct
@@ -7445,7 +7431,6 @@ module F (X : Set.OrderedType) = struct
 
   and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
 end
-
 (* Tests for recursive modules *)
 
 let test number result expected =
@@ -8375,7 +8360,6 @@ module type CORE0 = sig
   module V : VALUE
 
   val setglobal : V.state -> string -> V.value -> unit
-
   (* five more functions common to core and evaluator *)
 end
 
@@ -8383,7 +8367,6 @@ module type CORE = sig
   include CORE0
 
   val apply : V.value -> V.state -> V.value list -> V.value
-
   (* apply function f in state s to list of args *)
 end
 
@@ -9105,7 +9088,6 @@ module OK = struct
     match r with
     | { x; y } -> y + y
   ;;
-
   (* ok *)
 end
 
@@ -9571,7 +9553,6 @@ let () = proj1 (inj2 42)
 let _ = ~-1
 
 class id = [%exp]
-
 (* checkpoint *)
 
 (* Subtyping is "syntactic" *)

--- a/test/passing/module_attributes.ml.ref
+++ b/test/passing/module_attributes.ml.ref
@@ -5,14 +5,11 @@ include struct
 end
 [@warning "item"] [@@warning "structure"]
 
-include M
-[@warning "item"] [@@warning "structure"]
+include M [@warning "item"] [@@warning "structure"]
 
-include (M : S)
-[@warning "item"] [@@warning "structure"]
+include (M : S) [@warning "item"] [@@warning "structure"]
 
-include M (N)
-[@warning "item"] [@@warning "structure"]
+include M (N) [@warning "item"] [@@warning "structure"]
 
 include [%ext] [@warning "item"] [@@warning "structure"]
 

--- a/test/passing/open.ml
+++ b/test/passing/open.ml
@@ -182,9 +182,11 @@ let _ =
   (* f *) let (* g *) open (* h *) A (* i *) (B) (* j *) in (* k *)
   ()
 
-(* l *) open (* m *) struct
+(* l *)
+open (* m *) struct
   type t
-end (* n *)
+end
+(* n *)
 
 open A
 open B

--- a/test/passing/open.ml.ref
+++ b/test/passing/open.ml.ref
@@ -190,11 +190,9 @@ let _ =
   ()
 
 (* l *)
-
 open (* m *) struct
   type t
 end
-
 (* n *)
 
 open A

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -492,7 +492,6 @@ module M_S : S = M
 let is_s x = match x with M_S.A _ -> true | _ -> false
 
 let a2 = M_S.A 20
-
 (* ERROR: Cannot create a value using a private constructor *)
 
 (* Extensions can be rebound *)
@@ -552,11 +551,9 @@ type +'a foo = ..
 type 'a foo += A of (int -> 'a)
 
 type 'a foo += B of ('a -> int)
-
 (* ERROR: Parameter variances are not satisfied *)
 
 type _ foo += C : ('a -> int) -> 'a foo
-
 (* ERROR: Parameter variances are not satisfied *)
 
 type 'a bar = ..
@@ -646,7 +643,6 @@ let _ =
     (object
        method m = 3
     end )
-
 (* Invald_arg *)
 
 (* Typed names *)
@@ -999,12 +995,10 @@ let fint (type t) (x : t) (tag : t ty) = match tag with Int -> x > 0
 
 let f (type t) (x : t) (tag : t ty) =
   match tag with Int -> x > 0 | Bool -> x
-
 (* val f : 'a -> 'a ty -> bool = <fun> *)
 
 let g (type t) (x : t) (tag : t ty) =
   match tag with Bool -> x | Int -> x > 0
-
 (* Error: This expression has type bool but an expression was expected of
    type t = int *)
 
@@ -1055,7 +1049,6 @@ let rec variantize : type t. t ty -> t -> variant =
   | List ty1 ->
       VList (List.map (variantize ty1) x) (* t = 'a list for some 'a *)
   | Pair (ty1, ty2) -> VPair (variantize ty1 (fst x), variantize ty2 (snd x))
-
 (* t = ('a, 'b) for some 'a and 'b *)
 
 exception VariantMismatch
@@ -2283,7 +2276,6 @@ let f : type env a. (env, a) typ -> (env, a) typ -> int =
   | Tbool, Tbool -> 1
   | Tvar var, tb -> 2
   | _ -> .
-
 (* error *)
 
 (* let x = f Tint (Tvar Zero) ;; *)
@@ -2403,7 +2395,6 @@ type tag = [`TagA | `TagB | `TagC]
 type 'a poly =
   | AandBTags : [< `TagA of int | `TagB] poly
   | ATag : [< `TagA of int] poly
-
 (* constraint 'a = [< `TagA of int | `TagB] *)
 
 let intA = function `TagA i -> i
@@ -2417,7 +2408,6 @@ type _ wrapPoly =
 
 let example6 : type a. a wrapPoly -> a -> int =
  fun w -> match w with WrapPoly ATag -> intA | WrapPoly _ -> intA
-
 (* This should not be allowed *)
 
 let _ = example6 (WrapPoly AandBTags) `TagB (* This causes a seg fault *)
@@ -2542,7 +2532,6 @@ let f (Aux x) =
   | Succ (Succ (Succ Zero)) -> "3"
   | Succ (Succ (Succ (Succ Zero))) -> "4"
   | _ -> .
-
 (* error *)
 
 type _ t = C : ((('a -> 'o) -> 'o) -> ('b -> 'o) -> 'o) t
@@ -2776,7 +2765,6 @@ let rec pre_subst f = function
   | Fork (t1, t2) -> Fork (pre_subst f t1, pre_subst f t2)
 
 let comp_subst f g (x : 'a fin) = pre_subst f (g x)
-
 (* val comp_subst : ('b fin -> 'c term) -> ('a fin -> 'b term) -> 'a fin ->
    'c term *)
 
@@ -2790,7 +2778,6 @@ let rec thin : type n. n succ fin -> n fin -> n succ fin =
   | FS x, FS y -> FS (thin x y)
 
 let bind t f = match t with None -> None | Some x -> f x
-
 (* val bind : 'a option -> ('a -> 'b option) -> 'b option *)
 
 let rec thick : type n. n succ fin -> n succ fin -> n fin option =
@@ -2815,11 +2802,9 @@ let rec check : type n. n succ fin -> n succ term -> n term option =
           bind (check x t2) (fun t2 -> Some (Fork (t1, t2))) )
 
 let subst_var x t' y = match thick x y with None -> t' | Some y' -> Var y'
-
 (* val subst_var : 'a succ fin -> 'a term -> 'a succ fin -> 'a term *)
 
 let subst x t' = pre_subst (subst_var x t')
-
 (* val subst : 'a succ fin -> 'a term -> 'a succ term -> 'a term *)
 
 (* 5 A Refinement of Substitution *)
@@ -2860,7 +2845,6 @@ let rec sub' : type m. m ealist -> m fin -> m term = function
         (fun t' -> weaken_term (subst_var x t t'))
 
 let subst' d = pre_subst (sub' d)
-
 (* val subst' : 'a ealist -> 'a term -> 'a term *)
 
 (* 6 First-Order Unification *)
@@ -2869,11 +2853,9 @@ let flex_flex x y =
   match thick x y with
   | Some y' -> asnoc Anil (Var y') x
   | None -> EAlist Anil
-
 (* val flex_flex : 'a succ fin -> 'a succ fin -> 'a succ ealist *)
 
 let flex_rigid x t = bind (check x t) (fun t' -> Some (asnoc Anil t' x))
-
 (* val flex_rigid : 'a succ fin -> 'a succ term -> 'a succ ealist option *)
 
 let rec amgu : type m. m term -> m term -> m ealist -> m ealist option =
@@ -2898,7 +2880,6 @@ let rec amgu : type m. m term -> m term -> m ealist -> m ealist option =
         (fun (EAlist d) -> Some (asnoc d r z))
 
 let mgu s t = amgu s t (EAlist Anil)
-
 (* val mgu : 'a term -> 'a term -> 'a ealist option *)
 
 let s = Fork (Var FZ, Fork (Var (FS (FS FZ)), Leaf))
@@ -3642,7 +3623,6 @@ let () =
   print_newline () ;
   print e3 ;
   print_newline ()
-
 (* Full fledge version, using objects to structure code *)
 
 open StdLabels
@@ -3859,7 +3839,6 @@ let () =
   print_newline () ;
   print e3 ;
   print_newline ()
-
 (* Full fledge version, using objects to structure code *)
 
 open StdLabels
@@ -4784,7 +4763,6 @@ module A_annotated_alias : S with type t = (module A.A_S) = A
 let _ = f (module A_annotated_alias) (* ok *)
 
 let _ = f (module A_annotated_alias : S with type t = (module A.A_S))
-
 (* ok *)
 
 module A_alias = A
@@ -4798,7 +4776,6 @@ let _ = f (module A_alias_expanded : S with type t = (module A.A_S)) (* ok *)
 let _ = f (module A_alias_expanded) (* ok *)
 
 let _ = f (module A_alias : S with type t = (module A.A_S))
-
 (* doesn't type *)
 
 let _ = f (module A_alias) (* doesn't type either *)
@@ -4815,7 +4792,6 @@ module Bazoinks = struct
 end
 
 module Bug = Foo (Bazoinks) (Bazoinks)
-
 (* PR#6992, reported by Stephen Dolan *)
 
 type (_, _) eq = Eq : ('a, 'a) eq
@@ -5024,7 +5000,6 @@ module rec M : sig
 end = struct
   external f : int -> int = "%identity"
 end
-
 (* with module *)
 
 module type S = sig
@@ -6353,7 +6328,6 @@ module M : sig
 end = struct
   type refer = {poly: 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a)}
 end
-
 (* ocamlc -c pr3918a.mli pr3918b.mli rm -f pr3918a.cmi ocamlc -c pr3918c.ml *)
 
 open Pr3918b
@@ -6398,7 +6372,6 @@ module Make' (Unit : sig end) : Priv' = struct
 end
 
 module A' = Make' ()
-
 (* PR5057 *)
 
 module TT = struct
@@ -6417,7 +6390,6 @@ let () =
     ()
   in
   f `A
-
 (* This one should fail *)
 
 let f flag =
@@ -7024,7 +6996,6 @@ struct
 
   let iter f = Diet.iter (Elt.iter f)
 end
-
 (* PR 4470: simplified from OMake's sources *)
 
 module rec DirElt : sig
@@ -7044,7 +7015,6 @@ and DirHash : sig
 end = struct
   type t = DirCompare.t list
 end
-
 (* PR 4758, PR 4266 *)
 
 module PR_4758 = struct
@@ -7139,7 +7109,6 @@ module F (X : Set.OrderedType) = struct
 
   and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
 end
-
 (* Tests for recursive modules *)
 
 let test number result expected =
@@ -8021,7 +7990,6 @@ module type CORE0 = sig
   module V : VALUE
 
   val setglobal : V.state -> string -> V.value -> unit
-
   (* five more functions common to core and evaluator *)
 end
 
@@ -8029,7 +7997,6 @@ module type CORE = sig
   include CORE0
 
   val apply : V.value -> V.state -> V.value list -> V.value
-
   (* apply function f in state s to list of args *)
 end
 
@@ -8480,7 +8447,6 @@ let f :
     -> int = function
   | A, A, A, A, A, A, A, _, U, U -> 1
   | _, _, _, _, _, _, _, G, _, _ -> 1
-
 (*| _ -> _ *)
 
 (* Unused cases *)
@@ -8685,12 +8651,9 @@ module OK = struct
   let f2 r =
     ignore (r : t) ;
     r.x
-
   (* non principal *)
 
-  let f3 (r : t) = match r with {x; y} -> y + y
-
-  (* ok *)
+  let f3 (r : t) = match r with {x; y} -> y + y (* ok *)
 end
 
 module F1 = struct
@@ -9093,7 +9056,6 @@ let () = proj1 (inj2 42)
 let _ = ~-1
 
 class id = [%exp]
-
 (* checkpoint *)
 
 (* Subtyping is "syntactic" *)

--- a/test/passing/tag_only.ml
+++ b/test/passing/tag_only.ml
@@ -103,30 +103,25 @@ class b =
 
 [@@@ocamlformat "doc-comments-tag-only=fit"]
 
-open Module
-(** @deprecated *)
+open Module  (** @deprecated *)
 
 (** abc
 
     @deprecated *)
 open Module
 
-open Module
-(** @author A *)
+open Module  (** @author A *)
 
-open Module
-(** @inline *)
+open Module  (** @inline *)
 
-include Abc
-(** @inline *)
+include Abc  (** @inline *)
 
 (** @inline *)
 include struct
   type t
 end
 
-include (Module : Type)
-(** @inline *)
+include (Module : Type)  (** @inline *)
 
 module A = B  (** @inline *)
 


### PR DESCRIPTION
Motivation:
```ocaml
let _ = assert (foo (bar + baz <= quux))
(* this comment should stay attached to the preceding item *)

let _ = foo
```
was formatted as:
```ocaml
let _ = assert (foo (bar + baz <= quux))

(* this comment should stay attached to the preceding item *)

let _ = foo
```
because the comment was wrongfully attached to the second item instead of the first one.

edit: no diff with test_branch.sh after the unnecessary commits were dropped.