### PR TITLE
Add unit tests for Translation_unit.parse_and_format

### DIFF
--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1536,6 +1536,8 @@ let conventional_profile =
   ; wrap_comments= C.default Formatting.wrap_comments
   ; wrap_fun_args= C.default Formatting.wrap_fun_args }
 
+let default_profile = conventional_profile
+
 let compact_profile =
   { ocamlformat_profile with
     break_before_in= `Auto
@@ -1658,7 +1660,7 @@ let janestreet_profile =
   ; wrap_comments= false
   ; wrap_fun_args= false }
 
-let selected_profile_ref = ref (Some conventional_profile)
+let selected_profile_ref = ref (Some default_profile)
 
 let (_profile : t option C.t) =
   let doc =
@@ -1672,7 +1674,7 @@ let (_profile : t option C.t) =
       , "The $(b,conventional) profile aims to be as familiar and \
          \"conventional\" appearing as the available options allow." )
     ; ( "default"
-      , Some conventional_profile
+      , Some default_profile
       , "$(b,default) is an alias for the $(b,conventional) profile." )
     ; ( "compact"
       , Some compact_profile
@@ -1994,7 +1996,7 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
   in
   let files = if !disable_conf_files then [] else files in
   let conf =
-    let init = conventional_profile in
+    let init = default_profile in
     List.fold files ~init ~f:read_config_file
     |> update_using_env |> C.update_using_cmdline
   in

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -81,6 +81,8 @@ type t =
   ; wrap_comments: bool  (** Wrap comments at margin. *)
   ; wrap_fun_args: bool }
 
+val default_profile : t
+
 type file = Stdin | File of string
 
 type input = {kind: Syntax.t; name: string; file: file; conf: t}

--- a/test/unit/test_translation_unit.ml
+++ b/test/unit/test_translation_unit.ml
@@ -1,0 +1,32 @@
+open! Base
+open Ocamlformat_lib
+
+let test_parse_and_format kind_name ~fg test_name ~input ~expected =
+  let test_name =
+    Stdlib.Format.sprintf "parse_and_format %s: %s" kind_name test_name
+  in
+  ( test_name
+  , `Quick
+  , fun () ->
+      let actual =
+        Translation_unit.parse_and_format fg ~input_name:"<test>"
+          ~source:input Conf.default_profile
+          Conf.
+            {debug= false; margin_check= false; format_invalid_files= false}
+        |> Result.map_error ~f:(fun e ->
+               Translation_unit.Error.print Stdlib.Format.str_formatter e ;
+               Stdlib.Format.flush_str_formatter () )
+      in
+      Alcotest.(check (result string string)) test_name expected actual )
+
+let test_parse_and_format_signature =
+  let make_test = test_parse_and_format "signature" ~fg:Signature in
+  [make_test "val" ~input:"val x :\n \nint" ~expected:(Ok "val x : int\n")]
+
+let test_parse_and_format_use_file =
+  let make_test = test_parse_and_format "use_file" ~fg:Use_file in
+  [make_test "let" ~input:"let x =\n\n y" ~expected:(Ok "let x = y\n")]
+
+let tests =
+  List.concat
+    [test_parse_and_format_signature @ test_parse_and_format_use_file]

--- a/test/unit/test_translation_unit.mli
+++ b/test/unit/test_translation_unit.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test_case list

--- a/test/unit/test_unit.ml
+++ b/test/unit/test_unit.ml
@@ -115,6 +115,7 @@ let tests =
   ; ("non overlapping interval tree", Test_noit.tests)
   ; ("Ast", Test_ast.tests)
   ; ("Literal_lexer", Test_literal_lexer.tests)
-  ; ("Fmt", Test_fmt.tests) ]
+  ; ("Fmt", Test_fmt.tests)
+  ; ("Translation_unit", Test_translation_unit.tests) ]
 
 let () = Alcotest.run "ocamlformat" tests


### PR DESCRIPTION
Extracted from #1586
- add unit tests
- define an alias `default_profile` for `conventional_profile` (should have been since the beginning) so default_profile is the base of the configuration construction, export `default_profile` for the unit tests
- no behavioral change