### PR TITLE
Add Fmt.sequence as a generalization for ($)

### DIFF
--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -152,11 +152,7 @@ let list_fl xs pp =
   list_pn xs (fun ~prev x ~next ->
       pp ~first:(Option.is_none prev) ~last:(Option.is_none next) x )
 
-let rec list_k l pp_sep pp =
-  match l with
-  | [] -> noop
-  | [x] -> pp x
-  | x :: xs -> pp x $ pp_sep $ list_k xs pp_sep pp
+let list_k l sep f = List.map l ~f |> List.intersperse ~sep |> sequence
 
 let list xs sep pp = list_k xs (fmt sep) pp
 

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -99,6 +99,19 @@ let cbreak ~fits ~breaks =
 
 let noop = with_pp (fun _ -> ())
 
+let sequence l =
+  let rec go l len =
+    match l with
+    | [] -> noop
+    | [x] -> x
+    | l ->
+        let a_len = len / 2 in
+        let b_len = len - a_len in
+        let a, b = List.split_n l a_len in
+        go a a_len $ go b b_len
+  in
+  go l (List.length l)
+
 let fmt f = with_pp (fun fs -> Format.fprintf fs f)
 
 (** Primitive types -----------------------------------------------------*)

--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -30,6 +30,9 @@ val sp : sp -> t
 val ( $ ) : t -> t -> t
 (** Format concatenation: [a $ b] formats [a], then [b]. *)
 
+val sequence : t list -> t
+(** Format concatenation of n elements. *)
+
 val ( >$ ) : t -> ('b -> t) -> 'b -> t
 (** Pre-compose a format thunk onto a function returning a format thunk. *)
 

--- a/test/unit/test_fmt.ml
+++ b/test/unit/test_fmt.ml
@@ -75,4 +75,21 @@ let tests_list_pn =
         let l = ["a"; "b"; "c"; "d"; "e"] in
         Fmt.fmt_if_k false (Fmt.list_pn l pp_spy) ) ]
 
-let tests = tests_lazy @ tests_list_pn
+let tests_sequence =
+  let test name term ~expected =
+    ( "sequence: " ^ name
+    , `Quick
+    , fun () ->
+        let got = eval_fmt term in
+        Alcotest.check Alcotest.string Caml.__LOC__ expected got )
+  in
+  [ test "1 element" (Fmt.sequence [Fmt.char 'c']) ~expected:"c"
+  ; test "empty list" (Fmt.sequence []) ~expected:""
+  ; test "list"
+      (Fmt.sequence [Fmt.str "a"; Fmt.str "b"; Fmt.str "c"; Fmt.str "d"])
+      ~expected:"abcd"
+  ; test "long list"
+      (Fmt.sequence (List.init 300_000 ~f:(fun _ -> Fmt.noop)))
+      ~expected:"" ]
+
+let tests = tests_lazy @ tests_list_pn @ tests_sequence


### PR DESCRIPTION
It is specially optimized so that large lists can be formatted without chaining ($), which consumes linear stack space.

It is implemented as a balanced tree of ($), which will take logarithmic stack space.

(this also implement list_k in terms of sequence)