### PR TITLE
Use a separate lexer for merlin-specific inputs (type disambiguations)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,7 +45,7 @@
     - Break the line and reindent the cursor when pressing <ENTER>
   (#1639, #1685, @gpetiot) (#1687, @bcc32)
 
-  + Type identifiers can have a disambiguation suffix (e.g. `t/2`), as produced by the compiler (#1697, @trefis)
+  + Type identifiers can have a disambiguation suffix (e.g. `t/2`), as produced by the compiler (#1697, #1699, @trefis, @gpetiot)
 
 ### 0.18.0 (2021-03-30)
 

--- a/lib/Ast_passes.ml
+++ b/lib/Ast_passes.ml
@@ -57,11 +57,11 @@ module Ast0 = struct
   module Parse = struct
     let implementation = Parse.implementation
 
-    let interface = Parse.interface
+    let interface = Parse_merlin.interface
 
     let use_file = Parse.use_file
 
-    let core_type = Parse.core_type
+    let core_type = Parse_merlin.core_type
 
     let module_type (lx : Lexing.lexbuf) =
       let pre = "module X : " in

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -71,13 +71,14 @@ module Error = struct
     | Invalid_source {exn; input_name} -> (
         let reason =
           match exn with
-          | Syntaxerr.Error _ | Lexer.Error _ -> " (syntax error)"
+          | Syntaxerr.Error _ | Lexer.Error _ | Lexer_merlin.Error _ ->
+              " (syntax error)"
           | Warning50 _ -> " (misplaced documentation comments - warning 50)"
           | _ -> ""
         in
         Format.fprintf fmt "%s: ignoring %S%s\n%!" exe input_name reason ;
         match exn with
-        | Syntaxerr.Error _ | Lexer.Error _ ->
+        | Syntaxerr.Error _ | Lexer.Error _ | Lexer_merlin.Error _ ->
             Location.report_exception fmt exn
         | Warning50 l ->
             List.iter l ~f:(fun (l, w) -> Warning.print_warning l w) ;
@@ -186,7 +187,9 @@ module Error = struct
                        @{<error>Error@}: Comment (* %s *) dropped.\n\
                        %!"
                       Location.print loc msg )
-            | `Cannot_parse ((Syntaxerr.Error _ | Lexer.Error _) as exn) ->
+            | `Cannot_parse
+                ( (Syntaxerr.Error _ | Lexer.Error _ | Lexer_merlin.Error _)
+                as exn ) ->
                 if debug then Location.report_exception fmt exn
             | `Warning50 l ->
                 if debug then

--- a/test/passing/tests/source.ml
+++ b/test/passing/tests/source.ml
@@ -7397,3 +7397,6 @@ let xxxxxx =
   let%map (* _____________________________
              __________ *)()            = yyyyyyyy in
   { zzzzzzzzzzzzz }
+
+let _ = a/2
+let _ = a/2n

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -9235,3 +9235,7 @@ f
 let xxxxxx =
   let%map (* _____________________________ __________ *) () = yyyyyyyy in
   {zzzzzzzzzzzzz}
+
+let _ = a / 2
+
+let _ = a / 2n

--- a/vendor/ocaml-4.12/dune
+++ b/vendor/ocaml-4.12/dune
@@ -6,6 +6,8 @@
 
 (ocamllex lexer)
 
+(ocamllex lexer_merlin)
+
 (menhir
  (infer false)
  (flags

--- a/vendor/ocaml-4.12/lexer_merlin.mll
+++ b/vendor/ocaml-4.12/lexer_merlin.mll
@@ -368,6 +368,8 @@ let hex_float_literal =
   (['p' 'P'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']* )?
 let literal_modifier = ['G'-'Z' 'g'-'z']
 
+let type_disambig = ['/'] ['0'-'9']+
+
 rule token = parse
   | ('\\' as bs) newline {
       if not !escaped_newlines then error lexbuf (Illegal_character bs);
@@ -399,6 +401,15 @@ rule token = parse
   | "?" (lowercase_latin1 identchar_latin1 * as name) ':'
       { warn_latin1 lexbuf;
         OPTLABEL name }
+  | lowercase identchar * type_disambig as name
+      { try Hashtbl.find keyword_table name
+        with Not_found -> TLIDENT name }
+  | lowercase_latin1 identchar_latin1 * type_disambig as name
+      { warn_latin1 lexbuf; TLIDENT name }
+  | uppercase identchar * type_disambig as name
+      { TUIDENT name } (* No capitalized keywords *)
+  | uppercase_latin1 identchar_latin1 * type_disambig as name
+      { warn_latin1 lexbuf; TUIDENT name }
   | lowercase identchar * as name
       { try Hashtbl.find keyword_table name
         with Not_found -> LIDENT name }

--- a/vendor/ocaml-4.12/parse_merlin.ml
+++ b/vendor/ocaml-4.12/parse_merlin.ml
@@ -1,0 +1,175 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Entry points in the parser *)
+
+module Lexer = Lexer_merlin
+
+(* Skip tokens to the end of the phrase *)
+
+let last_token = ref Parser.EOF
+
+let token lexbuf =
+  let token = Lexer.token lexbuf in
+  last_token := token;
+  token
+
+let rec skip_phrase lexbuf =
+  match token lexbuf with
+  | Parser.SEMISEMI | Parser.EOF -> ()
+  | _ -> skip_phrase lexbuf
+  | exception (Lexer.Error (Lexer.Unterminated_comment _, _)
+              | Lexer.Error (Lexer.Unterminated_string, _)
+              | Lexer.Error (Lexer.Reserved_sequence _, _)
+              | Lexer.Error (Lexer.Unterminated_string_in_comment _, _)
+              | Lexer.Error (Lexer.Illegal_character _, _)) ->
+      skip_phrase lexbuf
+
+let maybe_skip_phrase lexbuf =
+  match !last_token with
+  | Parser.SEMISEMI | Parser.EOF -> ()
+  | _ -> skip_phrase lexbuf
+
+let wrap parsing_fun lexbuf =
+  try
+    Docstrings.init ();
+    Lexer.init ();
+    let ast = parsing_fun lexbuf in
+    Parsing.clear_parser();
+    Docstrings.warn_bad_docstrings ();
+    last_token := Parser.EOF;
+    ast
+  with
+  | Lexer.Error(Lexer.Illegal_character _, _) as err
+    when !Location.input_name = "//toplevel//"->
+      skip_phrase lexbuf;
+      raise err
+  | Syntaxerr.Error _ as err
+    when !Location.input_name = "//toplevel//" ->
+      maybe_skip_phrase lexbuf;
+      raise err
+  | Parsing.Parse_error | Syntaxerr.Escape_error ->
+      let loc = Location.curr lexbuf in
+      if !Location.input_name = "//toplevel//"
+      then maybe_skip_phrase lexbuf;
+      raise(Syntaxerr.Error(Syntaxerr.Other loc))
+
+let rec loop lexbuf in_error checkpoint =
+  let module I = Parser.MenhirInterpreter in
+  match checkpoint with
+  | I.InputNeeded _env ->
+      let triple =
+        if in_error then
+          (* The parser detected an error.
+             At this point we don't want to consume input anymore. In the
+             top-level, it would translate into waiting for the user to type
+             something, just to raise an error at some earlier position, rather
+             than just raising the error immediately.
+
+             This worked before with yacc because, AFAICT (@let-def):
+             - yacc eagerly reduces "default reduction" (when the next action
+               is to reduce the same production no matter what token is read,
+               yacc reduces it immediately rather than waiting for that token
+               to be read)
+             - error productions in OCaml grammar are always in a position that
+               allows default reduction ("error" symbol is the last producer,
+               and the lookahead token will not be used to disambiguate between
+               two possible error rules)
+             This solution is fragile because it relies on an optimization
+             (default reduction), that changes the semantics of the parser the
+             way it is implemented in Yacc (an optimization that changes
+             semantics? hmmmm).
+
+             Rather than relying on implementation details of the parser, when
+             an error is detected in this loop we stop looking at the input and
+             fill the parser with EOF tokens.
+             The skip_phrase logic will resynchronize the input stream by
+             looking for the next ';;'.  *)
+          (Parser.EOF, lexbuf.Lexing.lex_curr_p, lexbuf.Lexing.lex_curr_p)
+        else
+          let token = token lexbuf in
+          (token, lexbuf.Lexing.lex_start_p, lexbuf.Lexing.lex_curr_p)
+      in
+      let checkpoint = I.offer checkpoint triple in
+      loop lexbuf in_error checkpoint
+  | I.Shifting _ | I.AboutToReduce _ ->
+      loop lexbuf in_error (I.resume checkpoint)
+  | I.Accepted v -> v
+  | I.Rejected -> raise Parser.Error
+  | I.HandlingError _ ->
+      loop lexbuf true (I.resume checkpoint)
+
+let wrap_menhir entry lexbuf =
+  let initial = entry lexbuf.Lexing.lex_curr_p in
+  wrap (fun lexbuf -> loop lexbuf false initial) lexbuf
+
+let implementation = wrap_menhir Parser.Incremental.implementation
+and interface = wrap_menhir Parser.Incremental.interface
+and toplevel_phrase = wrap_menhir Parser.Incremental.toplevel_phrase
+and use_file = wrap_menhir Parser.Incremental.use_file
+and core_type = wrap_menhir Parser.Incremental.parse_core_type
+and expression = wrap_menhir Parser.Incremental.parse_expression
+and pattern = wrap_menhir Parser.Incremental.parse_pattern
+
+let longident = wrap_menhir Parser.Incremental.parse_any_longident
+let val_ident = wrap_menhir Parser.Incremental.parse_val_longident
+let constr_ident= wrap_menhir Parser.Incremental.parse_constr_longident
+let extended_module_path =
+  wrap_menhir Parser.Incremental.parse_mod_ext_longident
+let simple_module_path = wrap_menhir Parser.Incremental.parse_mod_longident
+let type_ident = wrap_menhir Parser.Incremental.parse_mty_longident
+
+(* Error reporting for Syntaxerr *)
+(* The code has been moved here so that one can reuse Pprintast.tyvar *)
+
+let prepare_error err =
+  let open Syntaxerr in
+  match err with
+  | Unclosed(opening_loc, opening, closing_loc, closing) ->
+      Location.errorf
+        ~loc:closing_loc
+        ~sub:[
+          Location.msg ~loc:opening_loc
+            "This '%s' might be unmatched" opening
+        ]
+        "Syntax error: '%s' expected" closing
+
+  | Expecting (loc, nonterm) ->
+      Location.errorf ~loc "Syntax error: %s expected." nonterm
+  | Not_expecting (loc, nonterm) ->
+      Location.errorf ~loc "Syntax error: %s not expected." nonterm
+  | Applicative_path loc ->
+      Location.errorf ~loc
+        "Syntax error: applicative paths of the form F(X).t \
+         are not supported when the option -no-app-func is set."
+  | Variable_in_scope (loc, var) ->
+      Location.errorf ~loc
+        "In this scoped type, variable %a \
+         is reserved for the local type %s."
+        Pprintast.tyvar var var
+  | Other loc ->
+      Location.errorf ~loc "Syntax error"
+  | Ill_formed_ast (loc, s) ->
+      Location.errorf ~loc
+        "broken invariant in parsetree: %s" s
+  | Invalid_package_type (loc, s) ->
+      Location.errorf ~loc "invalid package type: %s" s
+
+let () =
+  Location.register_error_of_exn
+    (function
+      | Syntaxerr.Error err -> Some (prepare_error err)
+      | _ -> None
+    )

--- a/vendor/ocaml-4.12/parse_merlin.mli
+++ b/vendor/ocaml-4.12/parse_merlin.mli
@@ -1,0 +1,108 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Entry points in the parser
+
+  {b Warning:} this module is unstable and part of
+  {{!Compiler_libs}compiler-libs}.
+
+*)
+
+val implementation : Lexing.lexbuf -> Parsetree.structure
+val interface : Lexing.lexbuf -> Parsetree.signature
+val toplevel_phrase : Lexing.lexbuf -> Parsetree.toplevel_phrase
+val use_file : Lexing.lexbuf -> Parsetree.toplevel_phrase list
+val core_type : Lexing.lexbuf -> Parsetree.core_type
+val expression : Lexing.lexbuf -> Parsetree.expression
+val pattern : Lexing.lexbuf -> Parsetree.pattern
+
+(** The functions below can be used to parse Longident safely. *)
+
+val longident: Lexing.lexbuf -> Longident.t
+(**
+   The function [longident] is guaranteed to parse all subclasses
+   of {!Longident.t} used in OCaml: values, constructors, simple or extended
+   module paths, and types or module types.
+
+   However, this function accepts inputs which are not accepted by the
+   compiler, because they combine functor applications and infix operators.
+   In valid OCaml syntax, only value-level identifiers may end with infix
+   operators [Foo.( + )].
+   Moreover, in value-level identifiers the module path [Foo] must be simple
+   ([M.N] rather than [F(X)]): functor applications may only appear in
+   type-level identifiers.
+   As a consequence, a path such as [F(X).( + )] is not a valid OCaml
+   identifier; but it is accepted by this function.
+*)
+
+(** The next functions are specialized to a subclass of {!Longident.t} *)
+
+val val_ident: Lexing.lexbuf -> Longident.t
+(**
+   This function parses a syntactically valid path for a value. For instance,
+   [x], [M.x], and [(+.)] are valid. Contrarily, [M.A], [F(X).x], and [true]
+   are rejected.
+
+   Longident for OCaml's value cannot contain functor application.
+   The last component of the {!Longident.t} is not capitalized,
+   but can be an operator [A.Path.To.(.%.%.(;..)<-)]
+*)
+
+val constr_ident: Lexing.lexbuf -> Longident.t
+(**
+   This function parses a syntactically valid path for a variant constructor.
+   For instance, [A], [M.A] and [M.(::)] are valid, but both [M.a]
+   and [F(X).A] are rejected.
+
+   Longident for OCaml's variant constructors cannot contain functor
+   application.
+   The last component of the {!Longident.t} is capitalized,
+   or it may be one the special constructors: [true],[false],[()],[[]],[(::)].
+   Among those special constructors, only [(::)] can be prefixed by a module
+   path ([A.B.C.(::)]).
+*)
+
+
+val simple_module_path: Lexing.lexbuf -> Longident.t
+(**
+   This function parses a syntactically valid path for a module.
+   For instance, [A], and [M.A] are valid, but both [M.a]
+   and [F(X).A] are rejected.
+
+   Longident for OCaml's module cannot contain functor application.
+   The last component of the {!Longident.t} is capitalized.
+*)
+
+
+val extended_module_path: Lexing.lexbuf -> Longident.t
+(**
+   This function parse syntactically valid path for an extended module.
+   For instance, [A.B] and [F(A).B] are valid. Contrarily,
+   [(.%())] or [[]] are both rejected.
+
+   The last component of the {!Longident.t} is capitalized.
+
+*)
+
+val type_ident: Lexing.lexbuf -> Longident.t
+(**
+   This function parse syntactically valid path for a type or a module type.
+   For instance, [A], [t], [M.t] and [F(X).t] are valid. Contrarily,
+   [(.%())] or [[]] are both rejected.
+
+   In path for type and module types, only operators and special constructors
+   are rejected.
+
+*)


### PR DESCRIPTION
#1697 follow-up, fixes the regression on arithmetic use of `/`. Having a separate lexer is the only solution that worked, as I didn't find any way of disabling some rules in the lexer (and having conditional branching made some characters or lexems disappear).

cc @hhugo  @trefis @voodoos