### PR TITLE
Clean the interface of Translation_unit errors

### DIFF
--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -26,12 +26,6 @@ exception
 
 let internal_error msg kvs = raise (Internal_error (msg, kvs))
 
-type error =
-  | Invalid_source of {exn: exn}
-  | Unstable of {iteration: int; prev: string; next: string}
-  | Ocamlformat_bug of {exn: exn}
-  | User_error of string
-
 let ellipsis n msg =
   let msg = String.strip msg in
   if n > 0 && String.length msg > (n * 2) + 10 then
@@ -39,6 +33,157 @@ let ellipsis n msg =
   else msg
 
 let ellipsis_cmt = ellipsis 50
+
+let chop_any_extension s =
+  match Filename.chop_extension s with
+  | r -> r
+  | exception Invalid_argument _ -> s
+
+let exe = chop_any_extension (Filename.basename Caml.Sys.argv.(0))
+
+module Error = struct
+  type t =
+    | Invalid_source of {exn: exn; input_name: string}
+    | Unstable of
+        {iteration: int; prev: string; next: string; input_name: string}
+    | Ocamlformat_bug of {exn: exn; input_name: string}
+    | User_error of string
+
+  let equal : t -> t -> bool = Poly.equal
+
+  let print ?(debug = false) ?(quiet = false) fmt = function
+    | Invalid_source _ when quiet -> ()
+    | Invalid_source {exn; input_name} -> (
+        let reason =
+          match exn with
+          | Syntaxerr.Error _ | Lexer.Error _ -> " (syntax error)"
+          | Warning50 _ -> " (misplaced documentation comments - warning 50)"
+          | _ -> ""
+        in
+        Format.fprintf fmt "%s: ignoring %S%s\n%!" exe input_name reason ;
+        match exn with
+        | Syntaxerr.Error _ | Lexer.Error _ ->
+            Location.report_exception fmt exn
+        | Warning50 l ->
+            List.iter l ~f:(fun (l, w) -> print_warning l w) ;
+            Format.fprintf fmt
+              "@{<warning>Hint@}: (Warning 50) This file contains a \
+               documentation comment (** ... *) that the OCaml compiler \
+               does not know how to attach to the AST. OCamlformat does not \
+               support these cases. You can find more information at: \
+               https://github.com/ocaml-ppx/ocamlformat#overview. If you'd \
+               like to disable this check and let ocamlformat make a choice \
+               (though it might not be consistent with the ocaml compilers \
+               and odoc), you can set the --no-comment-check option.\n\
+               %!"
+        | exn -> Format.fprintf fmt "%s\n%!" (Exn.to_string exn) )
+    | Unstable {iteration; prev; next; input_name} ->
+        if debug then (
+          let ext = Filename.extension input_name in
+          let input_name =
+            Filename.chop_extension (Filename.basename input_name)
+          in
+          let p =
+            Filename.temp_file input_name (Printf.sprintf ".prev%s" ext)
+          in
+          Out_channel.write_all p ~data:prev ;
+          let n =
+            Filename.temp_file input_name (Printf.sprintf ".next%s" ext)
+          in
+          Out_channel.write_all n ~data:next ;
+          ignore (Unix.system (Printf.sprintf "diff %S %S 1>&2" p n)) ;
+          Unix.unlink p ;
+          Unix.unlink n ) ;
+        if iteration <= 1 then
+          Format.fprintf fmt
+            "%s: %S was not already formatted. ([max-iters = 1])\n%!" exe
+            input_name
+        else (
+          Format.fprintf fmt
+            "%s: Cannot process %S.\n\
+            \  Please report this bug at \
+             https://github.com/ocaml-ppx/ocamlformat/issues.\n\
+             %!"
+            exe input_name ;
+          Format.fprintf fmt
+            "  BUG: formatting did not stabilize after %i iterations.\n%!"
+            iteration )
+    | User_error msg -> Format.fprintf fmt "%s: %s.\n%!" exe msg
+    | Ocamlformat_bug {exn; input_name} -> (
+        Format.fprintf fmt
+          "%s: Cannot process %S.\n\
+          \  Please report this bug at \
+           https://github.com/ocaml-ppx/ocamlformat/issues.\n\
+           %!"
+          exe input_name ;
+        match exn with
+        | Internal_error (m, l) ->
+            let s =
+              match m with
+              | `Cannot_parse _ -> "generating invalid ocaml syntax"
+              | `Ast_changed -> "ast changed"
+              | `Doc_comment _ -> "doc comments changed"
+              | `Comment -> "comments changed"
+              | `Comment_dropped _ -> "comments dropped"
+              | `Warning50 _ -> "misplaced documentation comments"
+            in
+            Format.fprintf fmt "  BUG: %s.\n%!" s ;
+            ( match m with
+            | `Doc_comment l when not quiet ->
+                List.iter l ~f:(function
+                  | Normalize.Moved (loc_before, loc_after, msg) ->
+                      if Location.compare loc_before Location.none = 0 then
+                        Format.fprintf fmt
+                          "%!@{<loc>%a@}:@,\
+                           @{<error>Error@}: Docstring (** %s *) added.\n\
+                           %!"
+                          Location.print loc_after (ellipsis_cmt msg)
+                      else if Location.compare loc_after Location.none = 0
+                      then
+                        Format.fprintf fmt
+                          "%!@{<loc>%a@}:@,\
+                           @{<error>Error@}: Docstring (** %s *) dropped.\n\
+                           %!"
+                          Location.print loc_before (ellipsis_cmt msg)
+                      else
+                        Format.fprintf fmt
+                          "%!@{<loc>%a@}:@,\
+                           @{<error>Error@}: Docstring (** %s *) moved to \
+                           @{<loc>%a@}.\n\
+                           %!"
+                          Location.print loc_before (ellipsis_cmt msg)
+                          Location.print loc_after
+                  | Normalize.Unstable (loc, s) ->
+                      Format.fprintf fmt
+                        "%!@{<loc>%a@}:@,\
+                         @{<error>Error@}: Formatting of (** %s *) is \
+                         unstable (e.g. parses as a list or not depending \
+                         on the margin), please tighten up this comment in \
+                         the source or disable the formatting using the \
+                         option --no-parse-docstrings.\n\
+                         %!"
+                        Location.print loc (ellipsis_cmt s) )
+            | `Comment_dropped l when not quiet ->
+                List.iter l ~f:(fun Cmt.{txt= msg; loc} ->
+                    Format.fprintf fmt
+                      "%!@{<loc>%a@}:@,\
+                       @{<error>Error@}: Comment (* %s *) dropped.\n\
+                       %!"
+                      Location.print loc (ellipsis_cmt msg) )
+            | `Cannot_parse ((Syntaxerr.Error _ | Lexer.Error _) as exn) ->
+                if debug then Location.report_exception fmt exn
+            | `Warning50 l ->
+                if debug then
+                  List.iter l ~f:(fun (l, w) -> print_warning l w)
+            | _ -> () ) ;
+            if debug then
+              List.iter l ~f:(fun (msg, sexp) ->
+                  Format.fprintf fmt "  %s: %s\n%!" msg (Sexp.to_string sexp) )
+        | exn ->
+            Format.fprintf fmt
+              "  BUG: unhandled exception. Use [--debug] for details.\n%!" ;
+            if debug then Format.fprintf fmt "%s\n%!" (Exn.to_string exn) )
+end
 
 let with_file input_name output_file suf ext f =
   let dir =
@@ -60,138 +205,6 @@ let dump_formatted ~input_name ?output_file ~suffix fmted =
   let ext = Filename.extension input_name in
   with_file input_name output_file suffix ext (fun oc ->
       Out_channel.output_string oc fmted )
-
-let print_error ~fmt ~exe ~debug ~quiet ~input_name error =
-  match error with
-  | Invalid_source _ when quiet -> ()
-  | Invalid_source {exn} -> (
-      let reason =
-        match exn with
-        | Syntaxerr.Error _ | Lexer.Error _ -> " (syntax error)"
-        | Warning50 _ -> " (misplaced documentation comments - warning 50)"
-        | _ -> ""
-      in
-      Format.fprintf fmt "%s: ignoring %S%s\n%!" exe input_name reason ;
-      match exn with
-      | Syntaxerr.Error _ | Lexer.Error _ ->
-          Location.report_exception fmt exn
-      | Warning50 l ->
-          List.iter l ~f:(fun (l, w) -> print_warning l w) ;
-          Format.fprintf fmt
-            "@{<warning>Hint@}: (Warning 50) This file contains a \
-             documentation comment (** ... *) that the OCaml compiler does \
-             not know how to attach to the AST. OCamlformat does not \
-             support these cases. You can find more information at: \
-             https://github.com/ocaml-ppx/ocamlformat#overview. If you'd \
-             like to disable this check and let ocamlformat make a choice \
-             (though it might not be consistent with the ocaml compilers \
-             and odoc), you can set the --no-comment-check option.\n\
-             %!"
-      | exn -> Format.fprintf fmt "%s\n%!" (Exn.to_string exn) )
-  | Unstable {iteration; prev; next} ->
-      if debug then (
-        let ext = Filename.extension input_name in
-        let input_name =
-          Filename.chop_extension (Filename.basename input_name)
-        in
-        let p =
-          Filename.temp_file input_name (Printf.sprintf ".prev%s" ext)
-        in
-        Out_channel.write_all p ~data:prev ;
-        let n =
-          Filename.temp_file input_name (Printf.sprintf ".next%s" ext)
-        in
-        Out_channel.write_all n ~data:next ;
-        ignore (Unix.system (Printf.sprintf "diff %S %S 1>&2" p n)) ;
-        Unix.unlink p ;
-        Unix.unlink n ) ;
-      if iteration <= 1 then
-        Format.fprintf fmt
-          "%s: %S was not already formatted. ([max-iters = 1])\n%!" exe
-          input_name
-      else (
-        Format.fprintf fmt
-          "%s: Cannot process %S.\n\
-          \  Please report this bug at \
-           https://github.com/ocaml-ppx/ocamlformat/issues.\n\
-           %!"
-          exe input_name ;
-        Format.fprintf fmt
-          "  BUG: formatting did not stabilize after %i iterations.\n%!"
-          iteration )
-  | User_error msg -> Format.fprintf fmt "%s: %s.\n%!" exe msg
-  | Ocamlformat_bug {exn} -> (
-      Format.fprintf fmt
-        "%s: Cannot process %S.\n\
-        \  Please report this bug at \
-         https://github.com/ocaml-ppx/ocamlformat/issues.\n\
-         %!"
-        exe input_name ;
-      match exn with
-      | Internal_error (m, l) ->
-          let s =
-            match m with
-            | `Cannot_parse _ -> "generating invalid ocaml syntax"
-            | `Ast_changed -> "ast changed"
-            | `Doc_comment _ -> "doc comments changed"
-            | `Comment -> "comments changed"
-            | `Comment_dropped _ -> "comments dropped"
-            | `Warning50 _ -> "misplaced documentation comments"
-          in
-          Format.fprintf fmt "  BUG: %s.\n%!" s ;
-          ( match m with
-          | `Doc_comment l when not quiet ->
-              List.iter l ~f:(function
-                | Normalize.Moved (loc_before, loc_after, msg) ->
-                    if Location.compare loc_before Location.none = 0 then
-                      Format.fprintf fmt
-                        "%!@{<loc>%a@}:@,\
-                         @{<error>Error@}: Docstring (** %s *) added.\n\
-                         %!"
-                        Location.print loc_after (ellipsis_cmt msg)
-                    else if Location.compare loc_after Location.none = 0 then
-                      Format.fprintf fmt
-                        "%!@{<loc>%a@}:@,\
-                         @{<error>Error@}: Docstring (** %s *) dropped.\n\
-                         %!"
-                        Location.print loc_before (ellipsis_cmt msg)
-                    else
-                      Format.fprintf fmt
-                        "%!@{<loc>%a@}:@,\
-                         @{<error>Error@}: Docstring (** %s *) moved to \
-                         @{<loc>%a@}.\n\
-                         %!"
-                        Location.print loc_before (ellipsis_cmt msg)
-                        Location.print loc_after
-                | Normalize.Unstable (loc, s) ->
-                    Format.fprintf fmt
-                      "%!@{<loc>%a@}:@,\
-                       @{<error>Error@}: Formatting of (** %s *) is \
-                       unstable (e.g. parses as a list or not depending on \
-                       the margin), please tighten up this comment in the \
-                       source or disable the formatting using the option \
-                       --no-parse-docstrings.\n\
-                       %!"
-                      Location.print loc (ellipsis_cmt s) )
-          | `Comment_dropped l when not quiet ->
-              List.iter l ~f:(fun Cmt.{txt= msg; loc} ->
-                  Format.fprintf fmt
-                    "%!@{<loc>%a@}:@,\
-                     @{<error>Error@}: Comment (* %s *) dropped.\n\
-                     %!"
-                    Location.print loc (ellipsis_cmt msg) )
-          | `Cannot_parse ((Syntaxerr.Error _ | Lexer.Error _) as exn) ->
-              if debug then Location.report_exception fmt exn
-          | `Warning50 l ->
-              if debug then List.iter l ~f:(fun (l, w) -> print_warning l w)
-          | _ -> () ) ;
-          if debug then
-            List.iter l ~f:(fun (msg, sexp) ->
-                Format.fprintf fmt "  %s: %s\n%!" msg (Sexp.to_string sexp) )
-      | exn ->
-          Format.fprintf fmt
-            "  BUG: unhandled exception. Use [--debug] for details.\n%!" ;
-          if debug then Format.fprintf fmt "%s\n%!" (Exn.to_string exn) )
 
 let check_all_locations fmt cmts_t =
   match Cmts.remaining_locs cmts_t with
@@ -288,7 +301,7 @@ let format (type a b) (fg0 : a list Ast_passes.Ast0.t)
                Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)) )
       in
       ( match parse fg0 conf ~source:fmted with
-      | exception Sys_error msg -> Error (User_error msg)
+      | exception Sys_error msg -> Error (Error.User_error msg)
       | exception Warning50 l -> internal_error (`Warning50 l) (exn_args ())
       | exception exn ->
           if opts.Conf.format_invalid_files then (
@@ -370,26 +383,28 @@ let format (type a b) (fg0 : a list Ast_passes.Ast0.t)
       (* Too many iteration ? *)
       if i >= conf.max_iters then (
         Caml.flush_all () ;
-        Error (Unstable {iteration= i; prev= prev_source; next= fmted}) )
+        Error
+          (Unstable {iteration= i; prev= prev_source; next= fmted; input_name}
+          ) )
       else
         (* All good, continue *)
         print_check ~i:(i + 1) ~conf ~prev_source:fmted t_new
   in
   try print_check ~i:1 ~conf ~prev_source parsed with
   | Sys_error msg -> Error (User_error msg)
-  | exn -> Error (Ocamlformat_bug {exn})
+  | exn -> Error (Ocamlformat_bug {exn; input_name})
 
 let parse_result fragment conf (opts : Conf.opts) ~source ~input_name =
   match parse fragment conf ~source with
   | exception exn ->
       if opts.format_invalid_files then (
         match parse fragment conf ~source:(recover fragment source) with
-        | exception exn -> Error (Invalid_source {exn})
+        | exception exn -> Error (Error.Invalid_source {exn; input_name})
         | parsed ->
             Format.fprintf Format.err_formatter
               "Warning: %s is invalid, recovering.\n%!" input_name ;
             Ok parsed )
-      else Error (Invalid_source {exn})
+      else Error (Invalid_source {exn; input_name})
   | parsed -> Ok parsed
 
 let parse_and_format (type a b) (fg0 : a list Ast_passes.Ast0.t)

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -9,7 +9,13 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type error
+module Error : sig
+  type t
+
+  val equal : t -> t -> bool
+
+  val print : ?debug:bool -> ?quiet:bool -> Format.formatter -> t -> unit
+end
 
 val parse_and_format :
      Syntax.t
@@ -18,17 +24,6 @@ val parse_and_format :
   -> source:string
   -> Conf.t
   -> Conf.opts
-  -> (string, error) Result.t
+  -> (string, Error.t) Result.t
 (** [parse_and_format kind conf ?output_file ~input_name ~source] parses and
     formats [source] as a list of fragments. *)
-
-val print_error :
-     fmt:Format.formatter
-  -> exe:string
-  -> debug:bool
-  -> quiet:bool
-  -> input_name:string
-  -> error
-  -> unit
-(** [print_error conf ?fmt ~input_name e] prints the error message
-    corresponding to error [e] on the [fmt] formatter (stderr by default). *)


### PR DESCRIPTION
Simplification extracted from #1586 to help with writing unit tests for translation_unit functions, no behavioral change.