### PR TITLE
RFC: Disambiguated types strike again

### DIFF
--- a/test/passing/tests/disambiguated_types.ml
+++ b/test/passing/tests/disambiguated_types.ml
@@ -1,0 +1,5 @@
+let t : int = 4
+
+let x : t/2 = t / 2
+
+let x : foo M/2.e0/2 = foo M / 2.e0 / 2

--- a/test/passing/tests/sig_value.mli
+++ b/test/passing/tests/sig_value.mli
@@ -7,3 +7,5 @@ val f : f:((string * string)[@att]) (** doc *) -> unit
 val f : f:((string * string)[@att]) (** doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc *) -> unit
 val f : f:((string * string)[@att]) -> unit
 val f : f:((string * string)) (** doc *) -> unit
+
+val f : t/1 -> f:(unit -> unit t/2) -> unit M/2.t/2

--- a/test/passing/tests/sig_value.mli.ref
+++ b/test/passing/tests/sig_value.mli.ref
@@ -21,3 +21,5 @@ val f :
 val f : f:(string * string[@att]) -> unit
 
 val f : f:string * string (** doc *) -> unit
+
+val f : t/1 -> f:(unit -> unit t/2) -> unit M/2.t/2

--- a/test/rpc/rpc_test.expected
+++ b/test/rpc/rpc_test.expected
@@ -35,6 +35,9 @@ Output: aaa -> bbb -> ccc -> ddd -> eee -> fff -> ggg
 int'
 Output: val x : int
 
+[ocf] Format 'val write : 'a    t/1 -> 'a ->unit M/2.t/2'
+Output: val write : 'a t/1 -> 'a -> unit M/2.t/2
+
 [ocf] Format 'x + y * z'
 Output: x + (y * z)
 

--- a/test/rpc/rpc_test.ml
+++ b/test/rpc/rpc_test.ml
@@ -97,6 +97,7 @@ let () =
   protect_unit @@ config [("margin", "80")] ;
   protect_string @@ format "aaa -> bbb -> ccc -> ddd -> eee -> fff -> ggg" ;
   protect_string @@ format "val x :\n \nint" ;
+  protect_string @@ format "val write : 'a    t/1 -> 'a ->unit M/2.t/2" ;
   protect_string @@ format "x + y * z" ;
   protect_string @@ format "let x = 4 in x" ;
   protect_string @@ format "sig end" ;

--- a/vendor/ocaml-4.13/parse.ml
+++ b/vendor/ocaml-4.13/parse.ml
@@ -40,14 +40,44 @@ let maybe_skip_phrase lexbuf =
   | Parser.SEMISEMI | Parser.EOF -> ()
   | _ -> skip_phrase lexbuf
 
-type 'a parser =
-  (Lexing.lexbuf -> Parser.token) -> Lexing.lexbuf -> 'a
+type 'a parser = Lexing.position -> 'a Parser.MenhirInterpreter.checkpoint
 
 let wrap (parser : 'a parser) lexbuf : 'a =
   try
     Docstrings.init ();
     Lexer.init ();
-    let ast = parser token lexbuf in
+    let open Parser.MenhirInterpreter in
+    let rec fix_resume = function
+      | InputNeeded _ | Accepted _ | Rejected | HandlingError _ as cp -> cp
+      | Shifting (_, _, _) | AboutToReduce (_, _) as cp ->
+        fix_resume (resume ~strategy:`Simplified cp)
+    in
+    let rec offer_input lexbuf cp tok =
+      let ptok = Lexing.(tok, lexbuf.lex_start_p, lexbuf.lex_curr_p) in
+      match fix_resume (offer cp ptok) with
+      | InputNeeded _ as cp ->
+          offer_input lexbuf cp (token lexbuf)
+      | Accepted x -> Some x
+      | Rejected -> None
+      | Shifting (_, _, _) | AboutToReduce (_, _) ->
+          assert false
+      | HandlingError _ as cp' ->
+        match Lexer.fallback lexbuf tok with
+        | Some tok' -> offer_input lexbuf cp tok'
+        | None -> main_loop lexbuf cp'
+    and main_loop lexbuf = function
+      | InputNeeded _ as cp ->
+          offer_input lexbuf cp (token lexbuf)
+      | Accepted x -> Some x
+      | Rejected -> None
+      | Shifting (_, _, _) | AboutToReduce (_, _) | HandlingError _ as cp ->
+        main_loop lexbuf (resume ~strategy:`Simplified cp)
+    in
+    let ast =
+      match main_loop lexbuf (parser lexbuf.Lexing.lex_curr_p) with
+      | Some ast -> ast
+      | None -> raise Parsing.Parse_error
+    in
     Parsing.clear_parser();
     Docstrings.warn_bad_docstrings ();
     last_token := Parser.EOF;
@@ -88,20 +118,20 @@ let wrap (parser : 'a parser) lexbuf : 'a =
    In either case, the parser will not attempt to read one token past
    the syntax error. *)
 
-let implementation = wrap Parser.implementation
-and interface = wrap Parser.interface
-and toplevel_phrase = wrap Parser.toplevel_phrase
-and use_file = wrap Parser.use_file
-and core_type = wrap Parser.parse_core_type
-and expression = wrap Parser.parse_expression
-and pattern = wrap Parser.parse_pattern
+let implementation = wrap Parser.Incremental.implementation
+and interface = wrap Parser.Incremental.interface
+and toplevel_phrase = wrap Parser.Incremental.toplevel_phrase
+and use_file = wrap Parser.Incremental.use_file
+and core_type = wrap Parser.Incremental.parse_core_type
+and expression = wrap Parser.Incremental.parse_expression
+and pattern = wrap Parser.Incremental.parse_pattern
 
-let longident = wrap Parser.parse_any_longident
-let val_ident = wrap Parser.parse_val_longident
-let constr_ident= wrap Parser.parse_constr_longident
-let extended_module_path = wrap Parser.parse_mod_ext_longident
-let simple_module_path = wrap Parser.parse_mod_longident
-let type_ident = wrap Parser.parse_mty_longident
+let longident = wrap Parser.Incremental.parse_any_longident
+let val_ident = wrap Parser.Incremental.parse_val_longident
+let constr_ident= wrap Parser.Incremental.parse_constr_longident
+let extended_module_path = wrap Parser.Incremental.parse_mod_ext_longident
+let simple_module_path = wrap Parser.Incremental.parse_mod_longident
+let type_ident = wrap Parser.Incremental.parse_mty_longident
 
 (* Error reporting for Syntaxerr *)
 (* The code has been moved here so that one can reuse Pprintast.tyvar *)

--- a/vendor/ocaml-4.13/parser.mly
+++ b/vendor/ocaml-4.13/parser.mly
@@ -765,6 +765,9 @@ let mk_directive ~loc name arg =
 
 %token EOL                    "\\n"      (* not great, but EOL is unused *)
 
+%token <string * string> TUIDENT (* First string is the identifier alone, the second includes disambiguation *)
+%token <string * string> TLIDENT
+
 /* Precedences and associativities.
 
 Tokens and rules have precedences.  A reduce/reduce conflict is resolved
@@ -3597,13 +3600,14 @@ label_longident:
     mk_longident(mod_longident, LIDENT) { $1 }
 ;
 type_longident:
-    mk_longident(mod_ext_longident, LIDENT)  { $1 }
+    mk_longident(mod_ext_longident, disambiguated_lident)  { $1 }
 ;
 mod_longident:
     mk_longident(mod_longident, UIDENT)  { $1 }
 ;
 mod_ext_longident:
-    mk_longident(mod_ext_longident, UIDENT) { $1 }
+    (*mk_longident(mod_ext_longident, UIDENT) { $1 }*)
+    mk_longident(mod_ext_longident, disambiguated_uident) { $1 }
   | mod_ext_longident LPAREN mod_ext_longident RPAREN
       { lapply ~loc:$sloc $1 $3 }
   | mod_ext_longident LPAREN error
@@ -3617,6 +3621,14 @@ clty_longident:
 ;
 class_longident:
    mk_longident(mod_longident,LIDENT) { $1 }
+;
+disambiguated_lident:
+    LIDENT { $1 }
+  | TLIDENT { snd $1 }
+;
+disambiguated_uident:
+    UIDENT { $1 }
+  | TUIDENT { snd $1 }
 ;
 
 /* BEGIN AVOID */


### PR DESCRIPTION
This is an attempt at improving "Type identifiers can have a disambiguation suffix #1697".

When printing type-checked terms, OCaml can produce modules and types identifiers with a "disambiguation suffix" like "M.4", "t.2" or "M.4/t".
This disambiguation suffix as the nice property of being lexically ambiguous: "t/2" is also "t divided by 2". We are saved by the fact that these contexts can be distinguished by the parser: type identifiers cannot occur in an expression context, and vice versa. Hopefully...

I would still like to check that this is indeed the case: there are many places where a disambiguated module name could appear, and I am not sure the current implementation is safe for all of these.

# Implementation

The implementation is quite close to the previous one. I had to reintroduce a custom parsing loop. The one vendored with OCaml was removed, thanks to the new "simplified" strategy that was built into Menhir.

Beside that the strategy is as follow.

Identifiers with a disambiguation suffix are lexed as `TLIDENT` / `TUIDENT` tokens. These tokens have two string parameters: one for the identifier alone and one for the complexe lexeme.

For instance `t/2` is lexed as `TLIDENT ("t", "t/2")`. In a context where disambiguation is allowed, the identifier is `"t/2"`, in other contexts it should behave like `LIDENT "t"`.

When finding a `TLIDENT`/`TUIDENT`, the custom parsing loop tries to parse it as it is. If it causes an error, it turns the token into `LIDENT`/`UIDENT` and rewind the lexer to just before the `/`.

# What next

Feel free to comment the approach. There is a second way I would like to try, which should be safer (it lets Menhir check the absence of conflicts), with a slightly more involved loop.