### PR TITLE
Revert "Type identifiers can have a disambiguation suffix"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,8 +45,6 @@
     - Break the line and reindent the cursor when pressing <ENTER>
   (#1639, #1685, @gpetiot) (#1687, @bcc32)
 
-  + Type identifiers can have a disambiguation suffix (e.g. `t/2`), as produced by the compiler (#1697, @trefis)
-
 ### 0.18.0 (2021-03-30)
 
 #### Bug fixes

--- a/test/passing/tests/sig_value.mli
+++ b/test/passing/tests/sig_value.mli
@@ -7,5 +7,3 @@ val f : f:((string * string)[@att]) (** doc *) -> unit
 val f : f:((string * string)[@att]) (** doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc *) -> unit
 val f : f:((string * string)[@att]) -> unit
 val f : f:((string * string)) (** doc *) -> unit
-
-val f : t/1 -> f:(unit -> unit t/2) -> unit M/2.t/2

--- a/test/passing/tests/sig_value.mli.ref
+++ b/test/passing/tests/sig_value.mli.ref
@@ -21,5 +21,3 @@ val f :
 val f : f:(string * string[@att]) -> unit
 
 val f : f:string * string (** doc *) -> unit
-
-val f : t/1 -> f:(unit -> unit t/2) -> unit M/2.t/2

--- a/test/rpc/rpc_test.expected
+++ b/test/rpc/rpc_test.expected
@@ -35,9 +35,6 @@ Output: aaa -> bbb -> ccc -> ddd -> eee -> fff -> ggg
 int'
 Output: val x : int
 
-[ocf] Format 'val write : 'a    t/1 -> 'a ->unit M/2.t/2'
-Output: val write : 'a t/1 -> 'a -> unit M/2.t/2
-
 [ocf] Format 'x + y * z'
 Output: x + (y * z)
 

--- a/test/rpc/rpc_test.ml
+++ b/test/rpc/rpc_test.ml
@@ -97,7 +97,6 @@ let () =
   protect_unit @@ config [("margin", "80")] ;
   protect_string @@ format "aaa -> bbb -> ccc -> ddd -> eee -> fff -> ggg" ;
   protect_string @@ format "val x :\n \nint" ;
-  protect_string @@ format "val write : 'a    t/1 -> 'a ->unit M/2.t/2" ;
   protect_string @@ format "x + y * z" ;
   protect_string @@ format "let x = 4 in x" ;
   protect_string @@ format "sig end" ;

--- a/vendor/ocaml-4.12/lexer.mll
+++ b/vendor/ocaml-4.12/lexer.mll
@@ -368,8 +368,6 @@ let hex_float_literal =
   (['p' 'P'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']* )?
 let literal_modifier = ['G'-'Z' 'g'-'z']
 
-let type_disambig = ['/'] ['0'-'9']+
-
 rule token = parse
   | ('\\' as bs) newline {
       if not !escaped_newlines then error lexbuf (Illegal_character bs);
@@ -401,15 +399,6 @@ rule token = parse
   | "?" (lowercase_latin1 identchar_latin1 * as name) ':'
       { warn_latin1 lexbuf;
         OPTLABEL name }
-  | lowercase identchar * type_disambig as name
-      { try Hashtbl.find keyword_table name
-        with Not_found -> TLIDENT name }
-  | lowercase_latin1 identchar_latin1 * type_disambig as name
-      { warn_latin1 lexbuf; TLIDENT name }
-  | uppercase identchar * type_disambig as name
-      { TUIDENT name } (* No capitalized keywords *)
-  | uppercase_latin1 identchar_latin1 * type_disambig as name
-      { warn_latin1 lexbuf; TUIDENT name }
   | lowercase identchar * as name
       { try Hashtbl.find keyword_table name
         with Not_found -> LIDENT name }

--- a/vendor/ocaml-4.12/parser.mly
+++ b/vendor/ocaml-4.12/parser.mly
@@ -710,9 +710,6 @@ let mk_directive ~loc name arg =
 
 %token EOL
 
-%token <string> TUIDENT
-%token <string> TLIDENT
-
 /* Precedences and associativities.
 
 Tokens and rules have precedences.  A reduce/reduce conflict is resolved
@@ -3516,27 +3513,17 @@ label_longident:
     mk_longident(mod_longident, LIDENT) { $1 }
 ;
 type_longident:
-  /*mk_longident(mod_ext_longident, LIDENT)  { $1 }*/
-  mk_longident(mod_ext_longident, disambiguated_lident)  { $1 }
+    mk_longident(mod_ext_longident, LIDENT)  { $1 }
 ;
 mod_longident:
     mk_longident(mod_longident, UIDENT)  { $1 }
 ;
 mod_ext_longident:
-    /*mk_longident(mod_ext_longident, UIDENT) { $1 }*/
-    mk_longident(mod_ext_longident, disambiguated_uident) { $1 }
+    mk_longident(mod_ext_longident, UIDENT) { $1 }
   | mod_ext_longident LPAREN mod_ext_longident RPAREN
       { lapply ~loc:$sloc $1 $3 }
   | mod_ext_longident LPAREN error
       { expecting $loc($3) "module path" }
-;
-disambiguated_lident:
-    LIDENT { $1 }
-  | TLIDENT { $1 }
-;
-disambiguated_uident:
-    UIDENT { $1 }
-  | TUIDENT { $1 }
 ;
 mty_longident:
     mk_longident(mod_ext_longident,ident) { $1 }


### PR DESCRIPTION
Reverts ocaml-ppx/ocamlformat#1697