### PR TITLE
Remove part of comment that is causing merlin to report an error, masking the real errors

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -499,8 +499,7 @@ let rec fmt_extension c ctx key (ext, pld) =
   | _, _, PSig [({psig_desc= Psig_type _; _} as si)], (Pld _ | Sig _ | Top)
     ->
       fmt_signature_item c ~ext (sub_sig ~ctx si)
-  (* Quoted extensions (since ocaml 4.11) {%ext delim|...|delim}. Comments
-     and attributes are not allowed by the parser. *)
+  (* Quoted extensions (since ocaml 4.11). *)
   | ( ("%" | "%%")
     , ext
     , PStr
@@ -514,6 +513,7 @@ let rec fmt_extension c ctx key (ext, pld) =
           ; pstr_loc } ]
     , _ )
     when Source.is_quoted_string c.source pstr_loc ->
+      (* Comments and attributes are not allowed by the parser *)
       assert (not (Cmts.has_before c.cmts loc)) ;
       assert (not (Cmts.has_after c.cmts loc)) ;
       assert (not (Cmts.has_before c.cmts pexp_loc)) ;


### PR DESCRIPTION
Having `{%ext delim|...|delim}` in the comment is causing an issue with merlin, it reports an error on the pattern-matching even though the matching is fine, and it's preventing from jumping to the real compilation errors, so I just remove this part, and move the part about the comments and attributes to a more suitable place.

(I use merlin.3.4.2)