### PR TITLE
Precise that ocamlformat is disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ This can be a hard price to pay, since this means losing the corresponding git h
 If you use a custom configuration, options you rely on might also get removed in
 a later release.
 
+Moreover if you adopt ocamlformat in one project it will not break your workflow in other projects. Indeed ocamlformat modify a file only if it can find a `.ocamlformat`, so adding a save hook in your editor will only simplify your workflow in project that use ocamlformat.
+
 ### What configuration should I use?
 
 The recommended way is to use a versioned default profile, such as:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This can be a hard price to pay, since this means losing the corresponding git h
 If you use a custom configuration, options you rely on might also get removed in
 a later release.
 
-Moreover if you adopt ocamlformat in one project it will not break your workflow in other projects. Indeed ocamlformat modify a file only if it can find a `.ocamlformat`, so adding a save hook in your editor will only simplify your workflow in project that use ocamlformat.
+Moreover if you adopt OCamlFormat in one project it will not break your workflow in your other projects. Indeed OCamlFormat modifies a file only if it can find an `.ocamlformat` file, so adding a save hook in your editor will only simplify your workflow in projects using OCamlFormat.
 
 ### What configuration should I use?
 


### PR DESCRIPTION
It could help setting up a project to use ocamlformat.

Edit the wording as much as you like in this PR. I though to open an issue but it was easier to propose the wording this way.

Additionally the message of the editor commmand `ocamlformat applied` could be replaced by `ocamlformat disabled in this project`.