### PR TITLE
Improve formatting of odoc tags: break between the arg and the desc in priority

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 #### Bug fixes
 
-  + Fix formatting of odoc tags: the argument should be on the same line, indent description that wraps (#1634, @gpetiot)
+  + Fix formatting of odoc tags: the argument should be on the same line, indent description that wraps (#1634, #1635, @gpetiot)
 
 #### Changes
 

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -201,11 +201,8 @@ and fmt_list_light c kind items =
   in
   vbox 0 (list items "@," fmt_item)
 
-and fmt_nestable_block_elements c ?(prefix = noop) = function
-  | [] -> noop
-  | elems ->
-      prefix
-      $ hovbox 0 (list_block_elem elems (fmt_nestable_block_element c))
+and fmt_nestable_block_elements c elems =
+  list_block_elem elems (fmt_nestable_block_element c)
 
 let at = char '@'
 
@@ -214,7 +211,9 @@ let space = fmt "@ "
 let fmt_tag_args ?arg ?txt c tag =
   at $ str tag
   $ opt arg (fun x -> char ' ' $ x)
-  $ opt txt (fun x -> fmt_nestable_block_elements c ~prefix:space x)
+  $ opt txt (function
+      | [] -> noop
+      | x -> space $ hovbox 0 (fmt_nestable_block_elements c x) )
 
 let wrap_see = function
   | `Url -> wrap "<" ">"

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -203,7 +203,9 @@ and fmt_list_light c kind items =
 
 and fmt_nestable_block_elements c ?(prefix = noop) = function
   | [] -> noop
-  | elems -> prefix $ list_block_elem elems (fmt_nestable_block_element c)
+  | elems ->
+      prefix
+      $ hovbox 0 (list_block_elem elems (fmt_nestable_block_element c))
 
 let at = char '@'
 

--- a/test/passing/tests/doc_comments.mli
+++ b/test/passing/tests/doc_comments.mli
@@ -101,6 +101,8 @@ val k : k
 
     @param foo [foo]
 
+    @param Foooooooooooooo_Baaaaaaaaaaaaar Fooooooooooo foooooooooooo fooooooooooo baaaaaaaaar
+
     @param Foooooooooooooooooooooooooooooooooooo_baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar Foo bar
 
     @raise foo [foo]

--- a/test/passing/tests/doc_comments.mli.ref
+++ b/test/passing/tests/doc_comments.mli.ref
@@ -88,9 +88,12 @@ val k : k
     @before Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
       Foo bar
     @deprecated [foo]
-    @deprecated Foooooooooooooooooooooooooooooooooooo
+    @deprecated
+      Foooooooooooooooooooooooooooooooooooo
       Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar Foo bar
     @param foo [foo]
+    @param Foooooooooooooo_Baaaaaaaaaaaaar
+      Fooooooooooo foooooooooooo fooooooooooo baaaaaaaaar
     @param Foooooooooooooooooooooooooooooooooooo_baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
       Foo bar
     @raise foo [foo]


### PR DESCRIPTION
Follow-up on #1634