### PR TITLE
Fix formatting of multiline non-wrapping comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@
 
   + Do not consider leading star '*' when checking the diff of doc comments (#1712, @hhugo)
 
+  + Fix formatting of multiline non-wrapping comments (#1723, @gpetiot)
+
 #### Changes
 
   + Improve the diff of unstable docstrings displayed in error messages (#1654, @gpetiot)

--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -90,11 +90,11 @@ let fmt_multiline_cmt ?epi ~opn_pos ~starts_with_sp first_line tl_lines =
     in
     fmt_if_k (not first) sep $ sp $ str (String.rstrip s)
   in
-  vbox 0 (list_fl unindented fmt_line $ fmt_opt epi)
+  vbox 0 ~name:"multiline" (list_fl unindented fmt_line $ fmt_opt epi)
 
 type pos = Before | Within | After
 
-let fmt cmt src ~wrap:wrap_comments ~ocp_indent_compat ~fmt_code pos =
+let fmt cmt ~wrap:wrap_comments ~ocp_indent_compat ~fmt_code pos =
   let open Fmt in
   let fmt_asterisk_prefixed_lines lines =
     vbox 1
@@ -106,7 +106,6 @@ let fmt cmt src ~wrap:wrap_comments ~ocp_indent_compat ~fmt_code pos =
             | _, Some _ -> str line $ fmt "@,*" ) )
   in
   let fmt_unwrapped_cmt {txt= s; loc} =
-    let begins_line = Source.begins_line src loc ~ignore_spaces:false in
     let is_sp = function ' ' | '\t' -> true | _ -> false in
     let epi =
       (* Preserve position of closing but strip empty lines at the end *)
@@ -119,8 +118,7 @@ let fmt cmt src ~wrap:wrap_comments ~ocp_indent_compat ~fmt_code pos =
     in
     let stripped = String.rstrip s in
     match String.split_lines stripped with
-    | first_line :: (_ :: _ as tl)
-      when (not begins_line) && not (String.is_empty first_line) ->
+    | first_line :: (_ :: _ as tl) when not (String.is_empty first_line) ->
         if ocp_indent_compat then
           (* Not adding artificial breaks and keeping the comment contents
              verbatim will not interfere with ocp-indent. *)
@@ -159,7 +157,7 @@ let fmt cmt src ~wrap:wrap_comments ~ocp_indent_compat ~fmt_code pos =
     match fmt_code source with
     | Ok formatted ->
         let cls : Fmt.s = if dollar_last then "$*)" else "*)" in
-        hvbox 2
+        hvbox 2 ~name:"code"
           (wrap "(*$" cls
              ( fmt "@;" $ formatted
              $ fmt_if (String.length str > 2) "@;<1 -2>" ) )

--- a/lib/Cmt.mli
+++ b/lib/Cmt.mli
@@ -25,7 +25,6 @@ type pos = Before | Within | After
 
 val fmt :
      t
-  -> Source.t
   -> wrap:bool
   -> ocp_indent_compat:bool
   -> fmt_code:(string -> (Fmt.t, unit) Result.t)

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -347,12 +347,12 @@ let fmt_cmts_aux t (conf : Conf.t) cmts ~fmt_code pos =
   let groups =
     List.group cmts ~break:(break_comment_group t.source conf.margin)
   in
-  vbox 0
+  vbox 0 ~name:"cmts"
     (list_pn groups (fun ~prev:_ group ~next ->
          ( match group with
          | [] -> impossible "previous match"
          | [cmt] ->
-             Cmt.fmt cmt t.source ~wrap:conf.wrap_comments
+             Cmt.fmt cmt ~wrap:conf.wrap_comments
                ~ocp_indent_compat:conf.ocp_indent_compat
                ~fmt_code:(fmt_code conf) pos
          | group ->

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -771,6 +771,18 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+   (with-outputs-to doc_comments-no-wrap.mli.output
+     (run %{bin:ocamlformat} --no-wrap-comments %{dep:tests/doc_comments.mli}))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/doc_comments-no-wrap.mli.ref doc_comments-no-wrap.mli.output)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
    (with-outputs-to doc_comments.ml.output
      (run %{bin:ocamlformat} %{dep:tests/doc_comments.ml}))))
 

--- a/test/passing/tests/cinaps.ml
+++ b/test/passing/tests/cinaps.ml
@@ -47,7 +47,7 @@ let foo = foo
    crash and the second become a mess *)
 
 (*$(**)"
-"*)
+  "*)
 
 (*$
   print_newline () ;

--- a/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
+++ b/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
@@ -434,3 +434,13 @@ val k : int
     Phasellus et nisi id neque ultrices vestibulum vitae non tortor. Mauris
     aliquet at risus sed rhoncus. Ut condimentum rhoncus orci, sit amet
     eleifend erat tempus quis. *)
+
+(** {[(* a b *)]} *)
+
+val a :
+     fooooooooooooooooooooooooooo (** {[(* a b *)]} *)
+  -> fooooooooooooooooooooooooo
+
+type x = {a: t  (** {[(* a b *)]} *); b: [`A  (** {[(* a b *)]} *)]}
+
+type x = A of a  (** {[(* a b *)]} *) | B of b  (** {[(* a b *)]} *)

--- a/test/passing/tests/doc_comments-no-wrap.mli.opts
+++ b/test/passing/tests/doc_comments-no-wrap.mli.opts
@@ -1,0 +1,1 @@
+--no-wrap-comments

--- a/test/passing/tests/doc_comments-no-wrap.mli.ref
+++ b/test/passing/tests/doc_comments-no-wrap.mli.ref
@@ -8,8 +8,8 @@ type block =
   | `Noblank
   | `Blocks of block list ]
 
-include M with type t := t
 (** Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod *)
+include M with type t := t
 
 val escape : string -> string
 (** [escape s] escapes [s] from the doc language. *)
@@ -46,8 +46,8 @@ val print :
   -> t
   -> unit
 
-(** {1:printers-and-escapes-used-by-cmdliner-module Printers and escapes
-    used by Cmdliner module} *)
+(** {1:printers-and-escapes-used-by-cmdliner-module Printers and escapes used
+    by Cmdliner module} *)
 
 val subst_vars :
      errs:Format.formatter
@@ -67,8 +67,8 @@ val doc_to_plain :
   -> Buffer.t
   -> string
   -> string
-(** [doc_to_plain b ~subst s] using [b], subsitutes in [s] variables by
-    their [subst] definition and renders cmdliner directives to plain text.
+(** [doc_to_plain b ~subst s] using [b], subsitutes in [s] variables by their
+    [subst] definition and renders cmdliner directives to plain text.
 
     @raise Invalid_argument in case of illegal syntax. *)
 
@@ -76,45 +76,32 @@ val k : k
 (** this is a comment
 
     @author foo
-
     @author Foooooooooooooooooooooooooooooooooooo Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
-
     @version foo
-
     @version Foooooooooooooooooooooooooooooooooooo Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
-
     @see <foo> foo
-
-    @see <https://slash-create.js.org/#/docs/main/latest/class/SlashCreator?scrollTo=registerCommandsIn> this url is very long
-
+    @see <https://slash-create.js.org/#/docs/main/latest/class/SlashCreator?scrollTo=registerCommandsIn>
+      this url is very long
     @since foo
-
     @since Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
-
     @before foo [foo]
-
-    @before Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar Foo bar
-
+    @before Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
+      Foo bar
     @deprecated [foo]
-
-    @deprecated Foooooooooooooooooooooooooooooooooooo Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar Foo bar
-
+    @deprecated
+      Foooooooooooooooooooooooooooooooooooo
+      Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar Foo bar
     @param foo [foo]
-
-    @param Foooooooooooooo_Baaaaaaaaaaaaar Fooooooooooo foooooooooooo fooooooooooo baaaaaaaaar
-
-    @param Foooooooooooooooooooooooooooooooooooo_baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar Foo bar
-
+    @param Foooooooooooooo_Baaaaaaaaaaaaar
+      Fooooooooooo foooooooooooo fooooooooooo baaaaaaaaar
+    @param Foooooooooooooooooooooooooooooooooooo_baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
+      Foo bar
     @raise foo [foo]
-
-    @raise Foooooooooooooooooooooooooooooooooooo_baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar Foo bar
-
+    @raise Foooooooooooooooooooooooooooooooooooo_baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
+      Foo bar
     @return [foo]
-
     @inline
-
     @canonical foo
-
     @canonical Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar *)
 
 val x : x
@@ -127,9 +114,9 @@ val x : x
     This module exposes functors to store raw contents into append-only
     stores as chunks of same size. It exposes the {{!AO} AO} functor which
     split the raw contents into [Data] blocks, addressed by [Node] blocks.
-    That's the usual rope-like representation of strings, but chunk trees
-    are always build as perfectly well-balanced and blocks are addressed by
-    their hash (or by the stable keys returned by the underlying store).
+    That's the usual rope-like representation of strings, but chunk trees are
+    always build as perfectly well-balanced and blocks are addressed by their
+    hash (or by the stable keys returned by the underlying store).
 
     A chunk has the following structure:
 
@@ -149,8 +136,8 @@ val x : x
 
     It also exposes {{!AO_stable} AO_stable} which -- as {{!AO} AO} does --
     stores raw contents into chunks of same size. But it also preserves the
-    nice properpty that values are addressed by their hash. instead of by
-    the hash of the root chunk node as it is the case for {{!AO} AO}. *)
+    nice properpty that values are addressed by their hash. instead of by the
+    hash of the root chunk node as it is the case for {{!AO} AO}. *)
 
 (** This is verbatim:
 
@@ -163,9 +150,9 @@ val x : x
     This is preformated code:
 
     {[
-let verbatim s =
-  s |> String.split_lines |> List.map ~f:String.strip
-  |> fun s -> list s "@," Fmt.str
+      let verbatim s =
+        s |> String.split_lines |> List.map ~f:String.strip
+        |> fun s -> list s "@," Fmt.str
     ]} *)
 
 (** Lists:
@@ -178,21 +165,21 @@ let verbatim s =
 
     list with long lines:
 
-    - xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx
-      xxx xxx xxx xxx xxx xxx xxx
-    - yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy
-      yyy yyy yyy yyy yyy yyy yyy
-    - zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
-      zzz zzz zzz zzz zzz zzz zzz
+    - xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx
+      xxx xxx xxx xxx xxx xxx
+    - yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy
+      yyy yyy yyy yyy yyy yyy
+    - zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
+      zzz zzz zzz zzz zzz zzz
 
     enumerated list with long lines:
 
-    + xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx
-      xxx xxx xxx xxx xxx xxx xxx
-    + yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy
-      yyy yyy yyy yyy yyy yyy yyy
-    + zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
-      zzz zzz zzz zzz zzz zzz zzz
+    + xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx xxx
+      xxx xxx xxx xxx xxx xxx
+    + yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy yyy
+      yyy yyy yyy yyy yyy yyy
+    + zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz zzz
+      zzz zzz zzz zzz zzz zzz
 
     list with sub lists:
 
@@ -208,7 +195,8 @@ let verbatim s =
         + a
         + b
         + c
-     }} *)
+     }
+    } *)
 
 (** {{:https://github.com/} Github} *)
 
@@ -265,13 +253,9 @@ end
 
 (** @canonical Module.Foo.Bar *)
 
-(** {v
-a
-    v} *)
+(** {v a v} *)
 
-(** {[
-b
-    ]} *)
+(** {[ b ]} *)
 
 (** - Odoc don't parse
 
@@ -282,8 +266,7 @@ b
 
         Def
      }
-     {- Hij
-     }
+     {- Hij }
      {- Klm
 
         {ul
@@ -291,49 +274,47 @@ b
 
             Qrs
          }
-         {- Tuv
-         }}
-     }} *)
+         {- Tuv }
+        }
+     }
+    } *)
 
 (** - {v
     Abc
     def
       v}
-    - {[
-A
-  B
-      ]} *)
+    - {[ A B ]} *)
 
 (** Code block
+
     {[ Single line ]}
-    {[
-      Multi
-      line
-    ]}
+    {[ Multi line ]}
     {[
       Multi
       line
         with
           indentation
     ]}
-    {[ Single long line HAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA ]}
+    {[
+      Single long line HAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    ]}
     {[
       With empty
 
       line
     ]}
-    {[ First line
-       on the same line
-       as opening ]}
- *)
+    {[
+      First line
+      on the same line
+      as opening
+    ]} *)
 
-module X :
-sig
-
-  (** {[ First line
-         on the same line
-         as opening ]} *)
-
+module X : sig
+  (** {[
+        First line
+        on the same line
+        as opening
+      ]} *)
 end
 
 (** {!module:A} {!module:A.B}
@@ -354,17 +335,12 @@ end
 
     {!constructor:C} {!constructor:M.C}
 
-    {!field:f} {!field:t.f} {!field:M.t.f}
- *)
+    {!field:f} {!field:t.f} {!field:M.t.f} *)
 
 (** {!modules:Foo}
-
     {!modules:Foo Bar.Baz}
-
     @canonical Foo
-
-    @canonical Foo.Bar
-*)
+    @canonical Foo.Bar *)
 
 (** {%html:<p>Raw markup</p>%} {%Without language%} {%other:Other language%} *)
 
@@ -376,92 +352,81 @@ end
     [Very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong] *)
 
 (** {[
-  for i = 1 to 3
-  do
-    Printf.printf "let x%d = %d\n" i i
-  done
-]} *)
+      for i = 1 to 3 do
+        Printf.printf "let x%d = %d\n" i i
+      done
+    ]} *)
 
 (** {[
-  print_newline ();
-  List.iter
-    (fun s -> Printf.printf "let ( %s ) = Pervasives.( %s )\n" s s)
-    ["+"; "-"; "*"; "/"]
-]}  *)
+      print_newline () ;
+      List.iter
+        (fun s -> Printf.printf "let ( %s ) = Pervasives.( %s )\n" s s)
+        ["+"; "-"; "*"; "/"]
+    ]} *)
 
 (** {[
-  #use "import.cinaps";;
+      #use "import.cinaps";;
 
-  List.iter all_fields ~f:(fun (name, type_) -> printf "\nexternal get_%s
-  : unit -> %s = \"get_%s\"" name type_ name)
-]} *)
-
-(** {[
-
-
-  List.iter all_fields ~f:(fun (name, type_) -> printf "\nexternal get_%s
-  : unit -> %s = \"get_%s\"" name type_ name)
-]} *)
+      List.iter all_fields ~f:(fun (name, type_) -> printf "\nexternal get_%s
+      : unit -> %s = \"get_%s\"" name type_ name)
+    ]} *)
 
 (** {[
-  let x = 1 in
-
-  (* fooooooo *)
-  let y = 2 in
-  (* foooooooo *)
-  z
-]} *)
+      List.iter all_fields ~f:(fun (name, type_) ->
+          printf "\nexternal get_%s\n: unit -> %s = \"get_%s\"" name type_
+            name )
+    ]} *)
 
 (** {[
-   let this  = is_short
-]}
+      let x = 1 in
+      (* fooooooo *)
+      let y = 2 in
+      (* foooooooo *)
+      z
+    ]} *)
 
-{[
-  does not parse: verbatim
-+/+/+ /+/+/ +/+//+/+/+/+/+/+/+/
-+/+/+ /+/+/ +/+//+/+/+/+/+/+/+/
-+/+/+ /+/+/ +/+//+/+/+/+/+/+/+/
-+/+/+ /+/+/ +/+//+/+
-]}
+(** {[ let this = is_short ]}
+    {[
+        does not parse: verbatim
+      +/+/+ /+/+/ +/+//+/+/+/+/+/+/+/
+      +/+/+ /+/+/ +/+//+/+/+/+/+/+/+/
+      +/+/+ /+/+/ +/+//+/+/+/+/+/+/+/
+      +/+/+ /+/+/ +/+//+/+
+    ]}
+    {[
+      [@@@ocamlformat "break-separators = after"]
 
-{[
-[@@@ocamlformat "break-separators = after"]
+      let fooooooooooooooooo =
+        [ foooooooooooooooooooooooooooooooo;
+          foooooooooooooooooooooooooooooooo;
+          foooooooooooooooooooooooooooooooo ]
+    ]}
+    {[
+      let fooooooooooooooooo =
+        [ foooooooooooooooooooooooooooooooo
+        ; foooooooooooooooooooooooooooooooo
+        ; foooooooooooooooooooooooooooooooo ]
+    ]} *)
 
-let fooooooooooooooooo =
-[ foooooooooooooooooooooooooooooooo
-; foooooooooooooooooooooooooooooooo
-; foooooooooooooooooooooooooooooooo ]
+(** This is a comment with code inside
 
-]}
+    {[
+      (** This is a comment with code inside [ let code inside = f inside ] *)
+      let code inside (* comment   *) = f inside
+    ]} *)
 
-{[
-let fooooooooooooooooo =
-[ foooooooooooooooooooooooooooooooo
-; foooooooooooooooooooooooooooooooo
-; foooooooooooooooooooooooooooooooo ]
-
-]} *)
-
-
-
-(**
-  This is a comment with code inside
-  {[
-    (** This is a comment with code inside
-        [ let code inside = f inside ]
-    *)
-    let code inside (* comment   *) = f inside
-  ]}
-*)
-
-(** {e foooooooo oooooooooo ooooooooo ooooooooo} {i fooooooooooooo oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
+(** {e foooooooo oooooooooo ooooooooo ooooooooo}
+    {i fooooooooooooo oooooooo oooooooooo}
+    {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
 
 (** {e foooooooo oooooooooo ooooooooo ooooooooo} {{!some ref} fooooooooooooo
     oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
 
-(** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooo {b eee + eee eee} *)
+(** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooo
+    {b eee + eee eee} *)
 
-(** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooooooo {b + eee + eee eee} *)
+(** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooooooo
+    {b + eee + eee eee} *)
 
 val f : int
 
@@ -503,7 +468,7 @@ val k : int
 
 (** Brackets must not be escaped in the first argument of some tags: *)
 
-(** @raise [Invalid_argument] if the argument is [None]. Sometimes [t.[x]]. *)
+(** @raise [Invalid_argument] if the argument is [None]. Sometimes [t.\[x\]]. *)
 
 (** @author [Abc] [def] \[hij\] *)
 
@@ -526,47 +491,65 @@ val k : int
 (** @see "[Abc]" [def] \[hij\] *)
 
 (** \[abc\] *)
+
 (** *)
+
 (**  *)
 
 (** [trim "  "] is [""] *)
 
-(** [trms (c × (Σᵢ₌₁ⁿ cᵢ × Πⱼ₌₁ᵐᵢ Xᵢⱼ^pᵢⱼ))]
-    is the sequence of terms [Xᵢⱼ] for each [i] and [j]. *)
+(** [trms (c × (Σᵢ₌₁ⁿ cᵢ × Πⱼ₌₁ᵐᵢ Xᵢⱼ^pᵢⱼ))] is the sequence of terms [Xᵢⱼ]
+    for each [i] and [j]. *)
 
-(**
+(** Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi lacinia
+    odio sit amet lobortis fringilla. Mauris diam massa, vulputate sit amet
+    lacus id, vestibulum bibendum lectus. Nullam tristique justo nisi,
+    gravida dapibus mi pulvinar at. Suspendisse pellentesque odio quis ipsum
+    tempor luctus.
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi lacinia odio sit amet lobortis fringilla. Mauris diam massa, vulputate sit amet lacus id, vestibulum bibendum lectus. Nullam tristique justo nisi, gravida dapibus mi pulvinar at. Suspendisse pellentesque odio quis ipsum tempor luctus.
+    Cras ultrices, magna sit amet faucibus molestie, sapien dolor ullamcorper
+    lorem, vel viverra tortor augue vel massa. Suspendisse nunc nisi,
+    consequat et ante nec, efficitur dapibus ipsum. Aenean vitae pellentesque
+    odio. Integer et ornare tellus, at tristique elit.
 
-Cras ultrices, magna sit amet faucibus molestie, sapien dolor ullamcorper lorem, vel viverra tortor augue vel massa. Suspendisse nunc nisi, consequat et ante nec, efficitur dapibus ipsum. Aenean vitae pellentesque odio. Integer et ornare tellus, at tristique elit.
+    Phasellus et nisi id neque ultrices vestibulum vitae non tortor. Mauris
+    aliquet at risus sed rhoncus. Ut condimentum rhoncus orci, sit amet
+    eleifend erat tempus quis. *)
 
-Phasellus et nisi id neque ultrices vestibulum vitae non tortor. Mauris aliquet at risus sed rhoncus. Ut condimentum rhoncus orci, sit amet eleifend erat tempus quis.
-
-*)
-
-(** {[(* a
-         b *)]} *)
+(** {[
+      (* a
+         b *)
+    ]} *)
 
 val a :
-  fooooooooooooooooooooooooooo
-  (** {[(* a
-           b *)]} *)
-  ->
-  fooooooooooooooooooooooooo
+     fooooooooooooooooooooooooooo
+     (** {[
+           (* a
+              b *)
+         ]} *)
+  -> fooooooooooooooooooooooooo
 
 type x =
-  { a : t
-  (** {[(* a
-           b *)]} *)
-  ; b : [` A
-  (** {[(* a
-           b *)]} *) ]
-  }
+  { a: t
+        (** {[
+              (* a
+                 b *)
+            ]} *)
+  ; b:
+      [ `A
+        (** {[
+              (* a
+                 b *)
+            ]} *) ] }
 
 type x =
   | A of a
-  (** {[(* a
-           b *)]} *)
+      (** {[
+            (* a
+               b *)
+          ]} *)
   | B of b
-  (** {[(* a
-           b *)]} *)
+      (** {[
+            (* a
+               b *)
+          ]} *)

--- a/test/passing/tests/doc_comments.mli.ref
+++ b/test/passing/tests/doc_comments.mli.ref
@@ -515,3 +515,13 @@ val k : int
     Phasellus et nisi id neque ultrices vestibulum vitae non tortor. Mauris
     aliquet at risus sed rhoncus. Ut condimentum rhoncus orci, sit amet
     eleifend erat tempus quis. *)
+
+(** {[ (* a b *) ]} *)
+
+val a :
+     fooooooooooooooooooooooooooo (** {[ (* a b *) ]} *)
+  -> fooooooooooooooooooooooooo
+
+type x = {a: t  (** {[ (* a b *) ]} *); b: [`A  (** {[ (* a b *) ]} *)]}
+
+type x = A of a  (** {[ (* a b *) ]} *) | B of b  (** {[ (* a b *) ]} *)


### PR DESCRIPTION
Fix #1693 

The diff of test_branch looks good:
<details>

```diff
diff --git a/infer/src/nullsafe/ThirdPartyAnnotationInfo.ml b/infer/src/nullsafe/ThirdPartyAnnotationInfo.ml
index d8c04d000..e83211e8a 100644
--- a/infer/src/nullsafe/ThirdPartyAnnotationInfo.ml
+++ b/infer/src/nullsafe/ThirdPartyAnnotationInfo.ml
@@ -66,7 +66,7 @@ let pp_parsing_error fmt { line_number; unparsable_method; parsing_error } =
 (* Consequtively evaluates results for all elements in a list,
    returns Ok (folded results) if all succeeded, or the first error.
    The evaluator function [f] has access to element's index.
- *)
+*)
 let bind_list_with_index ~init list ~f =
   List.foldi list ~init:(Ok init) ~f:(fun index acc elem ->
       Result.bind acc ~f:(fun acc -> f acc index elem))
diff --git a/infer/src/nullsafe/eradicateChecks.ml b/infer/src/nullsafe/eradicateChecks.ml
index e1c5dc916..ba8e0a11d 100644
--- a/infer/src/nullsafe/eradicateChecks.ml
+++ b/infer/src/nullsafe/eradicateChecks.ml
@@ -185,7 +185,7 @@ let lookup_field_in_typestate pname field_name typestate =
   TypeState.lookup_pvar pvar typestate
 
 (* Given a predicate over field name, look ups the field and returns a predicate
-  over this field value in a typestate, or true if there is no such a field in typestate *)
+   over this field value in a typestate, or true if there is no such a field in typestate *)
 let convert_predicate predicate_over_field_name field_name (pname, typestate) =
   let range_for_field = lookup_field_in_typestate pname field_name typestate in
   Option.exists range_for_field ~f:predicate_over_field_name
@@ -212,7 +212,7 @@ let get_nullability_upper_bound_for_typestate proc_name field_name typestate =
 
 (* Given the list of typestates (each corresponding to the final result of executing of some function),
    and the field, what is the upper bound of field nullability joined over all typestates?
- *)
+*)
 let get_nullability_upper_bound field_name typestate_list =
   (* Join upper bounds for all typestates in the list *)
   List.fold typestate_list ~init:Nullability.StrictNonnull
diff --git a/infer/src/nullsafe/modelTables.mli b/infer/src/nullsafe/modelTables.mli
index b9076c54c..3bfeaf70a 100644
--- a/infer/src/nullsafe/modelTables.mli
+++ b/infer/src/nullsafe/modelTables.mli
@@ -12,7 +12,7 @@ type model_table_t = (string, bool * bool list) Caml.Hashtbl.t
 (* The key is a unique string representation of a method.
    The value is nullability of its return value and params correspondingly.
    true corresponds to Nullable.
- *)
+*)
 
 val annotated_table_nullability : model_table_t
 
diff --git a/infer/src/nullsafe/typeCheck.ml b/infer/src/nullsafe/typeCheck.ml
index c3d55ef29..b1dc48865 100644
--- a/infer/src/nullsafe/typeCheck.ml
+++ b/infer/src/nullsafe/typeCheck.ml
@@ -304,7 +304,7 @@ let add_field_to_typestate_if_absent tenv access_loc typestate pvar
    1. The same as [convert_complex_exp_to_pvar]
    2. On top of this, if expr corresponds to a field access, stores this field in the typestate
       (if not stored yet).
-   *)
+*)
 let convert_complex_exp_to_pvar_and_register_field_in_typestate tenv idenv
     curr_pname (curr_annotated_signature : AnnotatedSignature.t) ~node
     ~(original_node : Procdesc.Node.t) ~is_assignment exp_ typestate loc =
@@ -419,7 +419,7 @@ let convert_complex_exp_to_pvar_and_register_field_in_typestate tenv idenv
      does not require the programmer to write a check.
    What is the difference between ~node and ~original_node? I don't know. This is an artifact of refactoring of
    very old code. Sorry, dear future supporter, if names don't make sense.
- *)
+*)
 let convert_complex_exp_to_pvar tenv idenv curr_pname ~is_assignment
     (curr_annotated_signature : AnnotatedSignature.t) ~node
     ~(original_node : Procdesc.Node.t) exp typestate loc =
@@ -1049,8 +1049,8 @@ let rec check_condition_for_sil_prune
       typestate
 
 (* If the function has @PropagatesNullable params the nullability of result is determined by
-  nullability of actual values of these params.
-  *)
+   nullability of actual values of these params.
+*)
 let clarify_ret_by_propagates_nullable ret
     (resolved_params : EradicateChecks.resolved_param list) =
   (* Nullability of actual values of params that are marked as propagating nullables *)
diff --git a/infer/src/nullsafe/typeErr.ml b/infer/src/nullsafe/typeErr.ml
index 9a9f0337c..6c5013afb 100644
--- a/infer/src/nullsafe/typeErr.ml
+++ b/infer/src/nullsafe/typeErr.ml
@@ -204,7 +204,7 @@ let get_field_name_for_error_suppressing = function
 
 (* The condition is redundant because a non-nullable object was (implicitly or explicitly) compared with null.
    Describes what exactly made nullsafe believe this is indeed a non-nullable.
- *)
+*)
 let get_nonnull_explanation_for_condition_redudant
     (nonnull_origin : TypeOrigin.t) =
   match nonnull_origin with
diff --git a/infer/src/nullsafe/unit/ThirdPartyMethodTests.ml b/infer/src/nullsafe/unit/ThirdPartyMethodTests.ml
index 19f5491a1..34b991a57 100644
--- a/infer/src/nullsafe/unit/ThirdPartyMethodTests.ml
+++ b/infer/src/nullsafe/unit/ThirdPartyMethodTests.ml
@@ -89,7 +89,7 @@ let%test_module "Third-party Method Tests OK Cases" =
    We let other tools to make thorough linting.
    Also we don't test exact error type, because this is an implementation detail
    needed merely to simplify diagnostics
-   *)
+*)
 let%test_module "Third-party Method Tests Bad Cases" =
   (module struct
     let%expect_test _ =
diff --git a/infer/src/test_determinator/testDeterminator.ml b/infer/src/test_determinator/testDeterminator.ml
index d14bc78ca..030af9b3a 100644
--- a/infer/src/test_determinator/testDeterminator.ml
+++ b/infer/src/test_determinator/testDeterminator.ml
@@ -234,7 +234,7 @@ let remove_llvm_suffix_native_symbols native_symbols =
   List.map ~f:remove_llvm_suffix_native_symbol native_symbols
 
 (* The clang plugin exports C++ mangled names in hashed form for perf reasons, so here we
-hash the incoming mangled names in the profiler samples, so that we can compare them. *)
+   hash the incoming mangled names in the profiler samples, so that we can compare them. *)
 let add_hash_mangled_native_symbols native_symbols =
   let add_hash_mangled_native_symbol native_symbol =
     let hash_mangled mangled_name =
diff --git a/benchmarks/sources/ml/boyer.ml b/benchmarks/sources/ml/boyer.ml
index 4eba4c7f79..9b27f51f22 100644
--- a/benchmarks/sources/ml/boyer.ml
+++ b/benchmarks/sources/ml/boyer.ml
@@ -1524,20 +1524,20 @@ let _ =
 *)
 
 (*********
-with
-    failure s ->
-      print_string "Exception failure("; print_string s; print_string ")\n"
-  | Unify ->
-      print_string "Exception Unify\n"
-  | match_failure(file,start,stop) ->
-      print_string "Exception match_failure(";
-      print_string file;
-      print_string ",";
-      print_int start;
-      print_string ",";
-      print_int stop;
-      print_string ")\n"
-  | _ ->
-      print_string "Exception ?\n"
+  with
+      failure s ->
+        print_string "Exception failure("; print_string s; print_string ")\n"
+    | Unify ->
+        print_string "Exception Unify\n"
+    | match_failure(file,start,stop) ->
+        print_string "Exception match_failure(";
+        print_string file;
+        print_string ",";
+        print_int start;
+        print_string ",";
+        print_int stop;
+        print_string ")\n"
+    | _ ->
+        print_string "Exception ?\n"
 
-**********)
+  **********)
diff --git a/benchmarks/sources/ml/boyer_no_exc.ml b/benchmarks/sources/ml/boyer_no_exc.ml
index 25155976ff..f42cd03033 100644
--- a/benchmarks/sources/ml/boyer_no_exc.ml
+++ b/benchmarks/sources/ml/boyer_no_exc.ml
@@ -1529,20 +1529,20 @@ let _ =
 *)
 
 (*********
-with
-    failure s ->
-      print_string "Exception failure("; print_string s; print_string ")\n"
-  | Unify ->
-      print_string "Exception Unify\n"
-  | match_failure(file,start,stop) ->
-      print_string "Exception match_failure(";
-      print_string file;
-      print_string ",";
-      print_int start;
-      print_string ",";
-      print_int stop;
-      print_string ")\n"
-  | _ ->
-      print_string "Exception ?\n"
+  with
+      failure s ->
+        print_string "Exception failure("; print_string s; print_string ")\n"
+    | Unify ->
+        print_string "Exception Unify\n"
+    | match_failure(file,start,stop) ->
+        print_string "Exception match_failure(";
+        print_string file;
+        print_string ",";
+        print_int start;
+        print_string ",";
+        print_int stop;
+        print_string ")\n"
+    | _ ->
+        print_string "Exception ?\n"
 
-**********)
+  **********)
diff --git a/benchmarks/sources/ml/kb.ml b/benchmarks/sources/ml/kb.ml
index ff56b4db52..f925701a32 100644
--- a/benchmarks/sources/ml/kb.ml
+++ b/benchmarks/sources/ml/kb.ml
@@ -93,7 +93,7 @@ let rec unify term1 term2 =
       else failwith "unify"
 
 (* We need to print terms with variables independently from input terms
-  obtained by parsing. We give arbitrary names v1,v2,... to their variables.
+   obtained by parsing. We give arbitrary names v1,v2,... to their variables.
 *)
 
 let infixes = [ "+"; "*" ]
@@ -340,10 +340,10 @@ let rec super m = function
   | _ -> []
 
 (* Ex :
-let (m,_) = <<F(A,B)>>
-and (n,_) = <<H(F(A,x),F(x,y))>> in super m n
-==> [[1],[2,Term ("B",[])];                      x <- B
-     [2],[2,Term ("A",[]); 1,Term ("B",[])]]     x <- A  y <- B
+   let (m,_) = <<F(A,B)>>
+   and (n,_) = <<H(F(A,x),F(x,y))>> in super m n
+   ==> [[1],[2,Term ("B",[])];                      x <- B
+        [2],[2,Term ("A",[]); 1,Term ("B",[])]]     x <- A  y <- B
 *)
 
 (* All (u,subst), u&[], such that n/u unifies with m *)
@@ -490,7 +490,7 @@ let kb_completion greater =
   kbrec
 
 (* complete_rules is assumed locally confluent, and checked Noetherian with
-  ordering greater, rules is any list of rules *)
+   ordering greater, rules is any list of rules *)
 
 let kb_complete greater complete_rules rules =
   let n = check_rules complete_rules
@@ -515,16 +515,16 @@ let kb_complete greater complete_rules rules =
 (* $Id: kbmain.ml 7017 2005-08-12 09:22:04Z xleroy $ *)
 
 (****
-let group_rules = [
-  { number = 1; numvars = 1;
-    lhs = Term("*", [Term("U",[]); Var 1]); rhs = Var 1 };
-  { number = 2; numvars = 1;
-    lhs = Term("*", [Term("I",[Var 1]); Var 1]); rhs = Term("U",[]) };
-  { number = 3; numvars = 3;
-    lhs = Term("*", [Term("*", [Var 1; Var 2]); Var 3]);
-    rhs = Term("*", [Var 1; Term("*", [Var 2; Var 3])]) }
-]
-****)
+  let group_rules = [
+    { number = 1; numvars = 1;
+      lhs = Term("*", [Term("U",[]); Var 1]); rhs = Var 1 };
+    { number = 2; numvars = 1;
+      lhs = Term("*", [Term("I",[Var 1]); Var 1]); rhs = Term("U",[]) };
+    { number = 3; numvars = 3;
+      lhs = Term("*", [Term("*", [Var 1; Var 2]); Var 3]);
+      rhs = Term("*", [Var 1; Term("*", [Var 2; Var 3])]) }
+  ]
+  ****)
 
 let geom_rules =
   [
diff --git a/benchmarks/sources/ml/kb_no_exc.ml b/benchmarks/sources/ml/kb_no_exc.ml
index 740757a0b8..7296a73ae3 100644
--- a/benchmarks/sources/ml/kb_no_exc.ml
+++ b/benchmarks/sources/ml/kb_no_exc.ml
@@ -100,7 +100,7 @@ let rec unify term1 term2 =
       else failwith "unify"
 
 (* We need to print terms with variables independently from input terms
-  obtained by parsing. We give arbitrary names v1,v2,... to their variables.
+   obtained by parsing. We give arbitrary names v1,v2,... to their variables.
 *)
 
 let infixes = [ "+"; "*" ]
@@ -378,10 +378,10 @@ let rec super m = function
   | _ -> []
 
 (* Ex :
-let (m,_) = <<F(A,B)>>
-and (n,_) = <<H(F(A,x),F(x,y))>> in super m n
-==> [[1],[2,Term ("B",[])];                      x <- B
-     [2],[2,Term ("A",[]); 1,Term ("B",[])]]     x <- A  y <- B
+   let (m,_) = <<F(A,B)>>
+   and (n,_) = <<H(F(A,x),F(x,y))>> in super m n
+   ==> [[1],[2,Term ("B",[])];                      x <- B
+        [2],[2,Term ("A",[]); 1,Term ("B",[])]]     x <- A  y <- B
 *)
 
 (* All (u,subst), u&[], such that n/u unifies with m *)
@@ -528,7 +528,7 @@ let kb_completion greater =
   kbrec
 
 (* complete_rules is assumed locally confluent, and checked Noetherian with
-  ordering greater, rules is any list of rules *)
+   ordering greater, rules is any list of rules *)
 
 let kb_complete greater complete_rules rules =
   let n = check_rules complete_rules
diff --git a/compiler/lib/generate.ml b/compiler/lib/generate.ml
index 0cce2042e9..35c9443f04 100644
--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -954,7 +954,7 @@ let _ =
     register_bin_prim "caml_string_equal" `Pure (fun cx cy _ ->
       bool (J.EBin (J.EqEq, cx, cy)))
      ]}
-   *)
+*)
 
 (****)
 (* when raising ocaml exception and [improved_stacktrace] is enabled,
diff --git a/compiler/tests-compiler/gh1007.ml b/compiler/tests-compiler/gh1007.ml
index b89cb25f83..1d4445f592 100644
--- a/compiler/tests-compiler/gh1007.ml
+++ b/compiler/tests-compiler/gh1007.ml
@@ -28,7 +28,7 @@
    for-loop.
 
    In the test below, [f] compiles into a for loop and
-   [MyList.stable_sort] gets inlined.  *)
+   [MyList.stable_sort] gets inlined. *)
 
 let%expect_test _ =
   let prog =
diff --git a/compiler/tests-num/test_big_ints.ml b/compiler/tests-num/test_big_ints.ml
index b769cede0e..dad6dc2c39 100644
--- a/compiler/tests-num/test_big_ints.ml
+++ b/compiler/tests-num/test_big_ints.ml
@@ -457,32 +457,32 @@ test 10 eq_big_int
       (mult_big_int bi2 (big_int_of_string "10"))
       (big_int_of_string "2") )
 (* test 11
- &&
-eq_big_int (bi1, (add_big_int (mult_big_int bi2 (big_int_of_string "10e0"))
-                              (big_int_of_string "20e-1"))) &&
-test 12
-eq_big_int (minus_big_int bi1,
-            (add_big_int (mult_big_int bi2 (big_int_of_string "-10e0"))
-                         (big_int_of_string "-20e-1"))) &&
-test 13
-eq_big_int (bi1, (add_big_int (mult_big_int bi2 (big_int_of_string "+10e0"))
-                              (big_int_of_string "+20e-1"))) &&
-test 14
-eq_big_int (minus_big_int bi1,
-            (add_big_int (mult_big_int bi2 (big_int_of_string "-10e+0"))
-                         (big_int_of_string "-20e-1"))) &&
-test 15
-eq_big_int (minus_big_int bi1,
-            (add_big_int (mult_big_int bi2 (big_int_of_string "-1e+1"))
-                         (big_int_of_string "-2e-0"))) &&
-test 16
-eq_big_int (minus_big_int bi1,
-            (add_big_int (mult_big_int bi2 (big_int_of_string "-0.1e+2"))
-                         (big_int_of_string "-2.0e-0"))) &&
-test 17
-eq_big_int (minus_big_int bi1,
-            (add_big_int (mult_big_int bi2 (big_int_of_string "-1.000e+1"))
-                         (big_int_of_string "-0.02e2")))*)
+    &&
+   eq_big_int (bi1, (add_big_int (mult_big_int bi2 (big_int_of_string "10e0"))
+                                 (big_int_of_string "20e-1"))) &&
+   test 12
+   eq_big_int (minus_big_int bi1,
+               (add_big_int (mult_big_int bi2 (big_int_of_string "-10e0"))
+                            (big_int_of_string "-20e-1"))) &&
+   test 13
+   eq_big_int (bi1, (add_big_int (mult_big_int bi2 (big_int_of_string "+10e0"))
+                                 (big_int_of_string "+20e-1"))) &&
+   test 14
+   eq_big_int (minus_big_int bi1,
+               (add_big_int (mult_big_int bi2 (big_int_of_string "-10e+0"))
+                            (big_int_of_string "-20e-1"))) &&
+   test 15
+   eq_big_int (minus_big_int bi1,
+               (add_big_int (mult_big_int bi2 (big_int_of_string "-1e+1"))
+                            (big_int_of_string "-2e-0"))) &&
+   test 16
+   eq_big_int (minus_big_int bi1,
+               (add_big_int (mult_big_int bi2 (big_int_of_string "-0.1e+2"))
+                            (big_int_of_string "-2.0e-0"))) &&
+   test 17
+   eq_big_int (minus_big_int bi1,
+               (add_big_int (mult_big_int bi2 (big_int_of_string "-1.000e+1"))
+                            (big_int_of_string "-0.02e2")))*)
 ;;
 
 test 18 eq_big_int (big_int_of_string "0xAbC", big_int_of_int 0xABC);;
diff --git a/compiler/tests-num/test_nums.ml b/compiler/tests-num/test_nums.ml
index 761b92d6f4..1ebcbd7716 100644
--- a/compiler/tests-num/test_nums.ml
+++ b/compiler/tests-num/test_nums.ml
@@ -184,19 +184,19 @@ testing_function "num_of_string";;
 test 1 eq_num (num_of_string "123/3456", Ratio (ratio_of_string "123/3456"));;
 
 (*********
-test 2
-eq_num (num_of_string "12.3/34.56", Ratio (ratio_of_string "1230/3456"));;
-test 3
-eq_num (num_of_string "1.23/325.6", Ratio (ratio_of_string "123/32560"));;
-test 4
-eq_num (num_of_string "12.3/345.6", Ratio (ratio_of_string "123/3456"));;
-set_error_when_null_denominator false;;
-test 5
-eq_num (num_of_string "12.3/0.0", Ratio (ratio_of_string "123/0"));;
-test 6
-eq_num (num_of_string "0/0", Ratio (ratio_of_string "0/0"));;
-set_error_when_null_denominator true;;
-*********)
+  test 2
+  eq_num (num_of_string "12.3/34.56", Ratio (ratio_of_string "1230/3456"));;
+  test 3
+  eq_num (num_of_string "1.23/325.6", Ratio (ratio_of_string "123/32560"));;
+  test 4
+  eq_num (num_of_string "12.3/345.6", Ratio (ratio_of_string "123/3456"));;
+  set_error_when_null_denominator false;;
+  test 5
+  eq_num (num_of_string "12.3/0.0", Ratio (ratio_of_string "123/0"));;
+  test 6
+  eq_num (num_of_string "0/0", Ratio (ratio_of_string "0/0"));;
+  set_error_when_null_denominator true;;
+  *********)
 test 7 eq_num
   (num_of_string "1234567890", Big_int (big_int_of_string "1234567890"))
 ;;
@@ -204,11 +204,11 @@ test 7 eq_num
 test 8 eq_num (num_of_string "12345", Int (int_of_string "12345"));;
 
 (*********
-test 9
-eq_num (num_of_string "0.23", Ratio (ratio_of_string "23/100"));;
-test 10
-eq_num (num_of_string "0.23", Ratio (ratio_of_string "0.23/1"));;
-********)
+  test 9
+  eq_num (num_of_string "0.23", Ratio (ratio_of_string "23/100"));;
+  test 10
+  eq_num (num_of_string "0.23", Ratio (ratio_of_string "0.23/1"));;
+  ********)
 
 failwith_test 11 num_of_string "frlshjkurty" (Failure "num_of_string");;
 
@@ -224,42 +224,42 @@ test 15 eq_num (num_of_string "0B101010", Big_int (big_int_of_int 42))
 
 (*******
 
-testing_function "immediate numbers";;
+  testing_function "immediate numbers";;
 
-standard arith false;;
+  standard arith false;;
 
-let x = (1/2) in
-test 0 eq_string (string_of_num x, "1/2");;
+  let x = (1/2) in
+  test 0 eq_string (string_of_num x, "1/2");;
 
-let y = 12345678901 in
-test 1 eq_string (string_of_num y, "12345678901");;
-testing_function "immediate numbers";;
+  let y = 12345678901 in
+  test 1 eq_string (string_of_num y, "12345678901");;
+  testing_function "immediate numbers";;
 
-let x = (1/2) in
-test 0 eq_string (string_of_num x, "1/2");;
+  let x = (1/2) in
+  test 0 eq_string (string_of_num x, "1/2");;
 
-let y = 12345678901 in
-test 1 eq_string (string_of_num y, "12345678901");;
+  let y = 12345678901 in
+  test 1 eq_string (string_of_num y, "12345678901");;
 
-testing_function "pattern_matching on nums";;
+  testing_function "pattern_matching on nums";;
 
-let f1 = function 0 -> true | _  -> false;;
+  let f1 = function 0 -> true | _  -> false;;
 
-test 1 eq (f1 0, true);;
+  test 1 eq (f1 0, true);;
 
-test 2 eq (f1 1, false);;
+  test 2 eq (f1 1, false);;
 
-test 3 eq (f1 (0/1), true);;
+  test 3 eq (f1 (0/1), true);;
 
-test 4 eq (f1 (let n = num_of_string "2000000000000000000000000" in n-n) ,
-            true);;
+  test 4 eq (f1 (let n = num_of_string "2000000000000000000000000" in n-n) ,
+              true);;
 
-test 5 eq (f1 (let n = num_of_string "2000000000000000000000000" in n/n-1) ,
-            true);;
+  test 5 eq (f1 (let n = num_of_string "2000000000000000000000000" in n/n-1) ,
+              true);;
 
-test 6 eq (f1 (let n = num_of_string "2000000000000000000000000" in n+1) ,
-            false);;
+  test 6 eq (f1 (let n = num_of_string "2000000000000000000000000" in n+1) ,
+              false);;
 
-test 7 eq (f1 (1/2), false);;
+  test 7 eq (f1 (1/2), false);;
 
-**************)
+  **************)
diff --git a/compiler/tests-num/test_ratios.ml b/compiler/tests-num/test_ratios.ml
index 3e2961f0a4..49574ec2ba 100644
--- a/compiler/tests-num/test_ratios.ml
+++ b/compiler/tests-num/test_ratios.ml
@@ -76,16 +76,16 @@ test 2 eq (null_denominator (create_ratio (big_int_of_int 1) zero_big_int), true
 ;;
 
 (*****
-testing_function "verify_null_denominator"
-;;
+  testing_function "verify_null_denominator"
+  ;;
 
-test 1
- eq (verify_null_denominator (ratio_of_string "0/1"), false)
-;;
-test 2
- eq (verify_null_denominator (ratio_of_string "0/0"), true)
-;;
-*****)
+  test 1
+   eq (verify_null_denominator (ratio_of_string "0/1"), false)
+  ;;
+  test 2
+   eq (verify_null_denominator (ratio_of_string "0/0"), true)
+  ;;
+  *****)
 
 testing_function "sign_ratio";;
 
@@ -928,23 +928,23 @@ test 1 eq_ratio
 ;;
 
 (***********
-test 2
-eq_ratio (ratio_of_string ("12.3/34.56"),
-          create_ratio (big_int_of_int 1230) (big_int_of_int 3456))
-;;
-test 3
-eq_ratio (ratio_of_string ("1.23/325.6"),
-          create_ratio (big_int_of_int 123) (big_int_of_int 32560))
-;;
-test 4
-eq_ratio (ratio_of_string ("12.3/345.6"),
-          create_ratio (big_int_of_int 123) (big_int_of_int 3456))
-;;
-test 5
-eq_ratio (ratio_of_string ("12.3/0.0"),
-          create_ratio (big_int_of_int 123) (big_int_of_int 0))
-;;
-***********)
+  test 2
+  eq_ratio (ratio_of_string ("12.3/34.56"),
+            create_ratio (big_int_of_int 1230) (big_int_of_int 3456))
+  ;;
+  test 3
+  eq_ratio (ratio_of_string ("1.23/325.6"),
+            create_ratio (big_int_of_int 123) (big_int_of_int 32560))
+  ;;
+  test 4
+  eq_ratio (ratio_of_string ("12.3/345.6"),
+            create_ratio (big_int_of_int 123) (big_int_of_int 3456))
+  ;;
+  test 5
+  eq_ratio (ratio_of_string ("12.3/0.0"),
+            create_ratio (big_int_of_int 123) (big_int_of_int 0))
+  ;;
+  ***********)
 test 6 eq_ratio
   (ratio_of_string "0/0", create_ratio (big_int_of_int 0) (big_int_of_int 0))
 ;;
@@ -957,83 +957,83 @@ test 7 eq_ratio
 failwith_test 8 ratio_of_string "frlshjkurty" (Failure "invalid digit");;
 
 (***********
-testing_function "msd_ratio"
-;;
-
-test 1
-eq_int (msd_ratio (create_ratio (big_int_of_int 0) (big_int_of_int 1)),
-        0)
-;;
-test 2
-eq_int (msd_ratio (create_ratio (big_int_of_int 1) (big_int_of_int 12)),
-        (-2))
-;;
-test 3
-eq_int (msd_ratio (create_ratio (big_int_of_int 12) (big_int_of_int 1)),
-        1)
-;;
-test 4
-eq_int (msd_ratio (create_ratio (big_int_of_int 1) (big_int_of_int 2)),
-        (-1))
-;;
-test 5
-eq_int (msd_ratio (create_ratio (big_int_of_int 2) (big_int_of_int 1)),
-        0)
-;;
-test 6
-eq_int (msd_ratio (create_ratio (big_int_of_int 25) (big_int_of_int 21)),
-        0)
-;;
-test 7
-eq_int (msd_ratio (create_ratio (big_int_of_int 35) (big_int_of_int 21)),
-        0)
-;;
-test 8
-eq_int (msd_ratio (create_ratio (big_int_of_int 215) (big_int_of_int 31)),
-        0)
-;;
-test 9
-eq_int (msd_ratio (create_ratio (big_int_of_int 2) (big_int_of_int 30)),
-        (-2))
-;;
-test 10
-eq_int (msd_ratio (create_ratio (big_int_of_int 2345)
-                                     (big_int_of_int 23456)),
-        (-2))
-;;
-test 11
-eq_int (msd_ratio (create_ratio (big_int_of_int 2345)
-                                     (big_int_of_int 2346)),
-        (-1))
-;;
-test 12
-eq_int (msd_ratio (create_ratio (big_int_of_int 2345)
-                                     (big_int_of_int 2344)),
-        0)
-;;
-test 13
-eq_int (msd_ratio (create_ratio (big_int_of_int 23456)
-                                     (big_int_of_int 2345)),
-        1)
-;;
-test 14
-eq_int (msd_ratio (create_ratio (big_int_of_int 23467)
-                                     (big_int_of_int 2345)),
-        1)
-;;
-failwith_test 15
-msd_ratio (create_ratio (big_int_of_int 1) (big_int_of_int 0))
-("msd_ratio "^infinite_failure)
-;;
-failwith_test 16
-msd_ratio (create_ratio (big_int_of_int (-1)) (big_int_of_int 0))
-("msd_ratio "^infinite_failure)
-;;
-failwith_test 17
-msd_ratio (create_ratio (big_int_of_int 0) (big_int_of_int 0))
-("msd_ratio "^infinite_failure)
-;;
-*************************)
+  testing_function "msd_ratio"
+  ;;
+
+  test 1
+  eq_int (msd_ratio (create_ratio (big_int_of_int 0) (big_int_of_int 1)),
+          0)
+  ;;
+  test 2
+  eq_int (msd_ratio (create_ratio (big_int_of_int 1) (big_int_of_int 12)),
+          (-2))
+  ;;
+  test 3
+  eq_int (msd_ratio (create_ratio (big_int_of_int 12) (big_int_of_int 1)),
+          1)
+  ;;
+  test 4
+  eq_int (msd_ratio (create_ratio (big_int_of_int 1) (big_int_of_int 2)),
+          (-1))
+  ;;
+  test 5
+  eq_int (msd_ratio (create_ratio (big_int_of_int 2) (big_int_of_int 1)),
+          0)
+  ;;
+  test 6
+  eq_int (msd_ratio (create_ratio (big_int_of_int 25) (big_int_of_int 21)),
+          0)
+  ;;
+  test 7
+  eq_int (msd_ratio (create_ratio (big_int_of_int 35) (big_int_of_int 21)),
+          0)
+  ;;
+  test 8
+  eq_int (msd_ratio (create_ratio (big_int_of_int 215) (big_int_of_int 31)),
+          0)
+  ;;
+  test 9
+  eq_int (msd_ratio (create_ratio (big_int_of_int 2) (big_int_of_int 30)),
+          (-2))
+  ;;
+  test 10
+  eq_int (msd_ratio (create_ratio (big_int_of_int 2345)
+                                       (big_int_of_int 23456)),
+          (-2))
+  ;;
+  test 11
+  eq_int (msd_ratio (create_ratio (big_int_of_int 2345)
+                                       (big_int_of_int 2346)),
+          (-1))
+  ;;
+  test 12
+  eq_int (msd_ratio (create_ratio (big_int_of_int 2345)
+                                       (big_int_of_int 2344)),
+          0)
+  ;;
+  test 13
+  eq_int (msd_ratio (create_ratio (big_int_of_int 23456)
+                                       (big_int_of_int 2345)),
+          1)
+  ;;
+  test 14
+  eq_int (msd_ratio (create_ratio (big_int_of_int 23467)
+                                       (big_int_of_int 2345)),
+          1)
+  ;;
+  failwith_test 15
+  msd_ratio (create_ratio (big_int_of_int 1) (big_int_of_int 0))
+  ("msd_ratio "^infinite_failure)
+  ;;
+  failwith_test 16
+  msd_ratio (create_ratio (big_int_of_int (-1)) (big_int_of_int 0))
+  ("msd_ratio "^infinite_failure)
+  ;;
+  failwith_test 17
+  msd_ratio (create_ratio (big_int_of_int 0) (big_int_of_int 0))
+  ("msd_ratio "^infinite_failure)
+  ;;
+  *************************)
 
 testing_function "round_futur_last_digit";;
 
diff --git a/compiler/tests-ocaml/lib-str/t01.ml b/compiler/tests-ocaml/lib-str/t01.ml
index adddc7570a..024fcbd390 100644
--- a/compiler/tests-ocaml/lib-str/t01.ml
+++ b/compiler/tests-ocaml/lib-str/t01.ml
@@ -1,8 +1,8 @@
 (* TEST
-* hasstr
-include str
-** bytecode
-** native
+   * hasstr
+   include str
+   ** bytecode
+   ** native
 *)
 
 open Printf
diff --git a/compiler/tests-ocaml/lib-string/test_string.ml b/compiler/tests-ocaml/lib-string/test_string.ml
index 048e02dd12..7c359bc5e5 100644
--- a/compiler/tests-ocaml/lib-string/test_string.ml
+++ b/compiler/tests-ocaml/lib-string/test_string.ml
@@ -38,14 +38,14 @@ let () =
 (* GPR#805/815/833 *)
 (* max_string_length is smaller in javascript *)
 (* let ()  =
-  if Sys.word_size = 32 then begin
-    let big = String.make Sys.max_string_length 'x' in
-    let push x l = l := x :: !l in
-    let (+=) a b = a := !a + b in
-    let sz, l = ref 0, ref [] in
-    while !sz >= 0 do push big l; sz += Sys.max_string_length done;
-    while !sz <= 0 do push big l; sz += Sys.max_string_length done;
-    try ignore (String.concat "" !l); assert false
-    with Invalid_argument _ -> ()
-  end
+   if Sys.word_size = 32 then begin
+     let big = String.make Sys.max_string_length 'x' in
+     let push x l = l := x :: !l in
+     let (+=) a b = a := !a + b in
+     let sz, l = ref 0, ref [] in
+     while !sz >= 0 do push big l; sz += Sys.max_string_length done;
+     while !sz <= 0 do push big l; sz += Sys.max_string_length done;
+     try ignore (String.concat "" !l); assert false
+     with Invalid_argument _ -> ()
+   end
 *)
diff --git a/lib/lwt/lwt_js_events.ml b/lib/lwt/lwt_js_events.ml
index d32df5c4db..5436e830fe 100644
+  eq_int (msd_ratio (create_ratio (big_int_of_int 23456)
+                                       (big_int_of_int 2345)),
+          1)
+  ;;
+  test 14
+  eq_int (msd_ratio (create_ratio (big_int_of_int 23467)
+                                       (big_int_of_int 2345)),
+          1)
+  ;;
+  failwith_test 15
+  msd_ratio (create_ratio (big_int_of_int 1) (big_int_of_int 0))
+  ("msd_ratio "^infinite_failure)
+  ;;
+  failwith_test 16
+  msd_ratio (create_ratio (big_int_of_int (-1)) (big_int_of_int 0))
+  ("msd_ratio "^infinite_failure)
+  ;;
+  failwith_test 17
+  msd_ratio (create_ratio (big_int_of_int 0) (big_int_of_int 0))
+  ("msd_ratio "^infinite_failure)
+  ;;
+  *************************)
 
 testing_function "round_futur_last_digit";;
 
diff --git a/compiler/tests-ocaml/lib-str/t01.ml b/compiler/tests-ocaml/lib-str/t01.ml
index adddc7570a..024fcbd390 100644
--- a/compiler/tests-ocaml/lib-str/t01.ml
+++ b/compiler/tests-ocaml/lib-str/t01.ml
@@ -1,8 +1,8 @@
 (* TEST
-* hasstr
-include str
-** bytecode
-** native
+   * hasstr
+   include str
+   ** bytecode
+   ** native
 *)
 
 open Printf
diff --git a/compiler/tests-ocaml/lib-string/test_string.ml b/compiler/tests-ocaml/lib-string/test_string.ml
index 048e02dd12..7c359bc5e5 100644
--- a/compiler/tests-ocaml/lib-string/test_string.ml
+++ b/compiler/tests-ocaml/lib-string/test_string.ml
@@ -38,14 +38,14 @@ let () =
 (* GPR#805/815/833 *)
 (* max_string_length is smaller in javascript *)
 (* let ()  =
-  if Sys.word_size = 32 then begin
-    let big = String.make Sys.max_string_length 'x' in
-    let push x l = l := x :: !l in
-    let (+=) a b = a := !a + b in
-    let sz, l = ref 0, ref [] in
-    while !sz >= 0 do push big l; sz += Sys.max_string_length done;
-    while !sz <= 0 do push big l; sz += Sys.max_string_length done;
-    try ignore (String.concat "" !l); assert false
-    with Invalid_argument _ -> ()
-  end
+   if Sys.word_size = 32 then begin
+     let big = String.make Sys.max_string_length 'x' in
+     let push x l = l := x :: !l in
+     let (+=) a b = a := !a + b in
+     let sz, l = ref 0, ref [] in
+     while !sz >= 0 do push big l; sz += Sys.max_string_length done;
+     while !sz <= 0 do push big l; sz += Sys.max_string_length done;
+     try ignore (String.concat "" !l); assert false
+     with Invalid_argument _ -> ()
+   end
 *)
diff --git a/lib/lwt/lwt_js_events.ml b/lib/lwt/lwt_js_events.ml
index d32df5c4db..5436e830fe 100644
--- a/lib/lwt/lwt_js_events.ml
+++ b/lib/lwt/lwt_js_events.ml
@@ -323,7 +323,7 @@ let mousewheel ?use_capture ?passive target =
   t
 
 (* let _DOMMouseScroll ?use_capture ?passive target =
-  make_event Dom_html.Event._DOMMouseScroll ?use_capture ?passive target
+   make_event Dom_html.Event._DOMMouseScroll ?use_capture ?passive target
 *)
 
 let touchstart ?use_capture ?passive target =
diff --git a/ppx/ppx_js/lib_internal/ppx_js_internal.ml b/ppx/ppx_js/lib_internal/ppx_js_internal.ml
index 13615492f5..7f658f5e9e 100644
--- a/ppx/ppx_js/lib_internal/ppx_js_internal.ml
+++ b/ppx/ppx_js/lib_internal/ppx_js_internal.ml
@@ -118,7 +118,7 @@ let make_str ?loc s =
   match loc with None -> mknoloc s | Some loc -> mkloc s loc
 
 (* [merlin_hide] tells merlin to not look at a node, or at any of its
-   descendants.  *)
+   descendants. *)
 let merlin_hide =
   {
     attr_name = { txt = "merlin.hide"; loc = Location.none };
diff --git a/toplevel/bin/jsoo_mkcmis.ml b/toplevel/bin/jsoo_mkcmis.ml
index 9f306e9ea1..05c5d3fbbf 100644
--- a/toplevel/bin/jsoo_mkcmis.ml
+++ b/toplevel/bin/jsoo_mkcmis.ml
@@ -18,7 +18,7 @@
  *)
 
 (* Helper to generate a javascript file containing
-  cmis needed to use findlib packages in the toplevel *)
+   cmis needed to use findlib packages in the toplevel *)
 (* #use "topfind" *)
 (* #require "findlib" *)
 (* #require "js_of_ocaml.compiler" *)
diff --git a/lambda/lambda.mli b/lambda/lambda.mli
index d1c961779..38a873829 100644
--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -268,7 +268,7 @@ type let_kind = Strict | Alias | StrictOpt
       in e'
     StrictOpt: e does not have side-effects, but depend on the store;
       we can discard e if x does not appear in e'
- *)
+*)
 
 type meth_kind = Self | Public | Cached
 
diff --git a/lambda/matching.ml b/lambda/matching.ml
index a0436fec6..4b5c183da 100644
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -84,7 +84,6 @@
        with <exit j> ->
          <third body>
    v}
-
 *)
 
 open Misc
diff --git a/lambda/switch.mli b/lambda/switch.mli
index d5be37164..bb5f9cab6 100644
--- a/lambda/switch.mli
+++ b/lambda/switch.mli
@@ -21,12 +21,12 @@
 (* For detecting action sharing, object style *)
 
 (* Store for actions in object style:
-  act_store : store an action, returns index in table
-              In case an action with equal key exists, returns index
-              of the stored action. Otherwise add entry in table.
-  act_store_shared : This stored action will always be shared.
-  act_get   : retrieve table
-  act_get_shared : retrieve table, with sharing explicit
+   act_store : store an action, returns index in table
+               In case an action with equal key exists, returns index
+               of the stored action. Otherwise add entry in table.
+   act_store_shared : This stored action will always be shared.
+   act_get   : retrieve table
+   act_get_shared : retrieve table, with sharing explicit
 *)
```

</details>