### PR TITLE
Break or-patterns after comments and preserve their position at the end of line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
   + Preserve the syntax of infix set/get operators (#1528, @gpetiot)
     `String.get` and similar calls used to be automatically rewritten to their corresponding infix form `.()`, that was incorrect when using the `-unsafe` compilation flag. Now the concrete syntax of these calls is preserved.
 
+  + Break or-patterns after comments and preserve their position at the end of line (#1555, @gpetiot)
+
 ### 0.16.0 (2020-11-16)
 
 #### Removed

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -944,7 +944,8 @@ and fmt_pattern_attributes c xpat k =
       Params.parens_if parens_attr c.conf
         (k $ fmt_attributes c ~key:"@" attrs)
 
-and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
+and fmt_pattern c ?pro ?parens ?(box = false) ({ctx= ctx0; ast= pat} as xpat)
+    =
   protect c (Pat pat)
   @@
   let ctx = Pat pat in
@@ -960,6 +961,7 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
         Cmts.fmt c ~pro:(break 1 0) ppat_loc
         @@ Cmts.fmt c ~pro:(break 1 0) loc (fmt_opt pro $ k)
   | _ -> fun k -> Cmts.fmt c ppat_loc (fmt_opt pro $ k) )
+  @@ hovbox_if box 0
   @@ fmt_pattern_attributes c xpat
   @@
   match ppat_desc with
@@ -1123,7 +1125,8 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
       let break {ast= p1; _} {ast= p2; _} =
         Poly.(c.conf.break_cases = `Nested)
         || (not (is_simple p1))
-        || not (is_simple p2)
+        || (not (is_simple p2))
+        || Cmts.has_after c.cmts p1.ppat_loc
       in
       let open_box =
         match c.conf.break_cases with
@@ -1159,7 +1162,8 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
                       Params.get_or_pattern_sep c.conf ~ctx:ctx0 ~cmts_before
                         ~space:(space xpat.ast)
                   in
-                  leading_cmt $ fmt_pattern c ~pro xpat
+                  leading_cmt
+                  $ fmt_pattern c ~box:true ~pro xpat
                   $ fmt_if_k last close_box ) )
         $ fmt_or_k nested
             (fits_breaks (if parens then ")" else "") "")

--- a/test/passing/break_cases-align.ml.ref
+++ b/test/passing/break_cases-align.ml.ref
@@ -231,8 +231,7 @@ let handler =
 
 let _ =
   match abc with
-  | Fooooooooooooooooo
-  (* comment *)
+  | Fooooooooooooooooo (* comment *)
   | Baaaaaaaaaaaaaaaar
   (* comment *)
   | Baaaaaaaaaaaaaaaaz (* comment *) ->
@@ -254,12 +253,9 @@ let _ =
       ()
 
 let foooooooooooooo = function
-  | Fooo
-  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
-  | Foo
-  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
-  | Foooooooooooooooo
-  (* foooooo foooo fooooooooooo *)
+  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo (* foooooo foooo fooooooooooo *)
   | Foooooooooooooo _
   (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
      Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
@@ -267,10 +263,9 @@ let foooooooooooooo = function
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
   | Foooooooooo
-  | FooooFoooooFoooooo
-  (* fooooooooooooooooooooooooooooooooooo *)
+  | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
@@ -278,9 +273,8 @@ let foooooooooooooo = function
 
 let get_nullability = function
   | ArrayAccess
-  | OptimisticFallback
-  (* non-null is the most optimistic type *)
+  | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-  (* This is a very special case, assigning non-null is a technical trick *)
+    (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull

--- a/test/passing/break_cases-all.ml.ref
+++ b/test/passing/break_cases-all.ml.ref
@@ -231,8 +231,7 @@ let handler =
 
 let _ =
   match abc with
-  | Fooooooooooooooooo
-  (* comment *)
+  | Fooooooooooooooooo (* comment *)
   | Baaaaaaaaaaaaaaaar
   (* comment *)
   | Baaaaaaaaaaaaaaaaz (* comment *) ->
@@ -254,12 +253,9 @@ let _ =
       ()
 
 let foooooooooooooo = function
-  | Fooo
-  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
-  | Foo
-  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
-  | Foooooooooooooooo
-  (* foooooo foooo fooooooooooo *)
+  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo (* foooooo foooo fooooooooooo *)
   | Foooooooooooooo _
   (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
      Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
@@ -267,10 +263,9 @@ let foooooooooooooo = function
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
   | Foooooooooo
-  | FooooFoooooFoooooo
-  (* fooooooooooooooooooooooooooooooooooo *)
+  | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
@@ -278,9 +273,8 @@ let foooooooooooooo = function
 
 let get_nullability = function
   | ArrayAccess
-  | OptimisticFallback
-  (* non-null is the most optimistic type *)
+  | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-  (* This is a very special case, assigning non-null is a technical trick *)
+    (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull

--- a/test/passing/break_cases-closing_on_separate_line.ml.ref
+++ b/test/passing/break_cases-closing_on_separate_line.ml.ref
@@ -244,8 +244,7 @@ let handler =
 
 let _ =
   match abc with
-  | Fooooooooooooooooo
-  (* comment *)
+  | Fooooooooooooooooo (* comment *)
   | Baaaaaaaaaaaaaaaar
   (* comment *)
   | Baaaaaaaaaaaaaaaaz (* comment *) ->
@@ -269,12 +268,9 @@ let _ =
       ()
 
 let foooooooooooooo = function
-  | Fooo
-  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
-  | Foo
-  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
-  | Foooooooooooooooo
-  (* foooooo foooo fooooooooooo *)
+  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo (* foooooo foooo fooooooooooo *)
   | Foooooooooooooo _
   (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
      Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
@@ -282,10 +278,9 @@ let foooooooooooooo = function
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
   | Foooooooooo
-  | FooooFoooooFoooooo
-  (* fooooooooooooooooooooooooooooooooooo *)
+  | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
@@ -293,9 +288,8 @@ let foooooooooooooo = function
 
 let get_nullability = function
   | ArrayAccess
-  | OptimisticFallback
-  (* non-null is the most optimistic type *)
+  | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-  (* This is a very special case, assigning non-null is a technical trick *)
+    (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull

--- a/test/passing/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref
+++ b/test/passing/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref
@@ -244,8 +244,7 @@ let handler =
 
 let _ =
   match abc with
-  | Fooooooooooooooooo
-  (* comment *)
+  | Fooooooooooooooooo (* comment *)
   | Baaaaaaaaaaaaaaaar
   (* comment *)
   | Baaaaaaaaaaaaaaaaz (* comment *) ->
@@ -269,12 +268,9 @@ let _ =
       ()
 
 let foooooooooooooo = function
-  | Fooo
-  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
-  | Foo
-  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
-  | Foooooooooooooooo
-  (* foooooo foooo fooooooooooo *)
+  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo (* foooooo foooo fooooooooooo *)
   | Foooooooooooooo _
   (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
      Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
@@ -282,10 +278,9 @@ let foooooooooooooo = function
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
   | Foooooooooo
-  | FooooFoooooFoooooo
-  (* fooooooooooooooooooooooooooooooooooo *)
+  | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
@@ -293,9 +288,8 @@ let foooooooooooooo = function
 
 let get_nullability = function
   | ArrayAccess
-  | OptimisticFallback
-  (* non-null is the most optimistic type *)
+  | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-  (* This is a very special case, assigning non-null is a technical trick *)
+    (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull

--- a/test/passing/break_cases-cosl_lnmp_cmei.ml.ref
+++ b/test/passing/break_cases-cosl_lnmp_cmei.ml.ref
@@ -244,8 +244,7 @@ let handler =
 
 let _ =
   match abc with
-  | Fooooooooooooooooo
-  (* comment *)
+  | Fooooooooooooooooo (* comment *)
   | Baaaaaaaaaaaaaaaar
   (* comment *)
   | Baaaaaaaaaaaaaaaaz (* comment *) ->
@@ -269,12 +268,9 @@ let _ =
       ()
 
 let foooooooooooooo = function
-  | Fooo
-  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
-  | Foo
-  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
-  | Foooooooooooooooo
-  (* foooooo foooo fooooooooooo *)
+  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo (* foooooo foooo fooooooooooo *)
   | Foooooooooooooo _
   (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
      Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
@@ -282,10 +278,9 @@ let foooooooooooooo = function
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
   | Foooooooooo
-  | FooooFoooooFoooooo
-  (* fooooooooooooooooooooooooooooooooooo *)
+  | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
@@ -293,9 +288,8 @@ let foooooooooooooo = function
 
 let get_nullability = function
   | ArrayAccess
-  | OptimisticFallback
-  (* non-null is the most optimistic type *)
+  | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-  (* This is a very special case, assigning non-null is a technical trick *)
+    (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull

--- a/test/passing/break_cases-fit_or_vertical.ml.ref
+++ b/test/passing/break_cases-fit_or_vertical.ml.ref
@@ -194,12 +194,10 @@ let handler =
 
 let _ =
   match abc with
-  | Fooooooooooooooooo
-  (* comment *)
+  | Fooooooooooooooooo (* comment *)
   | Baaaaaaaaaaaaaaaar
   (* comment *)
-  | Baaaaaaaaaaaaaaaaz
-  (* comment *) -> ()
+  | Baaaaaaaaaaaaaaaaz (* comment *) -> ()
 
 let _ =
   match x with
@@ -216,12 +214,9 @@ let _ =
         | Y _ ) } -> ()
 
 let foooooooooooooo = function
-  | Fooo
-  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
-  | Foo
-  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
-  | Foooooooooooooooo
-  (* foooooo foooo fooooooooooo *)
+  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo (* foooooo foooo fooooooooooo *)
   | Foooooooooooooo _
   (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
      Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
@@ -229,18 +224,16 @@ let foooooooooooooo = function
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
   | Foooooooooo
-  | FooooFoooooFoooooo
-  (* fooooooooooooooooooooooooooooooooooo *)
+  | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     -> Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
 
 let get_nullability = function
   | ArrayAccess
-  | OptimisticFallback
-  (* non-null is the most optimistic type *)
+  | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-  (* This is a very special case, assigning non-null is a technical trick *)
+    (* This is a very special case, assigning non-null is a technical trick *)
     -> Nullability.Nonnull

--- a/test/passing/break_cases-nested.ml.ref
+++ b/test/passing/break_cases-nested.ml.ref
@@ -231,7 +231,7 @@ let foooooooooooooo = function
   | Foooooooooo
   | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
@@ -241,6 +241,6 @@ let get_nullability = function
   | ArrayAccess
   | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-  (* This is a very special case, assigning non-null is a technical trick *)
+    (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull

--- a/test/passing/break_cases-normal_indent.ml.ref
+++ b/test/passing/break_cases-normal_indent.ml.ref
@@ -231,8 +231,7 @@ let handler =
 
 let _ =
   match abc with
-  | Fooooooooooooooooo
-  (* comment *)
+  | Fooooooooooooooooo (* comment *)
   | Baaaaaaaaaaaaaaaar
   (* comment *)
   | Baaaaaaaaaaaaaaaaz (* comment *) ->
@@ -254,12 +253,9 @@ let _ =
       ()
 
 let foooooooooooooo = function
-  | Fooo
-  (* fooooo foo foo foooooo foooooooo foooooooooooo *)
-  | Foo
-  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
-  | Foooooooooooooooo
-  (* foooooo foooo fooooooooooo *)
+  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo (* foooooo foooo fooooooooooo *)
   | Foooooooooooooo _
   (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
      Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
@@ -267,10 +263,9 @@ let foooooooooooooo = function
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
   | Foooooooooo
-  | FooooFoooooFoooooo
-  (* fooooooooooooooooooooooooooooooooooo *)
+  | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
@@ -278,9 +273,8 @@ let foooooooooooooo = function
 
 let get_nullability = function
   | ArrayAccess
-  | OptimisticFallback
-  (* non-null is the most optimistic type *)
+  | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-  (* This is a very special case, assigning non-null is a technical trick *)
+    (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull

--- a/test/passing/break_cases-toplevel.ml.ref
+++ b/test/passing/break_cases-toplevel.ml.ref
@@ -197,7 +197,8 @@ let handler =
 
 let _ =
   match abc with
-  | Fooooooooooooooooo (* comment *) | Baaaaaaaaaaaaaaaar
+  | Fooooooooooooooooo (* comment *)
+  | Baaaaaaaaaaaaaaaar
   (* comment *)
   | Baaaaaaaaaaaaaaaaz (* comment *) ->
       ()
@@ -218,27 +219,28 @@ let _ =
       ()
 
 let foooooooooooooo = function
-  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *) | Foo
-  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
-  | Foooooooooooooooo (* foooooo foooo fooooooooooo *) | Foooooooooooooo _
+  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo (* foooooo foooo fooooooooooo *)
+  | Foooooooooooooo _
   (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
      Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
      Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
-  | Foooooooooo | FooooFoooooFoooooo
-  (* fooooooooooooooooooooooooooooooooooo *)
+  | Foooooooooo
+  | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
 
 let get_nullability = function
-  | ArrayAccess | OptimisticFallback
-  (* non-null is the most optimistic type *)
+  | ArrayAccess
+  | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-  (* This is a very special case, assigning non-null is a technical trick *)
+    (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull

--- a/test/passing/break_cases.ml.ref
+++ b/test/passing/break_cases.ml.ref
@@ -169,7 +169,8 @@ let handler =
 
 let _ =
   match abc with
-  | Fooooooooooooooooo (* comment *) | Baaaaaaaaaaaaaaaar
+  | Fooooooooooooooooo (* comment *)
+  | Baaaaaaaaaaaaaaaar
   (* comment *)
   | Baaaaaaaaaaaaaaaaz (* comment *) ->
       ()
@@ -190,27 +191,28 @@ let _ =
       ()
 
 let foooooooooooooo = function
-  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *) | Foo
-  (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
-  | Foooooooooooooooo (* foooooo foooo fooooooooooo *) | Foooooooooooooo _
+  | Fooo (* fooooo foo foo foooooo foooooooo foooooooooooo *)
+  | Foo (* foooooo foooo fooooo fooooooo fooooooo fooooo *)
+  | Foooooooooooooooo (* foooooo foooo fooooooooooo *)
+  | Foooooooooooooo _
   (* Foooooooooooooooooooooooooooo fooooooooooooooooooooooooooo fooooooooo.
      Foooooooooooooooooooooooooooooooooooo foooooooooooooooooooooooo foooooo.
      Foooooooooooooooooooooooooooooooooooooo foooooooooooooooooooo
      foooooooooooooooooo foooooooo. Foooooooooooo fooooooooooo fooooooooooooo
      foooooooooooooo foooooo. *)
-  | Foooooooooo | FooooFoooooFoooooo
-  (* fooooooooooooooooooooooooooooooooooo *)
+  | Foooooooooo
+  | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-  (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
     ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
 
 let get_nullability = function
-  | ArrayAccess | OptimisticFallback
-  (* non-null is the most optimistic type *)
+  | ArrayAccess
+  | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-  (* This is a very special case, assigning non-null is a technical trick *)
+    (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull

--- a/test/passing/comment_in_empty.ml
+++ b/test/passing/comment_in_empty.ml
@@ -25,7 +25,8 @@ let _ = f "asd" (* te""st *) 3
 let x = function
   | [ (* empty list pat *) ]
    |[| (* empty array pat *) |]
-   |( (* unit pat *) ) | "" (* comment *) ->
+   |( (* unit pat *) )
+   |"" (* comment *) ->
       ()
 
 let x =


### PR DESCRIPTION
This is a general improvement required for #1554 and #1193

diff with test_branch:
(conventional profile)
```diff
diff --git a/infer/src/clang/cTrans.ml b/infer/src/clang/cTrans.ml
index ebdeb190a..88426021e 100644
--- a/infer/src/clang/cTrans.ml
+++ b/infer/src/clang/cTrans.ml
@@ -4038,7 +4038,8 @@ struct
       let is_by_ref =
         (* see http://en.cppreference.com/w/cpp/language/lambda *)
         match lci_capture_kind with
-        | `LCK_ByRef (* explicit with [&x] or implicit with [&] *) | `LCK_This
+        | `LCK_ByRef (* explicit with [&x] or implicit with [&] *)
+        | `LCK_This
         (* explicit with [this] or implicit with [&] *)
         | `LCK_VLAType
         (* capture a variable-length array by reference. we probably don't handle
diff --git a/infer/src/nullsafe/typeOrigin.ml b/infer/src/nullsafe/typeOrigin.ml
index 0b83bdcd8..07b278223 100644
--- a/infer/src/nullsafe/typeOrigin.ml
+++ b/infer/src/nullsafe/typeOrigin.ml
@@ -46,7 +46,8 @@ type t =
 let get_nullability = function
   | NullConst _ -> Nullability.Null
   | NonnullConst _ | This (* `this` can not be null according to Java rules *)
-  | New (* In Java `new` always create a non-null object  *) | ArrayLengthResult
+  | New (* In Java `new` always create a non-null object  *)
+  | ArrayLengthResult
   (* integer hence non-nullable *)
   | CallToGetKnownToContainsKey (* non-nullable by definition *)
   | InferredNonnull _
```

(janestreet profile)
```diff
diff --git a/infer/src/nullsafe/typeOrigin.ml b/infer/src/nullsafe/typeOrigin.ml
index 3459bc360..15fbcdadb 100644
--- a/infer/src/nullsafe/typeOrigin.ml
+++ b/infer/src/nullsafe/typeOrigin.ml
@@ -63,8 +63,8 @@ let get_nullability = function
      Hence we make potentially dangerous choice in favor of pragmatism.
   *)
   | ArrayAccess
-  | OptimisticFallback
-  (* non-null is the most optimistic type *) -> Nullability.StrictNonnull
+  | OptimisticFallback (* non-null is the most optimistic type *) ->
+    Nullability.StrictNonnull
   | Field { field_type = { nullability } } ->
     AnnotatedNullability.get_nullability nullability
   | CurrMethodParameter (Normal { param_annotated_type = { nullability } }) ->
```
