### PR TITLE
Disable the indentation feature in emacs for ocamlformat < 0.19.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,10 +40,10 @@
 
 #### New features
 
-  + Emacs integration:
+  + Emacs integration (disabled for ocamlformat < 0.19.0):
     - Indent a line or a region with ocamlformat when pressing <TAB>
     - Break the line and reindent the cursor when pressing <ENTER>
-  (#1639, @gpetiot)
+  (#1639, #1685, @gpetiot)
 
 ### 0.18.0 (2021-03-30)
 

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -398,7 +398,8 @@ With ARG, perform this action that many times."
   "Get the version of the installed ocamlformat."
   (car
    (split-string
-    (shell-command-to-string (format "%s --version" ocamlformat-command))
+    (shell-command-to-string
+     (format "%s --version" (shell-quote-argument ocamlformat-command)))
     "-")))
 
 (defun enable-indent ()

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -408,12 +408,11 @@ With ARG, perform this action that many times."
   "Whether the indentation feature is enabled."
   (version<= "0.19.0" (ocamlformat-version)))
 
-(if (enable-indent)
-  (progn
-    (add-hook 'tuareg-mode-hook 'ocamlformat-setup-indent t)
-    (add-hook 'tuareg-mode-hook 'set-newline-and-indent)
-    (add-hook 'caml-mode-hook 'ocamlformat-caml-mode-setup  t)
-    (add-hook 'caml-mode-hook 'set-newline-and-indent)))
+(when (enable-indent)
+  (add-hook 'tuareg-mode-hook 'ocamlformat-setup-indent t)
+  (add-hook 'tuareg-mode-hook 'set-newline-and-indent)
+  (add-hook 'caml-mode-hook 'ocamlformat-caml-mode-setup  t)
+  (add-hook 'caml-mode-hook 'set-newline-and-indent))
 
 (provide 'ocamlformat)
 

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -400,7 +400,9 @@ With ARG, perform this action that many times."
    (split-string
     (shell-command-to-string
      (format "%s --version" (shell-quote-argument ocamlformat-command)))
-    "-")))
+    "-"
+    t
+    split-string-default-separators)))
 
 (defun enable-indent ()
   "Whether the indentation feature is enabled."

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -394,11 +394,23 @@ With ARG, perform this action that many times."
 (defun set-newline-and-indent ()
   (local-set-key (kbd "RET") 'custom_newline-and-indent))
 
-(add-hook 'tuareg-mode-hook 'ocamlformat-setup-indent t)
-(add-hook 'tuareg-mode-hook 'set-newline-and-indent)
+(defun ocamlformat-version ()
+  "Get the version of the installed ocamlformat."
+  (car
+   (split-string
+    (shell-command-to-string (format "%s --version" ocamlformat-command))
+    "-")))
 
-(add-hook 'caml-mode-hook 'ocamlformat-caml-mode-setup  t)
-(add-hook 'caml-mode-hook 'set-newline-and-indent)
+(defun enable-indent ()
+  "Whether the indentation feature is enabled."
+  (version<= "0.19.0" (ocamlformat-version)))
+
+(if (enable-indent)
+  (progn
+    (add-hook 'tuareg-mode-hook 'ocamlformat-setup-indent t)
+    (add-hook 'tuareg-mode-hook 'set-newline-and-indent)
+    (add-hook 'caml-mode-hook 'ocamlformat-caml-mode-setup  t)
+    (add-hook 'caml-mode-hook 'set-newline-and-indent)))
 
 (provide 'ocamlformat)
 


### PR DESCRIPTION
Follow-up of #1639, tested with the current master branch, works well when simulating 0.16.* and 0.19.* versions as well.
cc @bcc32 let me know if that fixes the issue.