### PR TITLE
Consistently format comments attached to let-and bindings located at toplevel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@
 
   + Preserve `begin%ext` syntax for infix opererator expressions (#1653, @gpetiot)
 
+  + Consistently format comments attached to let-and bindings located at toplevel (#1663, @gpetiot)
+
 #### Changes
 
   + Improve the diff of unstable docstrings displayed in error messages (#1654, @gpetiot)

--- a/test/passing/tests/let_binding-in_indent.ml.ref
+++ b/test/passing/tests/let_binding-in_indent.ml.ref
@@ -195,3 +195,29 @@ let _ =
 let () =
   let* x = 1 (* blah *) and* y = 2 in
       ()
+
+let x = ()
+(* after x *)
+
+let y = ()
+
+let x = ()
+(* after x *)
+
+and y = ()
+
+(** doc x *)
+let x = () [@@foo]
+(* after x *)
+
+(** doc y *)
+let y = () [@@foo]
+(* after y *)
+
+(** doc x *)
+let x = ()
+(* after x *)
+
+(** doc y *)
+and y = () [@@foo]
+(* after y *)

--- a/test/passing/tests/let_binding-indent.ml.ref
+++ b/test/passing/tests/let_binding-indent.ml.ref
@@ -195,3 +195,29 @@ let _ =
 let () =
       let* x = 1 (* blah *) and* y = 2 in
       ()
+
+let x = ()
+(* after x *)
+
+let y = ()
+
+let x = ()
+(* after x *)
+
+and y = ()
+
+(** doc x *)
+let x = () [@@foo]
+(* after x *)
+
+(** doc y *)
+let y = () [@@foo]
+(* after y *)
+
+(** doc x *)
+let x = ()
+(* after x *)
+
+(** doc y *)
+and y = () [@@foo]
+(* after y *)

--- a/test/passing/tests/let_binding.ml
+++ b/test/passing/tests/let_binding.ml
@@ -182,3 +182,32 @@ let _ = f (let+ a b = c in d)
 let () =
   let* x = 1 (* blah *) and* y = 2 in
   ()
+
+let x = ()
+(* after x *)
+
+let y = ()
+
+let x = ()
+(* after x *)
+
+and y = ()
+
+let x = ()
+[@@foo]
+(* after x *)
+(** doc x *)
+
+let y = ()
+[@@foo]
+(* after y *)
+(** doc y *)
+
+let x = ()
+(* after x *)
+(** doc x *)
+
+and y = ()
+[@@foo]
+(* after y *)
+(** doc y *)

--- a/test/passing/tests/let_binding.ml.ref
+++ b/test/passing/tests/let_binding.ml.ref
@@ -195,3 +195,29 @@ let _ =
 let () =
   let* x = 1 (* blah *) and* y = 2 in
   ()
+
+let x = ()
+(* after x *)
+
+let y = ()
+
+let x = ()
+(* after x *)
+
+and y = ()
+
+(** doc x *)
+let x = () [@@foo]
+(* after x *)
+
+(** doc y *)
+let y = () [@@foo]
+(* after y *)
+
+(** doc x *)
+let x = ()
+(* after x *)
+
+(** doc y *)
+and y = () [@@foo]
+(* after y *)


### PR DESCRIPTION
Fix #586

No diff with conventional profile, slight fix with janestreet profile (still fitting within the margin, so better I guess):
```diff
diff --git a/src/dune_lang/decoder.ml b/src/dune_lang/decoder.ml
index 1f7e5cc3d..b79bb5ad2 100644
--- a/src/dune_lang/decoder.ml
+++ b/src/dune_lang/decoder.ml
@@ -585,8 +585,7 @@ let map_validate t ~f ctx state1 =
 
 (** TODO: Improve consistency of error messages, e.g. use %S consistently for
     field names: see [field_missing] and [field_present_too_many_times]. *)
-let field_missing loc name =
-  User_error.raise ~loc [ Pp.textf "field %s missing" name ]
+let field_missing loc name = User_error.raise ~loc [ Pp.textf "field %s missing" name ]
   [@@inline never]
 ;;
```