### PR TITLE
Improve breaking of comments to avoid violating the margin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@
 
   + Remove double parens around a functor in a module application (#1681, @gpetiot)
 
+  + Improve breaking of comments to avoid violating the margin (#1676, @jberdine)
+
 #### Changes
 
   + Improve the diff of unstable docstrings displayed in error messages (#1654, @gpetiot)

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -163,7 +163,8 @@ module Indexing_op = struct
     | Some (lhs :: args) -> (
       match ident with
       | {pexp_desc= Pexp_ident {txt= ident; loc}; pexp_attributes= []; _}
-      (* We only use the sugared form if it was already used in the source. *)
+      (* We only use the sugared form if it was already used in the
+         source. *)
         when loc.loc_ghost -> (
         match get_sugar_ident ident args with
         | None -> None

--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -147,8 +147,8 @@ let fmt cmt src ~wrap:wrap_comments ~ocp_indent_compat ~fmt_code pos =
       | [] -> assert false
       | [""] -> assert false
       | [""; ""] -> str "(* *)"
-      | [text] -> str "(*" $ fill_text text ~epi:(str "*)")
-      | [text; ""] -> str "(*" $ fill_text text ~epi:(str " *)")
+      | [text] -> str "(*" $ fill_text text ~epi:"*)"
+      | [text; ""] -> str "(*" $ fill_text text ~epi:" *)"
       | asterisk_prefixed_lines ->
           fmt_asterisk_prefixed_lines asterisk_prefixed_lines
   in

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1125,7 +1125,8 @@ module Formatting = struct
       (fun conf -> conf.wrap_fun_args)
 end
 
-(* Flags that can be modified in the config file that don't affect formatting *)
+(* Flags that can be modified in the config file that don't affect
+   formatting *)
 
 let project_root_witness = [".git"; ".hg"; "dune-project"]
 

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -345,14 +345,14 @@ let fill_text ?(epi = "") text =
   in
   str pro
   $ hovbox 0
-      ( hvbox 0
-          (hovbox 0
-             (list_pn lines (fun ~prev:_ curr ~next ->
+      (hvbox 0
+         (hovbox 0
+            ( list_pn lines (fun ~prev:_ curr ~next ->
                   fmt_line curr
                   $
                   match next with
                   | Some str when String.for_all str ~f:Char.is_whitespace ->
                       close_box $ fmt "\n@," $ open_hovbox 0
                   | Some _ when not (String.is_empty curr) -> fmt "@ "
-                  | _ -> str_as (String.length epi) "" ) ) )
-      $ str_as 0 epi )
+                  | _ -> noop )
+            $ str_as (String.length epi) epi ) ) )

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -355,4 +355,4 @@ let fill_text ?(epi = "") text =
                       close_box $ fmt "\n@," $ open_hovbox 0
                   | Some _ when not (String.is_empty curr) -> fmt "@ "
                   | _ -> noop )
-            $ str_as (String.length epi) epi ) ) )
+            $ str epi ) ) )

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -344,15 +344,14 @@ let fill_text ?(epi = "") text =
     else epi
   in
   str pro
-  $ hovbox 0
-      (hvbox 0
-         (hovbox 0
-            ( list_pn lines (fun ~prev:_ curr ~next ->
-                  fmt_line curr
-                  $
-                  match next with
-                  | Some str when String.for_all str ~f:Char.is_whitespace ->
-                      close_box $ fmt "\n@," $ open_hovbox 0
-                  | Some _ when not (String.is_empty curr) -> fmt "@ "
-                  | _ -> noop )
-            $ str epi ) ) )
+  $ hvbox 0
+      (hovbox 0
+         ( list_pn lines (fun ~prev:_ curr ~next ->
+               fmt_line curr
+               $
+               match next with
+               | Some str when String.for_all str ~f:Char.is_whitespace ->
+                   close_box $ fmt "\n@," $ open_hovbox 0
+               | Some _ when not (String.is_empty curr) -> fmt "@ "
+               | _ -> noop )
+         $ str epi ) )

--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -227,5 +227,5 @@ val hovbox_if : ?name:string -> bool -> int -> t -> t
 
 (** Text filling --------------------------------------------------------*)
 
-val fill_text : ?epi:t -> string -> t
+val fill_text : ?epi:string -> string -> t
 (** Format a non-empty string as filled text wrapped at the margin. *)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -38,9 +38,11 @@ module Cmts = struct
   let fmt c ?pro ?epi ?eol ?adj loc =
     (* remove the before comments from the map first *)
     let before = fmt_before c ?pro ?epi ?eol ?adj loc in
-    (* remove the within comments from the map by accepting the continuation *)
+    (* remove the within comments from the map by accepting the
+       continuation *)
     fun inner ->
-      (* delay the after comments until the within comments have been removed *)
+      (* delay the after comments until the within comments have been
+         removed *)
       let after = fmt_after c ?pro ?epi loc in
       let open Fmt in
       before $ inner $ after
@@ -1809,7 +1811,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         when List.for_all rev_e1N ~f:(fun (_, eI) ->
                  is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI) ) ->
           let e1N = List.rev rev_e1N in
-          (* side effects of Cmts.fmt c.cmts before Sugar.fun_ is important *)
+          (* side effects of Cmts.fmt c.cmts before Sugar.fun_ is
+             important *)
           let cmts_before = Cmts.fmt_before c pexp_loc in
           let xargs, xbody = Sugar.fun_ c.cmts (sub_exp ~ctx eN1) in
           let fmt_cstr, xbody = type_constr_and_body c xbody in

--- a/test/passing/tests/align_cases-break_all.ml.ref
+++ b/test/passing/tests/align_cases-break_all.ml.ref
@@ -57,7 +57,8 @@ let fooooooooooo =
       foo
   | 3453535353533 ->
       foooooooooooooooooo
-      (* foooooooooooooooooooooo foooooooooooooooo foooooooooooooo fooooooooo*)
+      (* foooooooooooooooooooooo foooooooooooooooo foooooooooooooo
+         fooooooooo*)
   | _ -> fooooooooooooooooooo
 
 let _ =

--- a/test/passing/tests/align_cases.ml
+++ b/test/passing/tests/align_cases.ml
@@ -57,7 +57,8 @@ let fooooooooooo =
       foo
   | 3453535353533 ->
       foooooooooooooooooo
-      (* foooooooooooooooooooooo foooooooooooooooo foooooooooooooo fooooooooo*)
+      (* foooooooooooooooooooooo foooooooooooooooo foooooooooooooo
+         fooooooooo*)
   | _ -> fooooooooooooooooooo
 
 let _ =

--- a/test/passing/tests/break_cases-align.ml.ref
+++ b/test/passing/tests/break_cases-align.ml.ref
@@ -265,8 +265,8 @@ let foooooooooooooo = function
   | Foooooooooo
   | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
-    ->
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo
+       fooo *) ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
@@ -275,8 +275,8 @@ let get_nullability = function
   | ArrayAccess
   | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-    (* This is a very special case, assigning non-null is a technical trick *)
-    ->
+    (* This is a very special case, assigning non-null is a technical
+       trick *) ->
       Nullability.Nonnull
 
 [@@@ocamlformat "exp-grouping=preserve"]

--- a/test/passing/tests/break_cases-all.ml.ref
+++ b/test/passing/tests/break_cases-all.ml.ref
@@ -265,8 +265,8 @@ let foooooooooooooo = function
   | Foooooooooo
   | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
-    ->
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo
+       fooo *) ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
@@ -275,8 +275,8 @@ let get_nullability = function
   | ArrayAccess
   | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-    (* This is a very special case, assigning non-null is a technical trick *)
-    ->
+    (* This is a very special case, assigning non-null is a technical
+       trick *) ->
       Nullability.Nonnull
 
 [@@@ocamlformat "exp-grouping=preserve"]

--- a/test/passing/tests/break_cases-closing_on_separate_line.ml.ref
+++ b/test/passing/tests/break_cases-closing_on_separate_line.ml.ref
@@ -280,8 +280,8 @@ let foooooooooooooo = function
   | Foooooooooo
   | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
-    ->
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo
+       fooo *) ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
@@ -290,8 +290,8 @@ let get_nullability = function
   | ArrayAccess
   | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-    (* This is a very special case, assigning non-null is a technical trick *)
-    ->
+    (* This is a very special case, assigning non-null is a technical
+       trick *) ->
       Nullability.Nonnull
 
 [@@@ocamlformat "exp-grouping=preserve"]

--- a/test/passing/tests/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref
+++ b/test/passing/tests/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.ref
@@ -280,8 +280,8 @@ let foooooooooooooo = function
   | Foooooooooo
   | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
-    ->
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo
+       fooo *) ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
@@ -290,8 +290,8 @@ let get_nullability = function
   | ArrayAccess
   | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-    (* This is a very special case, assigning non-null is a technical trick *)
-    ->
+    (* This is a very special case, assigning non-null is a technical
+       trick *) ->
       Nullability.Nonnull
 
 [@@@ocamlformat "exp-grouping=preserve"]

--- a/test/passing/tests/break_cases-cosl_lnmp_cmei.ml.ref
+++ b/test/passing/tests/break_cases-cosl_lnmp_cmei.ml.ref
@@ -280,8 +280,8 @@ let foooooooooooooo = function
   | Foooooooooo
   | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
-    ->
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo
+       fooo *) ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
@@ -290,8 +290,8 @@ let get_nullability = function
   | ArrayAccess
   | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-    (* This is a very special case, assigning non-null is a technical trick *)
-    ->
+    (* This is a very special case, assigning non-null is a technical
+       trick *) ->
       Nullability.Nonnull
 
 [@@@ocamlformat "exp-grouping=preserve"]

--- a/test/passing/tests/break_cases-fit_or_vertical.ml.ref
+++ b/test/passing/tests/break_cases-fit_or_vertical.ml.ref
@@ -226,8 +226,8 @@ let foooooooooooooo = function
   | Foooooooooo
   | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
-    -> Foooooooooo.Foooooo
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo
+       fooo *) -> Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
 
@@ -235,8 +235,8 @@ let get_nullability = function
   | ArrayAccess
   | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-    (* This is a very special case, assigning non-null is a technical trick *)
-    -> Nullability.Nonnull
+    (* This is a very special case, assigning non-null is a technical
+       trick *) -> Nullability.Nonnull
 
 [@@@ocamlformat "exp-grouping=preserve"]
 

--- a/test/passing/tests/break_cases-nested.ml.ref
+++ b/test/passing/tests/break_cases-nested.ml.ref
@@ -231,8 +231,8 @@ let foooooooooooooo = function
   | Foooooooooo
   | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
-    ->
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo
+       fooo *) ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
@@ -241,8 +241,8 @@ let get_nullability = function
   | ArrayAccess
   | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-    (* This is a very special case, assigning non-null is a technical trick *)
-    ->
+    (* This is a very special case, assigning non-null is a technical
+       trick *) ->
       Nullability.Nonnull
 
 [@@@ocamlformat "exp-grouping=preserve"]

--- a/test/passing/tests/break_cases-normal_indent.ml.ref
+++ b/test/passing/tests/break_cases-normal_indent.ml.ref
@@ -265,8 +265,8 @@ let foooooooooooooo = function
   | Foooooooooo
   | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
-    ->
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo
+       fooo *) ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
@@ -275,8 +275,8 @@ let get_nullability = function
   | ArrayAccess
   | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-    (* This is a very special case, assigning non-null is a technical trick *)
-    ->
+    (* This is a very special case, assigning non-null is a technical
+       trick *) ->
       Nullability.Nonnull
 
 [@@@ocamlformat "exp-grouping=preserve"]

--- a/test/passing/tests/break_cases-toplevel.ml.ref
+++ b/test/passing/tests/break_cases-toplevel.ml.ref
@@ -231,8 +231,8 @@ let foooooooooooooo = function
   | Foooooooooo
   | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
-    ->
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo
+       fooo *) ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
@@ -241,8 +241,8 @@ let get_nullability = function
   | ArrayAccess
   | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-    (* This is a very special case, assigning non-null is a technical trick *)
-    ->
+    (* This is a very special case, assigning non-null is a technical
+       trick *) ->
       Nullability.Nonnull
 
 [@@@ocamlformat "exp-grouping=preserve"]

--- a/test/passing/tests/break_cases.ml.ref
+++ b/test/passing/tests/break_cases.ml.ref
@@ -203,8 +203,8 @@ let foooooooooooooo = function
   | Foooooooooo
   | FooooFoooooFoooooo (* fooooooooooooooooooooooooooooooooooo *)
   | Foooo
-    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo fooo *)
-    ->
+    (* Fooo foooo fooooo foooooooo fooooooooo foooooooooooo fooooooooo
+       fooo *) ->
       Foooooooooo.Foooooo
   | Foooo {foooo_fooo= {foooooooooo}} ->
       Foooo_Foooo_fooooooo.get_foooooooooo fooooo_fooo
@@ -213,8 +213,8 @@ let get_nullability = function
   | ArrayAccess
   | OptimisticFallback (* non-null is the most optimistic type *)
   | Undef
-    (* This is a very special case, assigning non-null is a technical trick *)
-    ->
+    (* This is a very special case, assigning non-null is a technical
+       trick *) ->
       Nullability.Nonnull
 
 [@@@ocamlformat "exp-grouping=preserve"]

--- a/test/passing/tests/break_separators-after.ml.ref
+++ b/test/passing/tests/break_separators-after.ml.ref
@@ -521,7 +521,8 @@ let foooooooooooo =
 
 let foooooooooooo =
   { foooooooooooooo with
-    (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
+    (* foooooooooooooooo fooooooooooooooooooooooooo
+       foooooooooooooooooooooo *)
     fooooooooooooooooooooooooooooo= fooooooooooooo;
     fooooooooooooo= foooooooooooooo }
 

--- a/test/passing/tests/break_separators-after_docked.ml.ref
+++ b/test/passing/tests/break_separators-after_docked.ml.ref
@@ -560,7 +560,8 @@ let foooooooooooo =
 let foooooooooooo =
   {
     foooooooooooooo with
-    (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
+    (* foooooooooooooooo fooooooooooooooooooooooooo
+       foooooooooooooooooooooo *)
     fooooooooooooooooooooooooooooo= fooooooooooooo;
     fooooooooooooo= foooooooooooooo;
   }

--- a/test/passing/tests/break_separators-after_docked_wrap.ml.ref
+++ b/test/passing/tests/break_separators-after_docked_wrap.ml.ref
@@ -353,7 +353,8 @@ let foooooooooooo =
 let foooooooooooo =
   {
     foooooooooooooo with
-    (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
+    (* foooooooooooooooo fooooooooooooooooooooooooo
+       foooooooooooooooooooooo *)
     fooooooooooooooooooooooooooooo= fooooooooooooo;
     fooooooooooooo= foooooooooooooo;
   }

--- a/test/passing/tests/break_separators-after_wrap.ml.ref
+++ b/test/passing/tests/break_separators-after_wrap.ml.ref
@@ -316,7 +316,8 @@ let foooooooooooo =
 
 let foooooooooooo =
   { foooooooooooooo with
-    (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
+    (* foooooooooooooooo fooooooooooooooooooooooooo
+       foooooooooooooooooooooo *)
     fooooooooooooooooooooooooooooo= fooooooooooooo;
     fooooooooooooo= foooooooooooooo }
 

--- a/test/passing/tests/break_separators-before_docked.ml.ref
+++ b/test/passing/tests/break_separators-before_docked.ml.ref
@@ -560,7 +560,8 @@ let foooooooooooo =
 let foooooooooooo =
   {
     foooooooooooooo with
-    (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
+    (* foooooooooooooooo fooooooooooooooooooooooooo
+       foooooooooooooooooooooo *)
     fooooooooooooooooooooooooooooo= fooooooooooooo
   ; fooooooooooooo= foooooooooooooo
   }

--- a/test/passing/tests/break_separators-before_docked_wrap.ml.ref
+++ b/test/passing/tests/break_separators-before_docked_wrap.ml.ref
@@ -353,7 +353,8 @@ let foooooooooooo =
 let foooooooooooo =
   {
     foooooooooooooo with
-    (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
+    (* foooooooooooooooo fooooooooooooooooooooooooo
+       foooooooooooooooooooooo *)
     fooooooooooooooooooooooooooooo= fooooooooooooo
   ; fooooooooooooo= foooooooooooooo
   }

--- a/test/passing/tests/break_separators-wrap.ml.ref
+++ b/test/passing/tests/break_separators-wrap.ml.ref
@@ -316,7 +316,8 @@ let foooooooooooo =
 
 let foooooooooooo =
   { foooooooooooooo with
-    (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
+    (* foooooooooooooooo fooooooooooooooooooooooooo
+       foooooooooooooooooooooo *)
     fooooooooooooooooooooooooooooo= fooooooooooooo
   ; fooooooooooooo= foooooooooooooo }
 

--- a/test/passing/tests/break_separators.ml
+++ b/test/passing/tests/break_separators.ml
@@ -521,7 +521,8 @@ let foooooooooooo =
 
 let foooooooooooo =
   { foooooooooooooo with
-    (* foooooooooooooooo fooooooooooooooooooooooooo foooooooooooooooooooooo *)
+    (* foooooooooooooooo fooooooooooooooooooooooooo
+       foooooooooooooooooooooo *)
     fooooooooooooooooooooooooooooo= fooooooooooooo
   ; fooooooooooooo= foooooooooooooo }
 

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -182,7 +182,8 @@ let () =
   (* *)
   ()
 
-(* break when unicode sequence length measured in bytes but ¬ in code points *)
+(* break when unicode sequence length measured in bytes but ¬ in code
+   points *)
 
 type t =
   | Aaaaaaaaaa

--- a/test/passing/tests/infix_bind-break.ml.ref
+++ b/test/passing/tests/infix_bind-break.ml.ref
@@ -195,13 +195,15 @@ let f =
 
 let f =
   Ok ()
-  >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo foooooooooooooooo *)
+  >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo
+         foooooooooooooooo *)
   fun foooooo fooooo foooo foooooo ->
   Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 let f =
   Ok ()
-  >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo foooooooooooooooo *)
+  >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo
+         foooooooooooooooo *)
   function
   | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 

--- a/test/passing/tests/infix_bind-fit_or_vertical-break.ml.ref
+++ b/test/passing/tests/infix_bind-fit_or_vertical-break.ml.ref
@@ -200,13 +200,15 @@ let f =
 
 let f =
   Ok ()
-  >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo foooooooooooooooo *)
+  >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo
+         foooooooooooooooo *)
   fun foooooo fooooo foooo foooooo ->
   Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 let f =
   Ok ()
-  >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo foooooooooooooooo *)
+  >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo
+         foooooooooooooooo *)
   function
   | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 

--- a/test/passing/tests/js_args.ml.ref
+++ b/test/passing/tests/js_args.ml.ref
@@ -48,7 +48,8 @@ let () =
 
 (* Except in specific cases, we want the argument indented relative to the
    function being called. (Exceptions include "fun" arguments where the line
-   ends with "->" and subsequent lines beginning with operators, like above.) *)
+   ends with "->" and subsequent lines beginning with operators, like
+   above.) *)
 let () =
   Some
     (Message_store.create s "herd-retransmitter" ~unlink:true

--- a/test/passing/tests/js_to_do.ml.ref
+++ b/test/passing/tests/js_to_do.ml.ref
@@ -1,7 +1,6 @@
 (* Indentation that Jane Street needs to think about and make precise.
 
-   These are long term ideas, possibly even conflicting with other
-   tests. *)
+   These are long term ideas, possibly even conflicting with other tests. *)
 
 (* js-args *)
 
@@ -23,16 +22,16 @@ let _ =
    analogies are included in js-type.ml, (meant to be) consistent with the
    proposed type indentation.
 
-   Second, and more divergently, the proposed indentation of function
-   types is based on the idea of aligning the arguments, even the first
-   argument, even where that means automatically inserting spaces within
-   lines. This applies to the extra spaces in ":__unit" and
-   "(____Config.Network.t" below.
+   Second, and more divergently, the proposed indentation of function types
+   is based on the idea of aligning the arguments, even the first argument,
+   even where that means automatically inserting spaces within lines. This
+   applies to the extra spaces in ":__unit" and "(____Config.Network.t"
+   below.
 
-   We believe this fits into a more general incorporation of alignment
-   into ocp-indent, to replace our internal alignment tool with a
-   syntax-aware one. We like to align things for readability, like big
-   records, record types, lists used to build tables, etc.
+   We believe this fits into a more general incorporation of alignment into
+   ocp-indent, to replace our internal alignment tool with a syntax-aware
+   one. We like to align things for readability, like big records, record
+   types, lists used to build tables, etc.
 
    The proposal also includes indenting "->" in the circumstances below
    relative to the enclosing "()", by two spaces. In a sense, this happens

--- a/test/passing/tests/js_to_do.ml.ref
+++ b/test/passing/tests/js_to_do.ml.ref
@@ -1,6 +1,7 @@
 (* Indentation that Jane Street needs to think about and make precise.
 
-   These are long term ideas, possibly even conflicting with other tests. *)
+   These are long term ideas, possibly even conflicting with other
+   tests. *)
 
 (* js-args *)
 
@@ -22,16 +23,16 @@ let _ =
    analogies are included in js-type.ml, (meant to be) consistent with the
    proposed type indentation.
 
-   Second, and more divergently, the proposed indentation of function types
-   is based on the idea of aligning the arguments, even the first argument,
-   even where that means automatically inserting spaces within lines. This
-   applies to the extra spaces in ":__unit" and "(____Config.Network.t"
-   below.
+   Second, and more divergently, the proposed indentation of function
+   types is based on the idea of aligning the arguments, even the first
+   argument, even where that means automatically inserting spaces within
+   lines. This applies to the extra spaces in ":__unit" and
+   "(____Config.Network.t" below.
 
-   We believe this fits into a more general incorporation of alignment into
-   ocp-indent, to replace our internal alignment tool with a syntax-aware
-   one. We like to align things for readability, like big records, record
-   types, lists used to build tables, etc.
+   We believe this fits into a more general incorporation of alignment
+   into ocp-indent, to replace our internal alignment tool with a
+   syntax-aware one. We like to align things for readability, like big
+   records, record types, lists used to build tables, etc.
 
    The proposal also includes indenting "->" in the circumstances below
    relative to the enclosing "()", by two spaces. In a sense, this happens

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -3162,9 +3162,9 @@ Error: Types marked with the immediate attribute must be
 
 (* Implicit unpack allows to omit the signature in (val ...) expressions.
 
-   It also adds (module M : S) and (module M) patterns, relying on
-   implicit (val ...) for the implementation. Such patterns can only be used
-   in function definition, match clauses, and let ... in.
+   It also adds (module M : S) and (module M) patterns, relying on implicit
+   (val ...) for the implementation. Such patterns can only be used in
+   function definition, match clauses, and let ... in.
 
    New: implicit pack is also supported, and you only need to be able to
    infer the the module type path from the context. *)
@@ -4585,8 +4585,8 @@ end
 (* Requires -package tyxml module type PR6513_orig = sig module type S = sig
    type t type u end
 
-   module Make: functor (Html5: Html5_sigs.T with type 'a Xml.wrap = 'a
-   and type 'a wrap = 'a and type 'a list_wrap = 'a list) -> S with type t =
+   module Make: functor (Html5: Html5_sigs.T with type 'a Xml.wrap = 'a and
+   type 'a wrap = 'a and type 'a list_wrap = 'a list) -> S with type t =
    Html5_types.div Html5.elt and type u = < foo: Html5.uri > end *)
 module type S = sig
   include Set.S
@@ -5867,8 +5867,7 @@ let f (x : entity entity_container) = ()
 (* class world = object val entity_container : entity entity_container = new
    entity_container
 
-   method add_entity (s : entity) = entity_container#add_entity (s :>
-   entity)
+   method add_entity (s : entity) = entity_container#add_entity (s :> entity)
 
    end *)
 (* Two v's in the same class *)
@@ -7272,14 +7271,14 @@ end
 (* module type ASig = sig type a val a:a val print:a -> unit end module type
    BSig = sig type b val b:b val print:b -> unit end
 
-   module A = struct type a = int let a = 0 let print = print_int end
-   module B = struct type b = float let b = 0.0 let print = print_float end
+   module A = struct type a = int let a = 0 let print = print_int end module
+   B = struct type b = float let b = 0.0 let print = print_float end
 
    module MakeA (Empty:sig end) : ASig = A module MakeB (Empty:sig end) :
    BSig = B
 
-   module rec NewA : ASig = MakeA (struct end) and NewB : BSig with type b
-   = NewA.a = MakeB (struct end);; *)
+   module rec NewA : ASig = MakeA (struct end) and NewB : BSig with type b =
+   NewA.a = MakeB (struct end);; *)
 
 (* Expressions and bindings *)
 

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -3162,9 +3162,9 @@ Error: Types marked with the immediate attribute must be
 
 (* Implicit unpack allows to omit the signature in (val ...) expressions.
 
-   It also adds (module M : S) and (module M) patterns, relying on implicit
-   (val ...) for the implementation. Such patterns can only be used in
-   function definition, match clauses, and let ... in.
+   It also adds (module M : S) and (module M) patterns, relying on
+   implicit (val ...) for the implementation. Such patterns can only be used
+   in function definition, match clauses, and let ... in.
 
    New: implicit pack is also supported, and you only need to be able to
    infer the the module type path from the context. *)
@@ -4585,8 +4585,8 @@ end
 (* Requires -package tyxml module type PR6513_orig = sig module type S = sig
    type t type u end
 
-   module Make: functor (Html5: Html5_sigs.T with type 'a Xml.wrap = 'a and
-   type 'a wrap = 'a and type 'a list_wrap = 'a list) -> S with type t =
+   module Make: functor (Html5: Html5_sigs.T with type 'a Xml.wrap = 'a
+   and type 'a wrap = 'a and type 'a list_wrap = 'a list) -> S with type t =
    Html5_types.div Html5.elt and type u = < foo: Html5.uri > end *)
 module type S = sig
   include Set.S
@@ -5867,7 +5867,8 @@ let f (x : entity entity_container) = ()
 (* class world = object val entity_container : entity entity_container = new
    entity_container
 
-   method add_entity (s : entity) = entity_container#add_entity (s :> entity)
+   method add_entity (s : entity) = entity_container#add_entity (s :>
+   entity)
 
    end *)
 (* Two v's in the same class *)
@@ -6321,7 +6322,8 @@ module M : sig
 end = struct
   type refer = {poly: 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a)}
 end
-(* ocamlc -c pr3918a.mli pr3918b.mli rm -f pr3918a.cmi ocamlc -c pr3918c.ml *)
+(* ocamlc -c pr3918a.mli pr3918b.mli rm -f pr3918a.cmi ocamlc -c
+   pr3918c.ml *)
 
 open Pr3918b
 
@@ -7270,14 +7272,14 @@ end
 (* module type ASig = sig type a val a:a val print:a -> unit end module type
    BSig = sig type b val b:b val print:b -> unit end
 
-   module A = struct type a = int let a = 0 let print = print_int end module
-   B = struct type b = float let b = 0.0 let print = print_float end
+   module A = struct type a = int let a = 0 let print = print_int end
+   module B = struct type b = float let b = 0.0 let print = print_float end
 
    module MakeA (Empty:sig end) : ASig = A module MakeB (Empty:sig end) :
    BSig = B
 
-   module rec NewA : ASig = MakeA (struct end) and NewB : BSig with type b =
-   NewA.a = MakeB (struct end);; *)
+   module rec NewA : ASig = MakeA (struct end) and NewB : BSig with type b
+   = NewA.a = MakeB (struct end);; *)
 
 (* Expressions and bindings *)
 


### PR DESCRIPTION
Comments are wrapped without taking the width of the final ` *)` into consideration. This leads to sometimes violating the margin. This PR fixes this by printing an empty string with non-zero length inside the boxes containing the wrapped comment text, and then printing the final ` *)` with length 0.

The same problem affects docstrings, but this PR does not improve that issue. To do that would require, when traversing the structure of the parsed odoc structure, when the rightmost _leaf_ is encountered so that the wide empty string could be printed there before exiting the boxes.

Similarly, the same thing happens for closing parens, braces, semicolons, etc. and a similar requirement of knowing when the rightmost leaf is hit is needed.