### PR TITLE
Preserve begin%ext syntax for infix operator expressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@
 
   + Preserve begin-end keywords around infix operators (#1652, @gpetiot)
 
+  + Preserve `begin%ext` syntax for infix opererator expressions (#1653, @gpetiot)
+
 #### Changes
 
   + Improve the diff of unstable docstrings displayed in error messages (#1654, @gpetiot)

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -42,7 +42,8 @@ let parens c ?disambiguate k = parens_if true c ?disambiguate k
 
 module Exp = struct
   module Infix_op_arg = struct
-    let wrap (c : Conf.t) ?(parens_nested = false) ~parens ~loc source k =
+    let wrap (c : Conf.t) ?(parens_nested = false) ~ext ~parens ~loc source k
+        =
       match parens_or_begin_end c source ~loc with
       | `Parens when parens || parens_nested ->
           let opn, hint, cls =
@@ -58,7 +59,11 @@ module Exp = struct
             k
       | `Parens -> k
       | `Begin_end ->
-          vbox 2 (wrap "begin" "end" (wrap_k (break 1 0) (break 1000 ~-2) k))
+          vbox 2
+            (wrap_k
+               (str "begin" $ ext)
+               (str "end")
+               (wrap_k (break 1 0) (break 1000 ~-2) k) )
   end
 
   let wrap (c : Conf.t) ?(disambiguate = false) ?(fits_breaks = true)

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -21,6 +21,7 @@ module Exp : sig
     val wrap :
          Conf.t
       -> ?parens_nested:bool
+      -> ext:Fmt.t
       -> parens:bool
       -> loc:Location.t
       -> Source.t

--- a/test/passing/tests/extensions-indent.ml.ref
+++ b/test/passing/tests/extensions-indent.ml.ref
@@ -359,13 +359,10 @@ let _ = f [%ext new x]
 
 [@@@ocamlformat "exp-grouping=preserve"]
 
-(* TODO: begin/end keywords must be preserved *)
-
 let _ =
-  [%ext
-       begin
-         y >>= z
-       end]
+  begin%ext
+    y >>= z
+  end
 
 let _ =
   [%ext
@@ -375,10 +372,9 @@ let _ =
 
 let _ =
   x
-  >>= [%ext
-           begin
-             y >>= z
-           end]
+  >>= begin%ext
+        y >>= z
+      end
 
 let _ =
   x
@@ -389,10 +385,9 @@ let _ =
 
 let _ =
   f
-    [%ext
-         begin
-           y >>= z
-         end]
+    begin%ext
+      y >>= z
+    end
 
 let _ =
   f

--- a/test/passing/tests/extensions.ml
+++ b/test/passing/tests/extensions.ml
@@ -317,8 +317,6 @@ let _ = f [%ext new x]
 
 [@@@ocamlformat "exp-grouping=preserve"]
 
-(* TODO: begin/end keywords must be preserved *)
-
 let _ = begin%ext y >>= z end
 let _ = [%ext begin y >>= z end]
 let _ = x >>= begin%ext y >>= z end

--- a/test/passing/tests/extensions.ml.ref
+++ b/test/passing/tests/extensions.ml.ref
@@ -359,13 +359,10 @@ let _ = f [%ext new x]
 
 [@@@ocamlformat "exp-grouping=preserve"]
 
-(* TODO: begin/end keywords must be preserved *)
-
 let _ =
-  [%ext
-    begin
-      y >>= z
-    end]
+  begin%ext
+    y >>= z
+  end
 
 let _ =
   [%ext
@@ -375,10 +372,9 @@ let _ =
 
 let _ =
   x
-  >>= [%ext
-        begin
-          y >>= z
-        end]
+  >>= begin%ext
+        y >>= z
+      end
 
 let _ =
   x
@@ -389,10 +385,9 @@ let _ =
 
 let _ =
   f
-    [%ext
-      begin
-        y >>= z
-      end]
+    begin%ext
+      y >>= z
+    end
 
 let _ =
   f


### PR DESCRIPTION
Requires #1652, no diff with test_branch.sh