### PR TITLE
Attach location to the underscore of an open record pattern

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1024,17 +1024,12 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
           | _ -> fmt_record_field c ~rhs:(fmt_rhs ~ctx pat) lid1 )
       in
       let p1, p2 = Params.get_record_pat c.conf ~ctx:ctx0 in
-      let fmt_fields =
-        fmt_elements_collection
-          ~last_sep:(not (is_open closed_flag))
-          p1 fmt_field flds
+      let last_sep, fmt_underscore =
+        match closed_flag with
+        | Closed -> (true, noop)
+        | Open loc -> (false, Cmts.fmt c loc p2.wildcard)
       in
-      let fmt_underscore =
-        if is_open closed_flag then
-          opt (Source.loc_of_underscore c.source flds ppat_loc) (fun loc ->
-              Cmts.fmt c loc p2.wildcard )
-        else noop
-      in
+      let fmt_fields = fmt_elements_collection ~last_sep p1 fmt_field flds in
       hvbox_if parens 0
         (Params.parens_if parens c.conf
            (p1.box (fmt_fields $ fmt_underscore)) )

--- a/lib/Loc_tree.ml
+++ b/lib/Loc_tree.ml
@@ -27,9 +27,6 @@ let of_ast fragment ast src =
   in
   let pat m p =
     ( match p.ppat_desc with
-    | Ppat_record (flds, Open) ->
-        Option.iter (Source.loc_of_underscore src flds p.ppat_loc)
-          ~f:(fun loc -> locs := loc :: !locs)
     | Ppat_constant _ -> locs := Source.loc_of_pat_constant src p :: !locs
     | _ -> () ) ;
     Ast_mapper.default_mapper.pat m p

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -14,7 +14,9 @@ module Asttypes = struct
 
   let is_private = function Private -> true | Public -> false
 
-  let is_open = function Open -> true | Closed -> false
+  let is_open : closed_flag -> bool = function
+    | Open -> true
+    | Closed -> false
 
   let is_override = function Override -> true | Fresh -> false
 

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -227,17 +227,6 @@ let extension_using_sugar ~(name : string Location.loc)
 let type_constraint_is_first typ loc =
   Location.compare_start typ.ptyp_loc loc < 0
 
-let loc_of_underscore t flds (ppat_loc : Location.t) =
-  let end_last_field =
-    match List.last flds with
-    | Some (_, p) -> p.ppat_loc.loc_end
-    | None -> ppat_loc.loc_start
-  in
-  let loc_underscore = {ppat_loc with loc_start= end_last_field} in
-  let filter = function Parser.UNDERSCORE -> true | _ -> false in
-  let tokens = tokens_at t ~filter loc_underscore in
-  Option.map (List.hd tokens) ~f:snd
-
 let locs_of_interval source loc =
   let toks =
     tokens_at source loc ~filter:(function

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -76,13 +76,6 @@ val extend_loc_to_include_attributes : Location.t -> attributes -> Location.t
 
 val type_constraint_is_first : core_type -> Location.t -> bool
 
-val loc_of_underscore :
-  t -> ('a * pattern) list -> Location.t -> Location.t option
-(** [loc_of_underscore source fields loc] returns the location of the
-    underscore at the end of the record pattern of location [loc] with fields
-    [fields], if the record pattern is open (it ends with an underscore),
-    otherwise returns [None]. *)
-
 val locs_of_interval : t -> Location.t -> Location.t * Location.t
 (** Given the location of an interval pattern ['a'..'b'], return the
     locations of the constants that represent the bounds (['a'] and ['b']). *)

--- a/vendor/ocaml-4.13-extended/ast_helper.mli
+++ b/vendor/ocaml-4.13-extended/ast_helper.mli
@@ -112,8 +112,8 @@ module Pat:
     val construct: ?loc:loc -> ?attrs:attrs ->
       lid -> (str list * pattern) option -> pattern
     val variant: ?loc:loc -> ?attrs:attrs -> label -> pattern option -> pattern
-    val record: ?loc:loc -> ?attrs:attrs -> (lid * pattern) list -> closed_flag
-                -> pattern
+    val record: ?loc:loc -> ?attrs:attrs -> (lid * pattern) list
+                -> closed_flag_loc -> pattern
     val array: ?loc:loc -> ?attrs:attrs -> pattern list -> pattern
     val list: ?loc:loc -> ?attrs:attrs -> pattern list -> pattern
     val or_: ?loc:loc -> ?attrs:attrs -> pattern -> pattern -> pattern

--- a/vendor/ocaml-4.13-extended/ast_mapper.ml
+++ b/vendor/ocaml-4.13-extended/ast_mapper.ml
@@ -500,7 +500,10 @@ module P = struct
     | Ppat_variant (l, p) -> variant ~loc ~attrs l (map_opt (sub.pat sub) p)
     | Ppat_record (lpl, cf) ->
         record ~loc ~attrs
-               (List.map (map_tuple (map_loc sub) (sub.pat sub)) lpl) cf
+               (List.map (map_tuple (map_loc sub) (sub.pat sub)) lpl)
+               (match cf with
+                | Closed -> Closed
+                | Open loc -> Open (sub.location sub loc))
     | Ppat_array pl -> array ~loc ~attrs (List.map (sub.pat sub) pl)
     | Ppat_list pl -> list ~loc ~attrs (List.map (sub.pat sub) pl)
     | Ppat_or (p1, p2) -> or_ ~loc ~attrs (sub.pat sub p1) (sub.pat sub p2)

--- a/vendor/ocaml-4.13-extended/asttypes.mli
+++ b/vendor/ocaml-4.13-extended/asttypes.mli
@@ -44,6 +44,8 @@ type override_flag = Override | Fresh
 
 type closed_flag = Closed | Open
 
+type closed_flag_loc = Closed | Open of Location.t
+
 type label = string
 
 type arg_label =

--- a/vendor/ocaml-4.13-extended/parser.mly
+++ b/vendor/ocaml-4.13-extended/parser.mly
@@ -1094,8 +1094,8 @@ reversed_bar_llist(X):
 listx(delimiter, X, Y):
 | x = X ioption(delimiter)
     { [x], None }
-| x = X delimiter Y delimiter?
-    { [x], Some (make_loc $loc($3)) }
+| x = X delimiter y = mkloc(Y) delimiter?
+    { [x], Some y }
 | x = X
   delimiter
   tail = listx(delimiter, X, Y)
@@ -2815,7 +2815,7 @@ pattern_comma_list(self):
   listx(SEMI, record_pat_field, UNDERSCORE)
     { let fields, closed = $1 in
       let closed : closed_flag_loc =
-        match closed with Some loc -> Open loc | None -> Closed
+        match closed with Some {loc; _} -> Open loc | None -> Closed
       in
       fields, closed }
 ;

--- a/vendor/ocaml-4.13-extended/parser.mly
+++ b/vendor/ocaml-4.13-extended/parser.mly
@@ -1094,8 +1094,8 @@ reversed_bar_llist(X):
 listx(delimiter, X, Y):
 | x = X ioption(delimiter)
     { [x], None }
-| x = X delimiter y = Y delimiter?
-    { [x], Some y }
+| x = X delimiter Y delimiter?
+    { [x], Some (make_loc $loc($3)) }
 | x = X
   delimiter
   tail = listx(delimiter, X, Y)
@@ -2814,7 +2814,9 @@ pattern_comma_list(self):
 %inline record_pat_content:
   listx(SEMI, record_pat_field, UNDERSCORE)
     { let fields, closed = $1 in
-      let closed = match closed with Some () -> Open | None -> Closed in
+      let closed : closed_flag_loc =
+        match closed with Some loc -> Open loc | None -> Closed
+      in
       fields, closed }
 ;
 %inline record_pat_field:

--- a/vendor/ocaml-4.13-extended/parsetree.mli
+++ b/vendor/ocaml-4.13-extended/parsetree.mli
@@ -228,7 +228,7 @@ and pattern_desc =
         (* `A             (None)
            `A P           (Some P)
          *)
-  | Ppat_record of (Longident.t loc * pattern) list * closed_flag
+  | Ppat_record of (Longident.t loc * pattern) list * closed_flag_loc
         (* { l1=P1; ...; ln=Pn }     (flag = Closed)
            { l1=P1; ...; ln=Pn; _}   (flag = Open)
 

--- a/vendor/ocaml-4.13-extended/pprintast.ml
+++ b/vendor/ocaml-4.13-extended/pprintast.ml
@@ -371,7 +371,7 @@ and core_type1 ctxt f x =
           | Oinherit ct ->
             pp f "@[<hov2>%a@ @]" (core_type ctxt) ct
         in
-        let field_var f : Asttypes.closed_flag -> _ = function
+        let field_var f : Asttypes.closed_flag -> unit = function
           | Asttypes.Closed -> ()
           | Asttypes.Open ->
               match l with
@@ -484,7 +484,7 @@ and simple_pattern ctxt (f:Format.formatter) (x:pattern) : unit =
         begin match closed with
         | Closed ->
             pp f "@[<2>{@;%a@;}@]" (list longident_x_pattern ~sep:";@;") l
-        | Open _ ->
+        | _ ->
             pp f "@[<2>{@;%a;_}@]" (list longident_x_pattern ~sep:";@;") l
         end
     | Ppat_tuple l ->

--- a/vendor/ocaml-4.13-extended/pprintast.ml
+++ b/vendor/ocaml-4.13-extended/pprintast.ml
@@ -371,7 +371,7 @@ and core_type1 ctxt f x =
           | Oinherit ct ->
             pp f "@[<hov2>%a@ @]" (core_type ctxt) ct
         in
-        let field_var f = function
+        let field_var f : Asttypes.closed_flag -> _ = function
           | Asttypes.Closed -> ()
           | Asttypes.Open ->
               match l with
@@ -484,7 +484,7 @@ and simple_pattern ctxt (f:Format.formatter) (x:pattern) : unit =
         begin match closed with
         | Closed ->
             pp f "@[<2>{@;%a@;}@]" (list longident_x_pattern ~sep:";@;") l
-        | _ ->
+        | Open _ ->
             pp f "@[<2>{@;%a;_}@]" (list longident_x_pattern ~sep:";@;") l
         end
     | Ppat_tuple l ->

--- a/vendor/parse-wyc/lib/parser.mly
+++ b/vendor/parse-wyc/lib/parser.mly
@@ -1091,8 +1091,8 @@ reversed_bar_llist(X):
 listx(delimiter, X, Y):
 | x = X ioption(delimiter)
     { [x], None }
-| x = X delimiter y = Y delimiter?
-    { [x], Some y }
+| x = X delimiter Y delimiter?
+    { [x], Some (make_loc $loc($3)) }
 | x = X
   delimiter
   tail = listx(delimiter, X, Y)
@@ -2809,7 +2809,9 @@ pattern_comma_list(self):
 %inline record_pat_content:
   listx(SEMI, record_pat_field, UNDERSCORE)
     { let fields, closed = $1 in
-      let closed = match closed with Some () -> Open | None -> Closed in
+      let closed : closed_flag_loc =
+        match closed with Some loc -> Open loc | None -> Closed
+      in
       fields, closed }
 ;
 %inline record_pat_field:
@@ -3441,7 +3443,7 @@ meth_list:
   | head = inherit_field
       { [head], Closed }
   | DOTDOT
-      { [], Open }
+      { [], (Open : closed_flag) }
 ;
 %inline field:
   mkrhs(label) COLON poly_type_no_attr attributes

--- a/vendor/parse-wyc/lib/parser.mly
+++ b/vendor/parse-wyc/lib/parser.mly
@@ -1091,8 +1091,8 @@ reversed_bar_llist(X):
 listx(delimiter, X, Y):
 | x = X ioption(delimiter)
     { [x], None }
-| x = X delimiter Y delimiter?
-    { [x], Some (make_loc $loc($3)) }
+| x = X delimiter y = mkloc(Y) delimiter?
+    { [x], Some y }
 | x = X
   delimiter
   tail = listx(delimiter, X, Y)
@@ -2810,7 +2810,7 @@ pattern_comma_list(self):
   listx(SEMI, record_pat_field, UNDERSCORE)
     { let fields, closed = $1 in
       let closed : closed_flag_loc =
-        match closed with Some loc -> Open loc | None -> Closed
+        match closed with Some {loc; _} -> Open loc | None -> Closed
       in
       fields, closed }
 ;


### PR DESCRIPTION
Part of the effort to remove the "guessing the loc" code from ocamlformat and leverage more data from the parser.
No behavioral change.