### PR TITLE
Convert test for option 'parse-docstrings=false'

### DIFF
--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -759,13 +759,13 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
-   (with-outputs-to doc_comments-parse-docstrings.mli.output
-     (run %{bin:ocamlformat} --parse-docstrings %{dep:tests/doc_comments.mli}))))
+   (with-outputs-to doc_comments-no-parse-docstrings.mli.output
+     (run %{bin:ocamlformat} --no-parse-docstrings --max-iters=3 %{dep:tests/doc_comments.mli}))))
 
 (rule
  (alias runtest)
  (package ocamlformat)
- (action (diff tests/doc_comments-parse-docstrings.mli.ref doc_comments-parse-docstrings.mli.output)))
+ (action (diff tests/doc_comments-no-parse-docstrings.mli.ref doc_comments-no-parse-docstrings.mli.output)))
 
 (rule
  (deps tests/.ocamlformat )

--- a/test/passing/tests/doc_comments-no-parse-docstrings.mli.opts
+++ b/test/passing/tests/doc_comments-no-parse-docstrings.mli.opts
@@ -1,0 +1,2 @@
+--no-parse-docstrings
+--max-iters=3

--- a/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
+++ b/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
@@ -76,38 +76,63 @@ val k : k
 (** this is a comment
 
     @author foo
-    @author Foooooooooooooooooooooooooooooooooooo Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
+
+    @author Foooooooooooooooooooooooooooooooooooo
+    Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
+
     @version foo
-    @version Foooooooooooooooooooooooooooooooooooo Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
+
+    @version Foooooooooooooooooooooooooooooooooooo
+    Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
+
     @see <foo> foo
-    @see <https://slash-create.js.org/#/docs/main/latest/class/SlashCreator?scrollTo=registerCommandsIn>
-      this url is very long
+
+    @see
+    <https://slash-create.js.org/#/docs/main/latest/class/SlashCreator?scrollTo=registerCommandsIn>
+    this url is very long
+
     @since foo
-    @since Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
+
+    @since
+    Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
+
     @before foo [foo]
-    @before Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
-      Foo bar
+
+    @before
+    Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
+    Foo bar
+
     @deprecated [foo]
-    @deprecated
-      Foooooooooooooooooooooooooooooooooooo
-      Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar Foo bar
+
+    @deprecated Foooooooooooooooooooooooooooooooooooo
+    Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar Foo bar
+
     @param foo [foo]
-    @param Foooooooooooooo_Baaaaaaaaaaaaar
-      Fooooooooooo foooooooooooo fooooooooooo baaaaaaaaar
-    @param Foooooooooooooooooooooooooooooooooooo_baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
-      Foo bar
+
+    @param Foooooooooooooo_Baaaaaaaaaaaaar Fooooooooooo foooooooooooo
+    fooooooooooo baaaaaaaaar
+
+    @param
+    Foooooooooooooooooooooooooooooooooooo_baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
+    Foo bar
+
     @raise foo [foo]
-    @raise Foooooooooooooooooooooooooooooooooooo_baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
-      Foo bar
+
+    @raise
+    Foooooooooooooooooooooooooooooooooooo_baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
+    Foo bar
+
     @return [foo]
+
     @inline
+
     @canonical foo
-    @canonical Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar *)
+
+    @canonical
+    Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar *)
 
 val x : x
-(** a comment
-
-    @version foo *)
+(** a comment @version foo *)
 
 (** Managing Chunks.
 
@@ -120,15 +145,11 @@ val x : x
 
     A chunk has the following structure:
 
-    {v
-    --------------------------      --------------------------
-    | uint8_t type            |     | uint8_t type            |
-    ---------------------------     ---------------------------
-    | uint16_t                |     | uint64_t                |
-    ---------------------------     ---------------------------
-    | key children[length]    |     | byte data[length]       |
-    ---------------------------     ---------------------------
-    v}
+    {v -------------------------- -------------------------- | uint8_t type |
+    | uint8_t type | --------------------------- ---------------------------
+    | uint16_t | | uint64_t | ---------------------------
+    --------------------------- | key children[length] | | byte data[length]
+    | --------------------------- --------------------------- v}
 
     [type] is either [Data] (0) or [Index] (1). If the chunk contains data,
     [length] is the payload length. Otherwise it is the number of children
@@ -141,62 +162,40 @@ val x : x
 
 (** This is verbatim:
 
-    {v
-   o  o
-  /\  /\
-  /\  /\
-    v}
+    {v o o /\ /\ /\ /\ v}
 
     This is preformated code:
 
-    {[
-      let verbatim s =
-        s |> String.split_lines |> List.map ~f:String.strip
-        |> fun s -> list s "@," Fmt.str
-    ]} *)
+    {[ let verbatim s = s |> String.split_lines |> List.map ~f:String.strip
+    |> fun s -> list s "@," Fmt.str ]} *)
 
 (** Lists:
 
     list with short lines:
 
-    - x
-    - y
-    - z
+    - x - y - z
 
     list with long lines:
 
     - xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx
-      xxx xxx xxx xxx xxx xxx
-    - yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy
-      yyy yyy yyy yyy yyy yyy
-    - zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
-      zzz zzz zzz zzz zzz zzz
+    xxx xxx xxx xxx xxx xxx - yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy
+    yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy - zzz zzz zzz zzz zzz zzz
+    zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
 
     enumerated list with long lines:
 
     + xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx
-      xxx xxx xxx xxx xxx xxx
-    + yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy
-      yyy yyy yyy yyy yyy yyy
-    + zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
-      zzz zzz zzz zzz zzz zzz
+    xxx xxx xxx xxx xxx xxx + yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy
+    yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy + zzz zzz zzz zzz zzz zzz
+    zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
 
     list with sub lists:
 
-    {ul
-     {- xxx
+    {ul {- xxx
 
-        - a
-        - b
-        - c
-     }
-     {- yyy
+    - a - b - c } {- yyy
 
-        + a
-        + b
-        + c
-     }
-    } *)
+    + a + b + c }} *)
 
 (** {{:https://github.com/} Github} *)
 
@@ -214,8 +213,8 @@ val x : x
 
 (** return true if [\gamma(lhs) \subseteq \gamma(rhs)] *)
 
-(** Composition of functions: [(f >> g) x] is exactly equivalent to
-    [g (f (x))]. Left associative. *)
+(** Composition of functions: [(f >> g) x] is exactly equivalent to [g (f
+    (x))]. Left associative. *)
 
 (** [†] [Struct_rec] is *)
 
@@ -257,64 +256,21 @@ end
 
 (** {[ b ]} *)
 
-(** - Odoc don't parse
+(** - Odoc don't parse multiple paragraph in a list *)
 
-    multiple paragraph in a list *)
+(** {ul {- Abc Def } {- Hij } {- Klm {ul {- Nop Qrs } {- Tuv }} }} *)
 
-(** {ul
-     {- Abc
+(** - {v Abc def v} - {[ A B ]} *)
 
-        Def
-     }
-     {- Hij }
-     {- Klm
+(** Code block {[ Single line ]} {[ Multi line ]} {[ Multi line with
+    indentation ]} {[ Single long line
+    HAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA ]} {[ With
+    empty
 
-        {ul
-         {- Nop
-
-            Qrs
-         }
-         {- Tuv }
-        }
-     }
-    } *)
-
-(** - {v
-    Abc
-    def
-      v}
-    - {[ A B ]} *)
-
-(** Code block
-
-    {[ Single line ]}
-    {[ Multi line ]}
-    {[
-      Multi
-      line
-        with
-          indentation
-    ]}
-    {[
-      Single long line HAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    ]}
-    {[
-      With empty
-
-      line
-    ]}
-    {[
-      First line
-      on the same line
-      as opening
-    ]} *)
+    line ]} {[ First line on the same line as opening ]} *)
 
 module X : sig
-  (** {[
-        First line
-        on the same line
-        as opening
-      ]} *)
+  (** {[ First line on the same line as opening ]} *)
 end
 
 (** {!module:A} {!module:A.B}
@@ -337,96 +293,67 @@ end
 
     {!field:f} {!field:t.f} {!field:M.t.f} *)
 
-(** {!modules:Foo}
-    {!modules:Foo Bar.Baz}
-    @canonical Foo
-    @canonical Foo.Bar *)
+(** {!modules:Foo} {!modules:Foo Bar.Baz} @canonical Foo @canonical Foo.Bar *)
 
 (** {%html:<p>Raw markup</p>%} {%Without language%} {%other:Other language%} *)
 
-(** [Multi
-     Line]
+(** [Multi Line]
 
-    [ A lot of    spaces ]
+    [ A lot of spaces ]
 
-    [Very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong] *)
+    [Very
+    looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong] *)
 
-(** {[
-      for i = 1 to 3 do
-        Printf.printf "let x%d = %d\n" i i
-      done
-    ]} *)
+(** {[ for i = 1 to 3 do Printf.printf "let x%d = %d\n" i i done ]} *)
 
-(** {[
-      print_newline () ;
-      List.iter
-        (fun s -> Printf.printf "let ( %s ) = Pervasives.( %s )\n" s s)
-        ["+"; "-"; "*"; "/"]
-    ]} *)
+(** {[ print_newline (); List.iter (fun s -> Printf.printf "let ( %s ) =
+    Pervasives.( %s )\n" s s) ["+"; "-"; "*"; "/"] ]} *)
+
+(** {[ #use "import.cinaps";;
+
+    List.iter all_fields ~f:(fun (name, type_) -> printf "\nexternal get_%s :
+    unit -> %s = \"get_%s\"" name type_ name) ]} *)
 
 (** {[
-      #use "import.cinaps";;
 
-      List.iter all_fields ~f:(fun (name, type_) -> printf "\nexternal get_%s
-      : unit -> %s = \"get_%s\"" name type_ name)
-    ]} *)
+    List.iter all_fields ~f:(fun (name, type_) -> printf "\nexternal get_%s :
+    unit -> %s = \"get_%s\"" name type_ name) ]} *)
 
-(** {[
-      List.iter all_fields ~f:(fun (name, type_) ->
-          printf "\nexternal get_%s\n: unit -> %s = \"get_%s\"" name type_
-            name )
-    ]} *)
-
-(** {[
-      let x = 1 in
-      (* fooooooo *)
-      let y = 2 in
-      (* foooooooo *)
-      z
-    ]} *)
+(** {[ let x = 1 in (* fooooooo *) let y = 2 in (* foooooooo *) z ]} *)
 
 (** {[ let this = is_short ]}
-    {[
-        does not parse: verbatim
-      +/+/+ /+/+/ +/+//+/+/+/+/+/+/+/
-      +/+/+ /+/+/ +/+//+/+/+/+/+/+/+/
-      +/+/+ /+/+/ +/+//+/+/+/+/+/+/+/
-      +/+/+ /+/+/ +/+//+/+
-    ]}
-    {[
-      [@@@ocamlformat "break-separators = after"]
 
-      let fooooooooooooooooo =
-        [ foooooooooooooooooooooooooooooooo;
-          foooooooooooooooooooooooooooooooo;
-          foooooooooooooooooooooooooooooooo ]
+    {[ does not parse: verbatim +/+/+ /+/+/ +/+//+/+/+/+/+/+/+/ +/+/+ /+/+/
+    +/+//+/+/+/+/+/+/+/ +/+/+ /+/+/ +/+//+/+/+/+/+/+/+/ +/+/+ /+/+/ +/+//+/+
     ]}
-    {[
-      let fooooooooooooooooo =
-        [ foooooooooooooooooooooooooooooooo
-        ; foooooooooooooooooooooooooooooooo
-        ; foooooooooooooooooooooooooooooooo ]
+
+    {[ [@@@ocamlformat "break-separators = after"]
+
+    let fooooooooooooooooo = [ foooooooooooooooooooooooooooooooo ;
+    foooooooooooooooooooooooooooooooo ; foooooooooooooooooooooooooooooooo ]
+
+    ]}
+
+    {[ let fooooooooooooooooo = [ foooooooooooooooooooooooooooooooo ;
+    foooooooooooooooooooooooooooooooo ; foooooooooooooooooooooooooooooooo ]
+
     ]} *)
 
-(** This is a comment with code inside
+(** This is a comment with code inside {[ (** This is a comment with code
+    inside [ let code inside = f inside ] *) let code inside (* comment *) =
+    f inside ]} *)
 
-    {[
-      (** This is a comment with code inside [ let code inside = f inside ] *)
-      let code inside (* comment *) = f inside
-    ]} *)
-
-(** {e foooooooo oooooooooo ooooooooo ooooooooo}
-    {i fooooooooooooo oooooooo oooooooooo}
-    {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
+(** {e foooooooo oooooooooo ooooooooo ooooooooo} {i fooooooooooooo oooooooo
+    oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
 
 (** {e foooooooo oooooooooo ooooooooo ooooooooo} {{!some ref} fooooooooooooo
     oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
 
-(** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooo
-    {b eee + eee eee} *)
+(** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooo {b eee
+    + eee eee} *)
 
-(** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooooooo
-    {b + eee + eee eee} *)
+(** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooooooo {b
+    + eee + eee eee} *)
 
 val f : int
 
@@ -436,39 +363,31 @@ val k : int
 
 (**)
 
-(** {e foooooooo oooooooooo ooooooooo ooooooooo
-       {i fooooooooooooo oooooooo oooooooooo
-          {b fooooooooooooo oooooooooooo oooooo ooooooo}}} *)
+(** {e foooooooo oooooooooo ooooooooo ooooooooo {i fooooooooooooo oooooooo
+    oooooooooo {b fooooooooooooo oooooooooooo oooooo ooooooo}}} *)
 
-(** {e
-       {i fooooooooooooo oooooooo oooooooooo
-          {b fooooooooooooo oooooooooooo oooooo ooooooo}} foooooooo
-       oooooooooo ooooooooo ooooooooo} *)
+(** {e {i fooooooooooooo oooooooo oooooooooo {b fooooooooooooo oooooooooooo
+    oooooo ooooooo}} foooooooo oooooooooo ooooooooo ooooooooo} *)
 
 (** foooooooooo fooooooooooo
 
-    {e foooooooo oooooooooo ooooooooo ooooooooo
-       {i fooooooooooooo oooooooo oooooooooo
-          {b fooooooooooooo oooooooooooo oooooo ooooooo}} fooooooooooooo
-       foooooooooo fooooo
-       {i fooooooooooooo oooooooo oooooooooo
-          {b fooooooooooooo oooooooooooo oooooo ooooooo}}}
+    {e foooooooo oooooooooo ooooooooo ooooooooo {i fooooooooooooo oooooooo
+    oooooooooo {b fooooooooooooo oooooooooooo oooooo ooooooo}} fooooooooooooo
+    foooooooooo fooooo {i fooooooooooooo oooooooo oooooooooo {b
+    fooooooooooooo oooooooooooo oooooo ooooooo}}}
 
-    {e foooooooo oooooooooo ooooooooo ooooooooo
-       {i fooooooooooooo oooooooo oooooooooo}}
+    {e foooooooo oooooooooo ooooooooo ooooooooo {i fooooooooooooo oooooooo
+    oooooooooo}}
 
     fooooooooooooo foooooooooooooo:
 
-    - foo
-    - {e foooooooo oooooooooo ooooooooo ooooooooo
-         {i fooooooooooooo oooooooo oooooooooo}}
-    - {e foooooooo oooooooooo ooooooooo ooooooooo}
-      {i fooooooooooooo oooooooo oooooooooo}
-    - foo *)
+    - foo - {e foooooooo oooooooooo ooooooooo ooooooooo {i fooooooooooooo
+    oooooooo oooooooooo}} - {e foooooooo oooooooooo ooooooooo ooooooooo} {i
+    fooooooooooooo oooooooo oooooooooo} - foo *)
 
 (** Brackets must not be escaped in the first argument of some tags: *)
 
-(** @raise [Invalid_argument] if the argument is [None]. Sometimes [t.\[x\]]. *)
+(** @raise [Invalid_argument] if the argument is [None]. Sometimes [t.[x]]. *)
 
 (** @author [Abc] [def] \[hij\] *)
 
@@ -496,7 +415,7 @@ val k : int
 
 (**  *)
 
-(** [trim "  "] is [""] *)
+(** [trim " "] is [""] *)
 
 (** [trms (c × (Σᵢ₌₁ⁿ cᵢ × Πⱼ₌₁ᵐᵢ Xᵢⱼ^pᵢⱼ))] is the sequence of terms [Xᵢⱼ]
     for each [i] and [j]. *)

--- a/test/passing/tests/doc_comments-parse-docstrings.mli.opts
+++ b/test/passing/tests/doc_comments-parse-docstrings.mli.opts
@@ -1,1 +1,0 @@
---parse-docstrings


### PR DESCRIPTION
I just realized that the `parse-docstrings=true` option was already set in `test/passing/tests/.ocamlformat`:

```
profile = ocamlformat
break-cases = fit
margin = 77
parse-docstrings = true
wrap-comments = true
max-iters = 2
```

~and I don't think it would be worth it to reconvert this test to check `parse-docstrings=false` so we can just remove it!~
edit: wait finally maybe it's worth it, I'm gonna reconvert this test instead!