### PR TITLE
Consistently format let bindings and monadic let bindings, do not drop comments before monadic bindings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
   + Fix formatting of odoc tags: the argument should be on the same line, indent description that wraps (#1634, #1635, @gpetiot)
 
+  + Consistently format let bindings and monadic let bindings, do not drop comments before monadic bindings (#1636, @gpetiot)
+
 #### Changes
 
 #### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2183,7 +2183,6 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       in
       let bindings = Sugar.value_bindings bindings in
       let fmt_expr = fmt_expression c (sub_exp ~ctx body) in
-      let parens = parens || not (List.is_empty pexp_attributes) in
       fmt_let c ctx ~ext ~rec_flag ~bindings ~parens ~loc:pexp_loc
         ~attributes:pexp_attributes ~fmt_atrs ~fmt_expr
         ~body_loc:body.pexp_loc ~indent_after_in
@@ -2595,7 +2594,6 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       in
       let bindings = Sugar.binding_ops (let_ :: ands) in
       let fmt_expr = fmt_expression c (sub_exp ~ctx body) in
-      let parens = parens || not (List.is_empty pexp_attributes) in
       fmt_let c ctx ~ext ~rec_flag:Nonrecursive ~bindings ~parens
         ~loc:pexp_loc ~attributes:pexp_attributes ~fmt_atrs ~fmt_expr
         ~body_loc:body.pexp_loc ~indent_after_in
@@ -2779,7 +2777,6 @@ and fmt_class_expr c ?eol ?(box = true) ({ast= exp; _} as xexp) =
       in
       let bindings = Sugar.value_bindings bindings in
       let fmt_expr = fmt_class_expr c (sub_cl ~ctx body) in
-      let parens = parens || not (List.is_empty pcl_attributes) in
       fmt_let c ctx ~ext:None ~rec_flag ~bindings ~parens ~loc:pcl_loc
         ~attributes:pcl_attributes ~fmt_atrs ~fmt_expr ~body_loc:body.pcl_loc
         ~indent_after_in
@@ -4272,6 +4269,7 @@ and fmt_structure_item c ~last:last_item ?ext {ctx; ast= si} =
 
 and fmt_let c ctx ~ext ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr ~loc
     ~body_loc ~attributes ~indent_after_in =
+  let parens = parens || not (List.is_empty attributes) in
   let fmt_in indent =
     match c.conf.break_before_in with
     | `Fit_or_vertical -> break 1 (-indent) $ str "in"

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2169,6 +2169,11 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let fmt_expr = fmt_expression c (sub_exp ~ctx body) in
       fmt_let_bindings c ~ctx ?ext ~parens ~loc:pexp_loc ~fmt_atrs ~fmt_expr
         ~attributes:pexp_attributes rec_flag bindings body
+  | Pexp_letop {let_; ands; body} ->
+      let bindings = Sugar.binding_ops (let_ :: ands) in
+      let fmt_expr = fmt_expression c (sub_exp ~ctx body) in
+      fmt_let_bindings c ~ctx ?ext ~parens ~loc:pexp_loc ~fmt_atrs ~fmt_expr
+        ~attributes:pexp_attributes Nonrecursive bindings body
   | Pexp_letexception (ext_cstr, exp) ->
       let pre =
         str "let exception" $ fmt_extension_suffix c ext $ fmt "@ "
@@ -2558,11 +2563,6 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
            $ fmt_atrs ) )
   | Pexp_poly _ ->
       impossible "only used for methods, handled during method formatting"
-  | Pexp_letop {let_; ands; body} ->
-      let bindings = Sugar.binding_ops (let_ :: ands) in
-      let fmt_expr = fmt_expression c (sub_exp ~ctx body) in
-      fmt_let_bindings c ~ctx ?ext ~parens ~loc:pexp_loc ~fmt_atrs ~fmt_expr
-        ~attributes:pexp_attributes Nonrecursive bindings body
 
 and fmt_let_bindings c ~ctx ?ext ~parens ~loc ~attributes ~fmt_atrs ~fmt_expr
     rec_flag bindings body =

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -21,6 +21,8 @@ module Asttypes = struct
   let is_override = function Override -> true | Fresh -> false
 
   let is_mutable = function Mutable -> true | Immutable -> false
+
+  let is_recursive = function Recursive -> true | Nonrecursive -> false
 end
 
 module Position = struct

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -21,6 +21,8 @@ module Asttypes : sig
   val is_override : override_flag -> bool
 
   val is_mutable : mutable_flag -> bool
+
+  val is_recursive : rec_flag -> bool
 end
 
 module Position : sig

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -347,3 +347,26 @@ let polynewtype cmts pat body =
         ~after:pat2.ppat_loc ;
       polynewtype_ pvars body
   | _ -> None
+
+type let_binding =
+  { lb_op: string loc
+  ; lb_pat: pattern
+  ; lb_exp: expression
+  ; lb_attrs: attribute list
+  ; lb_loc: Location.t }
+
+let value_bindings vbs =
+  List.mapi vbs ~f:(fun i vb ->
+      { lb_op= Location.{txt= (if i = 0 then "let" else "and"); loc= none}
+      ; lb_pat= vb.pvb_pat
+      ; lb_exp= vb.pvb_expr
+      ; lb_attrs= vb.pvb_attributes
+      ; lb_loc= vb.pvb_loc } )
+
+let binding_ops bos =
+  List.map bos ~f:(fun bo ->
+      { lb_op= bo.pbop_op
+      ; lb_pat= bo.pbop_pat
+      ; lb_exp= bo.pbop_exp
+      ; lb_attrs= []
+      ; lb_loc= bo.pbop_loc } )

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -147,3 +147,14 @@ val polynewtype :
     Can be rewritten as:
 
     {[ let f : type r s. r s t = e ]} *)
+
+type let_binding =
+  { lb_op: string loc
+  ; lb_pat: pattern
+  ; lb_exp: expression
+  ; lb_attrs: attribute list
+  ; lb_loc: Location.t }
+
+val value_bindings : value_binding list -> let_binding list
+
+val binding_ops : binding_op list -> let_binding list

--- a/test/passing/tests/let_binding-in_indent.ml.ref
+++ b/test/passing/tests/let_binding-in_indent.ml.ref
@@ -190,4 +190,8 @@ let _ =
 let _ =
   f
     (let+ a b = c in
-         d)
+         d )
+
+let () =
+  let* x = 1 (* blah *) and* y = 2 in
+      ()

--- a/test/passing/tests/let_binding-indent.ml.ref
+++ b/test/passing/tests/let_binding-indent.ml.ref
@@ -190,4 +190,8 @@ let _ =
 let _ =
       f
         (let+ a b = c in
-         d)
+         d )
+
+let () =
+      let* x = 1 (* blah *) and* y = 2 in
+      ()

--- a/test/passing/tests/let_binding.ml
+++ b/test/passing/tests/let_binding.ml
@@ -178,3 +178,7 @@ let _ =
 
 
 let _ = f (let+ a b = c in d)
+
+let () =
+  let* x = 1 (* blah *) and* y = 2 in
+  ()

--- a/test/passing/tests/let_binding.ml.ref
+++ b/test/passing/tests/let_binding.ml.ref
@@ -190,4 +190,8 @@ let _ =
 let _ =
   f
     (let+ a b = c in
-     d)
+     d )
+
+let () =
+  let* x = 1 (* blah *) and* y = 2 in
+  ()


### PR DESCRIPTION
Fix #1623, no diff with test_branch.sh

- factorize formatting of `Pexp_let` and `Pexp_letop` with a new function `fmt_let_bindings`
- define a new sugared type `let_binding` in `Sugar`, with conversion functions; use it for `Pstr_value`, `Pcl_let`, `Pexp_let`, `Pexp_letop`
- side-effect: `indicate-multiline-delimiters` is now taken into consideration for letop bindings