### PR TITLE
Use consistent positioning for doc-comments in recursive type definitions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 #### Changes
 
+  + Use consistent positioning for doc-comments in recursive type definitions (#1647, @gpetiot)
+
 #### New features
 
 ### 0.18.0 (2021-03-30)

--- a/test/passing/tests/doc_comments-after.ml.ref
+++ b/test/passing/tests/doc_comments-after.ml.ref
@@ -290,3 +290,9 @@ let _ = ()
 (** @see 'file' *)
 
 (** @see "title" *)
+
+(** Foo *)
+type 'a or_subexpr = Sub of expression | Literal of 'a
+
+(** Bar *)
+and word = string or_subexpr list

--- a/test/passing/tests/doc_comments-before-except-val.ml.ref
+++ b/test/passing/tests/doc_comments-before-except-val.ml.ref
@@ -290,3 +290,9 @@ let _ = ()
 (** @see 'file' *)
 
 (** @see "title" *)
+
+(** Foo *)
+type 'a or_subexpr = Sub of expression | Literal of 'a
+
+(** Bar *)
+and word = string or_subexpr list

--- a/test/passing/tests/doc_comments-before.ml.ref
+++ b/test/passing/tests/doc_comments-before.ml.ref
@@ -290,3 +290,9 @@ let _ = ()
 (** @see 'file' *)
 
 (** @see "title" *)
+
+(** Foo *)
+type 'a or_subexpr = Sub of expression | Literal of 'a
+
+(** Bar *)
+and word = string or_subexpr list

--- a/test/passing/tests/doc_comments.ml
+++ b/test/passing/tests/doc_comments.ml
@@ -283,3 +283,9 @@ let _ = ()
 
 (** @see 'file' *)
 (** @see "title" *)
+
+(** Foo *)
+type 'a or_subexpr = Sub of expression | Literal of 'a
+
+(** Bar *)
+and word = string or_subexpr list

--- a/test/passing/tests/doc_comments.ml.ref
+++ b/test/passing/tests/doc_comments.ml.ref
@@ -290,3 +290,9 @@ let _ = ()
 (** @see 'file' *)
 
 (** @see "title" *)
+
+(** Foo *)
+type 'a or_subexpr = Sub of expression | Literal of 'a
+
+(** Bar *)
+and word = string or_subexpr list


### PR DESCRIPTION
Fix #1598

The diff of test_branch.sh with conventional profile: (more consistent)
```diff
diff --git a/infer/src/IR/Annot.ml b/infer/src/IR/Annot.ml
index 10b26c4c4..b081d4118 100644
--- a/infer/src/IR/Annot.ml
+++ b/infer/src/IR/Annot.ml
@@ -11,13 +11,13 @@
 open! IStd
 module F = Format
 
+(** Type to represent an [@Annotation] with potentially complex parameter values such as arrays or
+    other annotations. *)
 type t = {
   class_name : string;  (** name of the annotation *)
   parameters : parameter list;
 }
 [@@deriving compare, equal]
-(** Type to represent an [@Annotation] with potentially complex parameter values such as arrays or
-    other annotations. *)
 
 and parameter = { name : string option; value : value } [@@deriving compare]
 
diff --git a/infer/src/IR/Annot.mli b/infer/src/IR/Annot.mli
index 728e10466..a60505983 100644
--- a/infer/src/IR/Annot.mli
+++ b/infer/src/IR/Annot.mli
@@ -11,13 +11,13 @@
 open! IStd
 module F = Format
 
+(** Type to represent an [@Annotation] with potentially complex parameter values such as arrays or
+    other annotations. *)
 type t = {
   class_name : string;  (** name of the annotation *)
   parameters : parameter list;
 }
 [@@deriving compare, equal]
-(** Type to represent an [@Annotation] with potentially complex parameter values such as arrays or
-    other annotations. *)
 
 and parameter = { name : string option; value : value } [@@deriving compare]
 
diff --git a/infer/src/IR/Exp.ml b/infer/src/IR/Exp.ml
index 1d7e73fbb..300b0d2f7 100644
--- a/infer/src/IR/Exp.ml
+++ b/infer/src/IR/Exp.ml
@@ -23,12 +23,6 @@ type closure = {
   captured_vars : (t * Pvar.t * Typ.t * CapturedVar.capture_mode) list;
 }
 
-and sizeof_data = {
-  typ : Typ.t;
-  nbytes : int option;
-  dynamic_length : t option;
-  subtype : Subtype.t;
-}
 (** This records information about a [sizeof(typ)] expression.
 
     [nbytes] represents the result of the evaluation of [sizeof(typ)] if it is statically known.
@@ -39,6 +33,12 @@ and sizeof_data = {
     over-allocated.
 
     If [typ] is a struct type, the [dynamic_length] is that of the final extensible array, if any.*)
+and sizeof_data = {
+  typ : Typ.t;
+  nbytes : int option;
+  dynamic_length : t option;
+  subtype : Subtype.t;
+}
 
 (** Program expressions. *)
 and t =
diff --git a/infer/src/IR/Exp.mli b/infer/src/IR/Exp.mli
index dd5aaea52..0d06ca23c 100644
--- a/infer/src/IR/Exp.mli
+++ b/infer/src/IR/Exp.mli
@@ -18,12 +18,6 @@ type closure = {
   captured_vars : (t * Pvar.t * Typ.t * CapturedVar.capture_mode) list;
 }
 
-and sizeof_data = {
-  typ : Typ.t;
-  nbytes : int option;
-  dynamic_length : t option;
-  subtype : Subtype.t;
-}
 (** This records information about a [sizeof(typ)] expression.
 
     [nbytes] represents the result of the evaluation of [sizeof(typ)] if it is statically known.
@@ -34,6 +28,12 @@ and sizeof_data = {
     over-allocated.
 
     If [typ] is a struct type, the [dynamic_length] is that of the final extensible array, if any.*)
+and sizeof_data = {
+  typ : Typ.t;
+  nbytes : int option;
+  dynamic_length : t option;
+  subtype : Subtype.t;
+}
 
 (** Program expressions. *)
 and t =
diff --git a/infer/src/IR/Typ.ml b/infer/src/IR/Typ.ml
index b3bb4bdd6..b565be0ad 100644
--- a/infer/src/IR/Typ.ml
+++ b/infer/src/IR/Typ.ml
@@ -153,8 +153,8 @@ module T = struct
   type type_quals = { is_const : bool; is_restrict : bool; is_volatile : bool }
   [@@deriving compare, equal, yojson_of]
 
-  type t = { desc : desc; quals : type_quals }
   (** types for sil (structured) expressions *)
+  type t = { desc : desc; quals : type_quals }
 
   and desc =
     | Tint of ikind  (** integer type *)
diff --git a/infer/src/IR/Typ.mli b/infer/src/IR/Typ.mli
index 671a0b86a..8a5bfa476 100644
--- a/infer/src/IR/Typ.mli
+++ b/infer/src/IR/Typ.mli
@@ -95,8 +95,8 @@ val is_restrict : type_quals -> bool
 
 val is_volatile : type_quals -> bool
 
-type t = { desc : desc; quals : type_quals } [@@deriving compare, yojson_of]
 (** types for sil (structured) expressions *)
+type t = { desc : desc; quals : type_quals } [@@deriving compare, yojson_of]
 
 and desc =
   | Tint of ikind  (** integer type *)
diff --git a/infer/src/absint/AccessPath.mli b/infer/src/absint/AccessPath.mli
index 2acda4017..d116d35d0 100644
--- a/infer/src/absint/AccessPath.mli
+++ b/infer/src/absint/AccessPath.mli
@@ -17,9 +17,9 @@ type access =
   | FieldAccess of Fieldname.t  (** field name *)
 [@@deriving compare, equal]
 
-and t = base * access list [@@deriving compare]
 (** root var, and a list of accesses. closest to the root var is first that is, x.f.g is represented
     as (x, [f; g]) *)
+and t = base * access list [@@deriving compare]
 
 val get_typ : t -> Tenv.t -> Typ.t option
 (** get the typ of the last access in the list of accesses if the list is non-empty, or the base if
diff --git a/infer/src/biabduction/Predicates.ml b/infer/src/biabduction/Predicates.ml
index 3233728fb..c66be53b7 100644
--- a/infer/src/biabduction/Predicates.ml
+++ b/infer/src/biabduction/Predicates.ml
@@ -113,6 +113,8 @@ and 'inst hpara0 = {
 }
 [@@deriving compare]
 
+(** parameter for the higher-order doubly-linked list predicates. Assume that all the free
+    identifiers in body_dll should belong to cell, blink, flink, svars_dll, evars_dll. *)
 and 'inst hpara_dll0 = {
   cell : Ident.t;  (** address cell *)
   blink : Ident.t;  (** backward link *)
@@ -122,8 +124,6 @@ and 'inst hpara_dll0 = {
   body_dll : 'inst hpred0 list;
 }
 [@@deriving compare]
-(** parameter for the higher-order doubly-linked list predicates. Assume that all the free
-    identifiers in body_dll should belong to cell, blink, flink, svars_dll, evars_dll. *)
 
 type hpred = inst hpred0
 
diff --git a/infer/src/biabduction/Predicates.mli b/infer/src/biabduction/Predicates.mli
index 7f9b32962..5a4efadde 100644
--- a/infer/src/biabduction/Predicates.mli
+++ b/infer/src/biabduction/Predicates.mli
@@ -143,6 +143,8 @@ and 'inst hpara0 = {
 }
 [@@deriving compare]
 
+(** parameter for the higher-order doubly-linked list predicates. Assume that all the free
+    identifiers in body_dll should belong to cell, blink, flink, svars_dll, evars_dll. *)
 and 'inst hpara_dll0 = {
   cell : Ident.t;  (** address cell *)
   blink : Ident.t;  (** backward link *)
@@ -152,8 +154,6 @@ and 'inst hpara_dll0 = {
   body_dll : 'inst hpred0 list;
 }
 [@@deriving compare]
-(** parameter for the higher-order doubly-linked list predicates. Assume that all the free
-    identifiers in body_dll should belong to cell, blink, flink, svars_dll, evars_dll. *)
 
 type hpred = inst hpred0
 
diff --git a/sledge/src/llair/llair.mli b/sledge/src/llair/llair.mli
index b048702d0..6e23c88c3 100644
--- a/sledge/src/llair/llair.mli
+++ b/sledge/src/llair/llair.mli
@@ -58,9 +58,10 @@ type cmnd = inst iarray
 type label = string
 (** A label is a name of a block. *)
 
-type jump = private { mutable dst : block; mutable retreating : bool }
 (** A jump to a block. *)
+type jump = private { mutable dst : block; mutable retreating : bool }
 
+(** A call to a function. *)
 and 'a call = {
   mutable callee : 'a;
   typ : Typ.t;  (** Type of the callee. *)
@@ -72,7 +73,6 @@ and 'a call = {
       (** Holds unless [callee] is definitely not recursive. *)
   loc : Loc.t;
 }
-(** A call to a function. *)
 
 (** Block terminators for function call/return or other control transfers. *)
 and term = private
@@ -95,6 +95,7 @@ and term = private
           not [None]. *)
   | Unreachable  (** Halt as control is assumed to never reach [Unreachable]. *)
 
+(** A block is a destination of a jump with arguments, contains code. *)
 and block = private {
   lbl : label;
   cmnd : cmnd;
@@ -103,8 +104,9 @@ and block = private {
   mutable sort_index : int;
       (** Position in a topological order, ignoring [retreating] edges. *)
 }
-(** A block is a destination of a jump with arguments, contains code. *)
 
+(** A function is a control-flow graph with distinguished entry block, whose
+    parameters are the function parameters. *)
 and func = private {
   name : Function.t;
   formals : Reg.t iarray;  (** Formal parameters *)
@@ -114,8 +116,6 @@ and func = private {
   entry : block;
   loc : Loc.t;
 }
-(** A function is a control-flow graph with distinguished entry block, whose
-    parameters are the function parameters. *)
```