### PR TITLE
Add an ocaml-version option, format punned labelled arguments when OCaml 4.14+ syntax is selected

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,9 +25,12 @@
   + Handle merlin typed holes (#1698, @gpetiot)
 
   + Handle punned labelled arguments with type constraint in function applications.
-    For example, function application of the form `foo ~(x:int)` instead of the explicit `foo ~x:(x:int)`. (ocaml#10434) (#1756, @gpetiot)
+    For example, function application of the form `foo ~(x:int)` instead of the explicit `foo ~x:(x:int)`. (ocaml#10434) (#1756, #1759, @gpetiot)
+    This syntax is only produced when the output syntax is at least OCaml 4.13.
 
   + Allow explicit binders for type variables (ocaml#10437) (#1757, @gpetiot)
+
+  + Add a new `ocaml-version` option to select the version of OCaml syntax of the output (#1759, @gpetiot)
 
 ### 0.19.0 (2021-07-16)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@
 
   + Handle punned labelled arguments with type constraint in function applications.
     For example, function application of the form `foo ~(x:int)` instead of the explicit `foo ~x:(x:int)`. (ocaml#10434) (#1756, #1759, @gpetiot)
-    This syntax is only produced when the output syntax is at least OCaml 4.13.
+    This syntax is only produced when the output syntax is at least OCaml 4.14.
 
   + Allow explicit binders for type variables (ocaml#10437) (#1757, @gpetiot)
 

--- a/dune-project
+++ b/dune-project
@@ -52,7 +52,8 @@
    (>= 20201216))
   (menhirSdk
    (>= 20201216))
-  ocaml-version
+  (ocaml-version
+   (>= 3.2.0))
   ocp-indent
   (bisect_ppx
    (and
@@ -96,7 +97,8 @@
    (>= 20201216))
   (menhirSdk
    (>= 20201216))
-  ocaml-version
+  (ocaml-version
+   (>= 3.2.0))
   ocp-indent
   (bisect_ppx
    (and

--- a/dune-project
+++ b/dune-project
@@ -52,6 +52,7 @@
    (>= 20201216))
   (menhirSdk
    (>= 20201216))
+  ocaml-version
   ocp-indent
   (bisect_ppx
    (and
@@ -95,6 +96,7 @@
    (>= 20201216))
   (menhirSdk
    (>= 20201216))
+  ocaml-version
   ocp-indent
   (bisect_ppx
    (and

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -59,6 +59,7 @@ type t =
   ; max_iters: int
   ; module_item_spacing: [`Compact | `Preserve | `Sparse]
   ; nested_match: [`Wrap | `Align]
+  ; ocaml_version: Ocaml_version.t
   ; ocp_indent_compat: bool
   ; parens_ite: bool
   ; parens_tuple: [`Always | `Multi_line_only]
@@ -171,6 +172,14 @@ let info =
          $(b,#) are ignored and can be used as comments." ]
   in
   Term.info "ocamlformat" ~version:Version.version ~doc ~man
+
+let ocaml_version_conv =
+  let parse x =
+    match Ocaml_version.of_string x with
+    | Ok x -> `Ok x
+    | Error (`Msg x) -> `Error x
+  in
+  (parse, Ocaml_version.pp)
 
 (** Options affecting formatting *)
 module Formatting = struct
@@ -935,6 +944,16 @@ module Formatting = struct
       (fun conf x -> {conf with nested_match= x})
       (fun conf -> conf.nested_match)
 
+  let ocaml_version =
+    let docv = "V" in
+    let doc = "Version of OCaml syntax of the output." in
+    let default = Ocaml_version.sys_version in
+    let default_doc = "the currently installed OCaml version" in
+    C.any ocaml_version_conv ~names:["ocaml-version"] ~default ~default_doc
+      ~doc ~docv ~section
+      (fun conf x -> {conf with ocaml_version= x})
+      (fun conf -> conf.ocaml_version)
+
   let ocp_indent_compat =
     let doc =
       "Attempt to generate output which does not change (much) when \
@@ -1456,6 +1475,7 @@ let ocamlformat_profile =
   ; max_iters= 10
   ; module_item_spacing= `Sparse
   ; nested_match= `Wrap
+  ; ocaml_version= C.default Formatting.ocaml_version
   ; ocp_indent_compat= false
   ; parens_ite= false
   ; parens_tuple= `Always
@@ -1528,6 +1548,7 @@ let conventional_profile =
   ; max_iters= C.default max_iters
   ; module_item_spacing= C.default Formatting.module_item_spacing
   ; nested_match= C.default Formatting.nested_match
+  ; ocaml_version= C.default Formatting.ocaml_version
   ; ocp_indent_compat= C.default Formatting.ocp_indent_compat
   ; parens_ite= C.default Formatting.parens_ite
   ; parens_tuple= C.default Formatting.parens_tuple
@@ -1653,6 +1674,7 @@ let janestreet_profile =
   ; max_iters= ocamlformat_profile.max_iters
   ; module_item_spacing= `Compact
   ; nested_match= `Wrap
+  ; ocaml_version= C.default Formatting.ocaml_version
   ; ocp_indent_compat= true
   ; parens_ite= true
   ; parens_tuple= `Multi_line_only

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -63,6 +63,7 @@ type t =
             [max_iters] iterations. *)
   ; module_item_spacing: [`Compact | `Preserve | `Sparse]
   ; nested_match: [`Wrap | `Align]
+  ; ocaml_version: Ocaml_version.t
   ; ocp_indent_compat: bool  (** Try to indent like ocp-indent *)
   ; parens_ite: bool
   ; parens_tuple: [`Always | `Multi_line_only]

--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -80,9 +80,16 @@ module Make (C : CONFIG) = struct
       (in_attributes ~section allow_inline)
       deprecated_doc deprecated
 
-  let generated_doc conv ~allow_inline ~doc ~section ~default ~deprecated =
-    let default = Format.asprintf "%a" (Arg.conv_printer conv) default in
-    let default = if String.is_empty default then "none" else default in
+  let generated_doc ?default_doc conv ~allow_inline ~doc ~section ~default
+      ~deprecated =
+    let default_doc =
+      match default_doc with
+      | Some x -> x
+      | None -> Format.asprintf "%a" (Arg.conv_printer conv) default
+    in
+    let default =
+      if String.is_empty default_doc then "none" else default_doc
+    in
     Format.asprintf "%s The default value is $(b,%s).%s%a" doc default
       (in_attributes ~section allow_inline)
       deprecated_doc deprecated
@@ -134,13 +141,13 @@ module Make (C : CONFIG) = struct
     store := Pack opt :: !store ;
     opt
 
-  let any converter ~default ~docv ~names ~doc ~section
+  let any ?default_doc converter ~default ~docv ~names ~doc ~section
       ?(allow_inline = Poly.(section = `Formatting)) ?deprecated update
       get_value =
     let open Cmdliner in
     let doc =
-      generated_doc converter ~allow_inline ~doc ~section ~default
-        ~deprecated
+      generated_doc converter ?default_doc ~allow_inline ~doc ~section
+        ~default ~deprecated
     in
     let docs = section_name section in
     let term =

--- a/lib/Config_option.mli
+++ b/lib/Config_option.mli
@@ -64,7 +64,11 @@ module Make (C : CONFIG) : sig
   val flag : default:bool -> bool option_decl
 
   val any :
-    'a Cmdliner.Arg.conv -> default:'a -> docv:string -> 'a option_decl
+       ?default_doc:string
+    -> 'a Cmdliner.Arg.conv
+    -> default:'a
+    -> docv:string
+    -> 'a option_decl
 
   val removed_option :
     names:string list -> version:string -> msg:string -> unit

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1352,7 +1352,10 @@ and fmt_label_arg ?(box = true) ?epi ?parens ?eol c
       Cmts.fmt c loc @@ Cmts.fmt c ?eol arg.pexp_loc @@ fmt_label lbl ""
   | ( (Labelled l | Optional l)
     , Pexp_constraint ({pexp_desc= Pexp_ident {txt= Lident i; _}; _}, _) )
-    when String.equal l i && List.is_empty arg.pexp_attributes ->
+    when String.equal l i
+         && List.is_empty arg.pexp_attributes
+         && Ocaml_version.(compare c.conf.ocaml_version Releases.v4_13 >= 0)
+    ->
       let lbl =
         match lbl with
         | Labelled _ -> str "~"

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1354,7 +1354,7 @@ and fmt_label_arg ?(box = true) ?epi ?parens ?eol c
     , Pexp_constraint ({pexp_desc= Pexp_ident {txt= Lident i; _}; _}, _) )
     when String.equal l i
          && List.is_empty arg.pexp_attributes
-         && Ocaml_version.(compare c.conf.ocaml_version Releases.v4_13 >= 0)
+         && Ocaml_version.(compare c.conf.ocaml_version Releases.v4_14 >= 0)
     ->
       let lbl =
         match lbl with

--- a/lib/dune
+++ b/lib/dune
@@ -21,6 +21,7 @@
   format_
   ocaml_413
   ocamlformat_stdlib
+  ocaml-version
   ocp-indent.lib
   odoc-parser
   parse_wyc

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -364,6 +364,10 @@ OPTIONS (CODE FORMATTING STYLE)
        --no-wrap-fun-args
            Unset wrap-fun-args.
 
+       --ocaml-version=V
+           Version of OCaml syntax of the output. The default value is the
+           currently installed OCaml version.
+
        --ocp-indent-compat
            Attempt to generate output which does not change (much) when
            post-processing with ocp-indent. The flag is unset by default.

--- a/ocamlformat-rpc.opam
+++ b/ocamlformat-rpc.opam
@@ -21,6 +21,7 @@ depends: [
   "menhir" {>= "20201216"}
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
+  "ocaml-version"
   "ocp-indent"
   "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc-parser" {>= "0.9.0"}

--- a/ocamlformat-rpc.opam
+++ b/ocamlformat-rpc.opam
@@ -21,7 +21,7 @@ depends: [
   "menhir" {>= "20201216"}
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
-  "ocaml-version"
+  "ocaml-version" {>= "3.2.0"}
   "ocp-indent"
   "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc-parser" {>= "0.9.0"}

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -20,7 +20,7 @@ depends: [
   "menhir" {>= "20201216"}
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
-  "ocaml-version"
+  "ocaml-version" {>= "3.2.0"}
   "ocp-indent"
   "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc-parser" {>= "0.9.0"}

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -20,6 +20,7 @@ depends: [
   "menhir" {>= "20201216"}
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
+  "ocaml-version"
   "ocp-indent"
   "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc-parser" {>= "0.9.0"}

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1926,6 +1926,30 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+   (with-outputs-to labelled_args-412.ml.output
+     (run %{bin:ocamlformat} --ocaml-version=4.12 %{dep:tests/labelled_args.ml}))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/labelled_args-412.ml.ref labelled_args-412.ml.output)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+   (with-outputs-to labelled_args.ml.output
+     (run %{bin:ocamlformat} %{dep:tests/labelled_args.ml}))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/labelled_args.ml labelled_args.ml.output)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
    (with-outputs-to lazy.ml.output
      (run %{bin:ocamlformat} %{dep:tests/lazy.ml}))))
 

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1926,13 +1926,13 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
-   (with-outputs-to labelled_args-412.ml.output
-     (run %{bin:ocamlformat} --ocaml-version=4.12 %{dep:tests/labelled_args.ml}))))
+   (with-outputs-to labelled_args-414.ml.output
+     (run %{bin:ocamlformat} --ocaml-version=4.14.0 %{dep:tests/labelled_args.ml}))))
 
 (rule
  (alias runtest)
  (package ocamlformat)
- (action (diff tests/labelled_args-412.ml.ref labelled_args-412.ml.output)))
+ (action (diff tests/labelled_args-414.ml.ref labelled_args-414.ml.output)))
 
 (rule
  (deps tests/.ocamlformat )

--- a/test/passing/tests/.ocamlformat
+++ b/test/passing/tests/.ocamlformat
@@ -4,3 +4,4 @@ margin = 77
 parse-docstrings = true
 wrap-comments = true
 max-iters = 2
+ocaml-version = 4.13.0

--- a/test/passing/tests/apply.ml
+++ b/test/passing/tests/apply.ml
@@ -83,7 +83,3 @@ let _ =
     (loooooooooooong looooooooooooooong loooooooooooooong
        [loooooooooong; loooooooooooong; loooooooooooooooooooooong]
     )
-
-let _ =
-  let f ~y = y + 1 in
-  f ~(y : int)

--- a/test/passing/tests/labelled_args-412.ml.opts
+++ b/test/passing/tests/labelled_args-412.ml.opts
@@ -1,1 +1,0 @@
---ocaml-version=4.12

--- a/test/passing/tests/labelled_args-412.ml.opts
+++ b/test/passing/tests/labelled_args-412.ml.opts
@@ -1,0 +1,1 @@
+--ocaml-version=4.12

--- a/test/passing/tests/labelled_args-412.ml.ref
+++ b/test/passing/tests/labelled_args-412.ml.ref
@@ -1,0 +1,3 @@
+let _ =
+  let f ~y = y + 1 in
+  f ~y:(y : int)

--- a/test/passing/tests/labelled_args-414.ml.opts
+++ b/test/passing/tests/labelled_args-414.ml.opts
@@ -1,0 +1,1 @@
+--ocaml-version=4.14.0

--- a/test/passing/tests/labelled_args-414.ml.ref
+++ b/test/passing/tests/labelled_args-414.ml.ref
@@ -1,3 +1,3 @@
 let _ =
   let f ~y = y + 1 in
-  f ~y:(y : int)
+  f ~(y : int)

--- a/test/passing/tests/labelled_args.ml
+++ b/test/passing/tests/labelled_args.ml
@@ -1,0 +1,3 @@
+let _ =
+  let f ~y = y + 1 in
+  f ~(y : int)

--- a/test/passing/tests/labelled_args.ml
+++ b/test/passing/tests/labelled_args.ml
@@ -1,3 +1,3 @@
 let _ =
   let f ~y = y + 1 in
-  f ~(y : int)
+  f ~y:(y : int)

--- a/test/passing/tests/print_config.ml.ref
+++ b/test/passing/tests/print_config.ml.ref
@@ -19,6 +19,7 @@ parens-tuple-patterns=multi-line-only (profile ocamlformat (file tests/.ocamlfor
 parens-tuple=always (profile ocamlformat (file tests/.ocamlformat:1))
 parens-ite=false (profile ocamlformat (file tests/.ocamlformat:1))
 ocp-indent-compat=false (profile ocamlformat (file tests/.ocamlformat:1))
+ocaml-version=4.13.0 (file tests/.ocamlformat:7)
 nested-match=wrap (profile ocamlformat (file tests/.ocamlformat:1))
 module-item-spacing=sparse (file tests/dir1/dir2/.ocamlformat:1)
 max-indent=68 (profile ocamlformat (file tests/.ocamlformat:1))

--- a/test/passing/tests/verbose1.ml.ref
+++ b/test/passing/tests/verbose1.ml.ref
@@ -19,6 +19,7 @@ parens-tuple-patterns=multi-line-only (profile ocamlformat (file tests/.ocamlfor
 parens-tuple=always (profile ocamlformat (file tests/.ocamlformat:1))
 parens-ite=false (profile ocamlformat (file tests/.ocamlformat:1))
 ocp-indent-compat=false (profile ocamlformat (file tests/.ocamlformat:1))
+ocaml-version=4.13.0 (file tests/.ocamlformat:7)
 nested-match=wrap (profile ocamlformat (file tests/.ocamlformat:1))
 module-item-spacing=sparse (profile ocamlformat (file tests/.ocamlformat:1))
 max-indent=68 (profile ocamlformat (file tests/.ocamlformat:1))

--- a/test/passing/tests/verbose2.ml.ref
+++ b/test/passing/tests/verbose2.ml.ref
@@ -19,6 +19,7 @@ parens-tuple-patterns=multi-line-only (profile ocamlformat (file tests/.ocamlfor
 parens-tuple=always (profile ocamlformat (file tests/.ocamlformat:1))
 parens-ite=false (profile ocamlformat (file tests/.ocamlformat:1))
 ocp-indent-compat=false (profile ocamlformat (file tests/.ocamlformat:1))
+ocaml-version=4.13.0 (file tests/.ocamlformat:7)
 nested-match=wrap (profile ocamlformat (file tests/.ocamlformat:1))
 module-item-spacing=sparse (profile ocamlformat (file tests/.ocamlformat:1))
 max-indent=68 (profile ocamlformat (file tests/.ocamlformat:1))


### PR DESCRIPTION
Follow-up on #1756 