### PR TITLE
Fix misaligned higher-order functor parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Fix spacing between recursive module bindings and recursive module declarations (#2217, @gpetiot)
 - ocamlformat-rpc: use binary mode for stdin/stdout (#2218, @rgrinberg)
 - Fix interpretation of glob pattern in `.ocamlformat-ignore` under Windows (#2206, @nojb)
+- Fix misaligned higher-order functor parameters (#1768, @gpetiot)
 
 ### Changes
 

--- a/test/passing/tests/doc_comments-after.ml.err
+++ b/test/passing/tests/doc_comments-after.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/doc_comments.ml:301 exceeds the margin
+Warning: tests/doc_comments.ml:302 exceeds the margin

--- a/test/passing/tests/doc_comments-after.ml.ref
+++ b/test/passing/tests/doc_comments-after.ml.ref
@@ -124,7 +124,8 @@ module Comment_placement : sig
       (Foo : BAR)
       (Foo : BAR)
       (Foo : BAR)
-      (Foo : BAR) : sig end
+      (Foo : BAR) :
+    sig end
 
   (** Doc comment still goes after *)
   module Make (Config : sig

--- a/test/passing/tests/doc_comments-before-except-val.ml.err
+++ b/test/passing/tests/doc_comments-before-except-val.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/doc_comments.ml:301 exceeds the margin
+Warning: tests/doc_comments.ml:302 exceeds the margin

--- a/test/passing/tests/doc_comments-before-except-val.ml.ref
+++ b/test/passing/tests/doc_comments-before-except-val.ml.ref
@@ -124,7 +124,8 @@ module Comment_placement : sig
       (Foo : BAR)
       (Foo : BAR)
       (Foo : BAR)
-      (Foo : BAR) : sig end
+      (Foo : BAR) :
+    sig end
 
   (** Doc comment still goes after *)
   module Make (Config : sig

--- a/test/passing/tests/doc_comments-before.ml.err
+++ b/test/passing/tests/doc_comments-before.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/doc_comments.ml:301 exceeds the margin
+Warning: tests/doc_comments.ml:302 exceeds the margin

--- a/test/passing/tests/doc_comments-before.ml.ref
+++ b/test/passing/tests/doc_comments-before.ml.ref
@@ -124,7 +124,8 @@ module Comment_placement : sig
       (Foo : BAR)
       (Foo : BAR)
       (Foo : BAR)
-      (Foo : BAR) : sig end
+      (Foo : BAR) :
+    sig end
 
   (** Doc comment still goes after *)
   module Make (Config : sig

--- a/test/passing/tests/doc_comments.ml.err
+++ b/test/passing/tests/doc_comments.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/doc_comments.ml:301 exceeds the margin
+Warning: tests/doc_comments.ml:302 exceeds the margin

--- a/test/passing/tests/doc_comments.ml.ref
+++ b/test/passing/tests/doc_comments.ml.ref
@@ -124,7 +124,8 @@ module Comment_placement : sig
       (Foo : BAR)
       (Foo : BAR)
       (Foo : BAR)
-      (Foo : BAR) : sig end
+      (Foo : BAR) :
+    sig end
 
   (** Doc comment still goes after *)
   module Make (Config : sig

--- a/test/passing/tests/functor.ml
+++ b/test/passing/tests/functor.ml
@@ -12,14 +12,12 @@ module type M = functor (S : S) (T : T) -> U
 
 module type M = functor (S : S) () -> sig end
 
-module type M = functor
-  (SSSSS : SSSSSSSSSSSSSS)
-  (TTTTT : TTTTTTTTTTTTTTTT)
-  -> sig
-  val t1 : a
+module type M =
+  functor (SSSSS : SSSSSSSSSSSSSS) (TTTTT : TTTTTTTTTTTTTTTT) -> sig
+    val t1 : a
 
-  val t2 : b
-end
+    val t2 : b
+  end
 
 module M : functor () -> sig end = functor () -> struct end
 
@@ -60,21 +58,23 @@ module type Module_type_fail = sig
   include S
 end
 
-module type KV_MAKER = functor (G : Irmin_git.G) (C : Irmin.Contents.S) ->
-  S
-    with type key = string list
-     and type step = string
-     and type contents = C.t
-     and type branch = string
-     and module Git = G
+module type KV_MAKER =
+  functor (G : Irmin_git.G) (C : Irmin.Contents.S) ->
+    S
+      with type key = string list
+       and type step = string
+       and type contents = C.t
+       and type branch = string
+       and module Git = G
 
 module Make
     (TT : TableFormat.TABLES)
     (IT : InspectionTableFormat.TABLES with type 'a lr1state = int)
-    (ET : EngineTypes.TABLE
-            with type terminal = int
-             and type nonterminal = int
-             and type semantic_value = Obj.t)
+    (ET :
+      EngineTypes.TABLE
+        with type terminal = int
+         and type nonterminal = int
+         and type semantic_value = Obj.t)
     (E : sig
       type 'a env = (ET.state, ET.semantic_value, ET.token) EngineTypes.env
     end) =
@@ -88,3 +88,44 @@ module M = functor (_ : S) -> struct end
 module M (_ : S) = struct end
 
 module M : functor (_ : S) -> S' = functor (_ : S) -> struct end
+
+module type Bootstrap =
+  functor
+    (MakeH :
+       functor (Element : ORDERED) -> sig
+         module Elem : sig
+           type t = Element.t
+
+           val eq : t -> t -> bool
+         end
+
+         val eq : t -> t -> bool
+       end)
+    (Element : ORDERED)
+    -> sig
+    val eq : t -> t -> bool
+  end
+
+module type Compat =
+  functor
+    (_ : sig
+       val equal :
+            Types.constructor_description
+         -> Types.constructor_description
+         -> bool
+     end)
+    -> sig
+    val compat : pattern -> pattern -> bool
+  end
+
+module M : sig
+  module F :
+    functor
+      (X : sig
+         type x
+       end)
+      (X : sig
+         type y
+       end)
+      -> sig end
+end = struct end

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,7 +1,6 @@
-Warning: tests/js_source.ml:156 exceeds the margin
-Warning: tests/js_source.ml:3558 exceeds the margin
-Warning: tests/js_source.ml:9546 exceeds the margin
-Warning: tests/js_source.ml:9649 exceeds the margin
-Warning: tests/js_source.ml:9668 exceeds the margin
-Warning: tests/js_source.ml:9708 exceeds the margin
-Warning: tests/js_source.ml:9790 exceeds the margin
+Warning: tests/js_source.ml:3560 exceeds the margin
+Warning: tests/js_source.ml:9556 exceeds the margin
+Warning: tests/js_source.ml:9659 exceeds the margin
+Warning: tests/js_source.ml:9678 exceeds the margin
+Warning: tests/js_source.ml:9718 exceeds the margin
+Warning: tests/js_source.ml:9800 exceeds the margin

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -154,8 +154,8 @@ type t = [%foo: ((module M)[@foo])]
 module M = (functor [@foo] (M : S) -> (val x) [@foo] (struct end [@foo]))
 
 (* Module type expression *)
-module type S = functor [@foo] (M : S) -> functor (_ : (module type of M) [@foo]) -> sig end
-                                                                                     [@foo]
+module type S =
+  functor [@foo] (M : S) -> functor (_ : (module type of M) [@foo]) -> sig end [@foo]
 
 module type S = functor (_ : S) (_ : S) -> S
 module type S = functor (_ : functor (_ : S) -> S) -> S
@@ -2609,11 +2609,13 @@ type (_, _) t =
   | A : ('a, 'a) t
   | B : string -> ('a, 'b) t
 
-module M (A : sig
-    module type T
-  end) (B : sig
-          module type T
-        end) =
+module M
+    (A : sig
+       module type T
+     end)
+    (B : sig
+       module type T
+     end) =
 struct
   let f : ((module A.T), (module B.T)) t -> string = function
     | B s -> s
@@ -4747,9 +4749,10 @@ end
 let f (module M : S with type t = int) = { M.a = 0 }
 let flag = ref false
 
-module F (S : sig
-    module type T
-  end)
+module F
+    (S : sig
+       module type T
+     end)
     (A : S.T)
     (B : S.T) =
 struct
@@ -4799,8 +4802,8 @@ module type PR6513 = sig
     type uri
   end
 
-  module Make : functor (Html5 : T with type 'a wrap = 'a) ->
-    S with type u = < foo : Html5.uri >
+  module Make :
+    functor (Html5 : T with type 'a wrap = 'a) -> S with type u = < foo : Html5.uri >
 end
 
 (* Requires -package tyxml
@@ -4994,11 +4997,13 @@ let _ = f (module A_alias_expanded) (* ok *)
 let _ = f (module A_alias : S with type t = (module A.A_S)) (* doesn't type *)
 let _ = f (module A_alias) (* doesn't type either *)
 
-module Foo (Bar : sig
-    type a = private [> `A ]
-  end) (Baz : module type of struct
-          include Bar
-        end) =
+module Foo
+    (Bar : sig
+       type a = private [> `A ]
+     end)
+    (Baz : module type of struct
+       include Bar
+     end) =
 struct end
 
 module Bazoinks = struct
@@ -5428,11 +5433,12 @@ module F (X : sig end) = struct
   module N' = N
 end
 
-module G : functor (X : sig end) -> sig
-  module N' : sig
-    val x : int
-  end
-end =
+module G :
+  functor (X : sig end) -> sig
+    module N' : sig
+      val x : int
+    end
+  end =
   F
 
 module M5 = G (struct end);;
@@ -5602,11 +5608,13 @@ module M = struct
   type t = Y.t
 end
 
-module F (Y : sig
-    type t
-  end) (M : sig
-          type t = Y.t
-        end) =
+module F
+    (Y : sig
+       type t
+     end)
+    (M : sig
+       type t = Y.t
+     end) =
 struct end
 
 module G = F (M.Y)
@@ -7158,8 +7166,9 @@ type 'a tree =
   | E
   | N of 'a tree * 'a * 'a tree
 
-module Bootstrap2 (MakeDiet : functor (X : ORD) ->
-      SET with type t = X.t tree and type elt = X.t) : SET with type elt = int = struct
+module Bootstrap2
+    (MakeDiet : functor (X : ORD) -> SET with type t = X.t tree and type elt = X.t) :
+  SET with type elt = int = struct
   type elt = int
 
   module rec Elt : sig
@@ -7591,8 +7600,8 @@ module type HEAP = sig
   val deleteMin : heap -> heap
 end
 
-module Bootstrap (MakeH : functor (Element : ORDERED) ->
-      HEAP with module Elem = Element)
+module Bootstrap
+    (MakeH : functor (Element : ORDERED) -> HEAP with module Elem = Element)
     (Element : ORDERED) : HEAP with module Elem = Element = struct
   module Elem = Element
 
@@ -8297,8 +8306,9 @@ module type BARECODE = sig
 end
 
 module USERCODE (X : TYPEVIEW) = struct
-  module type F = functor (C : CORE with type V.usert = X.combined) ->
-    BARECODE with type state := C.V.state
+  module type F =
+    functor (C : CORE with type V.usert = X.combined) ->
+      BARECODE with type state := C.V.state
 end
 
 module Weapon = struct

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -154,8 +154,8 @@ type t = [%foo: ((module M)[@foo])]
 module M = (functor [@foo] (M : S) -> (val x) [@foo] (struct end [@foo]))
 
 (* Module type expression *)
-module type S = functor [@foo] (M : S) -> functor (_ : (module type of M) [@foo]) -> sig end
-[@foo]
+module type S =
+  functor [@foo] (M : S) -> functor (_ : (module type of M) [@foo]) -> sig end [@foo]
 
 module type S = functor (_ : S) (_ : S) -> S
 module type S = functor (_ : functor (_ : S) -> S) -> S
@@ -2609,11 +2609,13 @@ type (_, _) t =
   | A : ('a, 'a) t
   | B : string -> ('a, 'b) t
 
-module M (A : sig
-  module type T
-end) (B : sig
-  module type T
-end) =
+module M
+  (A : sig
+    module type T
+  end)
+  (B : sig
+    module type T
+  end) =
 struct
   let f : ((module A.T), (module B.T)) t -> string = function
     | B s -> s
@@ -4747,11 +4749,12 @@ end
 let f (module M : S with type t = int) = { M.a = 0 }
 let flag = ref false
 
-module F (S : sig
-  module type T
-end)
-(A : S.T)
-(B : S.T) =
+module F
+  (S : sig
+    module type T
+  end)
+  (A : S.T)
+  (B : S.T) =
 struct
   module X = (val if !flag then (module A) else (module B) : S.T)
 end
@@ -4799,8 +4802,8 @@ module type PR6513 = sig
     type uri
   end
 
-  module Make : functor (Html5 : T with type 'a wrap = 'a) ->
-    S with type u = < foo : Html5.uri >
+  module Make :
+    functor (Html5 : T with type 'a wrap = 'a) -> S with type u = < foo : Html5.uri >
 end
 
 (* Requires -package tyxml
@@ -4994,11 +4997,13 @@ let _ = f (module A_alias_expanded) (* ok *)
 let _ = f (module A_alias : S with type t = (module A.A_S)) (* doesn't type *)
 let _ = f (module A_alias) (* doesn't type either *)
 
-module Foo (Bar : sig
-  type a = private [> `A ]
-end) (Baz : module type of struct
-  include Bar
-end) =
+module Foo
+  (Bar : sig
+    type a = private [> `A ]
+  end)
+  (Baz : module type of struct
+    include Bar
+  end) =
 struct end
 
 module Bazoinks = struct
@@ -5428,11 +5433,12 @@ module F (X : sig end) = struct
   module N' = N
 end
 
-module G : functor (X : sig end) -> sig
-  module N' : sig
-    val x : int
-  end
-end =
+module G :
+  functor (X : sig end) -> sig
+    module N' : sig
+      val x : int
+    end
+  end =
   F
 
 module M5 = G (struct end);;
@@ -5602,11 +5608,13 @@ module M = struct
   type t = Y.t
 end
 
-module F (Y : sig
-  type t
-end) (M : sig
-  type t = Y.t
-end) =
+module F
+  (Y : sig
+    type t
+  end)
+  (M : sig
+    type t = Y.t
+  end) =
 struct end
 
 module G = F (M.Y)
@@ -7158,8 +7166,9 @@ type 'a tree =
   | E
   | N of 'a tree * 'a * 'a tree
 
-module Bootstrap2 (MakeDiet : functor (X : ORD) ->
-  SET with type t = X.t tree and type elt = X.t) : SET with type elt = int = struct
+module Bootstrap2
+  (MakeDiet : functor (X : ORD) -> SET with type t = X.t tree and type elt = X.t) :
+  SET with type elt = int = struct
   type elt = int
 
   module rec Elt : sig
@@ -7591,9 +7600,9 @@ module type HEAP = sig
   val deleteMin : heap -> heap
 end
 
-module Bootstrap (MakeH : functor (Element : ORDERED) ->
-  HEAP with module Elem = Element)
-(Element : ORDERED) : HEAP with module Elem = Element = struct
+module Bootstrap
+  (MakeH : functor (Element : ORDERED) -> HEAP with module Elem = Element)
+  (Element : ORDERED) : HEAP with module Elem = Element = struct
   module Elem = Element
 
   module rec BE : sig
@@ -8297,8 +8306,9 @@ module type BARECODE = sig
 end
 
 module USERCODE (X : TYPEVIEW) = struct
-  module type F = functor (C : CORE with type V.usert = X.combined) ->
-    BARECODE with type state := C.V.state
+  module type F =
+    functor (C : CORE with type V.usert = X.combined) ->
+      BARECODE with type state := C.V.state
 end
 
 module Weapon = struct

--- a/test/passing/tests/module.ml
+++ b/test/passing/tests/module.ml
@@ -116,3 +116,43 @@ let _ =
         N with type t = t (* ff *) )
   in
   ()
+
+module F1
+    (G : functor (_ : T) -> T)
+    (A : sig
+      val x : int
+    end) =
+struct end
+
+module F2
+    (G :
+      functor (_ : T) ->
+        T_________________________________________________________________________)
+    (A : sig
+      val x : int
+    end) =
+struct end
+
+module F3
+    (G :
+      functor
+        (_ : T____________________________________________)
+        (_ : T____________________________________________)
+        -> T)
+    (A : sig
+      val x : int
+    end) =
+struct end
+
+module M = struct
+  module M (F : sig end) (X : sig end) = struct end
+end
+
+module M = struct
+  module F
+      (X : sig
+        module type T
+      end)
+      (Res : X.T) =
+  Res
+  end

--- a/test/passing/tests/module.ml.err
+++ b/test/passing/tests/module.ml.err
@@ -1,0 +1,1 @@
+Warning: tests/module.ml:129 exceeds the margin

--- a/test/passing/tests/module_type.ml
+++ b/test/passing/tests/module_type.ml
@@ -72,16 +72,17 @@ module type S = sig
   exception E
 end
 
-module type S' = functor
-  (A : A)
-  (B : sig
-     type t
-   end)
-  (Cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-   : sig
-     type t
-   end)
-  -> S with type t = B.t
+module type S' =
+  functor
+    (A : A)
+    (B : sig
+       type t
+     end)
+    (Cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+     : sig
+       type t
+     end)
+    -> S with type t = B.t
 
 module M : sig
   include (* foo *) module type of K

--- a/test/passing/tests/module_type.ml.err
+++ b/test/passing/tests/module_type.ml.err
@@ -1,0 +1,1 @@
+Warning: tests/module_type.ml:80 exceeds the margin

--- a/test/passing/tests/shortcut_ext_attr.ml
+++ b/test/passing/tests/shortcut_ext_attr.ml
@@ -79,11 +79,9 @@ type t = [%foo: ((module M)[@foo])]
 module M = (functor [@foo] (M : S) -> (val x) [@foo] (struct end [@foo]))
 
 (* Module type expression *)
-module type S = functor [@foo1]
-  (M : S)
-  -> functor
-  (_ : (module type of M) [@foo2])
-  -> sig end [@foo3]
+module type S =
+  functor [@foo1] (M : S) ->
+    functor (_ : (module type of M) [@foo2]) -> sig end [@foo3]
 
 (* Structure items *)
 let%foo[@foo] x = 4

--- a/test/passing/tests/source.ml.err
+++ b/test/passing/tests/source.ml.err
@@ -1,2 +1,2 @@
-Warning: tests/source.ml:706 exceeds the margin
-Warning: tests/source.ml:2322 exceeds the margin
+Warning: tests/source.ml:704 exceeds the margin
+Warning: tests/source.ml:2320 exceeds the margin

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -183,11 +183,9 @@ type t = [%foo: ((module M)[@foo])]
 module M = (functor [@foo] (M : S) -> (val x) [@foo] (struct end [@foo]))
 
 (* Module type expression *)
-module type S = functor [@foo]
-  (M : S)
-  -> functor
-  (_ : (module type of M) [@foo])
-  -> sig end [@foo]
+module type S =
+  functor [@foo] (M : S) ->
+    functor (_ : (module type of M) [@foo]) -> sig end [@foo]
 
 module type S = functor (_ : S) (_ : S) -> S
 
@@ -2534,11 +2532,13 @@ let f : type a o. ((a -> o) -> o) t -> (a -> o) -> o =
 
 type (_, _) t = A : ('a, 'a) t | B : string -> ('a, 'b) t
 
-module M (A : sig
-  module type T
-end) (B : sig
-  module type T
-end) =
+module M
+    (A : sig
+      module type T
+    end)
+    (B : sig
+      module type T
+    end) =
 struct
   let f : ((module A.T), (module B.T)) t -> string = function B s -> s
 end
@@ -4507,11 +4507,12 @@ let f (module M : S with type t = int) = {M.a= 0}
 
 let flag = ref false
 
-module F (S : sig
-  module type T
-end)
-(A : S.T)
-(B : S.T) =
+module F
+    (S : sig
+      module type T
+    end)
+    (A : S.T)
+    (B : S.T) =
 struct
   module X = (val if !flag then (module A) else (module B) : S.T)
 end
@@ -4560,8 +4561,9 @@ module type PR6513 = sig
     type uri
   end
 
-  module Make : functor (Html5 : T with type 'a wrap = 'a) ->
-    S with type u = < foo: Html5.uri >
+  module Make :
+    functor (Html5 : T with type 'a wrap = 'a) ->
+      S with type u = < foo: Html5.uri >
 end
 
 (* Requires -package tyxml module type PR6513_orig = sig module type S = sig
@@ -4755,11 +4757,13 @@ let _ = f (module A_alias : S with type t = (module A.A_S))
 
 let _ = f (module A_alias) (* doesn't type either *)
 
-module Foo (Bar : sig
-  type a = private [> `A]
-end) (Baz : module type of struct
-  include Bar
-end) =
+module Foo
+    (Bar : sig
+      type a = private [> `A]
+    end)
+    (Baz : module type of struct
+      include Bar
+    end) =
 struct end
 
 module Bazoinks = struct
@@ -5184,11 +5188,12 @@ module F (X : sig end) = struct
   module N' = N
 end
 
-module G : functor (X : sig end) -> sig
-  module N' : sig
-    val x : int
-  end
-end =
+module G :
+  functor (X : sig end) -> sig
+    module N' : sig
+      val x : int
+    end
+  end =
   F
 
 module M5 = G (struct end) ;;
@@ -5360,11 +5365,13 @@ module M = struct
   type t = Y.t
 end
 
-module F (Y : sig
-  type t
-end) (M : sig
-  type t = Y.t
-end) =
+module F
+    (Y : sig
+      type t
+    end)
+    (M : sig
+      type t = Y.t
+    end) =
 struct end
 
 module G = F (M.Y)
@@ -6938,9 +6945,10 @@ end
 
 type 'a tree = E | N of 'a tree * 'a * 'a tree
 
-module Bootstrap2 (MakeDiet : functor (X : ORD) ->
-  SET with type t = X.t tree and type elt = X.t) : SET with type elt = int =
-struct
+module Bootstrap2
+    (MakeDiet :
+      functor (X : ORD) -> SET with type t = X.t tree and type elt = X.t) :
+  SET with type elt = int = struct
   type elt = int
 
   module rec Elt : sig
@@ -7361,9 +7369,9 @@ module type HEAP = sig
   val deleteMin : heap -> heap
 end
 
-module Bootstrap (MakeH : functor (Element : ORDERED) ->
-  HEAP with module Elem = Element)
-(Element : ORDERED) : HEAP with module Elem = Element = struct
+module Bootstrap
+    (MakeH : functor (Element : ORDERED) -> HEAP with module Elem = Element)
+    (Element : ORDERED) : HEAP with module Elem = Element = struct
   module Elem = Element
 
   module rec BE : sig
@@ -8048,8 +8056,9 @@ module type BARECODE = sig
 end
 
 module USERCODE (X : TYPEVIEW) = struct
-  module type F = functor (C : CORE with type V.usert = X.combined) ->
-    BARECODE with type state := C.V.state
+  module type F =
+    functor (C : CORE with type V.usert = X.combined) ->
+      BARECODE with type state := C.V.state
 end
 
 module Weapon = struct


### PR DESCRIPTION
I made some experiments to fix #1678, so far the diff on the conventional profile looks good.
cc @CraigFe since you opened the issue.

The idea is to not put the beginning of the functor on the same line as the module opening if the functor signature is going to be complex, I find it easier to read. Thoughts?

The example of #1678 looks like this:
```ocaml
module F1            
    (G : functor (_ : T) -> T) (A : sig
      val x : int
    end) =
struct end

module F2
    (G : functor (_ : T) ->
           T_________________________________________________________________________
    )
    (A : sig
      val x : int
    end) =
struct end

module F3
    (G : functor
           (_ : T____________________________________________)
           (_ : T____________________________________________)
           ->
           T)
    (A : sig
      val x : int
    end) =
struct end
```