### PR TITLE
Support BER MetaOCaml N111 (in Unix)

### DIFF
--- a/vendor/token-latest/411ber/token_latest.ml
+++ b/vendor/token-latest/411ber/token_latest.ml
@@ -1,0 +1,131 @@
+type token = Parser.token =
+  | WITH
+  | WHILE
+  | WHEN
+  | VIRTUAL
+  | VAL
+  | UNDERSCORE
+  | UIDENT of string
+  | TYPE
+  | TRY
+  | TRUE
+  | TO
+  | TILDE
+  | THEN
+  | STRUCT
+  | STRING of (string * Location.t * string option)
+  | STAR
+  | SIG
+  | SEMISEMI
+  | SEMI
+  | RPAREN
+  | REC
+  | RBRACKET
+  | RBRACE
+  | QUOTED_STRING_ITEM of
+      (string * Location.t * string * Location.t * string option)
+  | QUOTED_STRING_EXPR of
+      (string * Location.t * string * Location.t * string option)
+  | QUOTE
+  | QUESTION
+  | PRIVATE
+  | PREFIXOP of string
+  | PLUSEQ
+  | PLUSDOT
+  | PLUS
+  | PERCENT
+  | OR
+  | OPTLABEL of string
+  | OPEN
+  | OF
+  | OBJECT
+  | NONREC
+  | NEW
+  | MUTABLE
+  | MODULE
+  | MINUSGREATER
+  | MINUSDOT
+  | MINUS
+  | METHOD
+  | MATCH
+  | LPAREN
+  | LIDENT of string
+  | LETOP of string
+  | LET
+  | LESSMINUS
+  | LESS
+  | LBRACKETPERCENTPERCENT
+  | LBRACKETPERCENT
+  | LBRACKETLESS
+  | LBRACKETGREATER
+  | LBRACKETBAR
+  | LBRACKETATATAT
+  | LBRACKETATAT
+  | LBRACKETAT
+  | LBRACKET
+  | LBRACELESS
+  | LBRACE
+  | LAZY
+  | LABEL of string
+  | INT of (string * char option)
+  | INITIALIZER
+  | INHERIT
+  | INFIXOP4 of string
+  | INFIXOP3 of string
+  | INFIXOP2 of string
+  | INFIXOP1 of string
+  | INFIXOP0 of string
+  | INCLUDE
+  | IN
+  | IF
+  | HASHOP of string
+  | HASH
+  | GREATERRBRACKET
+  | GREATERRBRACE
+  | GREATERDOT
+  | GREATER
+  | FUNCTOR
+  | FUNCTION
+  | FUN
+  | FOR
+  | FLOAT of (string * char option)
+  | FALSE
+  | EXTERNAL
+  | EXCEPTION
+  | EQUAL
+  | EOL
+  | EOF
+  | END
+  | ELSE
+  | DOWNTO
+  | DOTTILDE
+  | DOTOP of string
+  | DOTLESS
+  | DOTDOT
+  | DOT
+  | DONE
+  | DOCSTRING of Docstrings.docstring
+  | DO
+  | CONSTRAINT
+  | COMMENT of (string * Location.t)
+  | COMMA
+  | COLONGREATER
+  | COLONEQUAL
+  | COLONCOLON
+  | COLON
+  | CLASS
+  | CHAR of char
+  | BEGIN
+  | BARRBRACKET
+  | BARBAR
+  | BAR
+  | BANG
+  | BACKQUOTE
+  | ASSERT
+  | AS
+  | ANDOP of string
+  | AND
+  | AMPERSAND
+  | AMPERAMPER
+
+let of_compiler_libs x = x

--- a/vendor/token-latest/detect/detect.ml
+++ b/vendor/token-latest/detect/detect.ml
@@ -1,5 +1,12 @@
 let dir_name version =
-  if version >= (4, 11) then "411"
+  if version >= (4, 11) then
+    match Sys.os_type with
+    | "Unix" -> begin  
+        match Sys.command "which metaocaml > /dev/null 2>&1" with
+        | 0 -> "411ber"
+        | _ -> "411"
+      end
+    | _ -> "411"
   else "408"
 
 let () =


### PR DESCRIPTION
This PR is for supporting BER MetaOCaml N111, which is OCaml 4.11.1 extended to  support meta-programming (see http://okmij.org/ftp/ML/MetaOCaml.html). Because MetaOCaml adds `>.`, `.~`, and `.<` to original OCaml syntax, it adds `GREATERDOT`, `DOTTILDE`, and `DOTLESS` to token.

I tested it but `tools/test_branch.sh ber-n111` did't work, of course because HEAD was not buildable in MetaOCaml.
The test by `make test` worked fine :-)