### PR TITLE
Fix comments on the same line as prev and next elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
   + Preserve the syntax of infix set/get operators (#1528, @gpetiot)
     `String.get` and similar calls used to be automatically rewritten to their corresponding infix form `.()`, that was incorrect when using the `-unsafe` compilation flag. Now the concrete syntax of these calls is preserved.
 
+  + Fix comments on the same line as prev and next elements (#1556, @gpetiot)
+
 ### 0.16.0 (2020-11-16)
 
 #### Removed

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -138,7 +138,7 @@ end = struct
               ( loc.loc_start.pos_lnum - prev.loc_end.pos_lnum
               , next.loc_start.pos_lnum - loc.loc_end.pos_lnum )
             with
-            | 0, 0 -> impossible "already tested by previous if"
+            | 0, 0 -> `Before_next
             | 0, _ when infix_symbol_before src loc -> `Before_next
             | 0, _ -> `After_prev
             | _ -> `Before_next

--- a/test/passing/js_source.ml
+++ b/test/passing/js_source.ml
@@ -7566,3 +7566,8 @@ let foo () =
     this is a medium length expression of_some sort
   then x
   else y
+
+let xxxxxx =
+  let%map (* _____________________________
+             __________ *)()            = yyyyyyyy in
+  { zzzzzzzzzzzzz }

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -9946,3 +9946,9 @@ let foo () =
   then x
   else y
 ;;
+
+let xxxxxx =
+  let%map (* _____________________________
+             __________ *) () = yyyyyyyy in
+  { zzzzzzzzzzzzz }
+;;

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -9946,3 +9946,9 @@ let foo () =
   then x
   else y
 ;;
+
+let xxxxxx =
+  let%map (* _____________________________
+             __________ *) () = yyyyyyyy in
+  { zzzzzzzzzzzzz }
+;;

--- a/test/passing/source.ml
+++ b/test/passing/source.ml
@@ -7392,3 +7392,8 @@ f
         ()
         (* comment *) | false -> ())
   ()
+
+let xxxxxx =
+  let%map (* _____________________________
+             __________ *)()            = yyyyyyyy in
+  { zzzzzzzzzzzzz }

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -9275,3 +9275,7 @@ f
     (* comment *)
     | false -> () )
   ()
+
+let xxxxxx =
+  let%map (* _____________________________ __________ *) () = yyyyyyyy in
+  {zzzzzzzzzzzzz}


### PR DESCRIPTION
Fix #1449, no diff with test_branch on conventional and janestreet profiles.