### PR TITLE
Use Pprintast instead of Printast for debugging

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -713,53 +713,23 @@ module T = struct
     | Top
 
   let dump fs = function
-    | Pld l -> Format.fprintf fs "Pld:@\n%a" Printast.payload l
+    | Pld l -> Format.fprintf fs "Pld:@\n%a" Pprintast.payload l
     | Typ t -> Format.fprintf fs "Typ:@\n%a" Pprintast.core_type t
     | Pat p -> Format.fprintf fs "Pat:@\n%a" Pprintast.pattern p
-    | Exp e ->
-        Format.fprintf fs "Exp:@\n%a@\n@\n%a" Pprintast.expression e
-          Printast.expression e
+    | Exp e -> Format.fprintf fs "Exp:@\n%a" Pprintast.expression e
     | Vb b ->
         let str =
           let open Ast_helper in
           Str.value Nonrecursive [b]
         in
-        Format.fprintf fs "Vb:@\n%a@\n@\n%a" Pprintast.structure [str]
-          Printast.implementation [str]
-    | Cl cl ->
-        let str =
-          let open Ast_helper in
-          Str.class_ [Ci.mk {txt= ""; loc= Location.none} cl]
-        in
-        Format.fprintf fs "Cl:@\n%a@\n%a" Pprintast.structure [str]
-          Printast.implementation [str]
-    | Mty mt ->
-        let si =
-          let open Ast_helper in
-          Sig.modtype (Mtd.mk {txt= ""; loc= Location.none} ~typ:mt)
-        in
-        Format.fprintf fs "Mty:@\n%a@\n%a" Pprintast.signature [si]
-          Printast.interface [si]
-    | Cty cty ->
-        let si =
-          let open Ast_helper in
-          Sig.class_type [Ci.mk {txt= ""; loc= Location.none} cty]
-        in
-        Format.fprintf fs "Cty:@\n%a@\n%a" Pprintast.signature [si]
-          Printast.interface [si]
-    | Mod m ->
-        let m =
-          let open Ast_helper in
-          Str.module_ (Mb.mk {txt= None; loc= Location.none} m)
-        in
-        Format.fprintf fs "Mod:@\n%a@\n%a" Pprintast.structure [m]
-          Printast.implementation [m]
-    | Sig s ->
-        Format.fprintf fs "Sig:@\n%a@\n%a" Pprintast.signature [s]
-          Printast.interface [s]
+        Format.fprintf fs "Vb:@\n%a" Pprintast.structure [str]
+    | Cl cl -> Format.fprintf fs "Cl:@\n%a" Pprintast.class_expr cl
+    | Mty mt -> Format.fprintf fs "Mty:@\n%a" Pprintast.module_type mt
+    | Cty cty -> Format.fprintf fs "Cty:@\n%a" Pprintast.class_type cty
+    | Mod m -> Format.fprintf fs "Mod:@\n%a" Pprintast.module_expr m
+    | Sig s -> Format.fprintf fs "Sig:@\n%a" Pprintast.signature_item s
     | Str s | Tli (`Item s) ->
-        Format.fprintf fs "Str:@\n%a@\n%a" Pprintast.structure [s]
-          Printast.implementation [s]
+        Format.fprintf fs "Str:@\n%a" Pprintast.structure_item s
     | Clf clf -> Format.fprintf fs "Clf:@\n%a@\n" Pprintast.class_field clf
     | Ctf ctf ->
         Format.fprintf fs "Ctf:@\n%a@\n" Pprintast.class_type_field ctf

--- a/lib/Ast_passes.mli
+++ b/lib/Ast_passes.mli
@@ -57,21 +57,13 @@ module Ast_final : sig
 
   val fold : 'a t -> 'r Ppxlib.Ast_traverse.fold -> 'a -> 'r -> 'r
 
-  module Printast : sig
-    val implementation : Format.formatter -> structure -> unit
-
-    val interface : Format.formatter -> signature -> unit
+  module Pprintast : sig
+    include module type of Ppxlib.Pprintast
 
     val payload : Format.formatter -> payload -> unit
 
-    val expression : Format.formatter -> expression -> unit
-
-    val use_file : Format.formatter -> toplevel_phrase list -> unit
-
     val ast : 'a t -> Format.formatter -> 'a -> unit
   end
-
-  module Pprintast = Ppxlib.Pprintast
 end
 
 val run : 'a Ast0.t -> 'b Ast_final.t -> 'a -> 'b

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -542,7 +542,7 @@ let diff (conf : Conf.t) x y =
               |> (fun {ast; _} -> Ast_passes.run Structure Structure ast)
               |> Normalize.normalize Structure conf
               |> Caml.Format.asprintf "%a"
-                   Ast_passes.Ast_final.Printast.implementation
+                   Ast_passes.Ast_final.Pprintast.structure
             with _ -> norm_non_code z
           else norm_non_code z
     in

--- a/lib/Normalize.ml
+++ b/lib/Normalize.ml
@@ -116,7 +116,7 @@ let rec odoc_nestable_block_element c fmt = function
           in
           let ast = c.normalize_code ast in
           Caml.Format.asprintf "AST,%a,COMMENTS,[%a]"
-            Ast_passes.Ast_final.Printast.implementation ast print_comments
+            Ast_passes.Ast_final.Pprintast.structure ast print_comments
             comments
         with _ -> txt
       in

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -271,7 +271,7 @@ let format (type a b) (fg0 : a Ast_passes.Ast0.t)
     if opts.Conf.debug then
       Some
         (dump_ast ~input_name ?output_file ~suffix (fun fmt ->
-             Ast_passes.Ast_final.Printast.ast fg fmt ast ) )
+             Ast_passes.Ast_final.Pprintast.ast fg fmt ast ) )
     else None
   in
   let dump_formatted ~suffix fmted =


### PR DESCRIPTION
Allows #1669 to not vendor `printast.ml`.
This only impacts debug mode. The `*.ast` files generated in Translation_unit will print the pretty-printed ast instead of the sexp representation, but it's a good thing as the changes in locations would add too much noise and make these files not exploitable.
