### PR TITLE
Add `line-endings=lf-unnormalized` option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,10 @@
 
   + Handle merlin typed holes (#1698, @gpetiot)
 
+  + Add `line-endings=lf-unnormalized` option to use LF as line endings in the
+    formatted output, but without modifying newlines in string literals or
+    comments. (#1703, @nojb)
+
 ### 0.19.0 (2021-07-16)
 
 #### Bug fixes

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -51,7 +51,7 @@ type t =
   ; let_binding_indent: int
   ; let_binding_spacing: [`Compact | `Sparse | `Double_semicolon]
   ; let_module: [`Compact | `Sparse]
-  ; line_endings: [`Lf | `Crlf]
+  ; line_endings: [`Lf | `Lf_unnormalized | `Crlf]
   ; margin: int
   ; match_indent: int
   ; match_indent_nested: [`Always | `Auto | `Never]
@@ -835,6 +835,10 @@ module Formatting = struct
     let doc = "Line endings used." in
     let all =
       [ ("lf", `Lf, "$(b,lf) uses Unix line endings.")
+      ; ( "lf-unnormalized"
+        , `Lf_unnormalized
+        , "$(b,lf-unnormalized) uses Unix line endings, but does not modify \
+           embedded newlines in quoted strings or comments." )
       ; ("crlf", `Crlf, "$(b,crlf) uses Windows line endings.") ]
     in
     C.choice ~names:["line-endings"] ~all ~doc ~allow_inline:false ~section
@@ -1645,7 +1649,7 @@ let janestreet_profile =
   ; let_binding_indent= 2
   ; let_binding_spacing= `Double_semicolon
   ; let_module= `Sparse
-  ; line_endings= `Lf
+  ; line_endings= `Lf_unnormalized
   ; margin= 90
   ; match_indent= 0
   ; match_indent_nested= `Never

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -53,7 +53,7 @@ type t =
   ; let_binding_indent: int
   ; let_binding_spacing: [`Compact | `Sparse | `Double_semicolon]
   ; let_module: [`Compact | `Sparse]
-  ; line_endings: [`Lf | `Crlf]
+  ; line_endings: [`Lf | `Lf_unnormalized | `Crlf]
   ; margin: int  (** Format code to fit within [margin] columns. *)
   ; match_indent: int
   ; match_indent_nested: [`Always | `Auto | `Never]

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -446,7 +446,11 @@ let parse_and_format (type a b) (fg0 : a Ast_passes.Ast0.t)
   format fg0 fgN ?output_file ~input_name ~prev_source:source ~parsed conf
     opts
   >>= fun formatted ->
-  Ok (normalize_eol ~line_endings:conf.Conf.line_endings formatted)
+  Ok
+    ( match conf.Conf.line_endings with
+    | `Lf_unnormalized -> formatted
+    | (`Lf | `Crlf) as line_endings -> normalize_eol ~line_endings formatted
+    )
 
 let parse_and_format = function
   | Syntax.Structure -> parse_and_format Structure Structure

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -272,10 +272,11 @@ OPTIONS (CODE FORMATTING STYLE)
            ... = and before the in if the module declaration does not fit on
            a single line. The default value is compact.
 
-       --line-endings={lf|crlf}
-           Line endings used. lf uses Unix line endings. crlf uses Windows
-           line endings. The default value is lf. Cannot be set in
-           attributes.
+       --line-endings={lf|lf-unnormalized|crlf}
+           Line endings used. lf uses Unix line endings. lf-unnormalized uses
+           Unix line endings, but does not modify embedded newlines in quoted
+           strings or comments. crlf uses Windows line endings. The default
+           value is lf. Cannot be set in attributes.
 
        -m COLS, --margin=COLS
            Format code to fit within COLS columns. The default value is 80.


### PR DESCRIPTION
Following discussion in #1748, this PR introduces an third option for the `line-endings` option which uses `lf` as the EOL for the pretty-printing algorithm but does not normalize embedded newlines in string literals (and comments, which are mostly treated the same way as strings). The `janestreet` profile is set to use this option by default.

On the implementation side this is achieved by not doing any newline normalization after pretty printing, making use of the fact that the output channel is already opened in binary mode.

The analogous option `crlf-unnormalized` is not implemented in this PR but could be implemented in a future PR if there is a demand for it (I haven't looked at the details).

The fact that embedded newlines in comments are also not normalized is somewhat unsatisfying, but doing something specific for comments would complicate the implementation. Unless there are bug reports, I prefer to keep it as simple as possible.

cc @ceastlund @hhugo @jberdine 