### PR TITLE
Fix normalization of odoc paragraphs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,9 @@
 
   + Improve breaking of comments to avoid violating the margin (#1676, @jberdine)
 
+  + Fix normalization of odoc paragraphs (#1695, @gpetiot)
+    Paragraphs must not be considered for the normalized form. They are only structural and the shape of a docstring organized in paragraphs only depend on linebreaks, which may be changed by the formatting.
+
 #### Changes
 
   + Improve the diff of unstable docstrings displayed in error messages (#1654, @gpetiot)

--- a/test/passing/tests/doc_comments-after.ml.ref
+++ b/test/passing/tests/doc_comments-after.ml.ref
@@ -290,3 +290,6 @@ let _ = ()
 (** @see 'file' *)
 
 (** @see "title" *)
+
+(** starts with linebreaks *)
+let a = 1

--- a/test/passing/tests/doc_comments-before-except-val.ml.ref
+++ b/test/passing/tests/doc_comments-before-except-val.ml.ref
@@ -290,3 +290,6 @@ let _ = ()
 (** @see 'file' *)
 
 (** @see "title" *)
+
+(** starts with linebreaks *)
+let a = 1

--- a/test/passing/tests/doc_comments-before.ml.ref
+++ b/test/passing/tests/doc_comments-before.ml.ref
@@ -290,3 +290,6 @@ let _ = ()
 (** @see 'file' *)
 
 (** @see "title" *)
+
+(** starts with linebreaks *)
+let a = 1

--- a/test/passing/tests/doc_comments.ml
+++ b/test/passing/tests/doc_comments.ml
@@ -283,3 +283,9 @@ let _ = ()
 
 (** @see 'file' *)
 (** @see "title" *)
+
+(**
+
+starts with linebreaks
+*)
+let a = 1

--- a/test/passing/tests/doc_comments.ml.ref
+++ b/test/passing/tests/doc_comments.ml.ref
@@ -290,3 +290,6 @@ let _ = ()
 (** @see 'file' *)
 
 (** @see "title" *)
+
+(** starts with linebreaks *)
+let a = 1


### PR DESCRIPTION
I added a comment to keep trace of it, paragraphs must not be considered for the normalized form. They are only structural and the shape of a docstring organized in paragraphs only depend on linebreaks, which may be changed by the formatting.

I also changed the normalized output of other nodes, using `Node(X,Y)` instead of `Node,X,Y` as it is more convenient for debugging. No diff with test_branch.sh

Fix #1686