### PR TITLE
Depend on odoc-parser instead of odoc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,9 @@
 
   + Improve position of `;;` tokens (#1688, @gpetiot)
 
+  + Depend on `odoc-parser` instead of `odoc` (#1683, @kit-ty-kate, @jonludlam)
+    The parser from odoc has been split from the main odoc package and put into its own package, `odoc-parser`.
+
 #### New features
 
   + Implement OCaml 4.13 features

--- a/dune-project
+++ b/dune-project
@@ -60,8 +60,8 @@
    (and
     :with-test
     (>= 2.5.0)))
-  (odoc
-   (>= 1.4.2))
+  (odoc-parser
+   (>= 0.9.0))
   re
   (stdio
    (< v0.15))
@@ -103,8 +103,8 @@
    (and
     :with-test
     (>= 2.5.0)))
-  (odoc
-   (>= 1.4.2))
+  (odoc-parser
+   (>= 0.9.0))
   re
   (stdio
    (< v0.15))

--- a/lib/Docstring.ml
+++ b/lib/Docstring.ml
@@ -15,13 +15,11 @@ let parse ~loc text =
     { location with
       pos_cnum= location.pos_cnum + 3 (* Length of comment opening *) }
   in
-  match Odoc_parser.parse_comment ~location ~text with
-  | exception _ ->
-      let span = Migrate_ast.Location.to_span loc in
-      Error [{Odoc_parser.Error.message = "comment could not be parsed"; location = span}]
-  | {value; warnings= []} -> Ok value
-  | {warnings; _} -> Error warnings
+  let v = Odoc_parser.parse_comment ~location ~text in
+  match Odoc_parser.warnings v with
+  | [] -> Ok (Odoc_parser.ast v)
+  | warnings -> Error warnings
 
 let warn fmt warning =
   Format.fprintf fmt "Warning: Invalid documentation comment:@,%s\n%!"
-    (Odoc_parser.Error.to_string warning)
+    (Odoc_parser.Warning.to_string warning)

--- a/lib/Docstring.ml
+++ b/lib/Docstring.ml
@@ -15,13 +15,13 @@ let parse ~loc text =
     { location with
       pos_cnum= location.pos_cnum + 3 (* Length of comment opening *) }
   in
-  match Odoc_parser.parse_comment_raw ~location ~text with
+  match Odoc_parser.parse_comment ~location ~text with
   | exception _ ->
       let span = Migrate_ast.Location.to_span loc in
-      Error [Odoc_model.Error.make "comment could not be parsed" span]
+      Error [{Odoc_parser.Error.message = "comment could not be parsed"; location = span}]
   | {value; warnings= []} -> Ok value
   | {warnings; _} -> Error warnings
 
 let warn fmt warning =
   Format.fprintf fmt "Warning: Invalid documentation comment:@,%s\n%!"
-    (Odoc_model.Error.to_string warning)
+    (Odoc_parser.Error.to_string warning)

--- a/lib/Docstring.mli
+++ b/lib/Docstring.mli
@@ -12,6 +12,6 @@
 val parse :
      loc:Warnings.loc
   -> string
-  -> (Odoc_parser.Ast.docs, Odoc_model.Error.t list) Result.t
+  -> (Odoc_parser.Ast.docs, Odoc_parser.Error.t list) Result.t
 
-val warn : Format.formatter -> Odoc_model.Error.t -> unit
+val warn : Format.formatter -> Odoc_parser.Error.t -> unit

--- a/lib/Docstring.mli
+++ b/lib/Docstring.mli
@@ -12,6 +12,6 @@
 val parse :
      loc:Warnings.loc
   -> string
-  -> (Odoc_parser.Ast.docs, Odoc_parser.Error.t list) Result.t
+  -> (Odoc_parser.Ast.t, Odoc_parser.Warning.t list) Result.t
 
-val warn : Format.formatter -> Odoc_parser.Error.t -> unit
+val warn : Format.formatter -> Odoc_parser.Warning.t -> unit

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -11,7 +11,7 @@
 
 open Fmt
 open Odoc_parser.Ast
-module Location_ = Odoc_parser.Location
+module Loc = Odoc_parser.Loc
 
 type conf = {fmt_code: string -> (Fmt.t, unit) Result.t}
 
@@ -56,7 +56,7 @@ let str_normalized ?(escape = escape_all) s =
   |> List.filter ~f:(Fn.non String.is_empty)
   |> fun s -> list s "@ " (fun s -> escape s |> str)
 
-let ign_loc ~f with_loc = f with_loc.Location_.value
+let ign_loc ~f with_loc = f with_loc.Loc.value
 
 let fmt_verbatim_block s =
   let force_break = String.contains s '\n' in
@@ -67,8 +67,10 @@ let fmt_verbatim_block s =
   in
   hvbox 0 (wrap "{v" "v}" content)
 
-let fmt_code_block conf s =
-  match conf.fmt_code s with
+let fmt_code_block conf s1 s2 =
+  let s2 = Odoc_parser.Loc.value s2 in
+  let _s1 = Option.map s1 ~f:Odoc_parser.Loc.value in
+  match conf.fmt_code s2 with
   | Ok formatted -> hvbox 0 (wrap "{[@;<1 2>" "@ ]}" formatted)
   | Error () ->
       let fmt_line ~first ~last:_ l =
@@ -77,7 +79,7 @@ let fmt_code_block conf s =
         else if String.length l = 0 then str "\n"
         else fmt "@," $ str l
       in
-      let lines = String.split_lines s in
+      let lines = String.split_lines s2 in
       let box = match lines with _ :: _ :: _ -> vbox 0 | _ -> hvbox 0 in
       box (wrap "{[@;<1 2>" "@ ]}" (vbox 0 (list_fl lines fmt_line)))
 
@@ -89,7 +91,7 @@ let fmt_reference = ign_loc ~f:str_normalized
 let list_should_use_heavy_syntax items =
   let heavy_nestable_block_elements = function
     (* More than one element or contains a list *)
-    | [{Location_.value= `List _; _}] | _ :: _ :: _ -> true
+    | [{Loc.value= `List _; _}] | _ :: _ :: _ -> true
     | [] | [_] -> false
   in
   List.exists items ~f:heavy_nestable_block_elements
@@ -107,10 +109,10 @@ let block_element_should_break elem next =
    depending on [block_element_should_break] *)
 let list_block_elem elems f =
   list_pn elems (fun ~prev:_ elem ~next ->
-      let elem = elem.Location_.value in
+      let elem = elem.Loc.value in
       let break =
         match next with
-        | Some {Location_.value= n; _}
+        | Some {Loc.value= n; _}
           when block_element_should_break
                  (elem :> block_element)
                  (n :> block_element) ->
@@ -120,8 +122,7 @@ let list_block_elem elems f =
       in
       f elem $ break )
 
-let space_elt : inline_element with_location =
-  Location_.(at (span []) (`Space ""))
+let space_elt : inline_element with_location = Loc.(at (span []) (`Space ""))
 
 let rec fmt_inline_elements elements =
   let wrap_elements opn cls ~always_wrap hd = function
@@ -173,7 +174,7 @@ let rec fmt_inline_elements elements =
 
 and fmt_nestable_block_element c = function
   | `Paragraph elems -> fmt_inline_elements elems
-  | `Code_block s -> fmt_code_block c s
+  | `Code_block (s1, s2) -> fmt_code_block c s1 s2
   | `Verbatim s -> fmt_verbatim_block s
   | `Modules mods ->
       hovbox 0
@@ -251,7 +252,7 @@ let fmt_block_element c = function
   | #nestable_block_element as elm ->
       hovbox 0 (fmt_nestable_block_element c elm)
 
-let fmt ~fmt_code (docs : docs) =
+let fmt ~fmt_code (docs : t) =
   vbox 0 (list_block_elem docs (fmt_block_element {fmt_code}))
 
 let diff c x y =
@@ -262,6 +263,4 @@ let diff c x y =
   Set.symmetric_diff (norm x) (norm y)
 
 let is_tag_only =
-  List.for_all ~f:(function
-    | {Location_.value= `Tag _; _} -> true
-    | _ -> false )
+  List.for_all ~f:(function {Loc.value= `Tag _; _} -> true | _ -> false)

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -67,9 +67,8 @@ let fmt_verbatim_block s =
   in
   hvbox 0 (wrap "{v" "v}" content)
 
-let fmt_code_block conf s1 s2 =
+let fmt_code_block conf _s1 s2 =
   let s2 = Odoc_parser.Loc.value s2 in
-  let _s1 = Option.map s1 ~f:Odoc_parser.Loc.value in
   match conf.fmt_code s2 with
   | Ok formatted -> hvbox 0 (wrap "{[@;<1 2>" "@ ]}" formatted)
   | Error () ->

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -11,7 +11,7 @@
 
 open Fmt
 open Odoc_parser.Ast
-module Location_ = Odoc_model.Location_
+module Location_ = Odoc_parser.Location
 
 type conf = {fmt_code: string -> (Fmt.t, unit) Result.t}
 

--- a/lib/Fmt_odoc.mli
+++ b/lib/Fmt_odoc.mli
@@ -10,13 +10,11 @@
 (**************************************************************************)
 
 val fmt :
-     fmt_code:(string -> (Fmt.t, unit) Result.t)
-  -> Odoc_parser.Ast.docs
-  -> Fmt.t
+  fmt_code:(string -> (Fmt.t, unit) Result.t) -> Odoc_parser.Ast.t -> Fmt.t
 
 val diff :
   Conf.t -> Cmt.t list -> Cmt.t list -> (string, string) Either.t Sequence.t
 (** Difference between two lists of doc comments. *)
 
-val is_tag_only : Odoc_parser.Ast.docs -> bool
+val is_tag_only : Odoc_parser.Ast.t -> bool
 (** [true] if the documentation only contains tags *)

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -46,8 +46,6 @@ module Position = struct
   include (val Comparator.make ~compare ~sexp_of_t)
 
   let distance p1 p2 = p2.pos_cnum - p1.pos_cnum
-
-  let to_point x = Odoc_parser.Loc.{line= x.pos_lnum; column= column x}
 end
 
 module Location = struct
@@ -109,12 +107,6 @@ module Location = struct
   let smallest loc stack =
     let min a b = if width a < width b then a else b in
     List.reduce_exn (loc :: stack) ~f:min
-
-  let to_span loc =
-    let open Odoc_parser.Loc in
-    { file= loc.loc_start.pos_fname
-    ; start= Position.to_point loc.loc_start
-    ; end_= Position.to_point loc.loc_end }
 
   let of_lexbuf (lexbuf : Lexing.lexbuf) =
     { loc_start= lexbuf.lex_start_p

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -47,7 +47,7 @@ module Position = struct
 
   let distance p1 p2 = p2.pos_cnum - p1.pos_cnum
 
-  let to_point x = Odoc_model.Location_.{line= x.pos_lnum; column= column x}
+  let to_point x = Odoc_parser.Location.{line= x.pos_lnum; column= column x}
 end
 
 module Location = struct
@@ -111,7 +111,7 @@ module Location = struct
     List.reduce_exn (loc :: stack) ~f:min
 
   let to_span loc =
-    let open Odoc_model.Location_ in
+    let open Odoc_parser.Location in
     { file= loc.loc_start.pos_fname
     ; start= Position.to_point loc.loc_start
     ; end_= Position.to_point loc.loc_end }

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -47,7 +47,7 @@ module Position = struct
 
   let distance p1 p2 = p2.pos_cnum - p1.pos_cnum
 
-  let to_point x = Odoc_parser.Location.{line= x.pos_lnum; column= column x}
+  let to_point x = Odoc_parser.Loc.{line= x.pos_lnum; column= column x}
 end
 
 module Location = struct
@@ -111,7 +111,7 @@ module Location = struct
     List.reduce_exn (loc :: stack) ~f:min
 
   let to_span loc =
-    let open Odoc_parser.Location in
+    let open Odoc_parser.Loc in
     { file= loc.loc_start.pos_fname
     ; start= Position.to_point loc.loc_start
     ; end_= Position.to_point loc.loc_end }

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -78,7 +78,7 @@ module Location : sig
 
   val is_single_line : t -> int -> bool
 
-  val to_span : t -> Odoc_model.Location_.span
+  val to_span : t -> Odoc_parser.Location.span
 
   val of_lexbuf : Lexing.lexbuf -> t
 

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -78,7 +78,7 @@ module Location : sig
 
   val is_single_line : t -> int -> bool
 
-  val to_span : t -> Odoc_parser.Location.span
+  val to_span : t -> Odoc_parser.Loc.span
 
   val of_lexbuf : Lexing.lexbuf -> t
 

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -78,8 +78,6 @@ module Location : sig
 
   val is_single_line : t -> int -> bool
 
-  val to_span : t -> Odoc_parser.Loc.span
-
   val of_lexbuf : Lexing.lexbuf -> t
 
   val print : Format.formatter -> t -> unit

--- a/lib/Normalize.ml
+++ b/lib/Normalize.ml
@@ -57,7 +57,7 @@ let list f fmt l =
 
 let str fmt s = Format.fprintf fmt "%s" (comment s)
 
-let ign_loc f fmt with_loc = f fmt with_loc.Odoc_model.Location_.value
+let ign_loc f fmt with_loc = f fmt with_loc.Odoc_parser.Location.value
 
 let fpf = Format.fprintf
 
@@ -175,9 +175,9 @@ let docstring c text =
   if not c.conf.parse_docstrings then comment text
   else
     let location = Lexing.dummy_pos in
-    let parsed = Odoc_parser.parse_comment_raw ~location ~text in
+    let parsed = Odoc_parser.parse_comment ~location ~text in
     Format.asprintf "Docstring(%a)%!" (odoc_docs c)
-      parsed.Odoc_model.Error.value
+      parsed.Odoc_parser.Error.value
 
 let sort_attributes : attributes -> attributes =
   List.sort ~compare:Poly.compare

--- a/lib/dune
+++ b/lib/dune
@@ -22,7 +22,6 @@
   ocaml_413
   ocamlformat_stdlib
   ocp-indent.lib
-  odoc.model
   odoc.parser
   parse_wyc
   re

--- a/lib/dune
+++ b/lib/dune
@@ -22,7 +22,7 @@
   ocaml_413
   ocamlformat_stdlib
   ocp-indent.lib
-  odoc.parser
+  odoc-parser
   parse_wyc
   re
   uuseg

--- a/ocamlformat-rpc.opam
+++ b/ocamlformat-rpc.opam
@@ -25,11 +25,12 @@ depends: [
   "menhirSdk" {>= "20200624"}
   "ocp-indent"
   "bisect_ppx" {with-test & >= "2.5.0"}
-  "odoc" {>= "1.4.2"}
+  "odoc-parser" {>= "0.9.0"}
   "re"
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -24,11 +24,12 @@ depends: [
   "menhirSdk" {>= "20200624"}
   "ocp-indent"
   "bisect_ppx" {with-test & >= "2.5.0"}
-  "odoc" {>= "1.4.2"}
+  "odoc-parser" {>= "0.9.0"}
   "re"
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/test/passing/tests/invalid_docstring.ml.ref
+++ b/test/passing/tests/invalid_docstring.ml.ref
@@ -1,4 +1,7 @@
 Warning: Invalid documentation comment:
-File "tests/invalid_docstring.ml", line 1, characters 0-7:
-comment could not be parsed
+File "tests/invalid_docstring.ml", line 1, characters 5-5:
+End of text is not allowed in '{v ... v}' (verbatim text).
+Warning: Invalid documentation comment:
+File "tests/invalid_docstring.ml", line 1, characters 3-5:
+'{v ... v}' (verbatim text) should not be empty.
 (**{v*)


### PR DESCRIPTION
This PR has been done on top of #1669 because the support for ppxlib master is for the moment required to get ocamlformat on OCaml 4.13. For the same reason, ocamlformat also requires odoc (master) but the API changed a little so here is a PR to fix this.

With this we get it working on OCaml 4.13 for free. Feel free to use https://github.com/kit-ty-kate/opam-alpha-repository/ for testing.