### PR TITLE
Prune infer/sledge/vendor/llvm-dune dir when running test_branch.sh

### DIFF
--- a/test-extra/Makefile
+++ b/test-extra/Makefile
@@ -21,7 +21,8 @@ XDIRS=code/ocaml
 PRUNE_DIRS= \
 	code/ocamlformat/test \
 	code/ocaml/experimental code/ocaml/testsuite/tests/parse-errors \
-	code/dune/test code/dune/vendor code/dune/otherlibs code/dune/example
+	code/dune/test code/dune/vendor code/dune/otherlibs code/dune/example \
+	code/infer/sledge/vendor/llvm-dune
 
 ALL_DIRS=$(DIRS) $(XDIRS)
 


### PR DESCRIPTION
This directory contains invalid doc comments that prevent the script test_branch.sh to give full results (it stops when it encounters this kind of error)