### PR TITLE
Format objects and classes consistently with structure and signature items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,13 +4,13 @@
 
 #### Bug fixes
 
-+ Fix extraneous parenthesis after 'let open' with 'closing-on-separate-line' (#1612, @Julow)
+  + Fix extraneous parenthesis after 'let open' with 'closing-on-separate-line' (#1612, @Julow)
 
 #### Changes
 
-+ Use dune instrumentation backend for bisect_ppx (#1550, @tmattio)
+  + Use dune instrumentation backend for bisect_ppx (#1550, @tmattio)
 
-+ Format objects and classes in a compact way (#1569, @bikallem)
+  + Format objects and classes consistently with structure and signature items (#1569, @bikallem)
 
 #### New features
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 + Use dune instrumentation backend for bisect_ppx (#1550, @tmattio)
 
++ Format objects and classes in a compact way (#1569, @bikallem)
+
 #### New features
 
 ### 0.17.0 (2021-02-15)

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -628,7 +628,12 @@ module Vb = struct
 end
 
 module Class_field = struct
-  let has_doc itm = Option.is_some (fst (doc_atrs itm.pcf_attributes))
+  let has_doc itm =
+    Option.is_some (fst (doc_atrs itm.pcf_attributes))
+    ||
+    match itm.pcf_desc with
+    | Pcf_attribute atr -> Option.is_some (fst (doc_atrs [atr]))
+    | _ -> false
 
   let is_simple (itm, c) =
     match c.Conf.module_item_spacing with
@@ -649,7 +654,12 @@ module Class_field = struct
 end
 
 module Class_type_field = struct
-  let has_doc itm = Option.is_some (fst (doc_atrs itm.pctf_attributes))
+  let has_doc itm =
+    Option.is_some (fst (doc_atrs itm.pctf_attributes))
+    ||
+    match itm.pctf_desc with
+    | Pctf_attribute atr -> Option.is_some (fst (doc_atrs [atr]))
+    | _ -> false
 
   let is_simple (itm, c) =
     match c.Conf.module_item_spacing with

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2360,7 +2360,7 @@ end = struct
                      true
                  | _ -> e0 == exp ) ->
           exposed_right_exp Non_apply exp
-      (* Non_apply is perhaps pessimistic *)
+          (* Non_apply is perhaps pessimistic *)
       | Pexp_record (_, Some ({pexp_desc= Pexp_apply (ident, [_]); _} as e0))
         when e0 == exp && Exp.is_prefix ident ->
           (* don't put parens around [!e] in [{ !e with a; b }] *)

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -156,6 +156,7 @@ type t =
   | Mod of module_expr
   | Sig of signature_item
   | Str of structure_item
+  | Clf of class_field
   | Tli of toplevel_item
   | Top
 

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -157,6 +157,7 @@ type t =
   | Sig of signature_item
   | Str of structure_item
   | Clf of class_field
+  | Ctf of class_type_field
   | Tli of toplevel_item
   | Top
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4240,7 +4240,7 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
       in
       hvbox 0 ~name:"value"
         (list_fl grps (fun ~first ~last grp ->
-             fmt_grp ~first ~last grp $ fmt_if (not last) "@;<1000 0>" ) )
+             fmt_grp ~first ~last grp $ fmt_if (not last) "\n@;<1000 0>" ) )
   | Pstr_modtype mtd -> fmt_module_type_declaration ?ext c ctx mtd
   | Pstr_extension (ext, atrs) ->
       let doc_before, doc_after, atrs = fmt_docstring_around_item c atrs in

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -122,19 +122,12 @@ class x =
   let[@foo] x = 3 in
   object
     inherit x [@@foo]
-
     val x = 3 [@@foo]
-
     val virtual x : t [@@foo]
-
     val! mutable x = 3 [@@foo]
-
     method x = 3 [@@foo]
-
     method virtual x : t [@@foo]
-
     method! private x = 3 [@@foo]
-
     initializer x [@@foo]
   end [@foo]
 
@@ -300,9 +293,7 @@ class bar : bar_t =
       | other -> super#cast other
 
     method bar = "bar"
-
     [@@@id]
-
     [%%id]
   end
 
@@ -3877,7 +3868,6 @@ class ['a] var_ops =
       | Not_found -> x
 
     method free (`Var s) = Names.singleton s
-
     method eval (#var as v) = v
   end
 
@@ -4125,7 +4115,6 @@ let var =
       | Not_found -> x
 
     method free (`Var s) = Names.singleton s
-
     method eval (#var as v) = v
   end
 ;;
@@ -6112,7 +6101,6 @@ class type exp =
 class app e1 e2 : exp =
   object
     val l = e1
-
     val r = e2
 
     method eval env =
@@ -6131,9 +6119,7 @@ class virtual ['subject, 'event] observer =
 class ['event] subject =
   object (self : 'subject)
     val mutable observers : ('subject, 'event) observer list = []
-
     method add_observer obs = observers <- obs :: observers
-
     method notify_observers (e : 'event) = List.iter (fun x -> x#notify self e) observers
   end
 
@@ -6142,18 +6128,14 @@ type id = int
 class entity (id : id) =
   object
     val ent_destroy_subject = new subject
-
     method destroy_subject : id subject = ent_destroy_subject
-
     method entity_id = id
   end
 
 class ['entity] entity_container =
   object (self)
     inherit ['entity, id] observer as observer
-
     method add_entity (e : 'entity) = e#destroy_subject#add_observer self
-
     method notify _ id = ()
   end
 
@@ -6173,7 +6155,6 @@ class world =
 class c v =
   object
     initializer print_endline v
-
     val v = 42
   end
 
@@ -6204,7 +6185,6 @@ class virtual ['a] c =
 let o =
   object (s : 'a)
     inherit ['a] c
-
     method m = 42
   end
 ;;
@@ -6238,7 +6218,6 @@ end
 class c (x : int) =
   object
     inherit M.c x
-
     method x : bool = x
   end
 
@@ -6253,14 +6232,12 @@ class alfa =
 class bravo a =
   object
     val y = (a :> alfa)
-
     initializer y#x "bravo initialized"
   end
 
 class charlie a =
   object
     inherit bravo a
-
     initializer y#x "charlie initialized"
   end
 
@@ -6298,15 +6275,10 @@ class type ['a] storage =
 class virtual ['a, 'cursor] storage_base =
   object (self : 'self)
     constraint 'cursor = 'a #cursor
-
     method virtual first : 'cursor
-
     method virtual len : int
-
     method virtual copy : 'self
-
     method virtual sub : int -> int -> 'self
-
     method virtual concat : 'a storage -> 'self
 
     method fold : 'b. ('a -> int -> 'b -> 'b) -> 'b -> 'b =
@@ -6415,19 +6387,12 @@ module UText = struct
   class text_raw buf =
     object (self : 'self)
       inherit [cursor] ustorage_base
-
       val contents = buf
-
       method first = new cursor (self :> text_raw) 0
-
       method len = String.length contents / 4
-
       method get i = get_buf contents (4 * i)
-
       method nth i = new cursor (self :> text_raw) i
-
       method copy = {<contents = String.copy contents>}
-
       method sub pos len = {<contents = String.sub contents (pos * 4) (len * 4)>}
 
       method concat (text : ustorage) =
@@ -6440,20 +6405,15 @@ module UText = struct
   and cursor text i =
     object
       val contents = text
-
       val mutable pos = i
-
       method get = contents#get pos
-
       method incr () = pos <- pos + 1
-
       method is_last = pos + 1 >= contents#len
     end
 
   class string_raw buf =
     object
       inherit text_raw buf
-
       method set i u = set_buf contents (4 * i) u
     end
 
@@ -6536,7 +6496,6 @@ class virtual name = object end
 and func (args_ty, ret_ty) =
   object (self)
     inherit name
-
     val mutable memo_args = None
 
     method arguments =
@@ -6588,7 +6547,6 @@ module Classdef = struct
   class virtual ['a, 'b] cl1 =
     object
       method virtual raise_trouble : int -> 'a
-
       method virtual m : 'a -> 'b -> int
     end
 
@@ -6613,7 +6571,6 @@ module Classdef = struct
   class virtual ['a, 'b] cl1 =
     object
       method virtual raise_trouble : int -> 'a
-
       method virtual m : 'a -> 'b -> int
     end
 
@@ -7890,7 +7847,6 @@ end = struct
   class d =
     object (self)
       inherit Class1.c as super
-
       method m (x : int) = super#m 0
     end
 end
@@ -8586,7 +8542,6 @@ let f x (type a) (y : a) = x = y
 class ['a] c =
   object (self)
     method m : 'a -> 'a = fun x -> x
-
     method n : 'a -> 'a = fun (type g) (x : g) -> self#m x
   end
 
@@ -9590,7 +9545,6 @@ let _ =
 class ['a] c () =
   object
     constraint 'a = < .. > -> unit
-
     method m : 'a = fun x -> ()
   end
 

--- a/test/passing/js_source.ml.ocp
+++ b/test/passing/js_source.ml.ocp
@@ -135,21 +135,13 @@ class x =
 class type t =
   object
     inherit t [@@foo]
-
     val x : t [@@foo]
-
     val mutable x : t [@@foo]
-
     method x : t [@@foo]
-
     method private x : t [@@foo]
-
     constraint t = t' [@@foo]
-
     [@@@abc]
-
     [%%id]
-
     [@@@aaa]
   end[@foo]
 
@@ -256,7 +248,6 @@ class type castable =
 class type foo_t =
   object
     inherit castable
-
     method foo : string
   end
 
@@ -277,7 +268,6 @@ class foo : foo_t =
 class type bar_t =
   object
     inherit foo
-
     method bar : string
   end
 
@@ -3849,9 +3839,7 @@ let ( !! ) = Lazy.force
 class type ['a, 'b] ops =
   object
     method free : x:'b -> ?y:'c -> Names.t
-
     method subst : sub:'a Subst.t -> 'b -> 'a
-
     method eval : 'b -> 'a
   end
 
@@ -4098,9 +4086,7 @@ let ( !! ) = Lazy.force
 class type ['a, 'b] ops =
   object
     method free : 'b -> Names.t
-
     method subst : sub:'a Subst.t -> 'b -> 'a
-
     method eval : 'b -> 'a
   end
 
@@ -6247,28 +6233,19 @@ exception Out_of_range
 class type ['a] cursor =
   object
     method get : 'a
-
     method incr : unit -> unit
-
     method is_last : bool
   end
 
 class type ['a] storage =
   object ('self)
     method first : 'a cursor
-
     method len : int
-
     method nth : int -> 'a cursor
-
     method copy : 'self
-
     method sub : int -> int -> 'self
-
     method concat : 'a storage -> 'self
-
     method fold : 'b. ('a -> int -> 'b -> 'b) -> 'b -> 'b
-
     method iter : ('a -> unit) -> unit
   end
 
@@ -6306,16 +6283,13 @@ class virtual ['a, 'cursor] storage_base =
 class type ['a] obj_input_channel =
   object
     method get : unit -> 'a
-
     method close : unit -> unit
   end
 
 class type ['a] obj_output_channel =
   object
     method put : 'a -> unit
-
     method flush : unit -> unit
-
     method close : unit -> unit
   end
 

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -122,19 +122,12 @@ class x =
     let[@foo] x = 3 in
     object
       inherit x [@@foo]
-
       val x = 3 [@@foo]
-
       val virtual x : t [@@foo]
-
       val! mutable x = 3 [@@foo]
-
       method x = 3 [@@foo]
-
       method virtual x : t [@@foo]
-
       method! private x = 3 [@@foo]
-
       initializer x [@@foo]
     end [@foo]
 
@@ -300,9 +293,7 @@ class bar : bar_t =
       | other -> super#cast other
 
     method bar = "bar"
-
     [@@@id]
-
     [%%id]
   end
 
@@ -3877,7 +3868,6 @@ class ['a] var_ops =
       | Not_found -> x
 
     method free (`Var s) = Names.singleton s
-
     method eval (#var as v) = v
   end
 
@@ -4125,7 +4115,6 @@ let var =
       | Not_found -> x
 
     method free (`Var s) = Names.singleton s
-
     method eval (#var as v) = v
   end
 ;;
@@ -6112,7 +6101,6 @@ class type exp =
 class app e1 e2 : exp =
   object
     val l = e1
-
     val r = e2
 
     method eval env =
@@ -6131,9 +6119,7 @@ class virtual ['subject, 'event] observer =
 class ['event] subject =
   object (self : 'subject)
     val mutable observers : ('subject, 'event) observer list = []
-
     method add_observer obs = observers <- obs :: observers
-
     method notify_observers (e : 'event) = List.iter (fun x -> x#notify self e) observers
   end
 
@@ -6142,18 +6128,14 @@ type id = int
 class entity (id : id) =
   object
     val ent_destroy_subject = new subject
-
     method destroy_subject : id subject = ent_destroy_subject
-
     method entity_id = id
   end
 
 class ['entity] entity_container =
   object (self)
     inherit ['entity, id] observer as observer
-
     method add_entity (e : 'entity) = e#destroy_subject#add_observer self
-
     method notify _ id = ()
   end
 
@@ -6173,7 +6155,6 @@ class world =
 class c v =
   object
     initializer print_endline v
-
     val v = 42
   end
 
@@ -6204,7 +6185,6 @@ class virtual ['a] c =
 let o =
   object (s : 'a)
     inherit ['a] c
-
     method m = 42
   end
 ;;
@@ -6238,7 +6218,6 @@ end
 class c (x : int) =
   object
     inherit M.c x
-
     method x : bool = x
   end
 
@@ -6253,14 +6232,12 @@ class alfa =
 class bravo a =
   object
     val y = (a :> alfa)
-
     initializer y#x "bravo initialized"
   end
 
 class charlie a =
   object
     inherit bravo a
-
     initializer y#x "charlie initialized"
   end
 
@@ -6298,15 +6275,10 @@ class type ['a] storage =
 class virtual ['a, 'cursor] storage_base =
   object (self : 'self)
     constraint 'cursor = 'a #cursor
-
     method virtual first : 'cursor
-
     method virtual len : int
-
     method virtual copy : 'self
-
     method virtual sub : int -> int -> 'self
-
     method virtual concat : 'a storage -> 'self
 
     method fold : 'b. ('a -> int -> 'b -> 'b) -> 'b -> 'b =
@@ -6415,19 +6387,12 @@ module UText = struct
   class text_raw buf =
     object (self : 'self)
       inherit [cursor] ustorage_base
-
       val contents = buf
-
       method first = new cursor (self :> text_raw) 0
-
       method len = String.length contents / 4
-
       method get i = get_buf contents (4 * i)
-
       method nth i = new cursor (self :> text_raw) i
-
       method copy = {<contents = String.copy contents>}
-
       method sub pos len = {<contents = String.sub contents (pos * 4) (len * 4)>}
 
       method concat (text : ustorage) =
@@ -6440,20 +6405,15 @@ module UText = struct
   and cursor text i =
     object
       val contents = text
-
       val mutable pos = i
-
       method get = contents#get pos
-
       method incr () = pos <- pos + 1
-
       method is_last = pos + 1 >= contents#len
     end
 
   class string_raw buf =
     object
       inherit text_raw buf
-
       method set i u = set_buf contents (4 * i) u
     end
 
@@ -6536,7 +6496,6 @@ class virtual name = object end
 and func (args_ty, ret_ty) =
   object (self)
     inherit name
-
     val mutable memo_args = None
 
     method arguments =
@@ -6588,7 +6547,6 @@ module Classdef = struct
   class virtual ['a, 'b] cl1 =
     object
       method virtual raise_trouble : int -> 'a
-
       method virtual m : 'a -> 'b -> int
     end
 
@@ -6613,7 +6571,6 @@ module Classdef = struct
   class virtual ['a, 'b] cl1 =
     object
       method virtual raise_trouble : int -> 'a
-
       method virtual m : 'a -> 'b -> int
     end
 
@@ -7890,7 +7847,6 @@ end = struct
   class d =
     object (self)
       inherit Class1.c as super
-
       method m (x : int) = super#m 0
     end
 end
@@ -8586,7 +8542,6 @@ let f x (type a) (y : a) = x = y
 class ['a] c =
   object (self)
     method m : 'a -> 'a = fun x -> x
-
     method n : 'a -> 'a = fun (type g) (x : g) -> self#m x
   end
 
@@ -9590,7 +9545,6 @@ let _ =
 class ['a] c () =
   object
     constraint 'a = < .. > -> unit
-
     method m : 'a = fun x -> ()
   end
 

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -135,21 +135,13 @@ class x =
 class type t =
   object
     inherit t [@@foo]
-
     val x : t [@@foo]
-
     val mutable x : t [@@foo]
-
     method x : t [@@foo]
-
     method private x : t [@@foo]
-
     constraint t = t' [@@foo]
-
     [@@@abc]
-
     [%%id]
-
     [@@@aaa]
   end[@foo]
 
@@ -256,7 +248,6 @@ class type castable =
 class type foo_t =
   object
     inherit castable
-
     method foo : string
   end
 
@@ -277,7 +268,6 @@ class foo : foo_t =
 class type bar_t =
   object
     inherit foo
-
     method bar : string
   end
 
@@ -3849,9 +3839,7 @@ let ( !! ) = Lazy.force
 class type ['a, 'b] ops =
   object
     method free : x:'b -> ?y:'c -> Names.t
-
     method subst : sub:'a Subst.t -> 'b -> 'a
-
     method eval : 'b -> 'a
   end
 
@@ -4098,9 +4086,7 @@ let ( !! ) = Lazy.force
 class type ['a, 'b] ops =
   object
     method free : 'b -> Names.t
-
     method subst : sub:'a Subst.t -> 'b -> 'a
-
     method eval : 'b -> 'a
   end
 
@@ -6247,28 +6233,19 @@ exception Out_of_range
 class type ['a] cursor =
   object
     method get : 'a
-
     method incr : unit -> unit
-
     method is_last : bool
   end
 
 class type ['a] storage =
   object ('self)
     method first : 'a cursor
-
     method len : int
-
     method nth : int -> 'a cursor
-
     method copy : 'self
-
     method sub : int -> int -> 'self
-
     method concat : 'a storage -> 'self
-
     method fold : 'b. ('a -> int -> 'b -> 'b) -> 'b -> 'b
-
     method iter : ('a -> unit) -> unit
   end
 
@@ -6306,16 +6283,13 @@ class virtual ['a, 'cursor] storage_base =
 class type ['a] obj_input_channel =
   object
     method get : unit -> 'a
-
     method close : unit -> unit
   end
 
 class type ['a] obj_output_channel =
   object
     method put : 'a -> unit
-
     method flush : unit -> unit
-
     method close : unit -> unit
   end
 

--- a/test/passing/object.ml
+++ b/test/passing/object.ml
@@ -194,7 +194,6 @@ class type x =
 
 class x =
   object
-
     (** floatting1 *)
 
     (** floatting2 *)

--- a/test/passing/object.ml
+++ b/test/passing/object.ml
@@ -194,6 +194,7 @@ class type x =
 
 class x =
   object
+
     (** floatting1 *)
 
     (** floatting2 *)

--- a/test/passing/shortcut_ext_attr.ml
+++ b/test/passing/shortcut_ext_attr.ml
@@ -59,23 +59,17 @@ class x =
 (* Class type expressions *)
 class type t =
   object
-    inherit t
-    [@@foo]
+    inherit t [@@foo]
 
-    val x : t
-    [@@foo]
+    val x : t [@@foo]
 
-    val mutable x : t
-    [@@foo]
+    val mutable x : t [@@foo]
 
-    method x : t
-    [@@foo]
+    method x : t [@@foo]
 
-    method private x : t
-    [@@foo]
+    method private x : t [@@foo]
 
-    constraint t = t'
-    [@@foo]
+    constraint t = t' [@@foo]
   end[@foo]
 
 (* Type expressions *)

--- a/test/passing/source.ml.ref
+++ b/test/passing/source.ml.ref
@@ -154,23 +154,17 @@ class x =
 (* Class type expressions *)
 class type t =
   object
-    inherit t
-    [@@foo]
+    inherit t [@@foo]
 
-    val x : t
-    [@@foo]
+    val x : t [@@foo]
 
-    val mutable x : t
-    [@@foo]
+    val mutable x : t [@@foo]
 
-    method x : t
-    [@@foo]
+    method x : t [@@foo]
 
-    method private x : t
-    [@@foo]
+    method private x : t [@@foo]
 
-    constraint t = t'
-    [@@foo]
+    constraint t = t' [@@foo]
 
     [@@@abc]
 


### PR DESCRIPTION
Addresses: #1223 

This PR formats OCaml `object ... end` syntactical structures. Specifically the PR formats `class_structure` and `class_signature` items (`class_field`s and `class_type_field`s) the same way as `structure_item`s in a module.

- [x] Implement formatting of `class_structure`
- [x] Implement formatting of `class_signature`
- [x] Make tests pass

This is now ready for review.

Thanks.