### PR TITLE
Clean up formatting of match/try expressions

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1513,6 +1513,20 @@ and fmt_infix_op_args c ~parens xexp op_args =
     (fits_breaks ")" ?hint cls)
     (list_fl groups fmt_op_arg_group)
 
+and fmt_match c ~parens ?ext ctx xexp cs e0 keyword =
+  let indent = Params.match_indent c.conf ~ctx:xexp.ctx in
+  hvbox indent
+    (Params.wrap_exp c.conf c.source ~loc:xexp.ast.pexp_loc ~parens
+       ~disambiguate:true
+       ( hvbox 0
+           ( str keyword
+           $ fmt_extension_suffix c ext
+           $ fmt_attributes c ~key:"@" xexp.ast.pexp_attributes
+           $ fmt "@;<1 2>"
+           $ fmt_expression c (sub_exp ~ctx e0)
+           $ fmt "@ with" )
+       $ fmt "@ " $ fmt_cases c ctx cs ) )
+
 and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
     ?ext ({ast= exp; ctx= ctx0} as xexp) =
   protect c (Exp exp)
@@ -2263,79 +2277,45 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                $ fmt_expression c (sub_exp ~ctx e0)
                $ closing )
            $ fmt_atrs ) )
-  | Pexp_match (e0, cs) | Pexp_try (e0, cs) -> (
-      let keyword =
-        match exp.pexp_desc with
-        | Pexp_match _ -> "match"
-        | Pexp_try _ -> "try"
-        | _ -> impossible "previous match"
+  | Pexp_try (e0, [{pc_lhs; pc_guard; pc_rhs}])
+    when Poly.(c.conf.single_case = `Compact && c.conf.break_cases <> `All)
+    ->
+      (* side effects of Cmts.fmt_before before [fmt_pattern] is important *)
+      let xpc_rhs = sub_exp ~ctx pc_rhs in
+      let leading_cmt = Cmts.fmt_before c pc_lhs.ppat_loc in
+      let parens_here, parens_for_exp =
+        if c.conf.leading_nested_match_parens then (false, None)
+        else (parenze_exp xpc_rhs, Some false)
       in
-      let compact =
-        match exp.pexp_desc with
-        | Pexp_try
-            ( _
-            , [ { pc_lhs=
-                    { ppat_desc=
-                        Ppat_or _ | Ppat_alias ({ppat_desc= Ppat_or _; _}, _)
-                    ; _ }
-                ; _ } ] )
-          when Poly.(c.conf.break_cases = `All) ->
-            None
-        | Pexp_try (_, [x]) when Poly.(c.conf.single_case = `Compact) ->
-            Some x
-        | _ -> None
-      in
-      match compact with
-      | None ->
-          let indent = Params.match_indent c.conf ~ctx:xexp.ctx in
-          hvbox indent
-            (Params.wrap_exp c.conf c.source ~loc:pexp_loc ~parens
-               ~disambiguate:true
+      Params.wrap_exp c.conf c.source ~loc:pexp_loc ~parens
+        ~disambiguate:true
+        (hvbox 2
+           ( hvbox 0
+               ( str "try"
+               $ fmt_extension_suffix c ext
+               $ fmt_attributes c ~key:"@" pexp_attributes
+               $ fmt "@;<1 2>"
+               $ fmt_expression c (sub_exp ~ctx e0) )
+           $ break 1 (-2)
+           $ hvbox 0
                ( hvbox 0
-                   ( str keyword
-                   $ fmt_extension_suffix c ext
-                   $ fmt_attributes c ~key:"@" pexp_attributes
-                   $ fmt "@;<1 2>"
-                   $ fmt_expression c (sub_exp ~ctx e0)
-                   $ fmt "@ with" )
-               $ fmt "@ " $ fmt_cases c ctx cs ) )
-      | Some {pc_lhs; pc_guard; pc_rhs} ->
-          (* side effects of Cmts.fmt_before before [fmt_pattern] is
-             important *)
-          let xpc_rhs = sub_exp ~ctx pc_rhs in
-          let leading_cmt = Cmts.fmt_before c pc_lhs.ppat_loc in
-          let parens_here, parens_for_exp =
-            if c.conf.leading_nested_match_parens then (false, None)
-            else (parenze_exp xpc_rhs, Some false)
-          in
-          Params.wrap_exp c.conf c.source ~loc:pexp_loc ~parens
-            ~disambiguate:true
-            (hvbox 2
-               ( hvbox 0
-                   ( str keyword
-                   $ fmt_extension_suffix c ext
-                   $ fmt_attributes c ~key:"@" pexp_attributes
-                   $ fmt "@;<1 2>"
-                   $ fmt_expression c (sub_exp ~ctx e0) )
-               $ break 1 (-2)
-               $ hvbox 0
-                   ( hvbox 0
-                       ( fmt "with@ " $ leading_cmt
-                       $ hvbox 0
-                           ( fmt_pattern c ~pro:(if_newline "| ")
-                               (sub_pat ~ctx pc_lhs)
-                           $ opt pc_guard (fun g ->
-                                 fmt "@ when "
-                                 $ fmt_expression c (sub_exp ~ctx g) )
-                           $ fmt "@ ->" $ fmt_if parens_here " (" ) )
-                   $ fmt "@;<1 2>"
-                   $ cbox 0 (fmt_expression c ?parens:parens_for_exp xpc_rhs)
-                   )
-               $ fmt_if parens_here
-                   ( match c.conf.indicate_multiline_delimiters with
-                   | `No -> ")"
-                   | `Space -> " )"
-                   | `Closing_on_separate_line -> "@;<1000 -2>)" ) ) ) )
+                   ( fmt "with@ " $ leading_cmt
+                   $ hvbox 0
+                       ( fmt_pattern c ~pro:(if_newline "| ")
+                           (sub_pat ~ctx pc_lhs)
+                       $ opt pc_guard (fun g ->
+                             fmt "@ when "
+                             $ fmt_expression c (sub_exp ~ctx g) )
+                       $ fmt "@ ->" $ fmt_if parens_here " (" ) )
+               $ fmt "@;<1 2>"
+               $ cbox 0 (fmt_expression c ?parens:parens_for_exp xpc_rhs) )
+           $ fmt_if parens_here
+               ( match c.conf.indicate_multiline_delimiters with
+               | `No -> ")"
+               | `Space -> " )"
+               | `Closing_on_separate_line -> "@;<1000 -2>)" ) ) )
+  | Pexp_match (e0, cs) -> fmt_match c ~parens ?ext ctx xexp cs e0 "match"
+  | Pexp_try (e0, cs) -> fmt_match c ~parens ?ext ctx xexp cs e0 "try"
   | Pexp_pack me ->
       let fmt_mod m =
         Params.parens_if parens c.conf


### PR DESCRIPTION
Just splitting the huge case into 3 cases: the compact one, 1 call to fmt_match for "match" and 1 call to fmt_match for "try"

The match on `Ppat_or _ | Ppat_alias ({ppat_desc= Ppat_or _; _}, _)` to decide whether it's a compact case or not has been removed and as I suspected it doesn't show in the tests or with test_branch, no behavioral change.

edit: I tried to see if there was a diff compared to master on some code that should mach the pattern above, but couldn't produce any, so I'm merging it.