### PR TITLE
Fix unstable broken-ref test

### DIFF
--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -55,14 +55,9 @@ module Error = struct
     let n = Filename.temp_file input_name (Printf.sprintf ".next%s" ext) in
     Out_channel.write_all p ~data:prev ;
     Out_channel.write_all n ~data:next ;
-    let anonymize =
-      "sed 's/a\\/tmp\\/[^ ]*/before/g' | sed 's/b\\/tmp\\/[^ ]*/after/g' | \
-       sed '/index .*/d'"
-    in
     ignore
       (Caml.Sys.command
-         (Printf.sprintf "git diff --no-index -u %S %S | %s 1>&2" p n
-            anonymize ) ) ;
+         (Printf.sprintf "git diff --no-index -u %S %S | sed '1,4d' 1>&2" p n) ) ;
     Caml.Sys.remove p ;
     Caml.Sys.remove n
 

--- a/test/failing/tests/unstable_docstrings.mli.broken-ref
+++ b/test/failing/tests/unstable_docstrings.mli.broken-ref
@@ -3,9 +3,6 @@ ocamlformat: Cannot process "tests/unstable_docstrings.mli".
   BUG: doc comments changed.
 File "_none_", line 0, characters -1--1::
 Error: Formatting of doc-comment is unstable (e.g. parses as a list or not depending on the margin):
-diff --git before after
---- before
-+++ after
 @@ -1,6 +1,7 @@
   Blablabla. Otherwise, the given protocol can not be:
 -    {ul


### PR DESCRIPTION
In this test, OCamlformat calls git diff then tries to hide the temporary file names in the output. This didn't work on my system, where temporary files are created into `/run/user/...` instead of `/tmp`.