### PR TITLE
Remove side-effects of Fmt.list_k that caused comments to be dropped

### DIFF
--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -157,7 +157,8 @@ let list_fl xs pp =
   list_pn xs (fun ~prev x ~next ->
       pp ~first:(Option.is_none prev) ~last:(Option.is_none next) x )
 
-let list_k l sep f = List.map l ~f |> List.intersperse ~sep |> sequence
+let list_k l sep f =
+  list_fl l (fun ~first:_ ~last x -> f x $ if last then noop else sep)
 
 let list xs sep pp = list_k xs (fmt sep) pp
 

--- a/test/unit/test_fmt.ml
+++ b/test/unit/test_fmt.ml
@@ -75,6 +75,31 @@ let tests_list_pn =
         let l = ["a"; "b"; "c"; "d"; "e"] in
         Fmt.fmt_if_k false (Fmt.list_pn l pp_spy) ) ]
 
+let tests_list_k =
+  let test name ~expected ~expected_calls f =
+    ( "list_k: " ^ name
+    , `Quick
+    , fun () ->
+        let calls = ref [] in
+        let record_call x = calls := x :: !calls in
+        let pp_spy x = record_call x ; Fmt.str x in
+        let term = f pp_spy in
+        let got = eval_fmt term in
+        Alcotest.check Alcotest.(string) Caml.__LOC__ expected got ;
+        let got_calls = List.rev !calls in
+        Alcotest.check
+          Alcotest.(list string)
+          Caml.__LOC__ expected_calls got_calls )
+  in
+  [ test "evaluation order" ~expected:"a b c d e"
+      ~expected_calls:["a"; "b"; "c"; "d"; "e"] (fun pp_spy ->
+        let l = ["a"; "b"; "c"; "d"; "e"] in
+        Fmt.list_k l (Fmt.str " ") pp_spy )
+  ; test "does not call pp if not formatting" ~expected:"" ~expected_calls:[]
+      (fun pp_spy ->
+        let l = ["a"; "b"; "c"; "d"; "e"] in
+        Fmt.fmt_if_k false (Fmt.list_k l (Fmt.str " ") pp_spy) ) ]
+
 let tests_sequence =
   let test name term ~expected =
     ( "sequence: " ^ name
@@ -92,4 +117,4 @@ let tests_sequence =
       (Fmt.sequence (List.init 300_000 ~f:(fun _ -> Fmt.noop)))
       ~expected:"" ]
 
-let tests = tests_lazy @ tests_list_pn @ tests_sequence
+let tests = tests_lazy @ tests_list_pn @ tests_list_k @ tests_sequence


### PR DESCRIPTION
Spotted while refactoring some code of Fmt_ast, where `Fmt.list`/`Fmt.list_k` could be used instead of `Fmt.list_pn`/`Fmt.list_fl`, some comments were not preserved due to this side-effect.

No diff with test_branch.sh