### PR TITLE
Improve comment position in pattern collection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,8 @@
 
   + Add buffer filename in the logs when applying ocamlformat (#1557, @dannywillems)
 
+  + Improve comment position in pattern collection (#1576, @gpetiot)
+
 ### 0.16.0 (2020-11-16)
 
 #### Removed

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -996,7 +996,8 @@ and fmt_pattern c ?pro ?parens ?(box = false) ({ctx= ctx0; ast= pat} as xpat)
         let pat =
           fmt_elements_collection p
             (fun (locs, xpat) ->
-              Cmts.fmt_list c ~eol:cmt_break locs (fmt_pattern c xpat) )
+              Cmts.fmt_list c ~eol:cmt_break locs
+                (hvbox 0 (fmt_pattern c xpat)) )
             loc_xpats
         in
         hvbox 0

--- a/test/passing/comments.ml.ref
+++ b/test/passing/comments.ml.ref
@@ -213,8 +213,7 @@ let rec fooooooooooo = function
   (* AA*)
   | [ (*BB*)
       (* CC *)
-    x
-    (* DD *)
+    x (* DD *)
     ; (* EE *)
       y
       (* FF *)


### PR DESCRIPTION
Diff with test_branch:

conventional profile:
```diff
diff --git a/infer/src/clang/cScope.ml b/infer/src/clang/cScope.ml
index c9e0888b3..6da93e232 100644
--- a/infer/src/clang/cScope.ml
+++ b/infer/src/clang/cScope.ml
@@ -109,8 +109,7 @@ module Variables = struct
     | CXXForRangeStmt
         ( _,
           [
-            _init
-            (* TODO: ignored here because ignored in [CTrans] *);
+            _init (* TODO: ignored here because ignored in [CTrans] *);
             iterator_decl;
             begin_stmt;
             end_stmt;
```

janestreet profile:
```diff
diff --git a/infer/src/clang/cScope.ml b/infer/src/clang/cScope.ml
index 6fc6fbffc..276f6d4c9 100644
--- a/infer/src/clang/cScope.ml
+++ b/infer/src/clang/cScope.ml
@@ -108,8 +108,7 @@ module Variables = struct
         }
     | CXXForRangeStmt
         ( _
-        , [ _init
-          (* TODO: ignored here because ignored in [CTrans] *)
+        , [ _init (* TODO: ignored here because ignored in [CTrans] *)
           ; iterator_decl
           ; begin_stmt
           ; end_stmt
```