### PR TITLE
Fix extraneous parenthesis after 'let open' with 'closing-on-separate-line'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 #### Bug fixes
 
++ Fix extraneous parenthesis after 'let open' with 'closing-on-separate-line' (#1612, @Julow)
+
 #### Changes
 
 #### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2279,8 +2279,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             fits_breaks ?force cls ""
             $ fits_breaks_if inner_parens ?force "" ")"
         | `Closing_on_separate_line ->
-            fmt_if_k force_fit (break 0 0) $
-            fits_breaks ?force cls ""
+            fmt_if_k force_fit (break 0 0)
+            $ fits_breaks ?force cls ""
             $ fits_breaks_if inner_parens ?force "" ~hint:(1000, 0) ")"
       in
       hovbox 0

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2279,7 +2279,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             fits_breaks ?force cls ""
             $ fits_breaks_if inner_parens ?force "" ")"
         | `Closing_on_separate_line ->
-            fmt_if_k (not can_skip_parens) (break 0 0 $ str cls)
+            fmt_if_k force_fit (break 0 0) $
+            fits_breaks ?force cls ""
             $ fits_breaks_if inner_parens ?force "" ~hint:(1000, 0) ")"
       in
       hovbox 0

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1876,6 +1876,16 @@
 (rule
  (deps .ocamlformat )
  (action
+   (with-outputs-to open-closing-on-separate-line.ml.output
+     (run %{bin:ocamlformat} --indicate-multiline-delimiters=closing-on-separate-line %{dep:open.ml}))))
+
+(rule
+ (alias runtest)
+ (action (diff open-closing-on-separate-line.ml.ref open-closing-on-separate-line.ml.output)))
+
+(rule
+ (deps .ocamlformat )
+ (action
    (with-outputs-to open.ml.output
      (run %{bin:ocamlformat} %{dep:open.ml}))))
 

--- a/test/passing/open-closing-on-separate-line.ml.opts
+++ b/test/passing/open-closing-on-separate-line.ml.opts
@@ -1,0 +1,1 @@
+--indicate-multiline-delimiters=closing-on-separate-line

--- a/test/passing/open-closing-on-separate-line.ml.ref
+++ b/test/passing/open-closing-on-separate-line.ml.ref
@@ -1,0 +1,299 @@
+let _ = Some_module.Submodule.(a + b)
+
+let _ = A.(a, b)
+
+let _ =
+  let open Some_module.Submodule in
+  AAAAAAAAAAAAAAAAAAAAAAAAAAAA.(a + b)
+
+let _ =
+  let open Some_module.Submodule in
+  let module A = MMMMMM in
+  a + b + c
+
+let _ =
+  let open Some_module.Submodule in
+  let exception A of int in
+  a + b
+
+let _ =
+  let open Some_module.Submodule in
+  [%except {| result |}]
+
+let _ =
+  let open Some_module.Submodule in
+  [%except {| loooooooooooooooooooooooooong result |}]
+
+let _ =
+  let open Some_module.Submodule in
+  let x = a + b in
+  let y = f x in
+  y
+
+let () =
+  ( (let open Term in
+    term_result
+      (const Phases.phase1 $ arch $ hub_id $ build_dir $ logs_dir
+     $ setup_logs
+      )
+    )
+  , Term.info "phase1" ~doc ~sdocs:Manpage.s_common_options ~exits ~man
+  )
+
+let () =
+  (let open Arg in
+  let doc = "Output all." in
+  value & flag & info ["all"] ~doc
+  )
+  $
+  let open Arg in
+  let doc = "Commit to git." in
+  value & flag & info ["commit"; "c"] ~doc
+
+let () =
+  Arg.(
+    let doc = "Output all." in
+    value & flag & info ["all"] ~doc
+  )
+  $ Arg.(
+      let doc = "Commit to git." in
+      value & flag & info ["commit"; "c"] ~doc
+    )
+
+let () = X.(f y i)
+
+let () = X.(i)
+
+let () =
+  let open X in
+  f y i
+
+let () =
+  let open X in
+  i
+
+let () =
+  let open! K in
+  x y z
+
+let x =
+  let Cstruct.{buffer= bigstring; off= offset; len= length} =
+    Cstruct.{toto= foooo}
+  in
+  fooooooooo
+
+open A
+open A.B
+
+open A (B)
+
+open struct
+  type t
+end
+
+open (
+  struct
+    type t
+  end :
+    T
+)
+
+open (
+  struct
+    type t
+  end :
+    sig
+      type t
+    end
+)
+
+open (val x)
+
+open (val x)
+
+open [%extension]
+
+open functor (A : T) -> T'
+
+module type T = sig
+  open A
+  open A.B
+  open A(B)
+end
+
+let x =
+  let open struct
+    type t' = t
+  end in
+  foo
+
+let x =
+  let open struct
+    open struct
+      type t = T
+    end
+
+    let y = T
+  end in
+  foo
+
+let x =
+  let open struct
+    open struct
+      let counter = ref 0
+    end
+  end in
+  foo
+
+let x =
+  let open struct
+    ;;
+    let open struct
+      let counter = ref 0
+    end in
+    foo
+  end in
+  foo
+
+let x =
+  let open struct
+    module A = struct
+      open struct
+        let x = 1
+      end
+
+      let y = x
+
+      open struct
+        let x = 1
+      end
+
+      let z = y + x
+    end
+  end in
+  foo
+
+class type a =
+  (* A'' *)
+  let open (* A' *) A (* A *) in
+  (* B *)
+  b
+
+class a =
+  (* A'' *)
+  let open (* A' *) A (* A *) in
+  (* B *)
+  b
+
+let _ =
+  (* a *)
+  let (* b *) open (* c *) struct
+    type t
+  end
+  (* d *) in
+  (* e *)
+  (* f *)
+  let (* g *) open (* h *) A (* i *) (B) (* j *) in
+  (* k *)
+  ()
+
+(* l *)
+open (* m *) struct
+  type t
+end
+(* n *)
+
+open A
+open B
+
+open struct
+  type t
+end
+
+open
+  functor
+    (A : S)
+    ->
+    struct
+      type t
+    end
+
+open
+  functor
+    (_ : S)
+    ->
+    struct
+      type t
+    end
+
+open A (B)
+
+open (A : S)
+
+open (val x)
+
+open [%ext]
+
+let _ =
+  let open A in
+  let open B in
+  let open struct
+    type t
+  end in
+  let open
+    functor
+      (A : S)
+      ->
+      struct
+        type t
+      end in
+  let open
+    functor
+      (_ : S)
+      ->
+      struct
+        type t
+      end in
+  let open A (B) in
+  let open (A : S) in
+  let open (val x) in
+  let open [%ext] in
+  ()
+
+open A [@@attr]
+open B [@@attr]
+
+open struct
+  type t
+end [@@attr]
+
+open
+  functor
+    (A : S)
+    ->
+    struct
+      type t
+    end [@@attr]
+
+open
+  functor
+    (_ : S)
+    ->
+    struct
+      type t
+    end [@@attr]
+
+open A (B) [@@attr]
+
+open (A : S) [@@attr]
+
+open (val x) [@@attr]
+
+open [%ext] [@@attr]
+
+let g =
+  M.f
+    ((let open M in
+     x
+     ) [@attr]
+    )


### PR DESCRIPTION
With the option `indicate-multiline-delimiters=closing-on-separate-line`,
an unpaired parenthesis was inserted after the expression of a 'let open':

```ocaml
let parse ~resolve_uri contents =
  let open Markup in
  contents |> string |> parse_html |> signals
  |> trees
       ~text:(fun s -> Feed.Html_T (String.concat "" s))
       ~element:(element ~resolve_uri)
  |> to_list |> to_feed_content
  )
```

This resulted in a crash.