### PR TITLE
Add missing deps required for parse-wyc (for the linter of the CI)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -56,9 +56,9 @@
   (menhir
    (>= 20180528))
   (menhirLib
-   (>= 20201214))
+   (>= 20200624))
   (menhirSdk
-   (>= 20201214))
+   (>= 20200624))
   (ocaml-migrate-parsetree
    (>= 2.1.0))
   (ocp-indent :with-test)

--- a/dune-project
+++ b/dune-project
@@ -55,6 +55,12 @@
   fpath
   (menhir
    (>= 20180528))
+  (menhirLib
+   (>= 20201214))
+  (menhirSdk
+   (>= 20201214))
+  (ocaml-migrate-parsetree
+   (>= 2.1.0))
   (ocp-indent :with-test)
   (odoc
    (>= 1.4.2))

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -21,6 +21,9 @@ depends: [
   "fix"
   "fpath"
   "menhir" {>= "20180528"}
+  "menhirLib" {>= "20201214"}
+  "menhirSdk" {>= "20201214"}
+  "ocaml-migrate-parsetree" {>= "2.1.0"}
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
   "ppxlib" {>= "0.18.0"}

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -21,8 +21,8 @@ depends: [
   "fix"
   "fpath"
   "menhir" {>= "20180528"}
-  "menhirLib" {>= "20201214"}
-  "menhirSdk" {>= "20201214"}
+  "menhirLib" {>= "20200624"}
+  "menhirSdk" {>= "20200624"}
   "ocaml-migrate-parsetree" {>= "2.1.0"}
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}


### PR DESCRIPTION
Changes suggested by the CI linter:

```
ocamlformat.opam: changes needed:
  "menhirLib" {>= 20201214}                [from vendor/parse-wyc/lib, vendor/parse-wyc/menhir-recover]
  "menhirSdk" {>= 20201214}                [from vendor/parse-wyc/menhir-recover]
  "ocaml-migrate-parsetree" {>= 2.1.0}     [from vendor/parse-wyc/lib]
```