### PR TITLE
Remove unused dependency to uutf

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -66,9 +66,7 @@
   (stdio
    (< v0.15))
   (uuseg
-   (>= 10.0.0))
-  (uutf
-   (>= 1.0.1))))
+   (>= 10.0.0))))
 
 (package
  (name ocamlformat-rpc)
@@ -108,9 +106,7 @@
   (stdio
    (< v0.15))
   (uuseg
-   (>= 10.0.0))
-  (uutf
-   (>= 1.0.1))))
+   (>= 10.0.0))))
 
 (package
  (name ocamlformat-rpc-lib)

--- a/ocamlformat-rpc.opam
+++ b/ocamlformat-rpc.opam
@@ -29,7 +29,6 @@ depends: [
   "re"
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}
-  "uutf" {>= "1.0.1"}
   "odoc" {with-doc}
 ]
 build: [

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -28,7 +28,6 @@ depends: [
   "re"
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}
-  "uutf" {>= "1.0.1"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
`dune external-lib-deps --missing @fmt` does not return any error for me but somehow does in the CI, so probably an `ocaml-ci` error.