### PR TITLE
ocamlformat.el: add buffer filename in logs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,12 @@
   + Preserve the syntax of infix set/get operators (#1528, @gpetiot)
     `String.get` and similar calls used to be automatically rewritten to their corresponding infix form `.()`, that was incorrect when using the `-unsafe` compilation flag. Now the concrete syntax of these calls is preserved.
 
+
+#### Changes
+
+  + Add buffer filename in the logs when applying ocamlformat (@dannywillems)
+
+
 ### 0.16.0 (2020-11-16)
 
 #### Removed

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -281,7 +281,7 @@ is nil."
                 (if ocamlformat--support-replace-buffer-contents
                     (ocamlformat--replace-buffer-contents outputfile)
                   (ocamlformat--patch-buffer outputfile))
-                (message "Applied ocamlformat"))
+                (message "Applied ocamlformat on %s" buffer-file-name))
             (if errbuf
                 (progn
                   (with-current-buffer errbuf
@@ -289,7 +289,7 @@ is nil."
                     (erase-buffer))
                   (ocamlformat--process-errors
                    (buffer-file-name) bufferfile errorfile errbuf)))
-            (message "Could not apply ocamlformat"))))
+            (message "Could not apply ocamlformat on %s" buffer-file-name))))
     (delete-file errorfile)
     (delete-file bufferfile)
     (delete-file outputfile)))


### PR DESCRIPTION
It is a bit more convenient to see on which file ocamlformat has been applied in logs.