### PR TITLE
Fix alignment of closing paren on separate line for anonymous functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@
 
   + Preserve begin-end keywords delimiting match cases (#1651, @gpetiot)
 
+  + Fix alignment of closing paren on separate line for anonymous functions (#1649, @gpetiot)
+
 #### Changes
 
 #### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2102,7 +2102,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       in
       hvbox_if (box || body_is_function) indent
         (Params.wrap_exp c.conf c.source ~loc:pexp_loc ~parens
-           ~disambiguate:true ~fits_breaks:false
+           ~disambiguate:true ~fits_breaks:false ~offset_closing_paren:(-2)
            ( hovbox 2
                ( hovbox 4
                    ( str "fun "

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -41,7 +41,7 @@ let parens_if parens (c : Conf.t) ?(disambiguate = false) k =
 let parens c ?disambiguate k = parens_if true c ?disambiguate k
 
 let wrap_exp (c : Conf.t) ?(disambiguate = false) ?(fits_breaks = true)
-    ~parens ~loc source k =
+    ?(offset_closing_paren = 0) ~parens ~loc source k =
   match parens_or_begin_end c source ~loc with
   | `Parens when disambiguate && c.Conf.disambiguate_non_breaking_match ->
       wrap_if_fits_or parens "(" ")" k
@@ -52,7 +52,8 @@ let wrap_exp (c : Conf.t) ?(disambiguate = false) ?(fits_breaks = true)
     | `Space ->
         Fmt.fits_breaks "(" "(" $ k $ Fmt.fits_breaks ")" ~hint:(1, 0) ")"
     | `Closing_on_separate_line ->
-        Fmt.fits_breaks "(" "(" $ k $ Fmt.fits_breaks ")" ~hint:(1000, 0) ")"
+        Fmt.fits_breaks "(" "(" $ k
+        $ Fmt.fits_breaks ")" ~hint:(1000, offset_closing_paren) ")"
     | _ -> wrap "(" ")" k )
   | `Begin_end ->
       vbox 2 (wrap "begin" "end" (wrap_k (break 1 0) (break 1000 ~-2) k))

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -21,6 +21,9 @@ val wrap_exp :
   -> ?disambiguate:bool
   -> ?fits_breaks:bool
   -> ?offset_closing_paren:int
+       (** Offset of the closing paren in case the line has been broken and
+           the option [indicate-multiline-delimiters] is set to
+           [closing-on-separate-line]. By default the offset is 0. *)
   -> parens:bool
   -> loc:Location.t
   -> Source.t

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -20,6 +20,7 @@ val wrap_exp :
      Conf.t
   -> ?disambiguate:bool
   -> ?fits_breaks:bool
+  -> ?offset_closing_paren:int
   -> parens:bool
   -> loc:Location.t
   -> Source.t

--- a/test/passing/tests/apply.ml
+++ b/test/passing/tests/apply.ml
@@ -58,7 +58,7 @@ let whatever a_function_name long_list_one some_other_thing =
     (fun long_list_one_elt ->
       do_something_with_a_function_and_some_things a_function_name
         long_list_one_elt some_other_thing
-      )
+    )
     long_list_one
 
 let whatever_labelled a_function_name long_list_one some_other_thing =

--- a/test/passing/tests/indicate_multiline_delimiters-cosl.ml.ref
+++ b/test/passing/tests/indicate_multiline_delimiters-cosl.ml.ref
@@ -5,3 +5,42 @@ let compare = function
   | Le -> ( <= )
   | Gt -> ( > )
   | Ge -> ( >= )
+
+let raise fmt =
+  Fmt.kstr
+    (fun error_message (result : _ result) ->
+      match result with
+      | Ok v -> v
+      | Error `Oh_no -> invalid_arg error_message
+    )
+    fmt
+
+let raise fmt =
+  Fmt.kstr
+    (fun error_message aaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbb ->
+      invalid_arg error_message
+    )
+    fmt
+
+let raise fmt =
+  Fmt.kstr
+    (fun error_message (result : _ result) ->
+      match result with
+      | Ok v -> v
+      | Error `Oh_no -> invalid_arg error_message
+    )
+    fmt
+
+let raise fmt =
+  Fmt.kstr
+    (fun error_message aaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbb ->
+      invalid_arg error_message
+    )
+    fmt
+
+let contrived =
+  List.map
+    ~f:(fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+      f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    )
+    l

--- a/test/passing/tests/indicate_multiline_delimiters-space.ml.ref
+++ b/test/passing/tests/indicate_multiline_delimiters-space.ml.ref
@@ -5,3 +5,37 @@ let compare = function
   | Le -> ( <= )
   | Gt -> ( > )
   | Ge -> ( >= )
+
+let raise fmt =
+  Fmt.kstr
+    (fun error_message (result : _ result) ->
+      match result with
+      | Ok v -> v
+      | Error `Oh_no -> invalid_arg error_message )
+    fmt
+
+let raise fmt =
+  Fmt.kstr
+    (fun error_message aaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbb ->
+      invalid_arg error_message )
+    fmt
+
+let raise fmt =
+  Fmt.kstr
+    (fun error_message (result : _ result) ->
+      match result with
+      | Ok v -> v
+      | Error `Oh_no -> invalid_arg error_message )
+    fmt
+
+let raise fmt =
+  Fmt.kstr
+    (fun error_message aaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbb ->
+      invalid_arg error_message )
+    fmt
+
+let contrived =
+  List.map
+    ~f:(fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+      f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa )
+    l

--- a/test/passing/tests/indicate_multiline_delimiters.ml
+++ b/test/passing/tests/indicate_multiline_delimiters.ml
@@ -5,3 +5,37 @@ let compare = function
   | Le -> ( <= )
   | Gt -> ( > )
   | Ge -> ( >= )
+
+let raise fmt =
+  Fmt.kstr
+    (fun error_message (result : _ result) ->
+      match result with
+      | Ok v -> v
+      | Error `Oh_no -> invalid_arg error_message)
+    fmt
+
+let raise fmt =
+  Fmt.kstr
+    (fun error_message aaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbb ->
+      invalid_arg error_message)
+    fmt
+
+let raise fmt =
+  Fmt.kstr
+    (fun error_message (result : _ result) ->
+      match result with
+      | Ok v -> v
+      | Error `Oh_no -> invalid_arg error_message)
+    fmt
+
+let raise fmt =
+  Fmt.kstr
+    (fun error_message aaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbb ->
+      invalid_arg error_message)
+    fmt
+
+let contrived =
+  List.map
+    ~f:(fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+      f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+    l


### PR DESCRIPTION
Fix #1579, the diff of test_branch.sh shows improvements of the paren alignment just like the tests I've added!