### PR TITLE
Support sugared form of coercions in let bindings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 
   + Type constrained patterns are now always parenthesized, parentheses were missing in a class context (#1734, @gpetiot)
 
-  + Fix formatting of type coercions (#1739, @gpetiot)
+  + Support sugared form of coercions in let bindings (#1739, @gpetiot)
 
 #### Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
   + Type constrained patterns are now always parenthesized, parentheses were missing in a class context (#1734, @gpetiot)
 
+  + Fix formatting of type coercions (#1739, @gpetiot)
+
 #### Changes
 
 #### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4309,6 +4309,15 @@ and fmt_value_binding c ~rec_flag ?ext ?in_ ?epi ctx
               $ fmt ".@ " $ fmt_core_type c xtyp )
         in
         ([], fmt_cstr)
+    | `Coerce (xtyp1, xtyp2) ->
+        let fmt_cstr =
+          opt xtyp1 (fun xtyp1 ->
+              fmt_or c.conf.ocp_indent_compat "@ : " " :@ "
+              $ fmt_core_type c xtyp1 )
+          $ fmt_or c.conf.ocp_indent_compat "@ :> " " :>@ "
+          $ fmt_core_type c xtyp2
+        in
+        ([], fmt_cstr)
     | `Other (xargs, xtyp) ->
         (xargs, fmt_type_cstr c ~in_constraint:false xtyp)
     | `None xargs -> (xargs, noop)

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -144,6 +144,7 @@ module Let_binding : sig
     ; lb_pat: pattern Ast.xt
     ; lb_typ:
         [ `Polynewtype of label loc list * core_type Ast.xt
+        | `Coerce of core_type Ast.xt option * core_type Ast.xt
         | `Other of arg_kind list * core_type Ast.xt
         | `None of arg_kind list ]
     ; lb_exp: expression Ast.xt

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -543,6 +543,18 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+   (with-outputs-to coerce.ml.output
+     (run %{bin:ocamlformat} %{dep:tests/coerce.ml}))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/coerce.ml coerce.ml.output)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
    (with-outputs-to comment_breaking.ml.output
      (run %{bin:ocamlformat} %{dep:tests/comment_breaking.ml}))))
 

--- a/test/passing/tests/coerce.ml
+++ b/test/passing/tests/coerce.ml
@@ -1,0 +1,25 @@
+let _ =
+  let a :> x = v in
+  let a : x :> y = v in
+  let a = (v :> x) in
+  let a = (v : x :> y) in
+  let a : x :> y = (v : x :> y) in
+  ()
+
+let a :> x = v
+
+let a : x :> y = v
+
+let a = (v :> x)
+
+let a = (v : x :> y)
+
+let a : x :> y = (v : x :> y)
+
+class c =
+  let a :> x = v in
+  let a : x :> y = v in
+  let a = (v :> x) in
+  let a = (v : x :> y) in
+  let a : x :> y = (v : x :> y) in
+  object end


### PR DESCRIPTION
Fix #1738, no diff with test_branch.sh

It should be treated the same as Pexp_constraint, the parser parses
```ocaml
let y :> _ = x
```
as
```
Ptop_def
  [
    structure_item (//toplevel//[2,1+0]..[2,1+14])
      Pstr_value Nonrec
      [
        <def>
          pattern (//toplevel//[2,1+4]..[2,1+10]) ghost
            Ppat_constraint
            pattern (//toplevel//[2,1+4]..[2,1+5])
              Ppat_var "y" (//toplevel//[2,1+4]..[2,1+5])
            core_type (//toplevel//[2,1+9]..[2,1+10]) ghost
              Ptyp_poly
              core_type (//toplevel//[2,1+9]..[2,1+10])
                Ptyp_any
          expression (//toplevel//[2,1+4]..[2,1+14]) ghost
            Pexp_coerce
            expression (//toplevel//[2,1+13]..[2,1+14])
              Pexp_ident "x" (//toplevel//[2,1+13]..[2,1+14])
            None
            core_type (//toplevel//[2,1+9]..[2,1+10])
              Ptyp_any
      ]
  ]
```

and
```ocaml
let y : _ :> _ = x
```
as
```
Ptop_def
  [
    structure_item (//toplevel//[1,0+0]..[1,0+18])
      Pstr_value Nonrec
      [
        <def>
          pattern (//toplevel//[1,0+4]..[1,0+14]) ghost
            Ppat_constraint
            pattern (//toplevel//[1,0+4]..[1,0+5])
              Ppat_var "y" (//toplevel//[1,0+4]..[1,0+5])
            core_type (//toplevel//[1,0+13]..[1,0+14]) ghost
              Ptyp_poly
              core_type (//toplevel//[1,0+13]..[1,0+14])
                Ptyp_any
          expression (//toplevel//[1,0+4]..[1,0+18]) ghost
            Pexp_coerce
            expression (//toplevel//[1,0+17]..[1,0+18])
              Pexp_ident "x" (//toplevel//[1,0+17]..[1,0+18])
            Some
              core_type (//toplevel//[1,0+8]..[1,0+9])
                Ptyp_any
            core_type (//toplevel//[1,0+13]..[1,0+14])
              Ptyp_any
      ]
  ]
```