### PR TITLE
Consistent positioning of lambda return type annotations when no-break-infix-before-func and pre/post extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,8 @@
 
   + Add buffer filename in the logs when applying ocamlformat (#1557, @dannywillems)
 
+  + Consistent positioning of lambda return type annotations when no-break-infix-before-func and pre/post extensions (#1581, @gpetiot)
+
 ### 0.16.0 (2020-11-16)
 
 #### Removed

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1687,6 +1687,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let cmts_before = Cmts.fmt_before c pexp_loc in
       let cmts_after = Cmts.fmt_after c pexp_loc in
       let xargs, xbody = Sugar.fun_ c.cmts (sub_exp ~ctx r) in
+      let fmt_cstr, xbody = type_constr_and_body c xbody in
       let indent_wrap = if parens then -2 else 0 in
       let pre_body, body = fmt_body c ?ext xbody in
       let followed_by_infix_op =
@@ -1715,7 +1716,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                            ~suf:(str " ")
                        $ hvbox_if
                            (not c.conf.wrap_fun_args)
-                           4 (fmt_fun_args c xargs)
+                           4
+                           (fmt_fun_args c xargs $ fmt_opt fmt_cstr)
                        $ fmt "@ ->" ) )
                $ pre_body )
            $ fmt_or followed_by_infix_op "@;<1000 0>" "@ "

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1560,6 +1560,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         ; _ }
       , e2 ) ->
       let xargs, xbody = Sugar.fun_ c.cmts (sub_exp ~ctx:(Str pld) call) in
+      let fmt_cstr, xbody = type_constr_and_body c xbody in
       let is_simple x = is_simple c.conf (expression_width c) x in
       let break xexp1 xexp2 = not (is_simple xexp1 && is_simple xexp2) in
       let grps =
@@ -1577,7 +1578,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                       ( fmt_str_loc c name $ str " fun "
                       $ fmt_attributes c ~suf:(str " ") call.pexp_attributes
                           ~key:"@"
-                      $ fmt_fun_args c xargs $ fmt "@ ->" )
+                      $ fmt_fun_args c xargs $ fmt_opt fmt_cstr $ fmt "@ ->"
+                      )
                   $ fmt "@ " $ fmt_expression c xbody ) )
            $ fmt "@ ;@ "
            $ list grps " ;@;<1000 0>" fmt_grp ) )
@@ -1597,6 +1599,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                           ; pstr_loc= _ } as pld ) ] )
             ; _ } ) ] ) ->
       let xargs, xbody = Sugar.fun_ c.cmts (sub_exp ~ctx:(Str pld) retn) in
+      let fmt_cstr, xbody = type_constr_and_body c xbody in
       hvbox 0
         (Params.wrap_exp c.conf c.source ~loc:pexp_loc ~parens
            ( fmt_expression c (sub_exp ~ctx e0)
@@ -1609,7 +1612,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                       ( fmt_str_loc c name $ str " fun "
                       $ fmt_attributes c ~suf:(str " ") retn.pexp_attributes
                           ~key:"@"
-                      $ fmt_fun_args c xargs $ fmt "@ ->" )
+                      $ fmt_fun_args c xargs $ fmt_opt fmt_cstr $ fmt "@ ->"
+                      )
                   $ fmt "@ " $ fmt_expression c xbody ) ) ) )
   | Pexp_apply (({pexp_desc= Pexp_ident ident; pexp_loc; _} as e0), args)
     when Option.is_some (Indexing_op.get_sugar e0 args) ->

--- a/test/passing/infix_bind-break.ml.ref
+++ b/test/passing/infix_bind-break.ml.ref
@@ -217,3 +217,11 @@ let _ = match () with A -> ( x |> function y -> y (* *) ) | B -> ()
 let _ = x |> function y -> ( function _ -> y (* A *) ) (* B *)
 
 let _ = () (* This is needed here to avoid the comment above from moving *)
+
+let encoder f =
+  let field_encode = unstage (t f.ftype) in
+  stagged @@ fun x k : t -> field_encode (f.fget x) k
+
+let encoder f =
+  let field_encode = unstage (t f.ftype) in
+  stagged @@ fun x k : t -> field_encode (f.fget x) k

--- a/test/passing/infix_bind-fit_or_vertical-break.ml.ref
+++ b/test/passing/infix_bind-fit_or_vertical-break.ml.ref
@@ -222,3 +222,11 @@ let _ = match () with A -> ( x |> function y -> y (* *) ) | B -> ()
 let _ = x |> function y -> ( function _ -> y (* A *) ) (* B *)
 
 let _ = () (* This is needed here to avoid the comment above from moving *)
+
+let encoder f =
+  let field_encode = unstage (t f.ftype) in
+  stagged @@ fun x k : t -> field_encode (f.fget x) k
+
+let encoder f =
+  let field_encode = unstage (t f.ftype) in
+  stagged @@ fun x k : t -> field_encode (f.fget x) k

--- a/test/passing/infix_bind-fit_or_vertical.ml.ref
+++ b/test/passing/infix_bind-fit_or_vertical.ml.ref
@@ -216,3 +216,11 @@ let _ = match () with A -> ( x |> function y -> y (* *) ) | B -> ()
 let _ = x |> function y -> ( function _ -> y (* A *) ) (* B *)
 
 let _ = () (* This is needed here to avoid the comment above from moving *)
+
+let encoder f =
+  let field_encode = unstage (t f.ftype) in
+  stagged @@ fun x k : t -> field_encode (f.fget x) k
+
+let encoder f =
+  let field_encode = unstage (t f.ftype) in
+  stagged @@ fun x k : t -> field_encode (f.fget x) k

--- a/test/passing/infix_bind.ml
+++ b/test/passing/infix_bind.ml
@@ -211,3 +211,11 @@ let _ = match () with A -> ( x |> function y -> y (* *) ) | B -> ()
 let _ = x |> function y -> ( function _ -> y (* A *) ) (* B *)
 
 let _ = () (* This is needed here to avoid the comment above from moving *)
+
+let encoder f =
+  let field_encode = unstage (t f.ftype) in
+  stagged @@ fun x k : t -> field_encode (f.fget x) k
+
+let encoder f =
+  let field_encode = unstage (t f.ftype) in
+  stagged @@ fun x k : t -> field_encode (f.fget x) k

--- a/test/passing/pre_post_extensions.ml
+++ b/test/passing/pre_post_extensions.ml
@@ -5,3 +5,11 @@ let f x =
   x
   |>
   [%Trace.retn fun {pf} -> pf "%i"]
+
+let f x =
+  [%Trace.call fun {pf} : t -> pf "%i" x]
+  ;
+  print_int x ;
+  x
+  |>
+  [%Trace.retn fun {pf} : t -> pf "%i"]


### PR DESCRIPTION
Fix #1580, no diff with test_branch.sh