### PR TITLE
Add script to build ocamlformat with mingw64

### DIFF
--- a/.github/workflows/build-mingw64.yml
+++ b/.github/workflows/build-mingw64.yml
@@ -1,0 +1,43 @@
+name: Build mingw64 binary
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        required: true
+        default: 'master'
+
+env:
+  CYGWINSETUP: setup-x86_64.exe
+  PACKAGES: make,curl,unzip,mingw64-x86_64-binutils,mingw64-x86_64-gcc-core,mingw64-x86_64-headers,mingw64-x86_64-runtime
+  SITE: https://mirrors.kernel.org/sourceware/cygwin
+
+jobs:
+  build:
+    runs-on: windows-latest
+    env:
+      SHELLOPTS: igncr
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          ref: ${{ github.event.inputs.ref }}
+      - name: Download Cygwin installer
+        run: |
+          curl.exe -o C:\${{ env.CYGWINSETUP }} https://www.cygwin.com/${{ env.CYGWINSETUP }}
+        shell: cmd
+      - name: Setup Cygwin
+        run: |
+          C:\${{ env.CYGWINSETUP }} -A -q -D -L -g -o -s ${{ env.SITE }} -l %LOCALAPPDATA%\cygwin64 -R C:\cygwin64 -C Base -P ${{ env.PACKAGES }}
+        shell: cmd
+      - name: Run build script
+        run: |
+          cd '${{ github.workspace }}'
+          bash tools/build-mingw64.sh
+        shell: C:\cygwin64\bin\bash.exe --login --norc '{0}'
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ocamlformat-${{ github.event.inputs.ref }}.exe
+          path: ${{ github.workspace }}\_build\install\default\bin\ocamlformat.exe
+          if-no-files-found: error

--- a/.github/workflows/build-mingw64.yml
+++ b/.github/workflows/build-mingw64.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CYGWINSETUP: setup-x86_64.exe
-  PACKAGES: git,m4,rsync,patchutils,make,curl,unzip,mingw64-x86_64-binutils,mingw64-x86_64-gcc-core,mingw64-x86_64-headers,mingw64-x86_64-runtime
+  PACKAGES: git,m4,patchutils,make,curl,unzip,mingw64-x86_64-binutils,mingw64-x86_64-gcc-core,mingw64-x86_64-headers,mingw64-x86_64-runtime
   SITE: https://mirrors.kernel.org/sourceware/cygwin
 
 jobs:

--- a/.github/workflows/build-mingw64.yml
+++ b/.github/workflows/build-mingw64.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CYGWINSETUP: setup-x86_64.exe
-  PACKAGES: make,curl,unzip,mingw64-x86_64-binutils,mingw64-x86_64-gcc-core,mingw64-x86_64-headers,mingw64-x86_64-runtime
+  PACKAGES: git,m4,rsync,patchutils,make,curl,unzip,mingw64-x86_64-binutils,mingw64-x86_64-gcc-core,mingw64-x86_64-headers,mingw64-x86_64-runtime
   SITE: https://mirrors.kernel.org/sourceware/cygwin
 
 jobs:
@@ -18,24 +18,24 @@ jobs:
     env:
       SHELLOPTS: igncr
     steps:
-      - name: Checkout repository
+      - name: Checkout Repository
         uses: actions/checkout@v1
         with:
           ref: ${{ github.event.inputs.ref }}
-      - name: Download Cygwin installer
+      - name: Download Cygwin Installer
         run: |
           curl.exe -o C:\${{ env.CYGWINSETUP }} https://www.cygwin.com/${{ env.CYGWINSETUP }}
         shell: cmd
       - name: Setup Cygwin
         run: |
-          C:\${{ env.CYGWINSETUP }} -A -q -D -L -g -o -s ${{ env.SITE }} -l %LOCALAPPDATA%\cygwin64 -R C:\cygwin64 -C Base -P ${{ env.PACKAGES }}
+          C:\${{ env.CYGWINSETUP }} -A -q -D -L -g -o -s ${{ env.SITE }} -l C:\cygwin64-cache -R C:\cygwin64 -C Base -P ${{ env.PACKAGES }}
         shell: cmd
-      - name: Run build script
+      - name: Run Build Script
         run: |
           cd '${{ github.workspace }}'
           bash tools/build-mingw64.sh
         shell: C:\cygwin64\bin\bash.exe --login --norc '{0}'
-      - name: Upload artifact
+      - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
           name: ocamlformat-${{ github.event.inputs.ref }}.exe

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 /test-extra/code
 /_opam
 /_coverage
-/build-mingw64
+/_build-mingw64

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /test-extra/code
 /_opam
 /_coverage
+/build-mingw64

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,11 @@
     - Break the line and reindent the cursor when pressing <ENTER>
   (#1639, #1685, @gpetiot) (#1687, @bcc32)
 
+#### Internal
+
+  + A script `tools/build-mingw64.sh` is provided to build a native Windows
+    binary of `ocamlformat` using `mingw64` toolchain under Cygwin.
+
 ### 0.18.0 (2021-03-30)
 
 #### Bug fixes

--- a/HACKING.org
+++ b/HACKING.org
@@ -222,3 +222,23 @@ End state:
 
 ...
 #+END_SRC
+
+* Building on Windows
+
+`ocamlformat` can be built as a native Windows binary using the `mingw64`
+toolchain under Cygwin. The following Cygwin packages are required:
+
+- `git`, `curl`, `unzip`
+- `m4`, `patchutils`, `make`
+- `mingw64-x86_64-binutils`, `mingw64-x86_64-gcc-core`, `mingw64-x86_64-headers`, `mingw64-x86_64-runtime`
+
+The binary is built by executing `bash tools/build-mingw64.sh` from the root of
+the repository. The first time the script is launched, it will install `opam` in
+the subdirectory `_build-mingw64` and use it to install all the dependencies of
+`ocamlformat` and then build the binary. Subsequent launches of the script will
+only rebuild `ocamlformat`. If you need to start from scratch again, simply
+remove the `_build-mingw64` directory.
+
+This script can also be triggered as a GitHub Action named `build-mingw64` which
+will build the binary in a GitHub worker and upload it back to GitHub. To
+retrieve it, select the Action run in question and scroll down to "Artifacts".

--- a/tools/build-mingw64.sh
+++ b/tools/build-mingw64.sh
@@ -4,101 +4,36 @@
 # All it requires is a standard Cygwin installation with the `mingw64'
 # toolchain.
 
-# The script builds `flexdll', `ocaml', `dune', `ocamlformat' and their
-# dependencies and leaves the resulting binary at
-#
-#   _build/install/default/bin/ocamlformat.exe
-
 set -euo pipefail
 
-root=$(git rev-parse --show-toplevel)
+opam_url=https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.2/opam64.tar.xz
 
-flexdll_version=0.39
-flexdll_url=https://github.com/alainfrisch/flexdll
-
-ocaml_version=4.12.0
-ocaml_url=https://github.com/ocaml/ocaml
-
-dune_version=2.9.0
-dune_url=https://github.com/ocaml/dune
-
-packages=(
-    https://github.com/janestreet/sexplib0                v0.14.0
-    https://github.com/ocaml-dune/csexp                   master
-    https://github.com/dune-universe/uuseg                duniverse-v13.0.0
-    https://github.com/ocaml/ocaml-re                     master
-    https://github.com/ocaml/odoc                         1.5.2
-    https://github.com/OCamlPro/ocp-indent                master
-    https://gitlab.inria.fr/fpottier/menhir               master
-    https://github.com/janestreet/stdio                   master
-    https://github.com/dune-universe/fpath                duniverse-v0.7.3
-    https://github.com/mirage/either                      main
-    https://github.com/dbuenzli/cmdliner                  master
-    https://github.com/janestreet/base                    v0.14.1
-    https://github.com/dune-universe/astring              duniverse-v0.8.5
-    https://github.com/dune-universe/uucp                 duniverse-v13.0.0
-    https://github.com/dune-universe/uutf                 duniverse-v1.0.2
-    https://github.com/ocaml-community/cppo               master
-    https://gitlab.inria.fr/fpottier/fix                  master
-    https://github.com/janestreet/result                  master
-    https://github.com/ocaml-ppx/ppxlib                   0.22.2
-    https://github.com/ocurrent/ocaml-version             master
-    https://github.com/ocaml-ppx/ppx_derivers             master
-    https://github.com/janestreet/ocaml-compiler-libs     master
-    https://github.com/ocaml/stdlib-shims                 master
-    https://github.com/ocaml-ppx/ocaml-migrate-parsetree  v2.2.0
-)
-
-build_dir=${root}/build-mingw64
+build_dir=_build-mingw64
 
 mkdir -p ${build_dir}
 
 cd ${build_dir}
 
-if ! [ -d _flexdll ]
-then
-    curl -O -L ${flexdll_url}/releases/download/${flexdll_version}/flexdll-bin-${flexdll_version}.zip
-    unzip -d _flexdll flexdll-bin-${flexdll_version}.zip
-fi
+curl -O -L ${opam_url}
 
-export PATH=$(pwd)/_flexdll:${PATH}
+tar xf $(basename ${opam_url})
 
-[ -d _ocaml ] || git clone -b ${ocaml_version} ${ocaml_url} _ocaml
+bash opam64/install.sh --prefix $(pwd)
 
-cd _ocaml
+export PATH=$(pwd)/bin:${PATH}
 
-if ! [ -f local/bin/ocamlc.exe ]
-then
-    set +eu
-    ./configure --build=x86_64-unknown-cygwin --host=x86_64-w64-mingw32 --prefix "$(cygpath -aml local)"
-    set -eu
-    make -j8
-    make install
-fi
+export OPAMROOT="$(cygpath -aml _opam)"
 
-export PATH=$(pwd)/local/bin:${PATH}
+opam init default "https://github.com/fdopen/opam-repository-mingw.git#opam2" -c "ocaml-variants.4.12.0+mingw64c" --disable-sandboxing --no-setup
+
+eval $(opam env)
 
 cd ..
 
-[ -d dune ] || git clone -b ${dune_version} ${dune_url} dune
+set +eu
+opam install -y --deps-only ./ocamlformat.opam
+set -eu
 
-cd dune
+dune subst
 
-if ! [ -f _build/install/default/bin/dune.exe ]
-then
-    make release
-fi
-
-export PATH=$(pwd)/_build/install/default/bin:${PATH}
-
-cd ..
-
-echo ${packages[@]} | xargs -n 2 | while read url ref
-do
-    dir=$(basename ${url})
-    [ -d ${dir} ] || git clone -b ${ref} ${url} ${dir}
-done
-
-cd ..
-
-dune build --profile=release ocamlformat.install
+dune build -p ocamlformat

--- a/tools/build-mingw64.sh
+++ b/tools/build-mingw64.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Script to build `ocamlformat' under Windows, using the `mingw64' toolchain.
+# All it requires is a standard Cygwin installation with the `mingw64'
+# toolchain.
+
+# The script builds `flexdll', `ocaml', `dune', `ocamlformat' and their
+# dependencies and leaves the resulting binary at
+#
+#   _build/install/default/bin/ocamlformat.exe
+
+set -euo pipefail
+
+root=$(git rev-parse --show-toplevel)
+
+flexdll_version=0.39
+flexdll_url=https://github.com/alainfrisch/flexdll
+
+ocaml_version=4.12.0
+ocaml_url=https://github.com/ocaml/ocaml
+
+dune_version=2.9.0
+dune_url=https://github.com/ocaml/dune
+
+packages=(
+    https://github.com/janestreet/sexplib0                v0.14.0
+    https://github.com/ocaml-dune/csexp                   master
+    https://github.com/dune-universe/uuseg                duniverse-v13.0.0
+    https://github.com/ocaml/ocaml-re                     master
+    https://github.com/ocaml/odoc                         1.5.2
+    https://github.com/OCamlPro/ocp-indent                master
+    https://gitlab.inria.fr/fpottier/menhir               master
+    https://github.com/janestreet/stdio                   master
+    https://github.com/dune-universe/fpath                duniverse-v0.7.3
+    https://github.com/mirage/either                      main
+    https://github.com/dbuenzli/cmdliner                  master
+    https://github.com/janestreet/base                    v0.14.1
+    https://github.com/dune-universe/astring              duniverse-v0.8.5
+    https://github.com/dune-universe/uucp                 duniverse-v13.0.0
+    https://github.com/dune-universe/uutf                 duniverse-v1.0.2
+    https://github.com/ocaml-community/cppo               master
+    https://gitlab.inria.fr/fpottier/fix                  master
+    https://github.com/janestreet/result                  master
+    https://github.com/ocaml-ppx/ppxlib                   0.22.2
+    https://github.com/ocurrent/ocaml-version             master
+    https://github.com/ocaml-ppx/ppx_derivers             master
+    https://github.com/janestreet/ocaml-compiler-libs     master
+    https://github.com/ocaml/stdlib-shims                 master
+    https://github.com/ocaml-ppx/ocaml-migrate-parsetree  v2.2.0
+)
+
+build_dir=${root}/build-mingw64
+
+mkdir -p ${build_dir}
+
+cd ${build_dir}
+
+if ! [ -d _flexdll ]
+then
+    curl -O -L ${flexdll_url}/releases/download/${flexdll_version}/flexdll-bin-${flexdll_version}.zip
+    unzip -d _flexdll flexdll-bin-${flexdll_version}.zip
+fi
+
+export PATH=$(pwd)/_flexdll:${PATH}
+
+[ -d _ocaml ] || git clone -b ${ocaml_version} ${ocaml_url} _ocaml
+
+cd _ocaml
+
+if ! [ -f local/bin/ocamlc.exe ]
+then
+    set +eu
+    ./configure --build=x86_64-unknown-cygwin --host=x86_64-w64-mingw32 --prefix "$(cygpath -aml local)"
+    set -eu
+    make -j8
+    make install
+fi
+
+export PATH=$(pwd)/local/bin:${PATH}
+
+cd ..
+
+[ -d dune ] || git clone -b ${dune_version} ${dune_url} dune
+
+cd dune
+
+if ! [ -f _build/install/default/bin/dune.exe ]
+then
+    make release
+fi
+
+export PATH=$(pwd)/_build/install/default/bin:${PATH}
+
+cd ..
+
+echo ${packages[@]} | xargs -n 2 | while read url ref
+do
+    dir=$(basename ${url})
+    [ -d ${dir} ] || git clone -b ${ref} ${url} ${dir}
+done
+
+cd ..
+
+dune build --profile=release ocamlformat.install

--- a/tools/build-mingw64.sh
+++ b/tools/build-mingw64.sh
@@ -7,6 +7,7 @@
 set -euo pipefail
 
 opam_url=https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.2/opam64.tar.xz
+opam_archive=$(basename ${opam_url})
 
 build_dir=_build-mingw64
 
@@ -14,11 +15,11 @@ mkdir -p ${build_dir}
 
 cd ${build_dir}
 
-curl -O -L ${opam_url}
+[ -f ${opam_archive} ] || curl -O -L ${opam_url}
 
-tar xf $(basename ${opam_url})
+[ -d opam64 ] || tar xf ${opam_archive}
 
-bash opam64/install.sh --prefix $(pwd)
+[ -f bin/opam.exe ] || bash opam64/install.sh --prefix $(pwd)
 
 export PATH=$(pwd)/bin:${PATH}
 


### PR DESCRIPTION
I noticed that this project has a need for easier testing and building on Windows (see #49 and #1700 and the issues linked therein). 

To try to improve the situation I wrote a quick-and-dirty shell script which will build a native Windows binary (using `mingw64` compiler) when run inside a standard Cygwin installation.

Since the script takes care of downloading and building `ocaml`, `flexlink`, `dune`, and all its dependencies, only the base `cygwin` system is required (with the `mingw64` compiler, of course!).

~~The exact version of each package is hard-coded in the script so it may need tweaking from time to time, but it sure beats the current situation (no easy way to build on Windows at all)!~~ (**UPDATE: we now use OPAM instead of manually specifying the dependencies.**)

Cheers!