### PR TITLE
Fix a typo in parsetree.mli (ocaml#10573)

### DIFF
--- a/vendor/ocaml-4.13-extended/parsetree.mli
+++ b/vendor/ocaml-4.13-extended/parsetree.mli
@@ -385,7 +385,7 @@ and expression_desc =
   | Pexp_open of open_declaration * expression
         (* M.(E)
            let open M in E
-           let! open M in E *)
+           let open! M in E *)
   | Pexp_letop of letop
         (* let* P = E in E
            let* P = E and* P = E in E *)

--- a/vendor/ocaml-4.13/parsetree.mli
+++ b/vendor/ocaml-4.13/parsetree.mli
@@ -381,7 +381,7 @@ and expression_desc =
   | Pexp_open of open_declaration * expression
         (* M.(E)
            let open M in E
-           let! open M in E *)
+           let open! M in E *)
   | Pexp_letop of letop
         (* let* P = E in E
            let* P = E and* P = E in E *)


### PR DESCRIPTION
Applying https://github.com/ocaml/ocaml/pull/10573