### PR TITLE
Allow disambiguated global identifiers (like t/2) so they can be formatted by tools like OCaml-LSP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,8 @@
 
   + Add a new `ocaml-version` option to select the version of OCaml syntax of the output (#1759, @gpetiot)
 
+  + Allow disambiguated global identifiers (like t/2) so they can be formatted by tools like OCaml-LSP (#1716, @let-def)
+
 ### 0.19.0 (2021-07-16)
 
 #### Bug fixes

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -55,7 +55,8 @@ module Token = struct
      |COLONCOLON | COLONEQUAL | DOTDOT | DOTOP _ | EQUAL | GREATER
      |HASHOP _ | INFIXOP0 _ | INFIXOP1 _ | INFIXOP2 _ | INFIXOP3 _
      |INFIXOP4 _ | LESS | LESSMINUS | LETOP _ | MINUS | MINUSDOT
-     |MINUSGREATER | PERCENT | PLUS | PLUSDOT | PLUSEQ | SEMI | STAR ->
+     |MINUSGREATER | PERCENT | PLUS | PLUSDOT | PLUSEQ | SEMI | SLASH | STAR
+      ->
         true
     | _ -> false
 end

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1155,6 +1155,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to disambiguated_types.ml.stdout
+   (with-stderr-to disambiguated_types.ml.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/disambiguated_types.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/disambiguated_types.ml disambiguated_types.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/disambiguated_types.ml.err disambiguated_types.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to doc_comments-after.ml.stdout
    (with-stderr-to doc_comments-after.ml.stderr
      (run %{bin:ocamlformat} --margin-check --doc-comments=after-when-possible %{dep:tests/doc_comments.ml})))))

--- a/test/passing/tests/disambiguated_types.ml
+++ b/test/passing/tests/disambiguated_types.ml
@@ -1,0 +1,5 @@
+let t : int = 4
+
+let x : t/2 = t / 2
+
+let x : foo M/2.e0/2 = foo M / 2.e0 / 2

--- a/test/passing/tests/disambiguated_types.ml
+++ b/test/passing/tests/disambiguated_types.ml
@@ -2,4 +2,4 @@ let t : int = 4
 
 let x : t/2 = t / 2
 
-let x : foo M/2.e0/2 = foo M / 2.e0 / 2
+let x : foo M/2.e0 e/2 = foo M / 2.e0

--- a/test/passing/tests/sig_value.mli
+++ b/test/passing/tests/sig_value.mli
@@ -8,4 +8,4 @@ val f : f:((string * string)[@att]) (** doc doc doc doc doc doc doc doc doc doc 
 val f : f:((string * string)[@att]) -> unit
 val f : f:((string * string)) (** doc *) -> unit
 
-val f : t/1 -> f:(unit -> unit t/2) -> unit M/2.t/2
+val f : t/1 -> f:(unit -> unit t/2) -> unit M/2.t

--- a/test/passing/tests/sig_value.mli
+++ b/test/passing/tests/sig_value.mli
@@ -7,3 +7,5 @@ val f : f:((string * string)[@att]) (** doc *) -> unit
 val f : f:((string * string)[@att]) (** doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc *) -> unit
 val f : f:((string * string)[@att]) -> unit
 val f : f:((string * string)) (** doc *) -> unit
+
+val f : t/1 -> f:(unit -> unit t/2) -> unit M/2.t/2

--- a/test/passing/tests/sig_value.mli.ref
+++ b/test/passing/tests/sig_value.mli.ref
@@ -22,4 +22,4 @@ val f : f:(string * string[@att]) -> unit
 
 val f : f:string * string (** doc *) -> unit
 
-val f : t/1 -> f:(unit -> unit t/2) -> unit M/2.t/2
+val f : t/1 -> f:(unit -> unit t/2) -> unit M/2.t

--- a/test/passing/tests/sig_value.mli.ref
+++ b/test/passing/tests/sig_value.mli.ref
@@ -21,3 +21,5 @@ val f :
 val f : f:(string * string[@att]) -> unit
 
 val f : f:string * string (** doc *) -> unit
+
+val f : t/1 -> f:(unit -> unit t/2) -> unit M/2.t/2

--- a/test/rpc/rpc_test.expected
+++ b/test/rpc/rpc_test.expected
@@ -35,8 +35,8 @@ Output: aaa -> bbb -> ccc -> ddd -> eee -> fff -> ggg
 int'
 Output: val x : int
 
-[ocf] Format 'val write : 'a    t/1 -> 'a ->unit M/2.t/2'
-Output: val write : 'a t/1 -> 'a -> unit M/2.t/2
+[ocf] Format 'val write : 'a    t/1 -> 'a ->unit M/2.t'
+Output: val write : 'a t/1 -> 'a -> unit M/2.t
 
 [ocf] Format 'x + y * z'
 Output: x + (y * z)

--- a/test/rpc/rpc_test.expected
+++ b/test/rpc/rpc_test.expected
@@ -35,6 +35,9 @@ Output: aaa -> bbb -> ccc -> ddd -> eee -> fff -> ggg
 int'
 Output: val x : int
 
+[ocf] Format 'val write : 'a    t/1 -> 'a ->unit M/2.t/2'
+Output: val write : 'a t/1 -> 'a -> unit M/2.t/2
+
 [ocf] Format 'x + y * z'
 Output: x + (y * z)
 

--- a/test/rpc/rpc_test.ml
+++ b/test/rpc/rpc_test.ml
@@ -97,6 +97,7 @@ let () =
   protect_unit @@ config [("margin", "80")] ;
   protect_string @@ format "aaa -> bbb -> ccc -> ddd -> eee -> fff -> ggg" ;
   protect_string @@ format "val x :\n \nint" ;
+  protect_string @@ format "val write : 'a    t/1 -> 'a ->unit M/2.t/2" ;
   protect_string @@ format "x + y * z" ;
   protect_string @@ format "let x = 4 in x" ;
   protect_string @@ format "sig end" ;

--- a/test/rpc/rpc_test.ml
+++ b/test/rpc/rpc_test.ml
@@ -97,7 +97,7 @@ let () =
   protect_unit @@ config [("margin", "80")] ;
   protect_string @@ format "aaa -> bbb -> ccc -> ddd -> eee -> fff -> ggg" ;
   protect_string @@ format "val x :\n \nint" ;
-  protect_string @@ format "val write : 'a    t/1 -> 'a ->unit M/2.t/2" ;
+  protect_string @@ format "val write : 'a    t/1 -> 'a ->unit M/2.t" ;
   protect_string @@ format "x + y * z" ;
   protect_string @@ format "let x = 4 in x" ;
   protect_string @@ format "sig end" ;

--- a/vendor/diff-parsers-ext-parsewyc.patch
+++ b/vendor/diff-parsers-ext-parsewyc.patch
@@ -1,6 +1,48 @@
 --- ocaml-4.13-extended/lexer.mll
 +++ parse-wyc/lib/lexer.mll
 @@@@
+ let is_keyword name = Hashtbl.mem keyword_table name
+ 
+ let check_label_name lexbuf name =
+   if is_keyword name then error lexbuf (Keyword_as_label name)
+ 
+-(* To "unlex" a few characters *)
+-let set_lexeme_length buf n = (
+-  let open Lexing in
+-  if n < 0 then
+-    invalid_arg "set_lexeme_length: offset should be positive";
+-  if n > buf.lex_curr_pos - buf.lex_start_pos then
+-    invalid_arg "set_lexeme_length: offset larger than lexeme";
+-  buf.lex_curr_pos <- buf.lex_start_pos + n;
+-  buf.lex_curr_p <- {buf.lex_start_p
+-                     with pos_cnum = buf.lex_abs_pos + buf.lex_curr_pos};
+-)
+-
+-let disambiguate lexbuf txt =
+-  let pos = ref 0 in
+-  let len = String.length txt in
+-  let is_digit c = c >= '0' && c <= '9' in
+-  while !pos < len && is_digit txt.[!pos] do incr pos done;
+-  let txt =
+-    if !pos < len then (
+-      set_lexeme_length lexbuf !pos;
+-      String.sub txt 0 !pos
+-    ) else
+-      txt
+-  in
+-  TYPE_DISAMBIGUATOR txt
+-
+-let try_disambiguate lexbuf = function
+-  | INT (txt, None) -> Some (disambiguate lexbuf txt)
+-  | FLOAT (txt, _)  -> Some (disambiguate lexbuf txt)
+-  | _ -> None
+-
+ (* Update the current location with file name and line number. *)
+ 
+ let update_loc lexbuf file line absolute chars =
+   let pos = lexbuf.lex_curr_p in
+   let new_file = match file with
+@@@@
  
  let escaped_newlines = ref false
  
@@ -70,6 +112,18 @@
          lexbuf.lex_curr_p <- { curpos with pos_cnum = curpos.pos_cnum - 1 };
          STAR
        }
+@@@@
+   | ['+' '-'] symbolchar * as op
+             { INFIXOP2 op }
+   | "**" symbolchar * as op
+             { INFIXOP4 op }
+   | '%'     { PERCENT }
+-  | '/'     { SLASH }
+   | ['*' '/' '%'] symbolchar * as op
+             { INFIXOP3 op }
+   | '#' symbolchar_or_hash + as op
+             { HASHOP op }
+   | "let" kwdopchar dotsymbolchar * as op
 @@@@
    | '\\' _
        { if not (in_comment ()) then begin
@@ -296,8 +350,12 @@
  %token RBRACE                 "}"
  %token RBRACKET               "]"
 @@@@
+ %token SEMI                   ";"
+ %token SEMISEMI               ";;"
+ %token HASH                   "#"
  %token <string> HASHOP        "##" (* just an example *)
  %token SIG                    "sig"
+-%token SLASH                  "/"
  %token STAR                   "*"
  %token <string * Location.t * string option>
         STRING                 "\"hello\"" (* just an example *)
@@ -319,6 +377,32 @@
  %token VIRTUAL                "virtual"
  %token WHEN                   "when"
  %token WHILE                  "while"
+@@@@
+ %token <string * Location.t> COMMENT    "(* comment *)"
+ %token <Docstrings.docstring> DOCSTRING "(** documentation *)"
+ 
+ %token EOL                    "\\n"      (* not great, but EOL is unused *)
+ 
+-%token <string> TYPE_DISAMBIGUATOR "2" (* just an example *)
+-
+ /* Precedences and associativities.
+ 
+ Tokens and rules have precedences.  A reduce/reduce conflict is resolved
+ in favor of the first rule (in source file order).  A shift/reduce conflict
+ is resolved by comparing the precedence and associativity of the token to
+@@@@
+ %right    INFIXOP1                      /* expr (e OP e OP e) */
+ %nonassoc below_LBRACKETAT
+ %nonassoc LBRACKETAT
+ %right    COLONCOLON                    /* expr (e :: e :: e) */
+ %left     INFIXOP2 PLUS PLUSDOT MINUS MINUSDOT PLUSEQ /* expr (e OP e OP e) */
+-%left     PERCENT SLASH INFIXOP3 STAR                 /* expr (e OP e OP e) */
++%left     PERCENT INFIXOP3 STAR                 /* expr (e OP e OP e) */
+ %right    INFIXOP4                      /* expr (e OP e OP e) */
+ %nonassoc prec_unary_minus prec_unary_plus /* unary - */
+ %nonassoc prec_constant_constructor     /* cf. simple_expr (C versus C x) */
+ %nonassoc prec_constr_appl              /* above AS BAR COLONCOLON COMMA */
+ %nonassoc below_HASH
 @@@@
  (* The syntax of module expressions is not properly stratified. The cases of
     functors, functor applications, and attributes interact and cause conflicts,
@@ -906,9 +990,36 @@
    | val_extra_ident           { $1 }
  ;
 @@@@
+   | PLUS           {"+"}
+   | PLUSDOT       {"+."}
+   | PLUSEQ        {"+="}
+   | MINUS          {"-"}
+   | MINUSDOT      {"-."}
+-  | SLASH          {"/"}
+   | STAR           {"*"}
+   | PERCENT        {"%"}
+   | EQUAL          {"="}
+   | LESS           {"<"}
+   | GREATER        {">"}
+@@@@
+ label_longident:
+     mk_longident(mod_longident, LIDENT) { $1 }
  ;
+ type_longident:
+     mk_longident(mod_ext_longident, LIDENT)  { $1 }
+-  | LIDENT SLASH TYPE_DISAMBIGUATOR          { Lident ($1 ^ "/" ^ $3) }
+ ;
+ mod_longident:
+     mk_longident(mod_longident, UIDENT)  { $1 }
+ ;
+-mod_ext_longident_:
+-    UIDENT                          { Lident $1 }
+-  | UIDENT SLASH TYPE_DISAMBIGUATOR { Lident ($1 ^ "/" ^ $3) }
+-  | mod_ext_longident DOT UIDENT    { Ldot($1,$3) }
+-;
  mod_ext_longident:
-     mk_longident(mod_ext_longident, UIDENT) { $1 }
+-    mod_ext_longident_ { $1 }
++    mk_longident(mod_ext_longident, UIDENT) { $1 }
    | mod_ext_longident LPAREN mod_ext_longident RPAREN
        { lapply ~loc:$sloc $1 $3 }
 -  | mod_ext_longident LPAREN error

--- a/vendor/diff-parsers-upstream-std.patch
+++ b/vendor/diff-parsers-upstream-std.patch
@@ -76,8 +76,195 @@
      let open Exp in
      let op = map_loc sub pbop_op in
      let pat = sub.pat sub pbop_pat in
+--- ocaml-4.13-upstream/lexer.mll
++++ ocaml-4.13/lexer.mll
+@@@@
+ let is_keyword name = Hashtbl.mem keyword_table name
+ 
+ let check_label_name lexbuf name =
+   if is_keyword name then error lexbuf (Keyword_as_label name)
+ 
++(* To "unlex" a few characters *)
++let set_lexeme_length buf n = (
++  let open Lexing in
++  if n < 0 then
++    invalid_arg "set_lexeme_length: offset should be positive";
++  if n > buf.lex_curr_pos - buf.lex_start_pos then
++    invalid_arg "set_lexeme_length: offset larger than lexeme";
++  buf.lex_curr_pos <- buf.lex_start_pos + n;
++  buf.lex_curr_p <- {buf.lex_start_p
++                     with pos_cnum = buf.lex_abs_pos + buf.lex_curr_pos};
++)
++
++let disambiguate lexbuf txt =
++  let pos = ref 0 in
++  let len = String.length txt in
++  let is_digit c = c >= '0' && c <= '9' in
++  while !pos < len && is_digit txt.[!pos] do incr pos done;
++  let txt =
++    if !pos < len then (
++      set_lexeme_length lexbuf !pos;
++      String.sub txt 0 !pos
++    ) else
++      txt
++  in
++  TYPE_DISAMBIGUATOR txt
++
++let try_disambiguate lexbuf = function
++  | INT (txt, None) -> Some (disambiguate lexbuf txt)
++  | FLOAT (txt, _)  -> Some (disambiguate lexbuf txt)
++  | _ -> None
++
+ (* Update the current location with file name and line number. *)
+ 
+ let update_loc lexbuf file line absolute chars =
+   let pos = lexbuf.lex_curr_p in
+   let new_file = match file with
+@@@@
+   | ['+' '-'] symbolchar * as op
+             { INFIXOP2 op }
+   | "**" symbolchar * as op
+             { INFIXOP4 op }
+   | '%'     { PERCENT }
++  | '/'     { SLASH }
+   | ['*' '/' '%'] symbolchar * as op
+             { INFIXOP3 op }
+   | '#' symbolchar_or_hash + as op
+             { HASHOP op }
+   | "let" kwdopchar dotsymbolchar * as op
+--- ocaml-4.13-upstream/parse.ml
++++ ocaml-4.13/parse.ml
+@@@@
+ let maybe_skip_phrase lexbuf =
+   match !last_token with
+   | Parser.SEMISEMI | Parser.EOF -> ()
+   | _ -> skip_phrase lexbuf
+ 
+-type 'a parser =
+-  (Lexing.lexbuf -> Parser.token) -> Lexing.lexbuf -> 'a
++type 'a parser = Lexing.position -> 'a Parser.MenhirInterpreter.checkpoint
+ 
+ let wrap (parser : 'a parser) lexbuf : 'a =
+   try
+     Docstrings.init ();
+     Lexer.init ();
+-    let ast = parser token lexbuf in
++    let open Parser.MenhirInterpreter in
++    let rec fix_resume = function
++      | InputNeeded _ | Accepted _ | Rejected | HandlingError _ as cp -> cp
++      | Shifting (_, _, _) | AboutToReduce (_, _) as cp ->
++        fix_resume (resume ~strategy:`Simplified cp)
++    in
++    let rec offer_input lexbuf cp tok =
++      let ptok = Lexing.(tok, lexbuf.lex_start_p, lexbuf.lex_curr_p) in
++      match fix_resume (offer cp ptok) with
++      | InputNeeded _ as cp ->
++          offer_input lexbuf cp (token lexbuf)
++      | Accepted x -> Some x
++      | Rejected -> None
++      | Shifting (_, _, _) | AboutToReduce (_, _) ->
++          assert false
++      | HandlingError _ as cp' ->
++        match Lexer.try_disambiguate lexbuf tok with
++        | Some tok' -> offer_input lexbuf cp tok'
++        | None -> main_loop lexbuf cp'
++    and main_loop lexbuf = function
++      | InputNeeded _ as cp ->
++          offer_input lexbuf cp (token lexbuf)
++      | Accepted x -> Some x
++      | Rejected -> None
++      | Shifting (_, _, _) | AboutToReduce (_, _) | HandlingError _ as cp ->
++        main_loop lexbuf (resume ~strategy:`Simplified cp)
++    in
++    let ast =
++      match main_loop lexbuf (parser lexbuf.Lexing.lex_curr_p) with
++      | Some ast -> ast
++      | None -> raise Parsing.Parse_error
++    in
+     Parsing.clear_parser();
+     Docstrings.warn_bad_docstrings ();
+     last_token := Parser.EOF;
+     ast
+   with
+@@@@
+      a production whose semantic action raises an exception.
+ 
+    In either case, the parser will not attempt to read one token past
+    the syntax error. *)
+ 
+-let implementation = wrap Parser.implementation
+-and interface = wrap Parser.interface
+-and toplevel_phrase = wrap Parser.toplevel_phrase
+-and use_file = wrap Parser.use_file
+-and core_type = wrap Parser.parse_core_type
+-and expression = wrap Parser.parse_expression
+-and pattern = wrap Parser.parse_pattern
+-
+-let longident = wrap Parser.parse_any_longident
+-let val_ident = wrap Parser.parse_val_longident
+-let constr_ident= wrap Parser.parse_constr_longident
+-let extended_module_path = wrap Parser.parse_mod_ext_longident
+-let simple_module_path = wrap Parser.parse_mod_longident
+-let type_ident = wrap Parser.parse_mty_longident
++let implementation = wrap Parser.Incremental.implementation
++and interface = wrap Parser.Incremental.interface
++and toplevel_phrase = wrap Parser.Incremental.toplevel_phrase
++and use_file = wrap Parser.Incremental.use_file
++and core_type = wrap Parser.Incremental.parse_core_type
++and expression = wrap Parser.Incremental.parse_expression
++and pattern = wrap Parser.Incremental.parse_pattern
++
++let longident = wrap Parser.Incremental.parse_any_longident
++let val_ident = wrap Parser.Incremental.parse_val_longident
++let constr_ident= wrap Parser.Incremental.parse_constr_longident
++let extended_module_path = wrap Parser.Incremental.parse_mod_ext_longident
++let simple_module_path = wrap Parser.Incremental.parse_mod_longident
++let type_ident = wrap Parser.Incremental.parse_mty_longident
+ 
+ (* Error reporting for Syntaxerr *)
+ (* The code has been moved here so that one can reuse Pprintast.tyvar *)
+ 
+ let prepare_error err =
 --- ocaml-4.13-upstream/parser.mly
 +++ ocaml-4.13/parser.mly
+@@@@
+ %token SEMI                   ";"
+ %token SEMISEMI               ";;"
+ %token HASH                   "#"
+ %token <string> HASHOP        "##" (* just an example *)
+ %token SIG                    "sig"
++%token SLASH                  "/"
+ %token STAR                   "*"
+ %token <string * Location.t * string option>
+        STRING                 "\"hello\"" (* just an example *)
+ %token <string * Location.t * string * Location.t * string option>
+        QUOTED_STRING_EXPR     "{%hello|world|}"  (* just an example *)
+@@@@
+ %token <string * Location.t> COMMENT    "(* comment *)"
+ %token <Docstrings.docstring> DOCSTRING "(** documentation *)"
+ 
+ %token EOL                    "\\n"      (* not great, but EOL is unused *)
+ 
++%token <string> TYPE_DISAMBIGUATOR "2" (* just an example *)
++
+ /* Precedences and associativities.
+ 
+ Tokens and rules have precedences.  A reduce/reduce conflict is resolved
+ in favor of the first rule (in source file order).  A shift/reduce conflict
+ is resolved by comparing the precedence and associativity of the token to
+@@@@
+ %right    INFIXOP1                      /* expr (e OP e OP e) */
+ %nonassoc below_LBRACKETAT
+ %nonassoc LBRACKETAT
+ %right    COLONCOLON                    /* expr (e :: e :: e) */
+ %left     INFIXOP2 PLUS PLUSDOT MINUS MINUSDOT PLUSEQ /* expr (e OP e OP e) */
+-%left     PERCENT INFIXOP3 STAR                 /* expr (e OP e OP e) */
++%left     PERCENT SLASH INFIXOP3 STAR                 /* expr (e OP e OP e) */
+ %right    INFIXOP4                      /* expr (e OP e OP e) */
+ %nonassoc prec_unary_minus prec_unary_plus /* unary - */
+ %nonassoc prec_constant_constructor     /* cf. simple_expr (C versus C x) */
+ %nonassoc prec_constr_appl              /* above AS BAR COLONCOLON COMMA */
+ %nonassoc below_HASH
 @@@@
  %nonassoc below_DOT
  %nonassoc DOT DOTOP
@@ -133,6 +320,42 @@
    | mod_longident DOT LPAREN seq_expr error
        { unclosed "(" $loc($3) ")" $loc($5) }
    | LBRACE record_expr_content RBRACE
+@@@@
+   | PLUS           {"+"}
+   | PLUSDOT       {"+."}
+   | PLUSEQ        {"+="}
+   | MINUS          {"-"}
+   | MINUSDOT      {"-."}
++  | SLASH          {"/"}
+   | STAR           {"*"}
+   | PERCENT        {"%"}
+   | EQUAL          {"="}
+   | LESS           {"<"}
+   | GREATER        {">"}
+@@@@
+ label_longident:
+     mk_longident(mod_longident, LIDENT) { $1 }
+ ;
+ type_longident:
+     mk_longident(mod_ext_longident, LIDENT)  { $1 }
++  | LIDENT SLASH TYPE_DISAMBIGUATOR          { Lident ($1 ^ "/" ^ $3) }
+ ;
+ mod_longident:
+     mk_longident(mod_longident, UIDENT)  { $1 }
+ ;
++mod_ext_longident_:
++    UIDENT                          { Lident $1 }
++  | UIDENT SLASH TYPE_DISAMBIGUATOR { Lident ($1 ^ "/" ^ $3) }
++  | mod_ext_longident DOT UIDENT    { Ldot($1,$3) }
++;
+ mod_ext_longident:
+-    mk_longident(mod_ext_longident, UIDENT) { $1 }
++    mod_ext_longident_ { $1 }
+   | mod_ext_longident LPAREN mod_ext_longident RPAREN
+       { lapply ~loc:$sloc $1 $3 }
+   | mod_ext_longident LPAREN error
+       { expecting $loc($3) "module path" }
+ ;
 --- ocaml-4.13-upstream/parsetree.mli
 +++ ocaml-4.13/parsetree.mli
 @@@@

--- a/vendor/ocaml-4.13/lexer.mll
+++ b/vendor/ocaml-4.13/lexer.mll
@@ -573,6 +573,7 @@ rule token = parse
   | "**" symbolchar * as op
             { INFIXOP4 op }
   | '%'     { PERCENT }
+  | '/'     { SLASH }
   | ['*' '/' '%'] symbolchar * as op
             { INFIXOP3 op }
   | '#' symbolchar_or_hash + as op

--- a/vendor/ocaml-4.13/lexer.mll
+++ b/vendor/ocaml-4.13/lexer.mll
@@ -234,6 +234,37 @@ let is_keyword name = Hashtbl.mem keyword_table name
 let check_label_name lexbuf name =
   if is_keyword name then error lexbuf (Keyword_as_label name)
 
+(* To "unlex" a few characters *)
+let set_lexeme_length buf n = (
+  let open Lexing in
+  if n < 0 then
+    invalid_arg "set_lexeme_length: offset should be positive";
+  if n > buf.lex_curr_pos - buf.lex_start_pos then
+    invalid_arg "set_lexeme_length: offset larger than lexeme";
+  buf.lex_curr_pos <- buf.lex_start_pos + n;
+  buf.lex_curr_p <- {buf.lex_start_p
+                     with pos_cnum = buf.lex_abs_pos + buf.lex_curr_pos};
+)
+
+let disambiguate lexbuf txt =
+  let pos = ref 0 in
+  let len = String.length txt in
+  let is_digit c = c >= '0' && c <= '9' in
+  while !pos < len && is_digit txt.[!pos] do incr pos done;
+  let txt =
+    if !pos < len then (
+      set_lexeme_length lexbuf !pos;
+      String.sub txt 0 !pos
+    ) else
+      txt
+  in
+  TYPE_DISAMBIGUATOR txt
+
+let try_disambiguate lexbuf = function
+  | INT (txt, None) -> Some (disambiguate lexbuf txt)
+  | FLOAT (txt, _)  -> Some (disambiguate lexbuf txt)
+  | _ -> None
+
 (* Update the current location with file name and line number. *)
 
 let update_loc lexbuf file line absolute chars =

--- a/vendor/ocaml-4.13/parser.mly
+++ b/vendor/ocaml-4.13/parser.mly
@@ -766,6 +766,8 @@ let mk_directive ~loc name arg =
 
 %token EOL                    "\\n"      (* not great, but EOL is unused *)
 
+%token <string> TYPE_DISAMBIGUATOR "2" (* just an example *)
+
 /* Precedences and associativities.
 
 Tokens and rules have precedences.  A reduce/reduce conflict is resolved
@@ -3611,12 +3613,18 @@ label_longident:
 ;
 type_longident:
     mk_longident(mod_ext_longident, LIDENT)  { $1 }
+  | LIDENT SLASH TYPE_DISAMBIGUATOR          { Lident ($1 ^ "/" ^ $3) }
 ;
 mod_longident:
     mk_longident(mod_longident, UIDENT)  { $1 }
 ;
+mod_ext_longident_:
+    UIDENT                          { Lident $1 }
+  | UIDENT SLASH TYPE_DISAMBIGUATOR { Lident ($1 ^ "/" ^ $3) }
+  | mod_ext_longident DOT UIDENT    { Ldot($1,$3) }
+;
 mod_ext_longident:
-    mk_longident(mod_ext_longident, UIDENT) { $1 }
+    mod_ext_longident_ { $1 }
   | mod_ext_longident LPAREN mod_ext_longident RPAREN
       { lapply ~loc:$sloc $1 $3 }
   | mod_ext_longident LPAREN error

--- a/vendor/ocaml-4.13/parser.mly
+++ b/vendor/ocaml-4.13/parser.mly
@@ -739,6 +739,7 @@ let mk_directive ~loc name arg =
 %token HASH                   "#"
 %token <string> HASHOP        "##" (* just an example *)
 %token SIG                    "sig"
+%token SLASH                  "/"
 %token STAR                   "*"
 %token <string * Location.t * string option>
        STRING                 "\"hello\"" (* just an example *)
@@ -813,7 +814,7 @@ The precedences must be listed from low to high.
 %nonassoc LBRACKETAT
 %right    COLONCOLON                    /* expr (e :: e :: e) */
 %left     INFIXOP2 PLUS PLUSDOT MINUS MINUSDOT PLUSEQ /* expr (e OP e OP e) */
-%left     PERCENT INFIXOP3 STAR                 /* expr (e OP e OP e) */
+%left     PERCENT SLASH INFIXOP3 STAR                 /* expr (e OP e OP e) */
 %right    INFIXOP4                      /* expr (e OP e OP e) */
 %nonassoc prec_unary_minus prec_unary_plus /* unary - */
 %nonassoc prec_constant_constructor     /* cf. simple_expr (C versus C x) */
@@ -3561,6 +3562,7 @@ operator:
   | PLUSEQ        {"+="}
   | MINUS          {"-"}
   | MINUSDOT      {"-."}
+  | SLASH          {"/"}
   | STAR           {"*"}
   | PERCENT        {"%"}
   | EQUAL          {"="}


### PR DESCRIPTION
This is an alternative implementation that solves the same problem as #1715 

By the way, if I am right, I updated the specification to better match the output of the typed printer: `M/2.t/2` is not allowed, disambiguators are only allowed on the first identifier of a path.

The patch is quite close to #1715: try to parse one way, fall back to the other in case of failure.
But contrary to #1715, we approach the problem differently: first we try to parse using normal OCaml rules (lexer is untouched).
In case of failure, we check if the token could be mistaken for a disambiguation suffix, which we call a `TYPE_DISAMBIGUATOR`. (FIXME: find a better name, it disambiguates global identifiers, not just types).

The benefit of this approach are two folds:
- first, by construction, the original grammar is not affected: more sentences are recognized, but all valid OCaml phrases are accepted in exactly the same way (modulo the fact that we distinguish "/" from other INFIXOP3, it is not necessary but it is cleaner)
- second, by shifting `/` inside the identifier rules, we should get some input from Menhir if that introduced a grammar conflict (luckily, there is none with the current rules)