### PR TITLE
Clean the sugaring of type-constrained let bindings

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4320,21 +4320,20 @@ and fmt_value_binding c ~rec_flag ?ext ?in_ ?epi ctx binding =
               $ list pvars " " (fmt_str_loc c)
               $ fmt ".@ " $ fmt_core_type c xtyp )
         in
-        (xpat, [], Some fmt_cstr, xbody)
+        (xpat, [], fmt_cstr, xbody)
     | Other_cstr (xpat, xargs, xtyp, xbody) ->
         let fmt_cstr =
-          Some
-            ( fmt_or_k c.conf.ocp_indent_compat
-                (fits_breaks " " ~hint:(1000, 0) "")
-                (fmt "@;<0 -1>")
-            $ cbox_if c.conf.ocp_indent_compat 0
-                (fmt_core_type c ~pro:":"
-                   ~pro_space:(not c.conf.ocp_indent_compat)
-                   ~box:(not c.conf.ocp_indent_compat)
-                   xtyp ) )
+          fmt_or_k c.conf.ocp_indent_compat
+            (fits_breaks " " ~hint:(1000, 0) "")
+            (fmt "@;<0 -1>")
+          $ cbox_if c.conf.ocp_indent_compat 0
+              (fmt_core_type c ~pro:":"
+                 ~pro_space:(not c.conf.ocp_indent_compat)
+                 ~box:(not c.conf.ocp_indent_compat)
+                 xtyp )
         in
         (xpat, xargs, fmt_cstr, xbody)
-    | No_cstr (xpat, xargs, xbody) -> (xpat, xargs, None, xbody)
+    | No_cstr (xpat, xargs, xbody) -> (xpat, xargs, noop, xbody)
   in
   let indent =
     match xbody.ast.pexp_desc with
@@ -4366,7 +4365,7 @@ and fmt_value_binding c ~rec_flag ?ext ?in_ ?epi ctx binding =
                       (not (List.is_empty xargs))
                       (fmt "@ " $ wrap_fun_decl_args c (fmt_fun_args c xargs))
                   )
-              $ fmt_opt fmt_cstr )
+              $ fmt_cstr )
           $ fmt_or_k c.conf.ocp_indent_compat
               (fits_breaks " =" ~hint:(1000, 0) "=")
               (fmt "@;<1 2>=")

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -372,4 +372,79 @@ module Let_binding = struct
         ; lb_exp= bo.pbop_exp
         ; lb_attrs= []
         ; lb_loc= bo.pbop_loc } )
+
+  type reloc_type_cstr =
+    | Polynewtype_cstr of
+        pattern xt * label loc list * core_type xt * expression xt
+    | Other_cstr of pattern xt * arg_kind list * core_type xt * expression xt
+    | No_cstr of pattern xt * arg_kind list * expression xt
+
+  let relocate_type_cstr cmts ~ctx {lb_pat; lb_exp; _} =
+    let ({ast= pat; _} as xpat) =
+      match (lb_pat.ppat_desc, lb_exp.pexp_desc) with
+      (* recognize and undo the pattern of code introduced by
+         ocaml/ocaml@fd0dc6a0fbf73323c37a73ea7e8ffc150059d6ff to fix
+         https://caml.inria.fr/mantis/view.php?id=7344 *)
+      | ( Ppat_constraint
+            ( ({ppat_desc= Ppat_var _; _} as pat)
+            , {ptyp_desc= Ptyp_poly ([], typ1); _} )
+        , Pexp_constraint (_, typ2) )
+        when equal_core_type typ1 typ2 ->
+          Cmts.relocate cmts ~src:lb_pat.ppat_loc ~before:pat.ppat_loc
+            ~after:pat.ppat_loc ;
+          sub_pat ~ctx:(Pat lb_pat) pat
+      | _ -> sub_pat ~ctx lb_pat
+    in
+    let pat_is_extension {ppat_desc; _} =
+      match ppat_desc with Ppat_extension _ -> true | _ -> false
+    in
+    let ({ast= body; _} as xbody) = sub_exp ~ctx lb_exp in
+    if
+      (not (List.is_empty xbody.ast.pexp_attributes)) || pat_is_extension pat
+    then No_cstr (xpat, [], xbody)
+    else
+      match polynewtype cmts pat body with
+      | Some (xpat, pvars, xtyp, xbody) ->
+          Polynewtype_cstr (xpat, pvars, xtyp, xbody)
+      | None -> (
+          let xpat =
+            match xpat.ast.ppat_desc with
+            | Ppat_constraint (p, {ptyp_desc= Ptyp_poly ([], _); _}) ->
+                sub_pat ~ctx:xpat.ctx p
+            | _ -> xpat
+          in
+          let xargs, ({ast= body; _} as xbody) =
+            match pat with
+            | {ppat_desc= Ppat_var _; ppat_attributes= []; _} ->
+                fun_ cmts ~will_keep_first_ast_node:false xbody
+            | _ -> ([], xbody)
+          in
+          let ctx = Exp body in
+          match (body.pexp_desc, pat.ppat_desc) with
+          | ( Pexp_constraint
+                ( ({pexp_desc= Pexp_pack _; pexp_attributes= []; _} as exp)
+                , ({ptyp_desc= Ptyp_package _; ptyp_attributes= []; _} as typ)
+                )
+            , _ )
+            when Source.type_constraint_is_first typ exp.pexp_loc ->
+              Cmts.relocate cmts ~src:body.pexp_loc ~before:exp.pexp_loc
+                ~after:exp.pexp_loc ;
+              Other_cstr (xpat, xargs, sub_typ ~ctx typ, sub_exp ~ctx exp)
+          | ( Pexp_constraint
+                ({pexp_desc= Pexp_pack _; _}, {ptyp_desc= Ptyp_package _; _})
+            , _ )
+           |Pexp_constraint _, Ppat_constraint _ ->
+              No_cstr (xpat, xargs, xbody)
+          | Pexp_constraint (exp, typ), _
+            when Source.type_constraint_is_first typ exp.pexp_loc ->
+              Cmts.relocate cmts ~src:body.pexp_loc ~before:exp.pexp_loc
+                ~after:exp.pexp_loc ;
+              Other_cstr (xpat, xargs, sub_typ ~ctx typ, sub_exp ~ctx exp)
+          (* The type constraint is always printed before the declaration for
+             functions, for other value bindings we preserve its position. *)
+          | Pexp_constraint (exp, typ), _ when not (List.is_empty xargs) ->
+              Cmts.relocate cmts ~src:body.pexp_loc ~before:exp.pexp_loc
+                ~after:exp.pexp_loc ;
+              Other_cstr (xpat, xargs, sub_typ ~ctx typ, sub_exp ~ctx exp)
+          | _ -> No_cstr (xpat, xargs, xbody) )
 end

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -349,25 +349,27 @@ let polynewtype cmts pat body =
     | None -> None )
   | _ -> None
 
-type let_binding =
-  { lb_op: string loc
-  ; lb_pat: pattern
-  ; lb_exp: expression
-  ; lb_attrs: attribute list
-  ; lb_loc: Location.t }
+module Let_binding = struct
+  type t =
+    { lb_op: string loc
+    ; lb_pat: pattern
+    ; lb_exp: expression
+    ; lb_attrs: attribute list
+    ; lb_loc: Location.t }
 
-let value_bindings vbs =
-  List.mapi vbs ~f:(fun i vb ->
-      { lb_op= Location.{txt= (if i = 0 then "let" else "and"); loc= none}
-      ; lb_pat= vb.pvb_pat
-      ; lb_exp= vb.pvb_expr
-      ; lb_attrs= vb.pvb_attributes
-      ; lb_loc= vb.pvb_loc } )
+  let of_value_bindings vbs =
+    List.mapi vbs ~f:(fun i vb ->
+        { lb_op= Location.{txt= (if i = 0 then "let" else "and"); loc= none}
+        ; lb_pat= vb.pvb_pat
+        ; lb_exp= vb.pvb_expr
+        ; lb_attrs= vb.pvb_attributes
+        ; lb_loc= vb.pvb_loc } )
 
-let binding_ops bos =
-  List.map bos ~f:(fun bo ->
-      { lb_op= bo.pbop_op
-      ; lb_pat= bo.pbop_pat
-      ; lb_exp= bo.pbop_exp
-      ; lb_attrs= []
-      ; lb_loc= bo.pbop_loc } )
+  let of_binding_ops bos =
+    List.map bos ~f:(fun bo ->
+        { lb_op= bo.pbop_op
+        ; lb_pat= bo.pbop_pat
+        ; lb_exp= bo.pbop_exp
+        ; lb_attrs= []
+        ; lb_loc= bo.pbop_loc } )
+end

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -337,6 +337,16 @@ let rec polynewtype_ cmts pvars body relocs =
       polynewtype_ cmts pvars exp relocs
   | _ -> None
 
+(** [polynewtype cmts pat exp] returns expression of a type-constrained
+    pattern [pat] with body [exp]. e.g.:
+
+    {v
+      let f: 'r 's. 'r 's t = fun (type r) -> fun (type s) -> (e : r s t)
+    v}
+
+    Can be rewritten as:
+
+    {[ let f : type r s. r s t = e ]} *)
 let polynewtype cmts pat body =
   let ctx = Pat pat in
   match pat.ppat_desc with

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -131,23 +131,6 @@ val mod_with :
 (** [mod_with m] returns the list of [with type] constraints of module type
     [m]. *)
 
-val polynewtype :
-     Cmts.t
-  -> pattern
-  -> expression
-  -> (pattern Ast.xt * label loc list * core_type Ast.xt * expression Ast.xt)
-     option
-(** [polynewtype cmts pat exp] returns expression of a type-constrained
-    pattern [pat] with body [exp]. e.g.:
-
-    {v
-      let f: 'r 's. 'r 's t = fun (type r) -> fun (type s) -> (e : r s t)
-    v}
-
-    Can be rewritten as:
-
-    {[ let f : type r s. r s t = e ]} *)
-
 module Let_binding : sig
   type t =
     { lb_op: string loc

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -134,24 +134,16 @@ val mod_with :
 module Let_binding : sig
   type t =
     { lb_op: string loc
-    ; lb_pat: pattern
-    ; lb_exp: expression
+    ; lb_pat: pattern Ast.xt
+    ; lb_typ:
+        [ `Polynewtype of label loc list * core_type Ast.xt
+        | `Other of arg_kind list * core_type Ast.xt
+        | `None of arg_kind list ]
+    ; lb_exp: expression Ast.xt
     ; lb_attrs: attribute list
     ; lb_loc: Location.t }
 
-  val of_value_bindings : value_binding list -> t list
+  val of_value_bindings : Cmts.t -> ctx:Ast.t -> value_binding list -> t list
 
-  val of_binding_ops : binding_op list -> t list
-
-  type reloc_type_cstr =
-    | Polynewtype_cstr of
-        pattern Ast.xt
-        * label loc list
-        * core_type Ast.xt
-        * expression Ast.xt
-    | Other_cstr of
-        pattern Ast.xt * arg_kind list * core_type Ast.xt * expression Ast.xt
-    | No_cstr of pattern Ast.xt * arg_kind list * expression Ast.xt
-
-  val relocate_type_cstr : Cmts.t -> ctx:Ast.t -> t -> reloc_type_cstr
+  val of_binding_ops : Cmts.t -> ctx:Ast.t -> binding_op list -> t list
 end

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -159,4 +159,16 @@ module Let_binding : sig
   val of_value_bindings : value_binding list -> t list
 
   val of_binding_ops : binding_op list -> t list
+
+  type reloc_type_cstr =
+    | Polynewtype_cstr of
+        pattern Ast.xt
+        * label loc list
+        * core_type Ast.xt
+        * expression Ast.xt
+    | Other_cstr of
+        pattern Ast.xt * arg_kind list * core_type Ast.xt * expression Ast.xt
+    | No_cstr of pattern Ast.xt * arg_kind list * expression Ast.xt
+
+  val relocate_type_cstr : Cmts.t -> ctx:Ast.t -> t -> reloc_type_cstr
 end

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -148,13 +148,15 @@ val polynewtype :
 
     {[ let f : type r s. r s t = e ]} *)
 
-type let_binding =
-  { lb_op: string loc
-  ; lb_pat: pattern
-  ; lb_exp: expression
-  ; lb_attrs: attribute list
-  ; lb_loc: Location.t }
+module Let_binding : sig
+  type t =
+    { lb_op: string loc
+    ; lb_pat: pattern
+    ; lb_exp: expression
+    ; lb_attrs: attribute list
+    ; lb_loc: Location.t }
 
-val value_bindings : value_binding list -> let_binding list
+  val of_value_bindings : value_binding list -> t list
 
-val binding_ops : binding_op list -> let_binding list
+  val of_binding_ops : binding_op list -> t list
+end


### PR DESCRIPTION
No diff exhibited by test_branch.sh with the main profiles. There shouldn't be any behavioral change.

This removes a lot of code of `Fmt_ast.fmt_value_binding` that is extracting the type constraint from the pattern and the expression, and it should have been done in `Sugar.ml`. I tried to simplify further the type of let_bindings (merging `Polynewtype` and `Other`) but couldn't find the right ctx for the polytype, so I've not touched this part of the code too much.