### PR TITLE
Fix comment position around list cons operator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@
 
   + Fix stack overflow on large string constants (#1562, @gpetiot)
 
+  + Fix comment position around list cons operator (#1567, @gpetiot)
+
 #### Changes
 
   + Add buffer filename in the logs when applying ocamlformat (#1557, @dannywillems)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2006,7 +2006,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         @@ hvbox indent_wrap
              ( fmt_expression c (sub_exp ~ctx x)
              $ fmt "@ "
-             $ hvbox 0
+             $ hovbox 0
                  ( Cmts.fmt c ~pro:noop loc (fmt "::@ ")
                  $ fmt_expression c (sub_exp ~ctx y) )
              $ fmt_atrs ) )

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1981,7 +1981,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       Params.parens_if parens c.conf (fmt_longident_loc c lid $ fmt_atrs)
   | Pexp_construct
       ( {txt= Lident "::"; loc}
-      , Some {pexp_desc= Pexp_tuple [x; y]; pexp_attributes= []; _} ) -> (
+      , Some {pexp_desc= Pexp_tuple [x; y]; pexp_attributes= []; pexp_loc; _}
+      ) -> (
     match Sugar.list_exp c.cmts exp with
     | Some (loc_xes, nil_loc) ->
         let p = Params.get_list_expr c.conf in
@@ -2001,7 +2002,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
              $ fmt_atrs ) )
     | None ->
         Params.parens_if parens c.conf
-        @@ Cmts.fmt c loc
+        @@ Cmts.fmt c pexp_loc
         @@ hvbox indent_wrap
              ( fmt_expression c (sub_exp ~ctx x)
              $ fmt "@ "

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1980,8 +1980,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
   | Pexp_construct (lid, None) ->
       Params.parens_if parens c.conf (fmt_longident_loc c lid $ fmt_atrs)
   | Pexp_construct
-      ( {txt= Lident "::"; loc= _}
-      , Some {pexp_desc= Pexp_tuple [_; _]; pexp_attributes= []; _} ) -> (
+      ( {txt= Lident "::"; loc}
+      , Some {pexp_desc= Pexp_tuple [x; y]; pexp_attributes= []; _} ) -> (
     match Sugar.list_exp c.cmts exp with
     | Some (loc_xes, nil_loc) ->
         let p = Params.get_list_expr c.conf in
@@ -2000,20 +2000,15 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                  $ Cmts.fmt_after c ~pro:(fmt "@ ") ~epi:noop nil_loc )
              $ fmt_atrs ) )
     | None ->
-        let loc_args = Sugar.infix_cons c.cmts xexp in
-        hvbox indent_wrap
-          ( fmt_infix_op_args c ~parens xexp
-              (List.mapi loc_args ~f:(fun i (locs, arg) ->
-                   let f l = Cmts.has_before c.cmts l in
-                   let has_cmts = List.exists ~f locs in
-                   let fmt_before_cmts = list locs "" (Cmts.fmt_before c) in
-                   let fmt_op = fmt_if (i > 0) "::" in
-                   let fmt_after_cmts = list locs "" (Cmts.fmt_after c) in
-                   ( has_cmts
-                   , fmt_before_cmts
-                   , fmt_after_cmts
-                   , (fmt_op, [(Nolabel, arg)]) ) ) )
-          $ fmt_atrs ) )
+        Params.parens_if parens c.conf
+        @@ Cmts.fmt c loc
+        @@ hvbox indent_wrap
+             ( fmt_expression c (sub_exp ~ctx x)
+             $ fmt "@ "
+             $ hvbox 0
+                 ( Cmts.fmt c ~pro:noop loc (fmt "::@ ")
+                 $ fmt_expression c (sub_exp ~ctx y) )
+             $ fmt_atrs ) )
   | Pexp_construct (({txt= Lident "::"; loc= _} as lid), Some arg) ->
       let opn, cls =
         match c.conf.indicate_multiline_delimiters with

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -203,29 +203,6 @@ let list_exp cmts exp =
   in
   list_exp_ exp []
 
-let infix_cons cmts xexp =
-  let rec infix_cons_ ({ast= exp; _} as xexp) =
-    let ctx = Exp exp in
-    let {pexp_desc; pexp_loc= l1; _} = exp in
-    match pexp_desc with
-    | Pexp_construct
-        ( {txt= Lident "::"; loc= l2}
-        , Some
-            { pexp_desc= Pexp_tuple [hd; tl]
-            ; pexp_loc= l3
-            ; pexp_attributes= []
-            ; _ } ) ->
-        Cmts.relocate cmts ~src:l1 ~before:hd.pexp_loc ~after:tl.pexp_loc ;
-        let xtl =
-          match tl.pexp_attributes with
-          | [] -> infix_cons_ (sub_exp ~ctx tl)
-          | _ -> [([], sub_exp ~ctx tl)]
-        in
-        ([l1; l2; l3], sub_exp ~ctx hd) :: xtl
-    | _ -> [([], xexp)]
-  in
-  infix_cons_ xexp
-
 let rec ite cmts ({ast= exp; _} as xexp) =
   let ctx = Exp exp in
   let {pexp_desc; pexp_loc; pexp_attributes; _} = exp in

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -81,11 +81,6 @@ val list_exp :
 (** [list_exp cmts exp] returns a list of expressions if [exp] is an
     expression corresponding to a list (empty list or (::) application). *)
 
-val infix_cons :
-  Cmts.t -> expression Ast.xt -> (Warnings.loc list * expression Ast.xt) list
-(** [infix_cons exp] returns a list of expressions if [exp] is an expression
-    corresponding to a list ((::) application). *)
-
 val ite :
      Cmts.t
   -> expression Ast.xt

--- a/test/passing/list-space_around.ml.ref
+++ b/test/passing/list-space_around.ml.ref
@@ -62,3 +62,5 @@ let x = function
       ()
 
 let _ = f ~x:(a :: b) (* comment *) ~y
+
+let _ = f ((* comment *) x :: y)

--- a/test/passing/list-space_around.ml.ref
+++ b/test/passing/list-space_around.ml.ref
@@ -60,3 +60,5 @@ let x = function
       (* "exercitation ullamco laboris nisi ut aliquip ex ea commodo " *)
     ] ->
       ()
+
+let _ = f ~x:(a :: b) (* comment *) ~y

--- a/test/passing/list.ml
+++ b/test/passing/list.ml
@@ -62,3 +62,5 @@ let x = function
       ()
 
 let _ = f ~x:(a :: b) (* comment *) ~y
+
+let _ = f ((* comment *) x :: y)

--- a/test/passing/list.ml
+++ b/test/passing/list.ml
@@ -60,3 +60,5 @@ let x = function
       (* "exercitation ullamco laboris nisi ut aliquip ex ea commodo " *)
     ] ->
       ()
+
+let _ = f ~x:(a :: b) (* comment *) ~y


### PR DESCRIPTION
Fix #1564

this removes the sugaring that was made for lists like `x :: y :: z` so there can be some significant diff on expressions like these, but it makes it much more easier to maintain this part of the code (in addition to fixing the comments' position that was messy because of the relocations). Any thoughts on the diff? (extract)

Unnecessary parens are removed:
```diff
diff --git a/examples/minesweeper/minesweeper.ml b/examples/minesweeper/minesweeper.ml
index e55d3b80d..7140990a5 100644
--- a/examples/minesweeper/minesweeper.ml
+++ b/examples/minesweeper/minesweeper.ml
@@ -102,7 +102,7 @@ let cells_to_see bd cf (i, j) =
         if bd.(x).(y).nbm <> 0 then c :: cells_to_see_rec l
         else
           let l1, l2 = relevant (neighbours cf c) in
-          (c :: l1) @ cells_to_see_rec (l2 @ l)
+          c :: l1 @ cells_to_see_rec (l2 @ l)
   in
```

the `::` operator is now indented with the expression instead of the opening parenthesis, and expressions are put below `::` if they break instead of floating on the right (reduces the amount of artificial indentation):
```diff
diff --git a/src/cache/messages.ml b/src/cache/messages.ml
index 4e8f41c9e..d6675a9db 100644
--- a/src/cache/messages.ml
+++ b/src/cache/messages.ml
@@ -37,13 +37,14 @@ let sexp_of_message : type a. version -> a message -> Sexp.t =
   | Lang versions ->
       cmd "lang"
         (Sexp.Atom "dune-cache-protocol"
-        :: (List.map ~f:(fun { major; minor } ->
-                Sexp.List
-                  [
-                    Sexp.Atom (string_of_int major);
-                    Sexp.Atom (string_of_int minor);
-                  ]))
-             versions)
+         ::
+         (List.map ~f:(fun { major; minor } ->
+              Sexp.List
+                [
+                  Sexp.Atom (string_of_int major);
+                  Sexp.Atom (string_of_int minor);
+                ]))
+           versions)
```

of course I tried to just fix the position of comments without having such huge diff, but didn't manage to do so with the way  fmt_infix_op_args is handled, and that's an abstraction I wanted to remove for some time as it artificially complicates the code and the cost/benefit is not clear on this one.