### PR TITLE
Fix normalization of sequences of expressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 #### Bug fixes
 
+  + Fix normalization of sequences of expressions (#1731, @gpetiot)
+
 #### Changes
 
 #### New features

--- a/lib/Normalize.ml
+++ b/lib/Normalize.ml
@@ -219,10 +219,21 @@ let make_mapper conf ~ignore_doc_comments =
   in
   let expr (m : Ast_mapper.mapper) exp =
     let exp = {exp with pexp_loc_stack= []} in
-    match exp.pexp_desc with
+    let {pexp_desc; pexp_loc= loc1; pexp_attributes= attrs1; _} = exp in
+    match pexp_desc with
     | Pexp_poly ({pexp_desc= Pexp_constraint (e, t); _}, None) ->
         m.expr m {exp with pexp_desc= Pexp_poly (e, Some t)}
     | Pexp_constraint (e, {ptyp_desc= Ptyp_poly ([], _t); _}) -> m.expr m e
+    | Pexp_sequence
+        ( exp1
+        , { pexp_desc= Pexp_sequence (exp2, exp3)
+          ; pexp_loc= loc2
+          ; pexp_attributes= attrs2
+          ; _ } ) ->
+        m.expr m
+          (Exp.sequence ~loc:loc1 ~attrs:attrs1
+             (Exp.sequence ~loc:loc2 ~attrs:attrs2 exp1 exp2)
+             exp3 )
     | _ -> Ast_mapper.default_mapper.expr m exp
   in
   let pat (m : Ast_mapper.mapper) pat =

--- a/test/passing/tests/sequence-preserve.ml.ref
+++ b/test/passing/tests/sequence-preserve.ml.ref
@@ -1,3 +1,10 @@
+let read_traces filename =
+  let ic = open_in_bin filename in
+  read_hashtable ~t:[%t: contracts_trace] 0 40 ic tbl1 ;
+  read_hashtable ~t:[%t: variables_trace] 40 70 ic tbl2 ;
+  read_hashtable ~t:[%t: expressions_trace] 70 100 ic tbl3 ;
+  close_in ic
+
 let foo x y =
   do_some_setup y ;
   do_some_setup y ;

--- a/test/passing/tests/sequence.ml
+++ b/test/passing/tests/sequence.ml
@@ -1,3 +1,12 @@
+let read_traces filename =
+  let ic = open_in_bin filename in
+  begin
+    read_hashtable ~t:[%t: contracts_trace] 0 40 ic tbl1;
+    read_hashtable ~t:[%t: variables_trace] 40 70 ic tbl2;
+    read_hashtable ~t:[%t: expressions_trace] 70 100 ic tbl3;
+  end;
+  close_in ic
+
 let foo x y =
   do_some_setup y ; do_some_setup y ;
 

--- a/test/passing/tests/sequence.ml.ref
+++ b/test/passing/tests/sequence.ml.ref
@@ -1,3 +1,10 @@
+let read_traces filename =
+  let ic = open_in_bin filename in
+  read_hashtable ~t:[%t: contracts_trace] 0 40 ic tbl1 ;
+  read_hashtable ~t:[%t: variables_trace] 40 70 ic tbl2 ;
+  read_hashtable ~t:[%t: expressions_trace] 70 100 ic tbl3 ;
+  close_in ic
+
 let foo x y =
   do_some_setup y ;
   do_some_setup y ;


### PR DESCRIPTION
Fix #1728 
Fix #1730
No diff with test_branch.sh

The normalization is now consistent with how sequences are formatted, to preserve the parentheses/begin-end keywords we would need to find a way to have them in the AST, the current implementation is not able to distinguish between
```ocaml
begin
  a;
  b;
  c;
  d
end
```
and
```ocaml
begin
  a;
  b
end;
begin
  c;
  d
end
```
that's why the begin-end keywords are not preserved (I am not even sure we would want to preserve them)