### PR TITLE
Enable indentation buffer by buffer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,7 +43,7 @@
   + Emacs integration (disabled for ocamlformat < 0.19.0):
     - Indent a line or a region with ocamlformat when pressing <TAB>
     - Break the line and reindent the cursor when pressing <ENTER>
-  (#1639, #1685, @gpetiot)
+  (#1639, #1685, @gpetiot) (#1687, @bcc32)
 
 ### 0.18.0 (2021-03-30)
 

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -367,11 +367,16 @@ is nil."
   (interactive nil)
   (ocamlformat-region (point) (point)))
 
+(defun ocamlformat--enable-indent ()
+  "Whether the indentation feature is enabled."
+  (version<= "0.19.0" (ocamlformat-version)))
+
 ;;;###autoload
 (defun ocamlformat-setup-indent ()
   (interactive nil)
-  (setq-local indent-line-function #'ocamlformat-line)
-  (setq-local indent-region-function #'ocamlformat-region))
+  (when (ocamlformat--enable-indent)
+    (setq-local indent-line-function #'ocamlformat-line)
+    (setq-local indent-region-function #'ocamlformat-region)))
 
 ;;;###autoload
 (defun ocamlformat-caml-mode-setup ()
@@ -393,7 +398,8 @@ With ARG, perform this action that many times."
 
 (defun ocamlformat-set-newline-and-indent ()
   "Bind RET to `ocamlformat-newline-and-indent'."
-  (local-set-key (kbd "RET") 'ocamlformat-newline-and-indent))
+  (when (ocamlformat--enable-indent)
+    (local-set-key (kbd "RET") 'ocamlformat-newline-and-indent)))
 
 (defun ocamlformat-version ()
   "Get the version of the installed ocamlformat."
@@ -405,15 +411,10 @@ With ARG, perform this action that many times."
     t
     split-string-default-separators)))
 
-(defun ocamlformat--enable-indent ()
-  "Whether the indentation feature is enabled."
-  (version<= "0.19.0" (ocamlformat-version)))
-
-(when (ocamlformat--enable-indent)
-  (add-hook 'tuareg-mode-hook 'ocamlformat-setup-indent t)
-  (add-hook 'tuareg-mode-hook 'ocamlformat-set-newline-and-indent)
-  (add-hook 'caml-mode-hook 'ocamlformat-caml-mode-setup  t)
-  (add-hook 'caml-mode-hook 'ocamlformat-set-newline-and-indent))
+(add-hook 'tuareg-mode-hook 'ocamlformat-setup-indent t)
+(add-hook 'tuareg-mode-hook 'ocamlformat-set-newline-and-indent)
+(add-hook 'caml-mode-hook 'ocamlformat-caml-mode-setup t)
+(add-hook 'caml-mode-hook 'ocamlformat-set-newline-and-indent)
 
 (provide 'ocamlformat)
 

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -378,7 +378,7 @@ is nil."
   (ocamlformat-setup-indent)
   (local-unset-key "\t"))  ;; caml-mode rebinds TAB !
 
-(defun custom_newline-and-indent (&optional arg)
+(defun ocamlformat-newline-and-indent (&optional arg)
   "Insert a newline, then indent according to `ocamlformat-line'.
 With ARG, perform this action that many times."
   (interactive "*p")
@@ -391,8 +391,9 @@ With ARG, perform this action that many times."
     (ocamlformat-line)
     (delete-backward-char 1 nil)))
 
-(defun set-newline-and-indent ()
-  (local-set-key (kbd "RET") 'custom_newline-and-indent))
+(defun ocamlformat-set-newline-and-indent ()
+  "Bind RET to `ocamlformat-newline-and-indent'."
+  (local-set-key (kbd "RET") 'ocamlformat-newline-and-indent))
 
 (defun ocamlformat-version ()
   "Get the version of the installed ocamlformat."
@@ -404,15 +405,15 @@ With ARG, perform this action that many times."
     t
     split-string-default-separators)))
 
-(defun enable-indent ()
+(defun ocamlformat--enable-indent ()
   "Whether the indentation feature is enabled."
   (version<= "0.19.0" (ocamlformat-version)))
 
-(when (enable-indent)
+(when (ocamlformat--enable-indent)
   (add-hook 'tuareg-mode-hook 'ocamlformat-setup-indent t)
-  (add-hook 'tuareg-mode-hook 'set-newline-and-indent)
+  (add-hook 'tuareg-mode-hook 'ocamlformat-set-newline-and-indent)
   (add-hook 'caml-mode-hook 'ocamlformat-caml-mode-setup  t)
-  (add-hook 'caml-mode-hook 'set-newline-and-indent))
+  (add-hook 'caml-mode-hook 'ocamlformat-set-newline-and-indent))
 
 (provide 'ocamlformat)
 

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -370,8 +370,8 @@ is nil."
 ;;;###autoload
 (defun ocamlformat-setup-indent ()
   (interactive nil)
-  (set (make-local-variable 'indent-line-function) #'ocamlformat-line)
-  (set (make-local-variable 'indent-region-function) #'ocamlformat-region))
+  (setq-local indent-line-function #'ocamlformat-line)
+  (setq-local indent-region-function #'ocamlformat-region))
 
 ;;;###autoload
 (defun ocamlformat-caml-mode-setup ()

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -389,7 +389,7 @@ With ARG, perform this action that many times."
     (newline nil t)
     (insert "x")
     (ocamlformat-line)
-    (delete-backward-char 1 nil)))
+    (delete-char -1)))
 
 (defun ocamlformat-set-newline-and-indent ()
   "Bind RET to `ocamlformat-newline-and-indent'."


### PR DESCRIPTION


When enabling indentation, we should check each buffer individually,
as $PATH may have changed (local variables, direnv-mode, etc.), or the
version of ocamlformat in $PATH may have changed (local opam
switches).

This also prevents ocamlformat.el from failing to load if ocamlformat
cannot be found at emacs startup.

