### PR TITLE
Rewrite types of AST to prepare the design of new passes

### DIFF
--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -19,19 +19,11 @@ Caml.at_exit (Format.pp_print_flush Format.err_formatter)
 ;;
 Caml.at_exit (Format_.pp_print_flush Format_.err_formatter)
 
-let format ?output_file ~kind:(Conf.Kind k) ~input_name ~source conf opts =
+let format ?output_file ~kind ~input_name ~source conf opts =
   if conf.Conf.disable then Ok source
   else
-    match k with
-    | Structure ->
-        Translation_unit.parse_and_format Structure k ?output_file
-          ~input_name ~source conf opts
-    | Signature ->
-        Translation_unit.parse_and_format Signature k ?output_file
-          ~input_name ~source conf opts
-    | Use_file ->
-        Translation_unit.parse_and_format Use_file k ?output_file ~input_name
-          ~source conf opts
+    Translation_unit.parse_and_format ~kind ?output_file ~input_name ~source
+      conf opts
 
 let to_output_file output_file data =
   match output_file with

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -22,7 +22,7 @@ Caml.at_exit (Format_.pp_print_flush Format_.err_formatter)
 let format ?output_file ~kind ~input_name ~source conf opts =
   if conf.Conf.disable then Ok source
   else
-    Translation_unit.parse_and_format ~kind ?output_file ~input_name ~source
+    Translation_unit.parse_and_format kind ?output_file ~input_name ~source
       conf opts
 
 let to_output_file output_file data =

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -19,11 +19,11 @@ Caml.at_exit (Format.pp_print_flush Format.err_formatter)
 ;;
 Caml.at_exit (Format_.pp_print_flush Format_.err_formatter)
 
-let format ?output_file ~kind:(Conf.Kind k) ~input_name ~source conf opts =
+let format ?output_file ~kind ~input_name ~source conf opts =
   if conf.Conf.disable then Ok source
   else
-    Translation_unit.parse_and_format k ?output_file ~input_name ~source conf
-      opts
+    Translation_unit.parse_and_format ~kind ?output_file ~input_name ~source
+      conf opts
 
 let to_output_file output_file data =
   match output_file with

--- a/bin/ocamlformat.ml
+++ b/bin/ocamlformat.ml
@@ -19,11 +19,19 @@ Caml.at_exit (Format.pp_print_flush Format.err_formatter)
 ;;
 Caml.at_exit (Format_.pp_print_flush Format_.err_formatter)
 
-let format ?output_file ~kind ~input_name ~source conf opts =
+let format ?output_file ~kind:(Conf.Kind k) ~input_name ~source conf opts =
   if conf.Conf.disable then Ok source
   else
-    Translation_unit.parse_and_format ~kind ?output_file ~input_name ~source
-      conf opts
+    match k with
+    | Structure ->
+        Translation_unit.parse_and_format Structure k ?output_file
+          ~input_name ~source conf opts
+    | Signature ->
+        Translation_unit.parse_and_format Signature k ?output_file
+          ~input_name ~source conf opts
+    | Use_file ->
+        Translation_unit.parse_and_format Use_file k ?output_file ~input_name
+          ~source conf opts
 
 let to_output_file output_file data =
   match output_file with

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -11,7 +11,7 @@
 
 (** Abstract syntax tree term *)
 
-module Location = Migrate_ast.Location
+open Migrate_ast
 open Ast_passes.Ast_final
 
 let init, register_reset, leading_nested_match_parens, parens_ite =

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -193,7 +193,7 @@ module String_id = struct
 end
 
 module Longident = struct
-  include Migrate_ast.Longident
+  include Longident
 
   let test ~f = function Longident.Lident i -> f i | _ -> false
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -11,8 +11,9 @@
 
 (** Abstract syntax tree term *)
 
-open Migrate_ast
-open Parsetree
+module Location = Migrate_ast.Location
+open Ast_passes.Ast_final
+module Printast = Ast_passes.Ast_final.Printast
 
 let init, register_reset, leading_nested_match_parens, parens_ite =
   let l = ref [] in
@@ -193,7 +194,7 @@ module String_id = struct
 end
 
 module Longident = struct
-  include Longident
+  include Migrate_ast.Longident
 
   let test ~f = function Longident.Lident i -> f i | _ -> false
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -13,7 +13,6 @@
 
 module Location = Migrate_ast.Location
 open Ast_passes.Ast_final
-module Printast = Ast_passes.Ast_final.Printast
 
 let init, register_reset, leading_nested_match_parens, parens_ite =
   let l = ref [] in

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -11,6 +11,7 @@
 
 (** Abstract syntax tree terms *)
 
+open Migrate_ast
 open Ast_passes.Ast_final
 
 val init : Conf.t -> unit
@@ -43,7 +44,7 @@ module String_id : sig
 end
 
 module Longident : sig
-  include module type of Migrate_ast.Longident
+  include module type of Longident
 
   val is_infix : t -> bool
   (** Holds for infix identifiers. *)

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -11,8 +11,7 @@
 
 (** Abstract syntax tree terms *)
 
-open Migrate_ast
-open Parsetree
+open Ast_passes.Ast_final
 
 val init : Conf.t -> unit
 (** Initialize internal state *)
@@ -44,7 +43,7 @@ module String_id : sig
 end
 
 module Longident : sig
-  include module type of Longident
+  include module type of Migrate_ast.Longident
 
   val is_infix : t -> bool
   (** Holds for infix identifiers. *)

--- a/lib/Ast_passes.ml
+++ b/lib/Ast_passes.ml
@@ -57,7 +57,7 @@ module Ast0 = struct
 
     let use_file lexbuf =
       List.filter (Ppxlib_ast.Parse.use_file lexbuf)
-        ~f:(fun (p : Parsetree.toplevel_phrase) ->
+        ~f:(fun (p : toplevel_phrase) ->
           match p with
           | Ptop_def [] -> false
           | Ptop_def (_ :: _) | Ptop_dir _ -> true )

--- a/lib/Ast_passes.ml
+++ b/lib/Ast_passes.ml
@@ -1,0 +1,56 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlFormat                               *)
+(*                                                                        *)
+(*            Copyright (c) Facebook, Inc. and its affiliates.            *)
+(*                                                                        *)
+(*      This source code is licensed under the MIT license found in       *)
+(*      the LICENSE file in the root directory of this source tree.       *)
+(*                                                                        *)
+(**************************************************************************)
+
+module Ast0 = struct
+  include Ppxlib.Parsetree
+
+  let equal_core_type : core_type -> core_type -> bool = Poly.equal
+
+  type use_file = toplevel_phrase list
+
+  type t =
+    | Past_str of structure
+    | Past_sig of signature
+    | Past_usf of use_file
+
+  class map =
+    object (self)
+      inherit Ppxlib.Ast_traverse.map
+
+      method use_file x = List.map x ~f:self#toplevel_phrase
+
+      method ast =
+        function
+        | Past_str x -> Past_str (self#structure x)
+        | Past_sig x -> Past_sig (self#signature x)
+        | Past_usf x -> Past_usf (self#use_file x)
+    end
+
+  let equal : t -> t -> bool = Poly.equal
+
+  let map (m : map) : t -> t = m#ast
+
+  let iter (i : Ppxlib.Ast_traverse.iter) : t -> unit = function
+    | Past_str x -> i#structure x
+    | Past_sig x -> i#signature x
+    | Past_usf x -> i#list i#toplevel_phrase x
+
+  let fold (f : 'a Ppxlib.Ast_traverse.fold) : t -> 'a -> 'a =
+   fun x acc ->
+    match x with
+    | Past_str x -> f#structure x acc
+    | Past_sig x -> f#signature x acc
+    | Past_usf x -> f#list f#toplevel_phrase x acc
+end
+
+module Ast_final = Ast0
+
+let run = Fn.id

--- a/lib/Ast_passes.ml
+++ b/lib/Ast_passes.ml
@@ -49,6 +49,27 @@ module Ast0 = struct
     | Past_str x -> f#structure x acc
     | Past_sig x -> f#signature x acc
     | Past_usf x -> f#list f#toplevel_phrase x acc
+
+  module Parse = struct
+    let implementation = Ppxlib_ast.Parse.implementation
+
+    let interface = Ppxlib_ast.Parse.interface
+
+    let use_file lexbuf =
+      List.filter (Ppxlib_ast.Parse.use_file lexbuf)
+        ~f:(fun (p : Parsetree.toplevel_phrase) ->
+          match p with
+          | Ptop_def [] -> false
+          | Ptop_def (_ :: _) | Ptop_dir _ -> true )
+
+    let ast ~(kind : Syntax.t) lexbuf : t =
+      match kind with
+      | Structure -> Past_str (implementation lexbuf)
+      | Signature -> Past_sig (interface lexbuf)
+      | Use_file -> Past_usf (use_file lexbuf)
+
+    let parser_version = Ocaml_version.sys_version
+  end
 end
 
 module Ast_final = struct

--- a/lib/Ast_passes.ml
+++ b/lib/Ast_passes.ml
@@ -51,6 +51,33 @@ module Ast0 = struct
     | Past_usf x -> f#list f#toplevel_phrase x acc
 end
 
-module Ast_final = Ast0
+module Ast_final = struct
+  include Ast0
+
+  module Printast = struct
+    let pp_sexp ppf sexp =
+      Format.fprintf ppf "%a" (Sexp.pp_hum_indent 2) sexp
+
+    let sexp_of = Ppxlib.Ast_traverse.sexp_of
+
+    let implementation ppf x = pp_sexp ppf (sexp_of#structure x)
+
+    let interface ppf x = pp_sexp ppf (sexp_of#signature x)
+
+    let expression ppf x = pp_sexp ppf (sexp_of#expression x)
+
+    let payload ppf x = pp_sexp ppf (sexp_of#payload x)
+
+    let use_file ppf x =
+      pp_sexp ppf (List.sexp_of_t sexp_of#toplevel_phrase x)
+
+    let ast ppf = function
+      | Past_str x -> implementation ppf x
+      | Past_sig x -> interface ppf x
+      | Past_usf x -> use_file ppf x
+  end
+
+  module Pprintast = Ppxlib.Pprintast
+end
 
 let run = Fn.id

--- a/lib/Ast_passes.mli
+++ b/lib/Ast_passes.mli
@@ -1,0 +1,53 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlFormat                               *)
+(*                                                                        *)
+(*            Copyright (c) Facebook, Inc. and its affiliates.            *)
+(*                                                                        *)
+(*      This source code is licensed under the MIT license found in       *)
+(*      the LICENSE file in the root directory of this source tree.       *)
+(*                                                                        *)
+(**************************************************************************)
+
+module Ast0 : sig
+  include module type of Ppxlib.Parsetree
+
+  type use_file = toplevel_phrase list
+
+  type t =
+    | Past_str of structure
+    | Past_sig of signature
+    | Past_usf of use_file
+end
+
+module Ast_final : sig
+  include module type of Ppxlib.Parsetree
+
+  val equal_core_type : core_type -> core_type -> bool
+
+  type use_file = toplevel_phrase list
+
+  type t =
+    | Past_str of structure
+    | Past_sig of signature
+    | Past_usf of use_file
+
+  val equal : t -> t -> bool
+
+  class map :
+    object
+      inherit Ppxlib.Ast_traverse.map
+
+      method use_file : use_file -> use_file
+
+      method ast : t -> t
+    end
+
+  val map : map -> t -> t
+
+  val iter : Ppxlib.Ast_traverse.iter -> t -> unit
+
+  val fold : 'r Ppxlib.Ast_traverse.fold -> t -> 'r -> 'r
+end
+
+val run : Ast0.t -> Ast_final.t

--- a/lib/Ast_passes.mli
+++ b/lib/Ast_passes.mli
@@ -14,13 +14,13 @@ module Ast0 : sig
 
   type use_file = toplevel_phrase list
 
-  type t =
-    | Past_str of structure
-    | Past_sig of signature
-    | Past_usf of use_file
+  type 'a t =
+    | Structure : structure t
+    | Signature : signature t
+    | Use_file : use_file t
 
   module Parse : sig
-    val ast : kind:Syntax.t -> Lexing.lexbuf -> t
+    val ast : 'a t -> Lexing.lexbuf -> 'a
 
     val parser_version : Ocaml_version.t
   end
@@ -33,27 +33,23 @@ module Ast_final : sig
 
   type use_file = toplevel_phrase list
 
-  type t =
-    | Past_str of structure
-    | Past_sig of signature
-    | Past_usf of use_file
+  type 'a t =
+    | Structure : structure t
+    | Signature : signature t
+    | Use_file : use_file t
 
-  val equal : t -> t -> bool
+  val equal : 'a t -> 'a -> 'a -> bool
 
   class map :
     object
       inherit Ppxlib.Ast_traverse.map
-
-      method use_file : use_file -> use_file
-
-      method ast : t -> t
     end
 
-  val map : map -> t -> t
+  val map : 'a t -> Ppxlib.Ast_traverse.map -> 'a -> 'a
 
-  val iter : Ppxlib.Ast_traverse.iter -> t -> unit
+  val iter : 'a t -> Ppxlib.Ast_traverse.iter -> 'a -> unit
 
-  val fold : 'r Ppxlib.Ast_traverse.fold -> t -> 'r -> 'r
+  val fold : 'a t -> 'r Ppxlib.Ast_traverse.fold -> 'a -> 'r -> 'r
 
   module Printast : sig
     val implementation : Format.formatter -> structure -> unit
@@ -66,10 +62,10 @@ module Ast_final : sig
 
     val use_file : Format.formatter -> toplevel_phrase list -> unit
 
-    val ast : Format.formatter -> t -> unit
+    val ast : 'a t -> Format.formatter -> 'a -> unit
   end
 
   module Pprintast = Ppxlib.Pprintast
 end
 
-val run : Ast0.t -> Ast_final.t
+val run : 'a Ast0.t -> 'b Ast_final.t -> 'a -> 'b

--- a/lib/Ast_passes.mli
+++ b/lib/Ast_passes.mli
@@ -18,6 +18,12 @@ module Ast0 : sig
     | Past_str of structure
     | Past_sig of signature
     | Past_usf of use_file
+
+  module Parse : sig
+    val ast : kind:Syntax.t -> Lexing.lexbuf -> t
+
+    val parser_version : Ocaml_version.t
+  end
 end
 
 module Ast_final : sig

--- a/lib/Ast_passes.mli
+++ b/lib/Ast_passes.mli
@@ -48,6 +48,22 @@ module Ast_final : sig
   val iter : Ppxlib.Ast_traverse.iter -> t -> unit
 
   val fold : 'r Ppxlib.Ast_traverse.fold -> t -> 'r -> 'r
+
+  module Printast : sig
+    val implementation : Format.formatter -> structure -> unit
+
+    val interface : Format.formatter -> signature -> unit
+
+    val payload : Format.formatter -> payload -> unit
+
+    val expression : Format.formatter -> expression -> unit
+
+    val use_file : Format.formatter -> toplevel_phrase list -> unit
+
+    val ast : Format.formatter -> t -> unit
+  end
+
+  module Pprintast = Ppxlib.Pprintast
 end
 
 val run : Ast0.t -> Ast_final.t

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -12,7 +12,8 @@
 (** Placing and formatting comments in a parsetree. *)
 
 module Format = Format_
-open Migrate_ast
+module Location = Migrate_ast.Location
+module Position = Migrate_ast.Position
 open Ast_passes
 
 type t =
@@ -544,7 +545,7 @@ let diff (conf : Conf.t) x y =
               Parse_with_comments.parse ~kind:Structure conf ~source:str
               |> (fun {ast; _} -> Ast_passes.run ast)
               |> Normalize.normalize conf
-              |> Caml.Format.asprintf "%a" Printast.ast
+              |> Caml.Format.asprintf "%a" Ast_passes.Ast_final.Printast.ast
             with _ -> norm_non_code z
           else norm_non_code z
     in

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -12,8 +12,7 @@
 (** Placing and formatting comments in a parsetree. *)
 
 module Format = Format_
-module Location = Migrate_ast.Location
-module Position = Migrate_ast.Position
+open Migrate_ast
 open Ast_passes
 
 type t =

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -13,7 +13,7 @@
 
 module Format = Format_
 open Migrate_ast
-open Parsetree
+open Ast_passes
 
 type t =
   { debug: bool
@@ -267,6 +267,7 @@ let relocate_pattern_matching_cmts (t : t) src tok ~whole_loc ~matched_loc =
 
 let relocate_ext_cmts (t : t) src ((_pre : string Location.loc), pld)
     ~whole_loc =
+  let open Ast_final in
   match pld with
   | PStr
       [ { pstr_desc=
@@ -292,6 +293,7 @@ let relocate_ext_cmts (t : t) src ((_pre : string Location.loc), pld)
   | _ -> ()
 
 let relocate_wrongfully_attached_cmts t src exp =
+  let open Ast_final in
   match exp.pexp_desc with
   | Pexp_match (e0, _) ->
       relocate_pattern_matching_cmts t src Parser.MATCH
@@ -354,7 +356,7 @@ let init ~debug source asts comments_n_docstrings =
         super#expression x
     end
   in
-  Parsetree.iter iter asts ; t
+  Ast_final.iter iter asts ; t
 
 let preserve fmt_x t =
   let buf = Buffer.create 128 in
@@ -539,10 +541,9 @@ let diff (conf : Conf.t) x y =
             let len = String.length str - chars_removed in
             let str = String.sub ~pos:1 ~len str in
             try
-              let t =
-                Parse_with_comments.parse ~kind:Structure conf ~source:str
-              in
-              Normalize.normalize conf t.ast
+              Parse_with_comments.parse ~kind:Structure conf ~source:str
+              |> (fun {ast; _} -> Ast_passes.run ast)
+              |> Normalize.normalize conf
               |> Caml.Format.asprintf "%a" Printast.ast
             with _ -> norm_non_code z
           else norm_non_code z

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -40,7 +40,7 @@ val relocate :
     [after]. *)
 
 val relocate_wrongfully_attached_cmts :
-  t -> Source.t -> Parsetree.expression -> unit
+  t -> Source.t -> Ast_final.expression -> unit
 (** [relocate_wrongfully_attached_cmts] relocates wrongfully attached
     comments, e.g. comments that should be attached to the whole
     pattern-matching expressions ([match-with] or [try-with] expressions) but

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -28,10 +28,9 @@ open Migrate_ast
 
 type t
 
-val init :
-  'a Traverse.fragment -> debug:bool -> Source.t -> 'a -> Cmt.t list -> t
-(** [init fragment source x comments] associates each comment in [comments]
-    with a source location appearing in [x]. It uses [Source] to help resolve
+val init : debug:bool -> Source.t -> Parsetree.t -> Cmt.t list -> t
+(** [init source x comments] associates each comment in [comments] with a
+    source location appearing in [x]. It uses [Source] to help resolve
     ambiguities. Initializes the state used by the [fmt] functions. *)
 
 val relocate :

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -24,11 +24,11 @@
     are multiple Ast terms with the same location. *)
 
 module Format = Format_
-open Migrate_ast
+open Ast_passes
 
 type t
 
-val init : debug:bool -> Source.t -> Parsetree.t -> Cmt.t list -> t
+val init : debug:bool -> Source.t -> Ast_final.t -> Cmt.t list -> t
 (** [init source x comments] associates each comment in [comments] with a
     source location appearing in [x]. It uses [Source] to help resolve
     ambiguities. Initializes the state used by the [fmt] functions. *)

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -28,9 +28,9 @@ open Ast_passes
 
 type t
 
-val init : debug:bool -> Source.t -> Ast_final.t -> Cmt.t list -> t
-(** [init source x comments] associates each comment in [comments] with a
-    source location appearing in [x]. It uses [Source] to help resolve
+val init : 'a Ast_final.t -> debug:bool -> Source.t -> 'a -> Cmt.t list -> t
+(** [init fragment source x comments] associates each comment in [comments]
+    with a source location appearing in [x]. It uses [Source] to help resolve
     ambiguities. Initializes the state used by the [fmt] functions. *)
 
 val relocate :

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -2196,7 +2196,7 @@ let validate () =
 
 let action () = parse info validate
 
-open Migrate_ast.Parsetree
+open Ast_passes.Ast_final
 
 let update ?(quiet = false) c {attr_name= {txt; loc}; attr_payload; _} =
   let result =

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1255,13 +1255,15 @@ let inputs =
   mk ~default
     Arg.(value & pos_all file_or_dash default & info [] ~doc ~docv ~docs)
 
-let kind : Syntax.t option ref =
+type kind = Kind : _ list Ast_passes.Ast_final.t -> kind
+
+let kind : kind option ref =
   let doc = "Parse file with unrecognized extension as an implementation." in
-  let impl = (Some Syntax.Use_file, Arg.info ["impl"] ~doc ~docs) in
+  let impl = (Some (Kind Use_file), Arg.info ["impl"] ~doc ~docs) in
   let doc = "Parse file with unrecognized extension as an interface." in
-  let intf = (Some Syntax.Signature, Arg.info ["intf"] ~doc ~docs) in
+  let intf = (Some (Kind Signature), Arg.info ["intf"] ~doc ~docs) in
   let doc = "Deprecated. Same as $(b,impl)." in
-  let use_file = (Some Syntax.Use_file, Arg.info ["use-file"] ~doc ~docs) in
+  let use_file = (Some (Kind Use_file), Arg.info ["use-file"] ~doc ~docs) in
   let default = None in
   mk ~default Arg.(value & vflag default [impl; intf; use_file])
 
@@ -2040,8 +2042,8 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
 
 let kind_of_ext fname =
   match Filename.extension fname with
-  | ".ml" | ".mlt" | ".eliom" -> Some Syntax.Use_file
-  | ".mli" | ".eliomi" -> Some Syntax.Signature
+  | ".ml" | ".mlt" | ".eliom" -> Some (Kind Use_file)
+  | ".mli" | ".eliomi" -> Some (Kind Signature)
   | _ -> None
 
 let validate_inputs () =
@@ -2064,7 +2066,7 @@ let validate_inputs () =
       let kind =
         Option.value ~default:f name
         |> kind_of_ext
-        |> Option.value ~default:Syntax.Use_file
+        |> Option.value ~default:(Kind Use_file)
       in
       Ok (`Single_file (kind, name, f))
   | _ :: _ :: _, Some _, _ ->
@@ -2075,7 +2077,9 @@ let validate_inputs () =
       List.map inputs ~f:(function
         | Stdin -> Error "Cannot specify stdin together with other inputs"
         | File f ->
-            let kind = Option.value ~default:Use_file (kind_of_ext f) in
+            let kind =
+              Option.value ~default:(Kind Use_file) (kind_of_ext f)
+            in
             Ok (kind, f) )
       |> Result.all
       |> Result.map ~f:(fun files -> `Several_files files)
@@ -2094,7 +2098,7 @@ let validate_action () =
   | (_, a1) :: (_, a2) :: _ ->
       Error (Printf.sprintf "Cannot specify %s with %s" a1 a2)
 
-type input = {kind: Syntax.t; name: string; file: file; conf: t}
+type input = {kind: kind; name: string; file: file; conf: t}
 
 type action =
   | In_out of input * string option

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1255,15 +1255,13 @@ let inputs =
   mk ~default
     Arg.(value & pos_all file_or_dash default & info [] ~doc ~docv ~docs)
 
-type kind = Kind : _ list Migrate_ast.Traverse.fragment -> kind
-
-let kind : kind option ref =
+let kind : Syntax.t option ref =
   let doc = "Parse file with unrecognized extension as an implementation." in
-  let impl = (Some (Kind Use_file), Arg.info ["impl"] ~doc ~docs) in
+  let impl = (Some Syntax.Use_file, Arg.info ["impl"] ~doc ~docs) in
   let doc = "Parse file with unrecognized extension as an interface." in
-  let intf = (Some (Kind Signature), Arg.info ["intf"] ~doc ~docs) in
+  let intf = (Some Syntax.Signature, Arg.info ["intf"] ~doc ~docs) in
   let doc = "Deprecated. Same as $(b,impl)." in
-  let use_file = (Some (Kind Use_file), Arg.info ["use-file"] ~doc ~docs) in
+  let use_file = (Some Syntax.Use_file, Arg.info ["use-file"] ~doc ~docs) in
   let default = None in
   mk ~default Arg.(value & vflag default [impl; intf; use_file])
 
@@ -2042,8 +2040,8 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
 
 let kind_of_ext fname =
   match Filename.extension fname with
-  | ".ml" | ".mlt" | ".eliom" -> Some (Kind Use_file)
-  | ".mli" | ".eliomi" -> Some (Kind Signature)
+  | ".ml" | ".mlt" | ".eliom" -> Some Syntax.Use_file
+  | ".mli" | ".eliomi" -> Some Syntax.Signature
   | _ -> None
 
 let validate_inputs () =
@@ -2066,7 +2064,7 @@ let validate_inputs () =
       let kind =
         Option.value ~default:f name
         |> kind_of_ext
-        |> Option.value ~default:(Kind Use_file)
+        |> Option.value ~default:Syntax.Use_file
       in
       Ok (`Single_file (kind, name, f))
   | _ :: _ :: _, Some _, _ ->
@@ -2077,9 +2075,7 @@ let validate_inputs () =
       List.map inputs ~f:(function
         | Stdin -> Error "Cannot specify stdin together with other inputs"
         | File f ->
-            let kind =
-              Option.value ~default:(Kind Use_file) (kind_of_ext f)
-            in
+            let kind = Option.value ~default:Use_file (kind_of_ext f) in
             Ok (kind, f) )
       |> Result.all
       |> Result.map ~f:(fun files -> `Several_files files)
@@ -2098,7 +2094,7 @@ let validate_action () =
   | (_, a1) :: (_, a2) :: _ ->
       Error (Printf.sprintf "Cannot specify %s with %s" a1 a2)
 
-type input = {kind: kind; name: string; file: file; conf: t}
+type input = {kind: Syntax.t; name: string; file: file; conf: t}
 
 type action =
   | In_out of input * string option

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1255,15 +1255,13 @@ let inputs =
   mk ~default
     Arg.(value & pos_all file_or_dash default & info [] ~doc ~docv ~docs)
 
-type kind = Kind : _ list Ast_passes.Ast_final.t -> kind
-
-let kind : kind option ref =
+let kind : Syntax.t option ref =
   let doc = "Parse file with unrecognized extension as an implementation." in
-  let impl = (Some (Kind Use_file), Arg.info ["impl"] ~doc ~docs) in
+  let impl = (Some Syntax.Use_file, Arg.info ["impl"] ~doc ~docs) in
   let doc = "Parse file with unrecognized extension as an interface." in
-  let intf = (Some (Kind Signature), Arg.info ["intf"] ~doc ~docs) in
+  let intf = (Some Syntax.Signature, Arg.info ["intf"] ~doc ~docs) in
   let doc = "Deprecated. Same as $(b,impl)." in
-  let use_file = (Some (Kind Use_file), Arg.info ["use-file"] ~doc ~docs) in
+  let use_file = (Some Syntax.Use_file, Arg.info ["use-file"] ~doc ~docs) in
   let default = None in
   mk ~default Arg.(value & vflag default [impl; intf; use_file])
 
@@ -2042,8 +2040,8 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
 
 let kind_of_ext fname =
   match Filename.extension fname with
-  | ".ml" | ".mlt" | ".eliom" -> Some (Kind Use_file)
-  | ".mli" | ".eliomi" -> Some (Kind Signature)
+  | ".ml" | ".mlt" | ".eliom" -> Some Syntax.Use_file
+  | ".mli" | ".eliomi" -> Some Syntax.Signature
   | _ -> None
 
 let validate_inputs () =
@@ -2066,7 +2064,7 @@ let validate_inputs () =
       let kind =
         Option.value ~default:f name
         |> kind_of_ext
-        |> Option.value ~default:(Kind Use_file)
+        |> Option.value ~default:Syntax.Use_file
       in
       Ok (`Single_file (kind, name, f))
   | _ :: _ :: _, Some _, _ ->
@@ -2077,9 +2075,7 @@ let validate_inputs () =
       List.map inputs ~f:(function
         | Stdin -> Error "Cannot specify stdin together with other inputs"
         | File f ->
-            let kind =
-              Option.value ~default:(Kind Use_file) (kind_of_ext f)
-            in
+            let kind = Option.value ~default:Use_file (kind_of_ext f) in
             Ok (kind, f) )
       |> Result.all
       |> Result.map ~f:(fun files -> `Several_files files)
@@ -2098,7 +2094,7 @@ let validate_action () =
   | (_, a1) :: (_, a2) :: _ ->
       Error (Printf.sprintf "Cannot specify %s with %s" a1 a2)
 
-type input = {kind: kind; name: string; file: file; conf: t}
+type input = {kind: Syntax.t; name: string; file: file; conf: t}
 
 type action =
   | In_out of input * string option

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -104,7 +104,7 @@ type opts =
 val action : unit -> (action * opts) Cmdliner.Term.result
 (** Formatting action: input type and source, and output destination. *)
 
-val update : ?quiet:bool -> t -> Migrate_ast.Parsetree.attribute -> t
+val update : ?quiet:bool -> t -> Ast_passes.Ast_final.attribute -> t
 (** [update ?quiet c a] updates configuration [c] after reading attribute
     [a]. [quiet] is false by default. *)
 

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -83,7 +83,9 @@ type t =
 
 type file = Stdin | File of string
 
-type input = {kind: Syntax.t; name: string; file: file; conf: t}
+type kind = Kind : _ list Ast_passes.Ast_final.t -> kind
+
+type input = {kind: kind; name: string; file: file; conf: t}
 
 type action =
   | In_out of input * string option

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -83,9 +83,7 @@ type t =
 
 type file = Stdin | File of string
 
-type kind = Kind : _ list Migrate_ast.Traverse.fragment -> kind
-
-type input = {kind: kind; name: string; file: file; conf: t}
+type input = {kind: Syntax.t; name: string; file: file; conf: t}
 
 type action =
   | In_out of input * string option

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -83,9 +83,7 @@ type t =
 
 type file = Stdin | File of string
 
-type kind = Kind : _ list Ast_passes.Ast_final.t -> kind
-
-type input = {kind: kind; name: string; file: file; conf: t}
+type input = {kind: Syntax.t; name: string; file: file; conf: t}
 
 type action =
   | In_out of input * string option

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -9,8 +9,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Migrate_ast
-open Parsetree
+open Ast_passes.Ast_final
 
 module Left = struct
   let rec core_type typ =

--- a/lib/Exposed.mli
+++ b/lib/Exposed.mli
@@ -15,8 +15,7 @@
     These are used to avoid emitting the sequences [\{<], [\[<], [>\}] and
     [>\]], which are reserved keywords. *)
 
-open Migrate_ast
-open Parsetree
+open Ast_passes.Ast_final
 
 (** Predicates for [<] on the LHS of printed AST nodes. *)
 module Left : sig

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -15,7 +15,7 @@ module Format = Format_
 
 open Migrate_ast
 open Asttypes
-open Parsetree
+open Ast_passes.Ast_final
 open Ast
 open Fmt
 
@@ -4562,6 +4562,7 @@ let fmt_code ~debug =
   let rec fmt_code conf s =
     match Parse_with_comments.parse ~kind:Structure conf ~source:s with
     | {ast= Past_str str as ast; comments; source; prefix= _} ->
+        let ast = Ast_passes.run ast in
         let cmts = Cmts.init ~debug source ast comments in
         let ctx = Pld (PStr str) in
         Ok (fmt_file ~ctx ~debug source cmts conf ast ~fmt_code)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1053,9 +1053,8 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
           | Ppat_constraint ({ppat_desc= Ppat_var {txt; _}; ppat_loc; _}, t)
             when field_alias ~field:lid1.txt (Longident.lident txt)
                  && List.is_empty ppat_attributes ->
-              if
-                Ocaml_version.(compare Parse.parser_version Releases.v4_12)
-                >= 0
+              let parser_version = Ast_passes.Ast0.Parse.parser_version in
+              if Ocaml_version.(compare parser_version Releases.v4_12) >= 0
               then
                 Cmts.relocate c.cmts ~src:ppat_loc ~before:lid1.loc
                   ~after:lid1.loc ;

--- a/lib/Fmt_ast.mli
+++ b/lib/Fmt_ast.mli
@@ -16,6 +16,6 @@ val fmt_ast :
   -> Source.t
   -> Cmts.t
   -> Conf.t
-  -> Migrate_ast.Parsetree.t
+  -> Ast_passes.Ast_final.t
   -> Fmt.t
 (** Format a fragment. *)

--- a/lib/Fmt_ast.mli
+++ b/lib/Fmt_ast.mli
@@ -12,10 +12,11 @@
 (** Format OCaml Ast *)
 
 val fmt_ast :
-     debug:bool
+     'a list Ast_passes.Ast_final.t
+  -> debug:bool
   -> Source.t
   -> Cmts.t
   -> Conf.t
-  -> Ast_passes.Ast_final.t
+  -> 'a list
   -> Fmt.t
 (** Format a fragment. *)

--- a/lib/Loc_tree.ml
+++ b/lib/Loc_tree.ml
@@ -9,8 +9,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Migrate_ast
-open Parsetree
+module Location = Migrate_ast.Location
+open Ast_passes.Ast_final
 include Non_overlapping_interval_tree.Make (Location)
 
 let fold src =
@@ -46,5 +46,5 @@ let fold src =
 
 (** Use Ast_mapper to collect all locs in ast, and create tree of them. *)
 let of_ast ast src =
-  let locs = Parsetree.fold (fold src) ast [] in
+  let locs = Ast_passes.Ast_final.fold (fold src) ast [] in
   (of_list locs, locs)

--- a/lib/Loc_tree.ml
+++ b/lib/Loc_tree.ml
@@ -45,6 +45,6 @@ let fold src =
   end
 
 (** Use Ast_mapper to collect all locs in ast, and create tree of them. *)
-let of_ast fragment ast src =
-  let locs = Traverse.fold fragment (fold src) ast [] in
+let of_ast ast src =
+  let locs = Parsetree.fold (fold src) ast [] in
   (of_list locs, locs)

--- a/lib/Loc_tree.ml
+++ b/lib/Loc_tree.ml
@@ -45,6 +45,6 @@ let fold src =
   end
 
 (** Use Ast_mapper to collect all locs in ast, and create tree of them. *)
-let of_ast ast src =
-  let locs = Ast_passes.Ast_final.fold (fold src) ast [] in
+let of_ast fragment ast src =
+  let locs = Ast_passes.Ast_final.fold fragment (fold src) ast [] in
   (of_list locs, locs)

--- a/lib/Loc_tree.mli
+++ b/lib/Loc_tree.mli
@@ -9,9 +9,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Migrate_ast
+open Ast_passes
 
 include Non_overlapping_interval_tree.S with type itv = Location.t
 
-val of_ast : Parsetree.t -> Source.t -> t * Location.t list
+val of_ast : Ast_final.t -> Source.t -> t * Location.t list
 (** Use Ast_mapper to collect all locs in ast, and create a tree of them. *)

--- a/lib/Loc_tree.mli
+++ b/lib/Loc_tree.mli
@@ -13,5 +13,5 @@ open Ast_passes
 
 include Non_overlapping_interval_tree.S with type itv = Location.t
 
-val of_ast : Ast_final.t -> Source.t -> t * Location.t list
+val of_ast : 'a Ast_final.t -> 'a -> Source.t -> t * Location.t list
 (** Use Ast_mapper to collect all locs in ast, and create a tree of them. *)

--- a/lib/Loc_tree.mli
+++ b/lib/Loc_tree.mli
@@ -13,5 +13,5 @@ open Migrate_ast
 
 include Non_overlapping_interval_tree.S with type itv = Location.t
 
-val of_ast : 'a Traverse.fragment -> 'a -> Source.t -> t * Location.t list
+val of_ast : Parsetree.t -> Source.t -> t * Location.t list
 (** Use Ast_mapper to collect all locs in ast, and create a tree of them. *)

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -9,8 +9,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Ast_helper = Ppxlib.Ast_helper
-
 module Asttypes = struct
   include Ppxlib.Asttypes
 

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -9,6 +9,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Ast_helper = Ppxlib.Ast_helper
+
 module Asttypes = struct
   include Ppxlib.Asttypes
 

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -21,27 +21,6 @@ module Asttypes = struct
   let is_mutable = function Mutable -> true | Immutable -> false
 end
 
-module Parse = struct
-  let implementation = Ppxlib_ast.Parse.implementation
-
-  let interface = Ppxlib_ast.Parse.interface
-
-  let use_file lexbuf =
-    List.filter (Ppxlib_ast.Parse.use_file lexbuf)
-      ~f:(fun (p : Parsetree.toplevel_phrase) ->
-        match p with
-        | Ptop_def [] -> false
-        | Ptop_def (_ :: _) | Ptop_dir _ -> true )
-
-  let ast ~(kind : Syntax.t) lexbuf : Ast_passes.Ast0.t =
-    match kind with
-    | Structure -> Past_str (implementation lexbuf)
-    | Signature -> Past_sig (interface lexbuf)
-    | Use_file -> Past_usf (use_file lexbuf)
-
-  let parser_version = Ocaml_version.sys_version
-end
-
 module Position = struct
   open Lexing
 

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -42,29 +42,6 @@ module Parse = struct
   let parser_version = Ocaml_version.sys_version
 end
 
-module Printast = struct
-  let pp_sexp ppf sexp = Format.fprintf ppf "%a" (Sexp.pp_hum_indent 2) sexp
-
-  let sexp_of = Ppxlib.Ast_traverse.sexp_of
-
-  let implementation ppf x = pp_sexp ppf (sexp_of#structure x)
-
-  let interface ppf x = pp_sexp ppf (sexp_of#signature x)
-
-  let expression ppf x = pp_sexp ppf (sexp_of#expression x)
-
-  let payload ppf x = pp_sexp ppf (sexp_of#payload x)
-
-  let use_file ppf x = pp_sexp ppf (List.sexp_of_t sexp_of#toplevel_phrase x)
-
-  let ast ppf = function
-    | Ast_passes.Ast_final.Past_str x -> implementation ppf x
-    | Ast_passes.Ast_final.Past_sig x -> interface ppf x
-    | Ast_passes.Ast_final.Past_usf x -> use_file ppf x
-end
-
-module Pprintast = Ppxlib.Pprintast
-
 module Position = struct
   open Lexing
 

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -11,36 +11,6 @@
 
 module Ast_helper = Ppxlib.Ast_helper
 
-module Parsetree : sig
-  include module type of Ppxlib.Parsetree
-
-  val equal_core_type : core_type -> core_type -> bool
-
-  type use_file = toplevel_phrase list
-
-  type t =
-    | Past_str of structure
-    | Past_sig of signature
-    | Past_usf of use_file
-
-  val equal : t -> t -> bool
-
-  class map :
-    object
-      inherit Ppxlib.Ast_traverse.map
-
-      method use_file : use_file -> use_file
-
-      method ast : t -> t
-    end
-
-  val map : map -> t -> t
-
-  val iter : Ppxlib.Ast_traverse.iter -> t -> unit
-
-  val fold : 'r Ppxlib.Ast_traverse.fold -> t -> 'r -> 'r
-end
-
 module Asttypes : sig
   include module type of Ppxlib.Asttypes
 
@@ -112,7 +82,7 @@ module Location : sig
 end
 
 module Parse : sig
-  val ast : kind:Syntax.t -> Lexing.lexbuf -> Parsetree.t
+  val ast : kind:Syntax.t -> Lexing.lexbuf -> Ast_passes.Ast0.t
 
   val parser_version : Ocaml_version.t
 end
@@ -128,7 +98,7 @@ module Printast : sig
 
   val use_file : Format.formatter -> Parsetree.toplevel_phrase list -> unit
 
-  val ast : Format.formatter -> Parsetree.t -> unit
+  val ast : Format.formatter -> Ast_passes.Ast_final.t -> unit
 end
 
 module Pprintast = Ppxlib.Pprintast

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -85,22 +85,6 @@ module Parse : sig
   val parser_version : Ocaml_version.t
 end
 
-module Printast : sig
-  val implementation : Format.formatter -> Parsetree.structure -> unit
-
-  val interface : Format.formatter -> Parsetree.signature -> unit
-
-  val payload : Format.formatter -> Parsetree.payload -> unit
-
-  val expression : Format.formatter -> Parsetree.expression -> unit
-
-  val use_file : Format.formatter -> Parsetree.toplevel_phrase list -> unit
-
-  val ast : Format.formatter -> Ast_passes.Ast_final.t -> unit
-end
-
-module Pprintast = Ppxlib.Pprintast
-
 module Longident : sig
   type t = Longident.t =
     | Lident of string

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -79,12 +79,6 @@ module Location : sig
   val to_span : t -> Odoc_model.Location_.span
 end
 
-module Parse : sig
-  val ast : kind:Syntax.t -> Lexing.lexbuf -> Ast_passes.Ast0.t
-
-  val parser_version : Ocaml_version.t
-end
-
 module Longident : sig
   type t = Longident.t =
     | Lident of string

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -9,6 +9,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Ast_helper = Ppxlib.Ast_helper
+
 module Asttypes : sig
   include module type of Ppxlib.Asttypes
 

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -9,8 +9,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Ast_helper = Ppxlib.Ast_helper
-
 module Asttypes : sig
   include module type of Ppxlib.Asttypes
 

--- a/lib/Normalize.ml
+++ b/lib/Normalize.ml
@@ -113,8 +113,8 @@ let rec odoc_nestable_block_element c fmt = function
                    Caml.Format.fprintf fmt "%s," txt )
           in
           let ast = c.normalize_code ast in
-          Caml.Format.asprintf "AST,%a,COMMENTS,[%a]" Printast.ast ast
-            print_comments comments
+          Caml.Format.asprintf "AST,%a,COMMENTS,[%a]"
+            Ast_passes.Ast_final.Printast.ast ast print_comments comments
         with _ -> txt
       in
       fpf fmt "Code_block,%a" str txt

--- a/lib/Normalize.mli
+++ b/lib/Normalize.mli
@@ -11,9 +11,9 @@
 
 (** Normalize abstract syntax trees *)
 
-open Migrate_ast
+open Ast_passes
 
-val dedup_cmts : Parsetree.t -> Cmt.t list -> Cmt.t list
+val dedup_cmts : Ast_final.t -> Cmt.t list -> Cmt.t list
 
 val comment : string -> string
 (** Normalize a comment. *)
@@ -21,11 +21,11 @@ val comment : string -> string
 val docstring : Conf.t -> string -> string
 (** Normalize a docstring. *)
 
-val normalize : Conf.t -> Parsetree.t -> Parsetree.t
+val normalize : Conf.t -> Ast_final.t -> Ast_final.t
 (** Normalize an AST fragment. *)
 
 val equal :
-  ignore_doc_comments:bool -> Conf.t -> Parsetree.t -> Parsetree.t -> bool
+  ignore_doc_comments:bool -> Conf.t -> Ast_final.t -> Ast_final.t -> bool
 (** Compare fragments for equality up to normalization. *)
 
 type docstring_error =
@@ -33,4 +33,4 @@ type docstring_error =
   | Unstable of Location.t * string
 
 val moved_docstrings :
-  Conf.t -> Parsetree.t -> Parsetree.t -> docstring_error list
+  Conf.t -> Ast_final.t -> Ast_final.t -> docstring_error list

--- a/lib/Normalize.mli
+++ b/lib/Normalize.mli
@@ -13,7 +13,7 @@
 
 open Ast_passes
 
-val dedup_cmts : Ast_final.t -> Cmt.t list -> Cmt.t list
+val dedup_cmts : 'a Ast_final.t -> 'a -> Cmt.t list -> Cmt.t list
 
 val comment : string -> string
 (** Normalize a comment. *)
@@ -21,11 +21,11 @@ val comment : string -> string
 val docstring : Conf.t -> string -> string
 (** Normalize a docstring. *)
 
-val normalize : Conf.t -> Ast_final.t -> Ast_final.t
+val normalize : 'a Ast_final.t -> Conf.t -> 'a -> 'a
 (** Normalize an AST fragment. *)
 
 val equal :
-  ignore_doc_comments:bool -> Conf.t -> Ast_final.t -> Ast_final.t -> bool
+  'a Ast_final.t -> ignore_doc_comments:bool -> Conf.t -> 'a -> 'a -> bool
 (** Compare fragments for equality up to normalization. *)
 
 type docstring_error =
@@ -33,4 +33,4 @@ type docstring_error =
   | Unstable of Location.t * string
 
 val moved_docstrings :
-  Conf.t -> Ast_final.t -> Ast_final.t -> docstring_error list
+  'a Ast_final.t -> Conf.t -> 'a -> 'a -> docstring_error list

--- a/lib/Normalize.mli
+++ b/lib/Normalize.mli
@@ -13,7 +13,7 @@
 
 open Migrate_ast
 
-val dedup_cmts : 'a Traverse.fragment -> 'a -> Cmt.t list -> Cmt.t list
+val dedup_cmts : Parsetree.t -> Cmt.t list -> Cmt.t list
 
 val comment : string -> string
 (** Normalize a comment. *)
@@ -21,16 +21,11 @@ val comment : string -> string
 val docstring : Conf.t -> string -> string
 (** Normalize a docstring. *)
 
-val normalize : 'a Traverse.fragment -> Conf.t -> 'a -> 'a
+val normalize : Conf.t -> Parsetree.t -> Parsetree.t
 (** Normalize an AST fragment. *)
 
 val equal :
-     'a Traverse.fragment
-  -> ignore_doc_comments:bool
-  -> Conf.t
-  -> 'a
-  -> 'a
-  -> bool
+  ignore_doc_comments:bool -> Conf.t -> Parsetree.t -> Parsetree.t -> bool
 (** Compare fragments for equality up to normalization. *)
 
 type docstring_error =
@@ -38,4 +33,4 @@ type docstring_error =
   | Unstable of Location.t * string
 
 val moved_docstrings :
-  'a Traverse.fragment -> Conf.t -> 'a -> 'a -> docstring_error list
+  Conf.t -> Parsetree.t -> Parsetree.t -> docstring_error list

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -10,7 +10,8 @@
 (**************************************************************************)
 
 module Format = Format_
-open Migrate_ast
+module Location = Migrate_ast.Location
+open Ast_passes.Ast_final
 open Fmt
 
 let parens_or_begin_end (c : Conf.t) source ~loc =

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -10,6 +10,7 @@
 (**************************************************************************)
 
 module Format = Format_
+open Ast_passes.Ast_final
 
 val parens_if : bool -> Conf.t -> ?disambiguate:bool -> Fmt.t -> Fmt.t
 
@@ -97,12 +98,12 @@ val get_if_then_else :
   -> parens:bool
   -> parens_bch:bool
   -> parens_prev_bch:bool
-  -> xcond:Migrate_ast.Parsetree.expression Ast.xt option
+  -> xcond:expression Ast.xt option
   -> expr_loc:Location.t
   -> bch_loc:Location.t
   -> fmt_extension_suffix:Fmt.t option
   -> fmt_attributes:Fmt.t
-  -> fmt_cond:(Migrate_ast.Parsetree.expression Ast.xt -> Fmt.t)
+  -> fmt_cond:(expression Ast.xt -> Fmt.t)
   -> Source.t
   -> if_then_else
 

--- a/lib/Parse_with_comments.ml
+++ b/lib/Parse_with_comments.ml
@@ -51,7 +51,7 @@ let fresh_lexbuf source =
   in
   (lexbuf, hash_bang)
 
-let parse ~kind (conf : Conf.t) ~source =
+let parse fragment (conf : Conf.t) ~source =
   let warnings =
     W.enable 50
     :: (if conf.quiet then List.map ~f:W.disable W.in_lexer else [])
@@ -67,7 +67,7 @@ let parse ~kind (conf : Conf.t) ~source =
           false )
         else not conf.quiet )
       ~f:(fun () ->
-        let ast = Ast_passes.Ast0.Parse.ast ~kind lexbuf in
+        let ast = Ast_passes.Ast0.Parse.ast fragment lexbuf in
         Warnings.check_fatal () ;
         let comments =
           List.map

--- a/lib/Parse_with_comments.ml
+++ b/lib/Parse_with_comments.ml
@@ -67,7 +67,7 @@ let parse ~kind (conf : Conf.t) ~source =
           false )
         else not conf.quiet )
       ~f:(fun () ->
-        let ast = Migrate_ast.Parse.ast ~kind lexbuf in
+        let ast = Ast_passes.Ast0.Parse.ast ~kind lexbuf in
         Warnings.check_fatal () ;
         let comments =
           List.map

--- a/lib/Parse_with_comments.ml
+++ b/lib/Parse_with_comments.ml
@@ -51,7 +51,7 @@ let fresh_lexbuf source =
   in
   (lexbuf, hash_bang)
 
-let parse fragment (conf : Conf.t) ~source =
+let parse ~kind (conf : Conf.t) ~source =
   let warnings =
     W.enable 50
     :: (if conf.quiet then List.map ~f:W.disable W.in_lexer else [])
@@ -67,7 +67,7 @@ let parse fragment (conf : Conf.t) ~source =
           false )
         else not conf.quiet )
       ~f:(fun () ->
-        let ast = Migrate_ast.Parse.fragment fragment lexbuf in
+        let ast = Migrate_ast.Parse.ast ~kind lexbuf in
         Warnings.check_fatal () ;
         let comments =
           List.map

--- a/lib/Parse_with_comments.mli
+++ b/lib/Parse_with_comments.mli
@@ -27,8 +27,5 @@ end
 exception Warning50 of (Location.t * Warnings.t) list
 
 val parse :
-     kind:Syntax.t
-  -> Conf.t
-  -> source:string
-  -> Migrate_ast.Parsetree.t with_comments
+  kind:Syntax.t -> Conf.t -> source:string -> Ast_passes.Ast0.t with_comments
 (** @raise [Warning50] on misplaced documentation comments. *)

--- a/lib/Parse_with_comments.mli
+++ b/lib/Parse_with_comments.mli
@@ -27,5 +27,5 @@ end
 exception Warning50 of (Location.t * Warnings.t) list
 
 val parse :
-  kind:Syntax.t -> Conf.t -> source:string -> Ast_passes.Ast0.t with_comments
+  'a Ast_passes.Ast0.t -> Conf.t -> source:string -> 'a with_comments
 (** @raise [Warning50] on misplaced documentation comments. *)

--- a/lib/Parse_with_comments.mli
+++ b/lib/Parse_with_comments.mli
@@ -27,8 +27,8 @@ end
 exception Warning50 of (Location.t * Warnings.t) list
 
 val parse :
-     'a Migrate_ast.Traverse.fragment
+     kind:Syntax.t
   -> Conf.t
   -> source:string
-  -> 'a with_comments
+  -> Migrate_ast.Parsetree.t with_comments
 (** @raise [Warning50] on misplaced documentation comments. *)

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -130,7 +130,8 @@ let is_long_pexp_open source {Parsetree.pexp_desc; _} =
 let is_long_functor_syntax (t : t) ~from = function
   | Parsetree.Unit -> false
   | Parsetree.Named ({loc= upto; _}, _) -> (
-      if Ocaml_version.(compare Parse.parser_version Releases.v4_12) < 0 then
+      let parser_version = Ast_passes.Ast0.Parse.parser_version in
+      if Ocaml_version.(compare parser_version Releases.v4_12) < 0 then
         (* before 4.12 the functor keyword is the first token of the functor
            parameter *)
         contains_token_between t ~from ~upto Parser.FUNCTOR

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -10,6 +10,7 @@
 (**************************************************************************)
 
 open Migrate_ast
+open Ast_passes.Ast_final
 
 (** Concrete syntax. *)
 type t = {text: string; tokens: (Parser.token * Location.t) array}
@@ -104,11 +105,9 @@ let has_cmt_same_line_after t (loc : Location.t) =
       nloc.loc_start.pos_lnum = loc.loc_end.pos_lnum
   | Some _ -> false
 
-let extend_loc_to_include_attributes (loc : Location.t)
-    (l : Parsetree.attributes) =
+let extend_loc_to_include_attributes (loc : Location.t) (l : attributes) =
   let loc_end =
-    List.fold l ~init:loc
-      ~f:(fun acc ({attr_loc; _} : Parsetree.attribute) ->
+    List.fold l ~init:loc ~f:(fun acc ({attr_loc; _} : attribute) ->
         if Location.compare_end attr_loc acc <= 0 then acc else attr_loc )
   in
   if phys_equal loc_end loc then loc
@@ -121,15 +120,15 @@ let contains_token_between t ~(from : Location.t) ~(upto : Location.t) tok =
   Source_code_position.ascending from upto < 0
   && not (List.is_empty (tokens_between t ~filter from upto))
 
-let is_long_pexp_open source {Parsetree.pexp_desc; _} =
+let is_long_pexp_open source {pexp_desc; _} =
   match pexp_desc with
   | Pexp_open ({popen_loc= from; _}, {pexp_loc= upto; _}) ->
       contains_token_between source ~from ~upto Parser.IN
   | _ -> false
 
 let is_long_functor_syntax (t : t) ~from = function
-  | Parsetree.Unit -> false
-  | Parsetree.Named ({loc= upto; _}, _) -> (
+  | Unit -> false
+  | Named ({loc= upto; _}, _) -> (
       let parser_version = Ast_passes.Ast0.Parse.parser_version in
       if Ocaml_version.(compare parser_version Releases.v4_12) < 0 then
         (* before 4.12 the functor keyword is the first token of the functor
@@ -146,12 +145,12 @@ let is_long_functor_syntax (t : t) ~from = function
         | Some (Parser.FUNCTOR, _) -> true
         | _ -> false )
 
-let is_long_pmod_functor t Parsetree.{pmod_desc; pmod_loc= from; _} =
+let is_long_pmod_functor t {pmod_desc; pmod_loc= from; _} =
   match pmod_desc with
   | Pmod_functor (fp, _) -> is_long_functor_syntax t ~from fp
   | _ -> false
 
-let is_long_pmty_functor t Parsetree.{pmty_desc; pmty_loc= from; _} =
+let is_long_pmty_functor t {pmty_desc; pmty_loc= from; _} =
   match pmty_desc with
   | Pmty_functor (fp, _) -> is_long_functor_syntax t ~from fp
   | _ -> false
@@ -235,12 +234,12 @@ let extension_using_sugar ~(name : string Location.loc)
   Source_code_position.ascending name.loc.loc_start payload.loc_start > 0
 
 let type_constraint_is_first typ loc =
-  Location.compare_start typ.Parsetree.ptyp_loc loc < 0
+  Location.compare_start typ.ptyp_loc loc < 0
 
 let loc_of_underscore t flds (ppat_loc : Location.t) =
   let end_last_field =
     match List.last flds with
-    | Some (_, p) -> p.Parsetree.ppat_loc.loc_end
+    | Some (_, p) -> p.ppat_loc.loc_end
     | None -> ppat_loc.loc_start
   in
   let loc_underscore = {ppat_loc with loc_start= end_last_field} in
@@ -264,7 +263,7 @@ let locs_of_interval source loc =
         "Ppat_interval is only produced by the sequence of 3 tokens: \
          CONSTANT-DOTDOT-CONSTANT "
 
-let loc_of_constant t loc (cst : Parsetree.constant) =
+let loc_of_constant t loc (cst : constant) =
   let filter : Parser.token -> bool =
     match cst with
     | Pconst_string _ -> ( function STRING _ -> true | _ -> false )
@@ -274,13 +273,13 @@ let loc_of_constant t loc (cst : Parsetree.constant) =
   in
   match tokens_at t loc ~filter with [(_, loc)] -> loc | _ -> loc
 
-let loc_of_pat_constant t (p : Parsetree.pattern) =
+let loc_of_pat_constant t (p : pattern) =
   match p.ppat_desc with
   | Ppat_constant cst ->
       loc_of_constant t (Location.smallest p.ppat_loc p.ppat_loc_stack) cst
   | _ -> impossible "loc_of_pat_constant is only called on constants"
 
-let loc_of_expr_constant t (e : Parsetree.expression) =
+let loc_of_expr_constant t (e : expression) =
   match e.pexp_desc with
   | Pexp_constant cst ->
       loc_of_constant t (Location.smallest e.pexp_loc e.pexp_loc_stack) cst

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -10,6 +10,7 @@
 (**************************************************************************)
 
 open Migrate_ast
+open Ast_passes.Ast_final
 
 type t
 
@@ -53,16 +54,16 @@ val string_literal : t -> [`Normalize | `Preserve] -> Location.t -> string
 
 val char_literal : t -> Location.t -> string
 
-val is_long_pexp_open : t -> Parsetree.expression -> bool
+val is_long_pexp_open : t -> expression -> bool
 (** [is_long_pexp_open source exp] holds if [exp] is a [Pexp_open] expression
     that is expressed in long ('let open') form in source. *)
 
-val is_long_pmod_functor : t -> Parsetree.module_expr -> bool
+val is_long_pmod_functor : t -> module_expr -> bool
 (** [is_long_pmod_functor source mod_exp] holds if [mod_exp] is a
     [Pmod_functor] expression that is expressed in long ('functor (M) ->')
     form in source. *)
 
-val is_long_pmty_functor : t -> Parsetree.module_type -> bool
+val is_long_pmty_functor : t -> module_type -> bool
 (** [is_long_pmty_functor source mod_type] holds if [mod_type] is a
     [Pmty_functor] type that is expressed in long ('functor (M) ->') form in
     source. *)
@@ -74,13 +75,12 @@ val ends_line : t -> Location.t -> bool
 val extension_using_sugar :
   name:string Location.loc -> payload:Location.t -> bool
 
-val extend_loc_to_include_attributes :
-  Location.t -> Parsetree.attributes -> Location.t
+val extend_loc_to_include_attributes : Location.t -> attributes -> Location.t
 
-val type_constraint_is_first : Parsetree.core_type -> Location.t -> bool
+val type_constraint_is_first : core_type -> Location.t -> bool
 
 val loc_of_underscore :
-  t -> ('a * Parsetree.pattern) list -> Location.t -> Location.t option
+  t -> ('a * pattern) list -> Location.t -> Location.t option
 (** [loc_of_underscore source fields loc] returns the location of the
     underscore at the end of the record pattern of location [loc] with fields
     [fields], if the record pattern is open (it ends with an underscore),
@@ -90,9 +90,9 @@ val locs_of_interval : t -> Location.t -> Location.t * Location.t
 (** Given the location of an interval pattern ['a'..'b'], return the
     locations of the constants that represent the bounds (['a'] and ['b']). *)
 
-val loc_of_pat_constant : t -> Parsetree.pattern -> Location.t
+val loc_of_pat_constant : t -> pattern -> Location.t
 
-val loc_of_expr_constant : t -> Parsetree.expression -> Location.t
+val loc_of_expr_constant : t -> expression -> Location.t
 
 val is_quoted_string : t -> Location.t -> bool
 

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -11,8 +11,8 @@
 
 open Migrate_ast
 open Asttypes
-open Parsetree
 open Ast
+open Ast_passes.Ast_final
 
 let rec arrow_typ cmts i ({ast= typ; _} as xtyp) =
   let ctx = Typ typ in

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -11,7 +11,7 @@
 
 open Migrate_ast
 open Asttypes
-open Parsetree
+open Ast_passes.Ast_final
 
 val arrow_typ :
      Cmts.t
@@ -101,8 +101,8 @@ val sequence :
 type functor_arg =
   | Unit
   | Named of label option loc * module_type Ast.xt
-      (** Equivalent of the [Parsetree.functor_parameter] type with a
-          contextualized module type. *)
+      (** Equivalent of the [functor_parameter] type with a contextualized
+          module type. *)
 
 val functor_type :
      Cmts.t

--- a/lib/Syntax.ml
+++ b/lib/Syntax.ml
@@ -9,13 +9,4 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Format OCaml Ast *)
-
-val fmt_ast :
-     debug:bool
-  -> Source.t
-  -> Cmts.t
-  -> Conf.t
-  -> Migrate_ast.Parsetree.t
-  -> Fmt.t
-(** Format a fragment. *)
+type t = Structure | Signature | Use_file

--- a/lib/Syntax.mli
+++ b/lib/Syntax.mli
@@ -9,13 +9,4 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Format OCaml Ast *)
-
-val fmt_ast :
-     debug:bool
-  -> Source.t
-  -> Cmts.t
-  -> Conf.t
-  -> Migrate_ast.Parsetree.t
-  -> Fmt.t
-(** Format a fragment. *)
+type t = Structure | Signature | Use_file

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -297,6 +297,7 @@ let format ~kind ?output_file ~input_name ~prev_source ~parsed conf opts =
           else internal_error (`Cannot_parse exn) (exn_args ())
       | t_new -> Ok t_new )
       >>= fun t_new ->
+      let t_new = {t_new with ast= Ast_passes.run t_new.ast} in
       (* Ast not preserved ? *)
       ( if
         not
@@ -388,4 +389,5 @@ let parse_and_format ~kind ?output_file ~input_name ~source conf opts =
   let open Result.Monad_infix in
   parse_result ~kind conf opts ~source ~input_name
   >>= fun parsed ->
+  let parsed = {parsed with ast= Ast_passes.run parsed.ast} in
   format ~kind ?output_file ~input_name ~prev_source:source ~parsed conf opts

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -403,14 +403,7 @@ let parse_and_format (type a b) (fg0 : a list Ast_passes.Ast0.t)
   format fg0 fgN ?output_file ~input_name ~prev_source:source ~parsed conf
     opts
 
-let parse_and_format ~kind ?output_file ~input_name ~source conf opts =
-  match kind with
-  | Syntax.Structure ->
-      parse_and_format Structure Structure ?output_file ~input_name ~source
-        conf opts
-  | Syntax.Signature ->
-      parse_and_format Signature Signature ?output_file ~input_name ~source
-        conf opts
-  | Syntax.Use_file ->
-      parse_and_format Use_file Use_file ?output_file ~input_name ~source
-        conf opts
+let parse_and_format = function
+  | Syntax.Structure -> parse_and_format Structure Structure
+  | Syntax.Signature -> parse_and_format Signature Signature
+  | Syntax.Use_file -> parse_and_format Use_file Use_file

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -402,3 +402,15 @@ let parse_and_format (type a b) (fg0 : a list Ast_passes.Ast0.t)
   let parsed = {parsed with ast= Ast_passes.run fg0 fgN parsed.ast} in
   format fg0 fgN ?output_file ~input_name ~prev_source:source ~parsed conf
     opts
+
+let parse_and_format ~kind ?output_file ~input_name ~source conf opts =
+  match kind with
+  | Syntax.Structure ->
+      parse_and_format Structure Structure ?output_file ~input_name ~source
+        conf opts
+  | Syntax.Signature ->
+      parse_and_format Signature Signature ?output_file ~input_name ~source
+        conf opts
+  | Syntax.Use_file ->
+      parse_and_format Use_file Use_file ?output_file ~input_name ~source
+        conf opts

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -11,7 +11,7 @@
 
 (** Translation units *)
 
-open Migrate_ast
+module Location = Migrate_ast.Location
 open Parse_with_comments
 
 exception
@@ -236,7 +236,7 @@ let format ~kind ?output_file ~input_name ~prev_source ~parsed conf opts =
     if opts.Conf.debug then
       Some
         (dump_ast ~input_name ?output_file ~suffix (fun fmt ->
-             Migrate_ast.Printast.ast fmt ast ) )
+             Ast_passes.Ast_final.Printast.ast fmt ast ) )
     else None
   in
   let dump_formatted ~suffix fmted =

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -12,15 +12,14 @@
 type error
 
 val parse_and_format :
-     _ list Ast_passes.Ast0.t
-  -> _ list Ast_passes.Ast_final.t
+     kind:Syntax.t
   -> ?output_file:string
   -> input_name:string
   -> source:string
   -> Conf.t
   -> Conf.opts
   -> (string, error) Result.t
-(** [parse_and_format conf ?output_file ~input_name ~source] parses and
+(** [parse_and_format ~kind conf ?output_file ~input_name ~source] parses and
     formats [source] as a list of fragments. *)
 
 val print_error :

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -12,15 +12,15 @@
 type error
 
 val parse_and_format :
-     _ list Migrate_ast.Traverse.fragment
+     kind:Syntax.t
   -> ?output_file:string
   -> input_name:string
   -> source:string
   -> Conf.t
   -> Conf.opts
   -> (string, error) Result.t
-(** [parse_and_format_impl conf ?output_file ~input_name ~source] parses and
-    formats [source] as a list of fragments. *)
+(** [parse_and_format_impl ~kind conf ?output_file ~input_name ~source]
+    parses and formats [source] as a list of fragments. *)
 
 val print_error :
      fmt:Format.formatter

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -19,8 +19,8 @@ val parse_and_format :
   -> Conf.t
   -> Conf.opts
   -> (string, error) Result.t
-(** [parse_and_format_impl ~kind conf ?output_file ~input_name ~source]
-    parses and formats [source] as a list of fragments. *)
+(** [parse_and_format ~kind conf ?output_file ~input_name ~source] parses and
+    formats [source] as a list of fragments. *)
 
 val print_error :
      fmt:Format.formatter

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -12,14 +12,14 @@
 type error
 
 val parse_and_format :
-     kind:Syntax.t
+     Syntax.t
   -> ?output_file:string
   -> input_name:string
   -> source:string
   -> Conf.t
   -> Conf.opts
   -> (string, error) Result.t
-(** [parse_and_format ~kind conf ?output_file ~input_name ~source] parses and
+(** [parse_and_format kind conf ?output_file ~input_name ~source] parses and
     formats [source] as a list of fragments. *)
 
 val print_error :

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -12,7 +12,8 @@
 type error
 
 val parse_and_format :
-     kind:Syntax.t
+     _ list Ast_passes.Ast0.t
+  -> _ list Ast_passes.Ast_final.t
   -> ?output_file:string
   -> input_name:string
   -> source:string

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -20,7 +20,7 @@ val parse_and_format :
   -> Conf.t
   -> Conf.opts
   -> (string, error) Result.t
-(** [parse_and_format ~kind conf ?output_file ~input_name ~source] parses and
+(** [parse_and_format conf ?output_file ~input_name ~source] parses and
     formats [source] as a list of fragments. *)
 
 val print_error :


### PR DESCRIPTION
The idea behind this PR is that at some point I would like to split the current processing in several passes and we should be able to handle transformations over ASTs with functions typed like `Ast0 -> Ast1` or something similar.
And the current representation with the type `_ fragment` is dragging me down for this work (or maybe I'm missing something).

for the record the current fragment type is
```ocaml
  type 'a fragment =
    | Structure : Parsetree.structure fragment
    | Signature : Parsetree.signature fragment
    | Use_file : Parsetree.toplevel_phrase list fragment
```
and we would need to rewrite it as
```ocaml
  type fragment =
    | Pfrag_str of structure
    | Pfrag_sig of signature
    | Pfrag_usf of use_file

  type t = (* unused for now, should eventually replace fragment *)
    | Str of structure list
    | Sig of signature list
    | Usf of use_file list
```

as a consequence, all functions of the form `'a Traverse.fragment -> 'a -> ...` have been rewritten as `Parsetree.fragment -> ...`

This PR is only some preliminary work, it can be improved before being merged, in particular I'm not satisfied with handling the type `Parsetree.fragment` instead of `Parsetree.t` (that should in the future be AstN.t) in particular for parsing function of Parse_with_comments and the formatting one in Fmt_ast, there was a trick to parse `'a list fragment` (so list of structures, signatures etc) but the rewritting is not immediate to retrieve `Parsetree.t` instead since the parsing functions only return structures, signatures, etc. I'm still trying to understand this trick cc @emillon 
What do you think?