### PR TITLE
Cache results of Cmts.preserve

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,10 @@
 
   + Avoid normalizing newlines inside quoted strings `{|...|}` (#1754, @nojb, @hhugo)
 
+  + Fix quadratic behavior when certain constructs are nested. This corresponds
+    to the cases where a partial layout is triggered to determine if a construct
+    fits on a single line for example. (#1750, #1766, @emillon)
+
 #### Changes
 
 #### New features

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -126,6 +126,11 @@ val diff :
   Conf.t -> Cmt.t list -> Cmt.t list -> (string, string) Either.t Sequence.t
 (** Difference between two lists of comments. *)
 
-val preserve : (unit -> Fmt.t) -> t -> string
+type layout_cache_key =
+  | Arg of Asttypes.arg_label * Parsetree.expression
+  | Pattern of Parsetree.pattern
+  | Expression of Parsetree.expression
+
+val preserve : cache_key:layout_cache_key -> (unit -> Fmt.t) -> t -> string
 (** [preserve f t] formats like [f ()] but returns a string and does not
     consume comments from [t]. *)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1366,7 +1366,10 @@ and fmt_label_arg ?(box = true) ?epi ?parens ?eol c
   | _ -> fmt_label lbl ":@," $ fmt_expression c ~box ?epi ?parens xarg
 
 and expression_width c xe =
-  String.length (Cmts.preserve (fun () -> fmt_expression c xe) c.cmts)
+  String.length
+    (Cmts.preserve ~cache_key:(Expression xe.ast)
+       (fun () -> fmt_expression c xe)
+       c.cmts )
 
 and fmt_args_grouped ?epi:(global_epi = noop) c ctx args =
   let fmt_arg c ~first:_ ~last (lbl, arg) =
@@ -1395,6 +1398,7 @@ and fmt_args_grouped ?epi:(global_epi = noop) c ctx args =
     let xexp = sub_exp ~ctx x in
     let output =
       Cmts.preserve
+        ~cache_key:(Arg (lbl, x))
         (fun () ->
           let cmts = Cmts.drop_before c.cmts x.pexp_loc in
           fmt_arg ~first:false ~last:false {c with cmts} (lbl, x) )
@@ -2972,7 +2976,11 @@ and fmt_cases c ctx cs =
     if Option.is_some pc_guard then None
     else
       let xpat = sub_pat ~ctx pc_lhs in
-      let fmted = Cmts.preserve (fun () -> fmt_pattern c xpat) c.cmts in
+      let fmted =
+        Cmts.preserve ~cache_key:(Pattern xpat.ast)
+          (fun () -> fmt_pattern c xpat)
+          c.cmts
+      in
       let len = String.length fmted in
       if len * 3 >= c.conf.margin || String.contains fmted '\n' then None
       else Some len

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1494,6 +1494,18 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+   (with-outputs-to issue1750.ml.output
+     (run %{bin:ocamlformat} %{dep:tests/issue1750.ml}))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/issue1750.ml issue1750.ml.output)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
    (with-outputs-to issue289.ml.output
      (run %{bin:ocamlformat} %{dep:tests/issue289.ml}))))
 

--- a/test/passing/tests/issue1750.ml
+++ b/test/passing/tests/issue1750.ml
@@ -1,0 +1,81 @@
+let _ =
+  all
+    [ all
+        [ all
+            [ all
+                [ f
+                    (all
+                       [ all
+                           [ all
+                               [ all
+                                   [ all
+                                       [ all
+                                           [ all
+                                               [ all
+                                                   [ all
+                                                       [ all
+                                                           [ all
+                                                               [ all
+                                                                   [ all
+                                                                       [ all
+                                                                           [ identify
+                                                                           ]
+                                                                       ] ] ]
+                                                           ] ] ] ] ] ] ] ] ]
+                       ] ) ] ] ] ]
+
+let _ = function
+  | [%p
+      function
+      | [%p
+          function
+          | [%p
+              function
+              | [%p
+                  function
+                  | [%p
+                      function
+                      | [%p
+                          function
+                          | [%p
+                              function
+                              | [%p
+                                  function
+                                  | [%p
+                                      function
+                                      | [%p
+                                          function
+                                          | [%p
+                                              function
+                                              | [%p
+                                                  function
+                                                  | [%p
+                                                      function
+                                                      | [%p
+                                                          function
+                                                          | [%p
+                                                              function
+                                                              | [%p
+                                                                  function
+                                                                  | [%p
+                                                                      function
+                                                                      | _ ->
+                                                                          ()]
+                                                                    ->
+                                                                      ()] ->
+                                                                  ()] ->
+                                                              ()] ->
+                                                          ()] ->
+                                                      ()] ->
+                                                  ()] ->
+                                              ()] ->
+                                          ()] ->
+                                      ()] ->
+                                  ()] ->
+                              ()] ->
+                          ()] ->
+                      ()] ->
+                  ()] ->
+              ()] ->
+          ()] ->
+      ()


### PR DESCRIPTION
The `preserve` function returns a string with the layout of a part of the AST. It is used in several places to determine if a subpart has a break for example.

This can be a problem when these constructions are nested, since laying out the external construction requires laying out the internal ones first, and this creates quadratic behavior.

This is solved by caching the results of these intermediate layouts. This cache is unbounded so there are bad corner cases. At worst, each cached point is associated to the result string which could mean quadratic memory consumption.

Some ways to fix this:
- use a LRU cache like the one from `core_kernel`
- store only a summary rather than the full string (length, number of lines, max indent)

In addition to #1750, a similar case can be triggered using nested cases. It seems that `expression_width` would be affected but I have not been able to reproduce that using that code path, so this part stays not cached.

Closes #1750
