### PR TITLE
Preserve begin-end keywords delimiting match cases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
 
   + Add missing parens around function at RHS of infix op (#1642, @gpetiot)
 
+  + Preserve begin-end keywords delimiting match cases (#1651, @gpetiot)
+
 #### Changes
 
 #### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3022,7 +3022,7 @@ and fmt_case c ctx ~first ~last ~padding case =
     | (Pexp_match _ | Pexp_try _), `Align -> last
     | _ -> false
   in
-  let parens_here, parens_for_exp =
+  let parens_branch, parens_for_exp =
     if align_nested_match then (false, Some false)
     else if c.conf.leading_nested_match_parens then (false, None)
     else if is_displaced_infix_op xrhs then (false, None)
@@ -3042,9 +3042,9 @@ and fmt_case c ctx ~first ~last ~padding case =
       (fmt "@;<1000 0>")
   in
   let indent = if align_nested_match then 0 else indent in
-  let p = Params.get_cases c.conf ~first ~indent ~parens_here in
-  let grouping =
-    Params.parens_or_begin_end c.conf c.source ~loc:pc_rhs.pexp_loc
+  let p =
+    Params.get_cases c.conf ~first ~indent ~parens_branch c.source
+      ~loc:pc_rhs.pexp_loc
   in
   p.leading_space $ leading_cmt
   $ p.box_all
@@ -3056,21 +3056,11 @@ and fmt_case c ctx ~first ~last ~padding case =
                     fmt "@;<1 2>when " $ fmt_expression c (sub_exp ~ctx g) )
               )
           $ p.break_before_arrow $ str "->" $ p.break_after_arrow
-          $ fmt_if parens_here
-              ( match grouping with
-              | `Parens -> " ("
-              | `Begin_end -> "@;<1 0>begin" ) )
+          $ p.open_paren_branch )
       $ p.break_after_opening_paren
       $ hovbox 0
           ( fmt_expression ?eol c ?parens:parens_for_exp xrhs
-          $ fmt_if parens_here
-              ( match grouping with
-              | `Parens -> (
-                match c.conf.indicate_multiline_delimiters with
-                | `Space -> "@ )"
-                | `No -> "@,)"
-                | `Closing_on_separate_line -> "@;<1000 -2>)" )
-              | `Begin_end -> "@;<1000 -2>end" ) ) )
+          $ p.close_paren_branch ) )
 
 and fmt_value_description ?ext c ctx vd =
   let {pval_name= {txt; loc}; pval_type; pval_prim; pval_attributes; pval_loc}

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -93,14 +93,16 @@ let get_cases (c : Conf.t) ~first ~indent ~parens_branch source ~loc =
       (match grouping with `Parens -> " (" | `Begin_end -> "@;<1 0>begin")
   in
   let close_paren_branch =
-    fmt_if parens_branch
+    fmt_if_k parens_branch
       ( match grouping with
       | `Parens -> (
         match c.indicate_multiline_delimiters with
-        | `Space -> "@ )"
-        | `No -> "@,)"
-        | `Closing_on_separate_line -> "@;<1000 -2>)" )
-      | `Begin_end -> "@;<1000 -2>end" )
+        | `Space -> fmt "@ )"
+        | `No -> fmt "@,)"
+        | `Closing_on_separate_line -> fmt "@;<1000 -2>)" )
+      | `Begin_end ->
+          let offset = match c.break_cases with `Nested -> 0 | _ -> -2 in
+          fits_breaks " end" ~level:1 ~hint:(1000, offset) "end" )
   in
   match c.break_cases with
   | `Fit ->

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -12,6 +12,9 @@
 module Format = Format_
 open Ast_passes.Ast_final
 
+val parens_or_begin_end :
+  Conf.t -> Source.t -> loc:Location.t -> [`Parens | `Begin_end]
+
 val parens_if : bool -> Conf.t -> ?disambiguate:bool -> Fmt.t -> Fmt.t
 
 val parens : Conf.t -> ?disambiguate:bool -> Fmt.t -> Fmt.t

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -12,9 +12,6 @@
 module Format = Format_
 open Ast_passes.Ast_final
 
-val parens_or_begin_end :
-  Conf.t -> Source.t -> loc:Location.t -> [`Parens | `Begin_end]
-
 val parens_if : bool -> Conf.t -> ?disambiguate:bool -> Fmt.t -> Fmt.t
 
 val parens : Conf.t -> ?disambiguate:bool -> Fmt.t -> Fmt.t
@@ -39,10 +36,18 @@ type cases =
   ; box_pattern_arrow: Fmt.t -> Fmt.t
   ; break_before_arrow: Fmt.t
   ; break_after_arrow: Fmt.t
-  ; break_after_opening_paren: Fmt.t }
+  ; open_paren_branch: Fmt.t
+  ; break_after_opening_paren: Fmt.t
+  ; close_paren_branch: Fmt.t }
 
 val get_cases :
-  Conf.t -> first:bool -> indent:int -> parens_here:bool -> cases
+     Conf.t
+  -> first:bool
+  -> indent:int
+  -> parens_branch:bool
+  -> Source.t
+  -> loc:Location.t
+  -> cases
 
 val wrap_tuple :
   Conf.t -> parens:bool -> no_parens_if_break:bool -> Fmt.t -> Fmt.t

--- a/test/passing/tests/break_cases-align.ml.ref
+++ b/test/passing/tests/break_cases-align.ml.ref
@@ -278,3 +278,23 @@ let get_nullability = function
     (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull
+
+[@@@ocamlformat "exp-grouping=preserve"]
+
+let _ =
+  match x with
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+  end
+  | A ->
+  match B with
+  | A -> fooooooooooooo
+  | B -> fooooooooooooo
+  | C -> fooooooooooooo
+  | D -> fooooooooooooo

--- a/test/passing/tests/break_cases-all.ml.ref
+++ b/test/passing/tests/break_cases-all.ml.ref
@@ -278,3 +278,24 @@ let get_nullability = function
     (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull
+
+[@@@ocamlformat "exp-grouping=preserve"]
+
+let _ =
+  match x with
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+    | C -> fooooooooooooo
+    | D -> fooooooooooooo
+  end

--- a/test/passing/tests/break_cases-closing_on_separate_line.ml.ref
+++ b/test/passing/tests/break_cases-closing_on_separate_line.ml.ref
@@ -293,3 +293,24 @@ let get_nullability = function
     (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull
+
+[@@@ocamlformat "exp-grouping=preserve"]
+
+let _ =
+  match x with
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+    | C -> fooooooooooooo
+    | D -> fooooooooooooo
+  end

--- a/test/passing/tests/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref
+++ b/test/passing/tests/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref
@@ -293,3 +293,27 @@ let get_nullability = function
     (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull
+
+[@@@ocamlformat "exp-grouping=preserve"]
+
+let _ =
+  match x with
+  | A ->
+    begin
+      match B with
+      | A -> fooooooooooooo
+    end
+  | A ->
+    begin
+      match B with
+      | A -> fooooooooooooo
+      | B -> fooooooooooooo
+    end
+  | A ->
+    begin
+      match B with
+      | A -> fooooooooooooo
+      | B -> fooooooooooooo
+      | C -> fooooooooooooo
+      | D -> fooooooooooooo
+    end

--- a/test/passing/tests/break_cases-cosl_lnmp_cmei.ml.ref
+++ b/test/passing/tests/break_cases-cosl_lnmp_cmei.ml.ref
@@ -293,3 +293,27 @@ let get_nullability = function
     (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull
+
+[@@@ocamlformat "exp-grouping=preserve"]
+
+let _ =
+  match x with
+  | A ->
+      begin
+        match B with
+        | A -> fooooooooooooo
+      end
+  | A ->
+      begin
+        match B with
+        | A -> fooooooooooooo
+        | B -> fooooooooooooo
+      end
+  | A ->
+      begin
+        match B with
+        | A -> fooooooooooooo
+        | B -> fooooooooooooo
+        | C -> fooooooooooooo
+        | D -> fooooooooooooo
+      end

--- a/test/passing/tests/break_cases-fit_or_vertical.ml.ref
+++ b/test/passing/tests/break_cases-fit_or_vertical.ml.ref
@@ -237,3 +237,24 @@ let get_nullability = function
   | Undef
     (* This is a very special case, assigning non-null is a technical trick *)
     -> Nullability.Nonnull
+
+[@@@ocamlformat "exp-grouping=preserve"]
+
+let _ =
+  match x with
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+    | C -> fooooooooooooo
+    | D -> fooooooooooooo
+  end

--- a/test/passing/tests/break_cases-nested.ml.ref
+++ b/test/passing/tests/break_cases-nested.ml.ref
@@ -244,3 +244,25 @@ let get_nullability = function
     (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull
+
+[@@@ocamlformat "exp-grouping=preserve"]
+
+let _ =
+  match x with
+  | A -> begin
+    match B with A -> fooooooooooooo
+  end
+  | A -> begin
+    match B with A -> fooooooooooooo | B -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A ->
+        fooooooooooooo
+    | B ->
+        fooooooooooooo
+    | C ->
+        fooooooooooooo
+    | D ->
+        fooooooooooooo
+    end

--- a/test/passing/tests/break_cases-normal_indent.ml.ref
+++ b/test/passing/tests/break_cases-normal_indent.ml.ref
@@ -278,3 +278,24 @@ let get_nullability = function
     (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull
+
+[@@@ocamlformat "exp-grouping=preserve"]
+
+let _ =
+  match x with
+  | A -> begin
+      match B with
+      | A -> fooooooooooooo
+    end
+  | A -> begin
+      match B with
+      | A -> fooooooooooooo
+      | B -> fooooooooooooo
+    end
+  | A -> begin
+      match B with
+      | A -> fooooooooooooo
+      | B -> fooooooooooooo
+      | C -> fooooooooooooo
+      | D -> fooooooooooooo
+    end

--- a/test/passing/tests/break_cases-toplevel.ml.ref
+++ b/test/passing/tests/break_cases-toplevel.ml.ref
@@ -244,3 +244,24 @@ let get_nullability = function
     (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull
+
+[@@@ocamlformat "exp-grouping=preserve"]
+
+let _ =
+  match x with
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+    | C -> fooooooooooooo
+    | D -> fooooooooooooo
+  end

--- a/test/passing/tests/break_cases.ml
+++ b/test/passing/tests/break_cases.ml
@@ -248,3 +248,24 @@ let get_nullability = function
   | Undef
   (* This is a very special case, assigning non-null is a technical trick *) ->
       Nullability.Nonnull
+
+[@@@ocamlformat "exp-grouping=preserve"]
+
+let _ =
+  match x with
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+    | C -> fooooooooooooo
+    | D -> fooooooooooooo
+  end

--- a/test/passing/tests/break_cases.ml.ref
+++ b/test/passing/tests/break_cases.ml.ref
@@ -216,3 +216,17 @@ let get_nullability = function
     (* This is a very special case, assigning non-null is a technical trick *)
     ->
       Nullability.Nonnull
+
+[@@@ocamlformat "exp-grouping=preserve"]
+
+let _ =
+  match x with
+  | A -> begin match B with A -> fooooooooooooo end
+  | A -> begin match B with A -> fooooooooooooo | B -> fooooooooooooo end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+    | C -> fooooooooooooo
+    | D -> fooooooooooooo
+  end

--- a/test/passing/tests/exp_grouping-parens.ml.ref
+++ b/test/passing/tests/exp_grouping-parens.ml.ref
@@ -253,6 +253,7 @@ let _ =
 
 let _ =
   match x with
+  | A -> ( match B with A -> fooooooooooooo )
   | A -> ( match B with A -> fooooooooooooo | B -> fooooooooooooo )
   | A -> (
     match B with

--- a/test/passing/tests/exp_grouping-parens.ml.ref
+++ b/test/passing/tests/exp_grouping-parens.ml.ref
@@ -250,3 +250,13 @@ let _ =
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
     Fooo fooo
   )
+
+let _ =
+  match x with
+  | A -> ( match B with A -> fooooooooooooo | B -> fooooooooooooo )
+  | A -> (
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+    | C -> fooooooooooooo
+    | D -> fooooooooooooo )

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -183,6 +183,10 @@ let _ =
   | A -> begin
     match B with
     | A -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
     | B -> fooooooooooooo
   end
   | A -> begin

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -177,3 +177,18 @@ let _ =
     foo.fooooo <- Fooo.foo fooo foo.fooooo;
     Fooo fooo
   end
+
+let _ =
+  match x with
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+    | C -> fooooooooooooo
+    | D -> fooooooooooooo
+  end

--- a/test/passing/tests/exp_grouping.ml.ref
+++ b/test/passing/tests/exp_grouping.ml.ref
@@ -276,6 +276,9 @@ let _ =
 let _ =
   match x with
   | A -> begin
+    match B with A -> fooooooooooooo
+  end
+  | A -> begin
     match B with A -> fooooooooooooo | B -> fooooooooooooo
   end
   | A -> begin

--- a/test/passing/tests/exp_grouping.ml.ref
+++ b/test/passing/tests/exp_grouping.ml.ref
@@ -275,12 +275,8 @@ let _ =
 
 let _ =
   match x with
-  | A -> begin
-    match B with A -> fooooooooooooo
-  end
-  | A -> begin
-    match B with A -> fooooooooooooo | B -> fooooooooooooo
-  end
+  | A -> begin match B with A -> fooooooooooooo end
+  | A -> begin match B with A -> fooooooooooooo | B -> fooooooooooooo end
   | A -> begin
     match B with
     | A -> fooooooooooooo

--- a/test/passing/tests/exp_grouping.ml.ref
+++ b/test/passing/tests/exp_grouping.ml.ref
@@ -272,3 +272,16 @@ let _ =
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
     Fooo fooo
   end
+
+let _ =
+  match x with
+  | A -> begin
+    match B with A -> fooooooooooooo | B -> fooooooooooooo
+  end
+  | A -> begin
+    match B with
+    | A -> fooooooooooooo
+    | B -> fooooooooooooo
+    | C -> fooooooooooooo
+    | D -> fooooooooooooo
+  end


### PR DESCRIPTION
Fix #1599, no diff with test_branch.sh

We can come up with a cleaner solution when we rewrite the formatting of match cases (these ones depend on so many options!)