### PR TITLE
Add missing break between pattern and attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,8 @@
   + Fix normalization of odoc paragraphs (#1695, @gpetiot)
     Paragraphs must not be considered for the normalized form. They are only structural and the shape of a docstring organized in paragraphs only depend on linebreaks, which may be changed by the formatting.
 
+  + Add missing break between pattern and attribute (#1711, @gpetiot)
+
 #### Changes
 
   + Improve the diff of unstable docstrings displayed in error messages (#1654, @gpetiot)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -913,7 +913,7 @@ and fmt_pattern_attributes c xpat k =
           | _ -> true )
       in
       Params.parens_if parens_attr c.conf
-        (k $ fmt_attributes c ~key:"@" attrs)
+        (k $ fmt_attributes c ~pre:Space ~key:"@" attrs)
 
 and fmt_pattern ?ext c ?pro ?parens ?(box = false)
     ({ctx= ctx0; ast= pat} as xpat) =

--- a/test/passing/tests/attributes.ml
+++ b/test/passing/tests/attributes.ml
@@ -355,3 +355,17 @@ let _ =
 let _ =
   (try[@ocaml.warning "-4"] bar with _ -> ()) ;
   foo
+
+let pp f ({cf_interface; cf_is_objc_block; cf_virtual} [@warning "+9"]) = ()
+
+let pp f
+    ({cf_assign_last_arg; cf_injected_destructor; cf_interface}
+      [@warning "+9"] ) =
+  ()
+
+let pp f
+    ({ cf_assign_last_arg
+     ; cf_injected_destructor
+     ; cf_interface
+     ; cf_is_objc_block } [@warning "+9"] ) =
+  ()

--- a/test/passing/tests/attributes.ml
+++ b/test/passing/tests/attributes.ml
@@ -1,6 +1,6 @@
 let _ = (function[@warning "-4"] None -> true | _ -> false) None
 
-let f (x[@warning ""]) = ()
+let f (x [@warning ""]) = ()
 
 let v = (fun [@inline] x -> x) 1
 
@@ -105,33 +105,33 @@ type u =
 [@@deriving something]
 [@@doc ["Ut at dolor a eros venenatis maximus ut at nisi."]]
 
-let ((A, B)[@test]) = ()
+let ((A, B) [@test]) = ()
 
-let ((lazy a)[@test]) = ()
+let ((lazy a) [@test]) = ()
 
-let ((exception a)[@test]) = ()
+let ((exception a) [@test]) = ()
 
-let ((B x)[@test]) = ()
+let ((B x) [@test]) = ()
 
-let ((`B x)[@test]) = ()
+let ((`B x) [@test]) = ()
 
-let (B[@test]) = ()
+let (B [@test]) = ()
 
-let (`B[@test]) = ()
+let (`B [@test]) = ()
 
-let (B.(A)[@test]) = ()
+let (B.(A) [@test]) = ()
 
-let ('x' .. 'z'[@test]) = ()
+let ('x' .. 'z' [@test]) = ()
 
-let (#test[@test]) = ()
+let (#test [@test]) = ()
 
-let ((module X)[@test]) = ()
+let ((module X) [@test]) = ()
 
-let (a[@test]) = ()
+let (a [@test]) = ()
 
-let (_[@test]) = ()
+let (_ [@test]) = ()
 
-let (""[@test]) = ()
+let ("" [@test]) = ()
 
 let _ = f x ~f:(fun [@test] x -> x)
 
@@ -149,7 +149,7 @@ let f = fun [@test] x y -> ()
 
 let f y = fun [@test] y -> ()
 
-let (f[@test]) = fun y -> fun [@test] y -> ()
+let (f [@test]) = fun y -> fun [@test] y -> ()
 
 module type T = sig
   class subst :
@@ -318,23 +318,23 @@ let _ =
 
 [@@@a (**b*)]
 
-let (Foo ((A | B)[@attr])) = ()
+let (Foo ((A | B) [@attr])) = ()
 
-let ([((A | B)[@attr]); b; c][@attr]) = ()
+let ([((A | B) [@attr]); b; c] [@attr]) = ()
 
-let ([|a; (A | B)[@attr]; c|][@attr]) = ()
+let ([|a; (A | B) [@attr]; c|] [@attr]) = ()
 
-let {b= (A | B)[@attr]} = ()
+let {b= (A | B) [@attr]} = ()
 
-let (`Foo ((`A | `B)[@attr])) = ()
+let (`Foo ((`A | `B) [@attr])) = ()
 
-let (A | B)[@attr], (A | B)[@attr] = ()
+let (A | B) [@attr], (A | B) [@attr] = ()
 
-let (A | B)[@attr] = ()
+let (A | B) [@attr] = ()
 
-let (Foo ((A | B)[@attr]) : (t[@attr])) = ()
+let (Foo ((A | B) [@attr]) : (t[@attr])) = ()
 
-let (M.(A | B)[@attr]) = ();;
+let (M.(A | B) [@attr]) = ();;
 
 (a_______________________________________________________________________________
 [@attr]) ()

--- a/test/passing/tests/extensions-indent.ml.ref
+++ b/test/passing/tests/extensions-indent.ml.ref
@@ -423,6 +423,6 @@ let _ =
   | (module%ext M : S) -> k
   | [%ext (module M : S)] -> k
   | (exception%ext e) -> k
-  | ((exception%ext e)[@attr]) -> k
+  | ((exception%ext e) [@attr]) -> k
   | [%ext? exception e] -> k
   | _ -> default

--- a/test/passing/tests/extensions.ml.ref
+++ b/test/passing/tests/extensions.ml.ref
@@ -423,6 +423,6 @@ let _ =
   | (module%ext M : S) -> k
   | [%ext (module M : S)] -> k
   | (exception%ext e) -> k
-  | ((exception%ext e)[@attr]) -> k
+  | ((exception%ext e) [@attr]) -> k
   | [%ext? exception e] -> k
   | _ -> default

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -1,6 +1,6 @@
 [@@@foo]
 
-let ((x[@foo]) : (unit[@foo])) = (() [@foo]) [@@foo]
+let ((x [@foo]) : (unit[@foo])) = (() [@foo]) [@@foo]
 
 type t = Foo of (t[@foo]) [@foo] [@@foo]
 
@@ -112,8 +112,8 @@ let () =
   [%foo
     match[@foo] () with
     | [%foo? (* Pattern expressions *)
-        ((lazy x)[@foo])] -> ()
-    | [%foo? ((exception x)[@foo])] -> ()]
+        ((lazy x) [@foo])] -> ()
+    | [%foo? ((exception x) [@foo])] -> ()]
 ;;
 
 (* Class expressions *)
@@ -862,7 +862,7 @@ end
 
 let f = function
   | Some (module M : S3) when M.x -> 1
-  | ((Some _)[@foooo]) -> 2
+  | ((Some _) [@foooo]) -> 2
   | None -> 3
 ;;
 
@@ -9376,7 +9376,7 @@ class c =
   end
 
 let f = function
-  | (x[@wee]) -> ()
+  | (x [@wee]) -> ()
 ;;
 
 let f = function
@@ -9387,13 +9387,13 @@ let f = function
 let f = function
   | [| x1; x2 |] -> ()
   | [||] -> ()
-  | ([| x |][@foo]) -> ()
+  | ([| x |] [@foo]) -> ()
   | _ -> ()
 ;;
 
 let g = function
   | { l = x } -> ()
-  | ({ l1 = x; l2 = y }[@foo]) -> ()
+  | ({ l1 = x; l2 = y } [@foo]) -> ()
   | { l1 = x; l2 = y; _ } -> ()
 ;;
 
@@ -9496,28 +9496,28 @@ let g x y = ~$(x.contents) y.contents
 let tail1 = ([ 1; 2 ] [@hello])
 let tail2 = 0 :: ([ 1; 2 ] [@hello])
 let tail3 = 0 :: ([] [@hello])
-let f ~l:(l[@foo]) = l
+let f ~l:(l [@foo]) = l
 let test x y = (( + ) [@foo]) x y
 let test x = (( ~- ) [@foo])x
 let test contents = { contents = contents [@foo] }
 
 class type t = object (_[@foo]) end
 
-class t = object (_[@foo]) end
+class t = object (_ [@foo]) end
 
 let test f x = f ~x:(x [@foo])
 
 let f = function
-  | (`A | `B)[@bar] | `C -> ()
+  | (`A | `B) [@bar] | `C -> ()
 ;;
 
 let f = function
-  | _ :: ((_ :: _)[@foo]) -> ()
+  | _ :: ((_ :: _) [@foo]) -> ()
   | _ -> ()
 ;;
 
 function
-| { contents = (contents[@foo]) } -> ()
+| { contents = (contents [@foo]) } -> ()
 ;;
 
 fun contents -> { contents = contents [@foo] };;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -1,6 +1,6 @@
 [@@@foo]
 
-let ((x[@foo]) : (unit[@foo])) = (() [@foo]) [@@foo]
+let ((x [@foo]) : (unit[@foo])) = (() [@foo]) [@@foo]
 
 type t = Foo of (t[@foo]) [@foo] [@@foo]
 
@@ -112,8 +112,8 @@ let () =
   [%foo
     match[@foo] () with
     | [%foo? (* Pattern expressions *)
-        ((lazy x)[@foo])] -> ()
-    | [%foo? ((exception x)[@foo])] -> ()]
+        ((lazy x) [@foo])] -> ()
+    | [%foo? ((exception x) [@foo])] -> ()]
 ;;
 
 (* Class expressions *)
@@ -862,7 +862,7 @@ end
 
 let f = function
   | Some (module M : S3) when M.x -> 1
-  | ((Some _)[@foooo]) -> 2
+  | ((Some _) [@foooo]) -> 2
   | None -> 3
 ;;
 
@@ -9376,7 +9376,7 @@ class c =
   end
 
 let f = function
-  | (x[@wee]) -> ()
+  | (x [@wee]) -> ()
 ;;
 
 let f = function
@@ -9387,13 +9387,13 @@ let f = function
 let f = function
   | [| x1; x2 |] -> ()
   | [||] -> ()
-  | ([| x |][@foo]) -> ()
+  | ([| x |] [@foo]) -> ()
   | _ -> ()
 ;;
 
 let g = function
   | { l = x } -> ()
-  | ({ l1 = x; l2 = y }[@foo]) -> ()
+  | ({ l1 = x; l2 = y } [@foo]) -> ()
   | { l1 = x; l2 = y; _ } -> ()
 ;;
 
@@ -9496,28 +9496,28 @@ let g x y = ~$(x.contents) y.contents
 let tail1 = ([ 1; 2 ] [@hello])
 let tail2 = 0 :: ([ 1; 2 ] [@hello])
 let tail3 = 0 :: ([] [@hello])
-let f ~l:(l[@foo]) = l
+let f ~l:(l [@foo]) = l
 let test x y = (( + ) [@foo]) x y
 let test x = (( ~- ) [@foo])x
 let test contents = { contents = contents [@foo] }
 
 class type t = object (_[@foo]) end
 
-class t = object (_[@foo]) end
+class t = object (_ [@foo]) end
 
 let test f x = f ~x:(x [@foo])
 
 let f = function
-  | (`A | `B)[@bar] | `C -> ()
+  | (`A | `B) [@bar] | `C -> ()
 ;;
 
 let f = function
-  | _ :: ((_ :: _)[@foo]) -> ()
+  | _ :: ((_ :: _) [@foo]) -> ()
   | _ -> ()
 ;;
 
 function
-| { contents = (contents[@foo]) } -> ()
+| { contents = (contents [@foo]) } -> ()
 ;;
 
 fun contents -> { contents = contents [@foo] };;

--- a/test/passing/tests/label_option_default_args.ml.ref
+++ b/test/passing/tests/label_option_default_args.ml.ref
@@ -162,14 +162,14 @@ let f ?open_:(Int.(zero)) = ()
 let f ?unpack:((module P)) = ()
 
 (* May need extra parens to handle attributes *)
-let f ?any:(_[@attr]) = ()
+let f ?any:(_ [@attr]) = ()
 
-let f ?constant:(0[@attr]) = ()
+let f ?constant:(0 [@attr]) = ()
 
-let f ?open_:(Int.(zero)[@attr]) = ()
+let f ?open_:(Int.(zero) [@attr]) = ()
 
-let f ?or_:((Some () | None)[@attr]) = ()
+let f ?or_:((Some () | None) [@attr]) = ()
 
-let f ?unpack:((module P)[@attr]) = ()
+let f ?unpack:((module P) [@attr]) = ()
 
-let f ?tuple:((1, 2)[@attr]) = ()
+let f ?tuple:((1, 2) [@attr]) = ()

--- a/test/passing/tests/object.ml
+++ b/test/passing/tests/object.ml
@@ -222,11 +222,11 @@ let o =
         Int_bin_comparison (self#expression a, op, self#expression b)
   end
 
-class f = fun [@inline] (b[@inline]) -> object end
+class f = fun [@inline] (b [@inline]) -> object end
 
 class f = [%test] [@test]
 
-class f a (b[@inline]) = object end
+class f a (b [@inline]) = object end
 
 class f =
   object (self)

--- a/test/passing/tests/shortcut_ext_attr.ml
+++ b/test/passing/tests/shortcut_ext_attr.ml
@@ -30,8 +30,8 @@ let () =
   [%foo
     match[@foo] () with
     | [%foo? (* Pattern expressions *)
-        ((lazy x)[@foo])] -> ()
-    | [%foo? ((exception x)[@foo])] -> ()]
+        ((lazy x) [@foo])] -> ()
+    | [%foo? ((exception x) [@foo])] -> ()]
 
 (* Class expressions *)
 class x =

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -1,6 +1,6 @@
 [@@@foo]
 
-let ((x[@foo]) : (unit[@foo])) = (() [@foo]) [@@foo]
+let ((x [@foo]) : (unit[@foo])) = (() [@foo]) [@@foo]
 
 type t = Foo of (t[@foo]) [@foo] [@@foo]
 
@@ -125,8 +125,8 @@ let () =
   [%foo
     match[@foo] () with
     | [%foo? (* Pattern expressions *)
-        ((lazy x)[@foo])] -> ()
-    | [%foo? ((exception x)[@foo])] -> ()]
+        ((lazy x) [@foo])] -> ()
+    | [%foo? ((exception x) [@foo])] -> ()]
 
 (* Class expressions *)
 class x =
@@ -954,7 +954,7 @@ end
 
 let f = function
   | Some (module M : S3) when M.x -> 1
-  | ((Some _)[@foooo]) -> 2
+  | ((Some _) [@foooo]) -> 2
   | None -> 3
 ;;
 
@@ -8949,19 +8949,19 @@ class c =
     inherit (fun () -> object end [@wee] : object end) ()
   end
 
-let f = function (x[@wee]) -> ()
+let f = function (x [@wee]) -> ()
 
 let f = function '1' .. '9' | '1' .. '8' -> () | 'a' .. 'z' -> ()
 
 let f = function
   | [|x1; x2|] -> ()
   | [||] -> ()
-  | ([|x|][@foo]) -> ()
+  | ([|x|] [@foo]) -> ()
   | _ -> ()
 
 let g = function
   | {l= x} -> ()
-  | ({l1= x; l2= y}[@foo]) -> ()
+  | ({l1= x; l2= y} [@foo]) -> ()
   | {l1= x; l2= y; _} -> ()
 
 let h ?l:(p = 1) ?y:u ?(x = 3) = 2
@@ -9066,7 +9066,7 @@ let tail2 = 0 :: ([1; 2] [@hello])
 
 let tail3 = 0 :: ([] [@hello])
 
-let f ~l:(l[@foo]) = l
+let f ~l:(l [@foo]) = l
 
 let test x y = (( + ) [@foo]) x y
 
@@ -9076,15 +9076,15 @@ let test contents = {contents= contents [@foo]}
 
 class type t = object (_[@foo]) end
 
-class t = object (_[@foo]) end
+class t = object (_ [@foo]) end
 
 let test f x = f ~x:(x [@foo])
 
-let f = function (`A | `B)[@bar] | `C -> ()
+let f = function (`A | `B) [@bar] | `C -> ()
 
-let f = function _ :: ((_ :: _)[@foo]) -> () | _ -> ();;
+let f = function _ :: ((_ :: _) [@foo]) -> () | _ -> ();;
 
-function {contents= (contents[@foo])} -> ();;
+function {contents= (contents [@foo])} -> ();;
 
 fun contents -> {contents= contents [@foo]};;
 

--- a/test/passing/tests/string.ml.ref
+++ b/test/passing/tests/string.ml.ref
@@ -24,7 +24,7 @@ let _ = ('\xff', '\255', '\n')
 
 let f = function '\xff' .. '\255' -> ()
 
-let f ("test"[@test "test"]) = 2;;
+let f ("test" [@test "test"]) = 2;;
 
 "@\n\
 \ xxxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxx \

--- a/test/passing/tests/types-compact-space_around-docked.ml.ref
+++ b/test/passing/tests/types-compact-space_around-docked.ml.ref
@@ -69,7 +69,7 @@ type loooooooooooooong_type =
   [ `Looooooooooooooooooong_type of int  (** Doc *)
   | `Looooooooooooooooooooong_variant of string (* Comment *) ]
 
-let (`A | `B)[@bar] = ()
+let (`A | `B) [@bar] = ()
 
 type t =
   | Internal_error of

--- a/test/passing/tests/types-compact-space_around.ml.ref
+++ b/test/passing/tests/types-compact-space_around.ml.ref
@@ -67,7 +67,7 @@ type loooooooooooooong_type =
   [ `Looooooooooooooooooong_type of int  (** Doc *)
   | `Looooooooooooooooooooong_variant of string (* Comment *) ]
 
-let (`A | `B)[@bar] = ()
+let (`A | `B) [@bar] = ()
 
 type t =
   | Internal_error of

--- a/test/passing/tests/types-compact.ml.ref
+++ b/test/passing/tests/types-compact.ml.ref
@@ -67,7 +67,7 @@ type loooooooooooooong_type =
   [ `Looooooooooooooooooong_type of int  (** Doc *)
   | `Looooooooooooooooooooong_variant of string (* Comment *) ]
 
-let (`A | `B)[@bar] = ()
+let (`A | `B) [@bar] = ()
 
 type t =
   | Internal_error of

--- a/test/passing/tests/types-indent.ml.ref
+++ b/test/passing/tests/types-indent.ml.ref
@@ -67,7 +67,7 @@ type loooooooooooooong_type =
       [ `Looooooooooooooooooong_type of int  (** Doc *)
       | `Looooooooooooooooooooong_variant of string (* Comment *) ]
 
-let (`A | `B)[@bar] = ()
+let (`A | `B) [@bar] = ()
 
 type t =
       | Internal_error of

--- a/test/passing/tests/types-sparse-space_around.ml.ref
+++ b/test/passing/tests/types-sparse-space_around.ml.ref
@@ -93,7 +93,7 @@ type loooooooooooooong_type =
   | `Looooooooooooooooooooong_variant of string (* Comment *)
   ]
 
-let (`A | `B)[@bar] = ()
+let (`A | `B) [@bar] = ()
 
 type t =
   | Internal_error of

--- a/test/passing/tests/types-sparse.ml.ref
+++ b/test/passing/tests/types-sparse.ml.ref
@@ -85,7 +85,7 @@ type loooooooooooooong_type =
   [ `Looooooooooooooooooong_type of int  (** Doc *)
   | `Looooooooooooooooooooong_variant of string (* Comment *) ]
 
-let (`A | `B)[@bar] = ()
+let (`A | `B) [@bar] = ()
 
 type t =
   | Internal_error of

--- a/test/passing/tests/types.ml
+++ b/test/passing/tests/types.ml
@@ -67,7 +67,7 @@ type loooooooooooooong_type =
   [ `Looooooooooooooooooong_type of int  (** Doc *)
   | `Looooooooooooooooooooong_variant of string (* Comment *) ]
 
-let (`A | `B)[@bar] = ()
+let (`A | `B) [@bar] = ()
 
 type t =
   | Internal_error of


### PR DESCRIPTION
Fix #1710, the diff of test_branch.sh looks good (just adding a space between the pattern and the attribute)