### PR TITLE
Fix excessive break and wrong indentation after a short-open when 'indicate-multiline-delimiters=closing-on-separate-line'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@
 
   + Fix non stabilizing comments after infix operators (`*`, `%`, `#`-ops) (#1776, @gpetiot)
 
+  + Fix excessive break and wrong indentation after a short-open when `indicate-multiline-delimiters=closing-on-separate-line` (#1786, @gpetiot)
+
 #### Changes
 
   + Preserve bracketed lists in the Parsetree (#1694, @gpetiot)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2245,7 +2245,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             fits_breaks ?force cls ""
             $ fits_breaks_if inner_parens ?force "" ")"
         | `Closing_on_separate_line ->
-            fmt_if_k force_fit (break 0 0)
+            fmt_if_k (force_fit && not can_skip_parens) (break 0 0)
             $ fits_breaks ?force cls ""
             $ fits_breaks_if inner_parens ?force "" ~hint:(1000, 0) ")"
       in

--- a/test/passing/tests/open-closing-on-separate-line.ml.ref
+++ b/test/passing/tests/open-closing-on-separate-line.ml.ref
@@ -338,3 +338,14 @@ let _ = M.((f, f) (* B *))
 let _ = M.((* A *) (f, f) (* B *))
 
 let _ = M.((* A *) ((f, f) (* B *) [@warning "foo"] (* C *)))
+
+let _ =
+  let _ =
+    Fooooooo.
+      [ (swap_1_c, {minimum_transfert_amount= 0.})
+      ; (swap_2_c, {minimum_transfert_amount= 0.})
+      ; (swap_3_c, {minimum_transfert_amount= 0.})
+      ]
+    
+  in
+  ()

--- a/test/passing/tests/open-closing-on-separate-line.ml.ref
+++ b/test/passing/tests/open-closing-on-separate-line.ml.ref
@@ -346,6 +346,5 @@ let _ =
       ; (swap_2_c, {minimum_transfert_amount= 0.})
       ; (swap_3_c, {minimum_transfert_amount= 0.})
       ]
-    
   in
   ()

--- a/test/passing/tests/open.ml
+++ b/test/passing/tests/open.ml
@@ -263,3 +263,14 @@ let _ = M.((f, f ) (* B *))
 let _ = M.((* A *) (f, f) (* B *))
 
 let _ = M.((* A *) (f, f) (* B *) [@warning "foo"] (* C *))
+
+let _ =
+  let _ =
+    Fooooooo.
+      [
+        (swap_1_c, { minimum_transfert_amount = 0. });
+        (swap_2_c, { minimum_transfert_amount = 0. });
+        (swap_3_c, { minimum_transfert_amount = 0. });
+      ]
+  in
+  ()

--- a/test/passing/tests/open.ml.ref
+++ b/test/passing/tests/open.ml.ref
@@ -328,3 +328,12 @@ let _ = M.((f, f) (* B *))
 let _ = M.((* A *) (f, f) (* B *))
 
 let _ = M.((* A *) ((f, f) (* B *) [@warning "foo"] (* C *)))
+
+let _ =
+  let _ =
+    Fooooooo.
+      [ (swap_1_c, {minimum_transfert_amount= 0.})
+      ; (swap_2_c, {minimum_transfert_amount= 0.})
+      ; (swap_3_c, {minimum_transfert_amount= 0.}) ]
+  in
+  ()


### PR DESCRIPTION
Fix #1762
Fix #1789

Here is the diff with the main profiles with `indicate-multiline-delimiters=closing-on-separate-line`:

# `ocamlformat` profile:

<details>

```diff
diff --git a/infer/src/backend/ondemand.ml b/infer/src/backend/ondemand.ml
index f1e199651..561895a93 100644
--- a/infer/src/backend/ondemand.ml
+++ b/infer/src/backend/ondemand.ml
@@ -205,7 +205,6 @@ let run_proc_analysis exe_env ~caller_pdesc callee_pdesc =
         Some
           BiabductionSummary.
             {preposts= []; phase= summary.payloads.biabduction |> opt_get_phase}
-          
       in
       {summary.payloads with biabduction}
     in
diff --git a/infer/src/base/Config.ml b/infer/src/base/Config.ml
index 75321cd2f..1e85546d8 100644
--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -1200,7 +1200,6 @@ and ( biabduction_write_dotty
           ; (Report, manual_generic)
           ; (ReportDiff, manual_generic)
           ]
-        
       "Apply issue-specific deduplication during analysis and/or reporting."
   and debug_level_analysis =
     CLOpt.mk_int ~long:"debug-level-analysis" ~default:0
@@ -1335,7 +1334,6 @@ and ( biabduction_write_dotty
           ; (Run, manual_generic)
           ; (Report, manual_generic)
           ]
-        
       "Also log messages to stdout and stderr"
   in
   let linters_developer_mode =
@@ -1553,7 +1551,6 @@ and force_delete_results_dir =
         ; (Compile, manual_generic)
         ; (Run, manual_generic)
         ]
-      
     "Do not refuse to delete the results directory if it doesn't look like an \
      infer results directory."
 
@@ -1706,7 +1703,6 @@ and issues_tests_fields =
         ; BugTrace
         ; NullsafeExtra
         ]
-      
     ~symbols:IssuesTestField.all_symbols ~eq:IssuesTestField.equal
     "Fields to emit with $(b,--issues-tests)"
 
@@ -2086,7 +2082,6 @@ and project_root =
         ; (Run, manual_generic)
         ; (Report, manual_generic)
         ]
-      
     ~meta:"dir" "Specify the root directory of the project"
 
 and pulse_cut_to_one_path_procedures_pattern =
@@ -2387,7 +2382,6 @@ and results_dir =
         ; (Run, manual_generic)
         ; (Report, manual_generic)
         ]
-      
     ~meta:"dir" "Write results and internal files in the specified directory"
 
 and scheduler =
@@ -2553,7 +2547,6 @@ and sqlite_cache_size =
         ; (Capture, manual_generic)
         ; (Run, manual_generic)
         ]
-      
     "SQLite cache size in pages (if positive) or kB (if negative), follows \
      formal of corresponding SQLite PRAGMA."
 
@@ -2565,7 +2558,6 @@ and sqlite_page_size =
         ; (Capture, manual_generic)
         ; (Run, manual_generic)
         ]
-      
     "SQLite page size in bytes, must be a power of two between 512 and 65536."
 
 and sqlite_lock_timeout =
@@ -2581,7 +2573,6 @@ and sqlite_lock_timeout =
         ; (Capture, manual_generic)
         ; (Run, manual_generic)
         ]
-      
     "Timeout for SQLite results database operations, in milliseconds."
 
 and sqlite_vfs =
diff --git a/infer/src/biabduction/Tabulation.ml b/infer/src/biabduction/Tabulation.ml
index a7438b470..fac4ffc88 100644
--- a/infer/src/biabduction/Tabulation.ml
+++ b/infer/src/biabduction/Tabulation.ml
@@ -107,7 +107,6 @@ let spec_rename_vars pname spec =
   in
   BiabductionSummary.
     {pre= pre''; posts= posts''; visited= spec.BiabductionSummary.visited}
-  
 
 (** Find and number the specs for [proc_attrs], after renaming their vars, and also return the
     parameters *)
diff --git a/infer/src/biabduction/interproc.ml b/infer/src/biabduction/interproc.ml
index 5c0964927..18e260179 100644
--- a/infer/src/biabduction/interproc.ml
+++ b/infer/src/biabduction/interproc.ml
@@ -604,7 +604,6 @@ let extract_specs ({InterproceduralAnalysis.tenv; _} as analysis_data) pdesc
   let mk_spec (pre, posts) =
     BiabductionSummary.
       {pre= Jprop.Prop (1, pre); posts; visited= Visitedset.empty}
-    
   in
   List.map ~f:mk_spec pre_post_list
 
diff --git a/infer/src/clang/cField_decl.ml b/infer/src/clang/cField_decl.ml
index 18375c863..7df5c3670 100644
--- a/infer/src/clang/cField_decl.ml
+++ b/infer/src/clang/cField_decl.ml
@@ -48,7 +48,6 @@ let build_sil_field qual_type_to_sil_type tenv class_tname ni_name qual_type
       ~f:(fun att ->
         Annot.
           {name= None; value= Str (Clang_ast_j.string_of_property_attribute att)}
-        
       )
       prop_attributes
   in
diff --git a/infer/src/clang/cTrans.ml b/infer/src/clang/cTrans.ml
index be121e048..b0e44f518 100644
--- a/infer/src/clang/cTrans.ml
+++ b/infer/src/clang/cTrans.ml
@@ -237,7 +237,6 @@ struct
         ; is_constexpr= false
         ; is_declared_unused= false
         }
-      
     in
     Procdesc.append_locals procdesc [var_data] ;
     (Exp.Lvar pvar, typ)
@@ -1748,7 +1747,6 @@ struct
                   ; is_constexpr= false
                   ; is_declared_unused= false
                   }
-                
               in
               Procdesc.append_locals context.procdesc [var_data] ;
               `Temp pvar
@@ -2655,7 +2653,6 @@ struct
               ; is_constexpr= false
               ; is_declared_unused= false
               }
-            
           in
           Procdesc.append_locals procdesc [var_data] ;
           `Temp pvar
diff --git a/infer/src/concurrency/starvation.ml b/infer/src/concurrency/starvation.ml
index 4101163e7..c24e56928 100644
--- a/infer/src/concurrency/starvation.ml
+++ b/infer/src/concurrency/starvation.ml
@@ -631,7 +631,6 @@ end = struct
       ; strict_mode_violation
       ; arbitrary_code_execution_under_lock
       ]
-    
 
   let issue_log_of loc_map =
     let log_report loc issue_log {issue_type; pname; ltr; message} =
diff --git a/infer/src/cost/ConfigImpactAnalysis.ml b/infer/src/cost/ConfigImpactAnalysis.ml
index 93ffef5e7..bb17b7555 100644
--- a/infer/src/cost/ConfigImpactAnalysis.ml
+++ b/infer/src/cost/ConfigImpactAnalysis.ml
@@ -875,7 +875,6 @@ module TransferFunctions = struct
               ; args
               ; ret
               }
-            
           in
           let instantiated_cost = get_instantiated_cost call in
           Dom.call tenv analyze_dependency ~instantiated_cost ~callee args
diff --git a/infer/src/infer.ml b/infer/src/infer.ml
index f54e92f75..c27e79a08 100644
--- a/infer/src/infer.ml
+++ b/infer/src/infer.ml
@@ -259,7 +259,6 @@ let () =
             , config_impact_current
             , config_impact_previous
             )
-          
         with
       | None, None, None, None, None, None ->
           L.die UserError
diff --git a/infer/src/nullsafe/ClassLevelAnalysis.ml b/infer/src/nullsafe/ClassLevelAnalysis.ml
index 3abf94128..2ad1e370e 100644
--- a/infer/src/nullsafe/ClassLevelAnalysis.ml
+++ b/infer/src/nullsafe/ClassLevelAnalysis.ml
@@ -16,7 +16,6 @@ let log_issue ?proc_name ~issue_log ~loc ~severity ~nullsafe_extra issue_type
       ; cost_polynomial= None
       ; cost_degree= None
       }
-    
   in
   let proc_name =
     Option.value proc_name ~default:Procname.Linters_dummy_method
@@ -120,7 +119,6 @@ let make_meta_issue modes_and_issues top_level_class_mode top_level_class_name =
       ; curr_nullsafe_mode= mode_to_json top_level_class_mode
       ; can_be_promoted_to= Option.map mode_to_promote_to ~f:mode_to_json
       }
-    
   in
   let issue_type, description, severity =
     if NullsafeMode.equal top_level_class_mode Default then
@@ -220,7 +218,6 @@ let report_meta_issue_for_top_level_class tenv source_file class_name
         ; field= None
         ; annotation_graph= None
         }
-      
     in
     log_issue ~issue_log ~loc:class_loc ~severity ~nullsafe_extra issue_type
       description
@@ -257,7 +254,6 @@ let analyze_nullsafe_annotations tenv source_file class_name class_struct
       ; field= None
       ; annotation_graph= None
       }
-    
   in
   match NullsafeMode.check_problematic_class_annotation tenv class_name with
   | Ok () ->
@@ -314,7 +310,6 @@ let report_annotation_graph source_file class_name class_struct annotation_graph
       ; field= None
       ; annotation_graph= Some annotation_graph
       }
-    
   in
   log_issue ~issue_log ~loc:class_loc ~severity:IssueType.Info ~nullsafe_extra
     IssueType.eradicate_annotation_graph ""
diff --git a/infer/src/nullsafe/NullsafeIssue.ml b/infer/src/nullsafe/NullsafeIssue.ml
index ce2932ef3..e75d3eef7 100644
--- a/infer/src/nullsafe/NullsafeIssue.ml
+++ b/infer/src/nullsafe/NullsafeIssue.ml
@@ -104,7 +104,6 @@ let to_nullable_method_json nullable_methods =
         ; package= Procname.Java.get_package pname |> Option.value ~default:""
         ; call_line= call_loc.Location.line
         }
-      
   )
 
 let java_type_to_string java_type =
@@ -122,7 +121,6 @@ let parameter_not_nullable_info_to_json {param_index; proc_name} :
       { name= Procname.Java.get_method proc_name
       ; params= get_params_string_list proc_name
       }
-    
   in
   Jsonbug_t.{class_name; package_name; method_info; param_index}
 
@@ -160,7 +158,6 @@ let get_nullsafe_extra
           ; package_name= JavaClassName.package java_class_name
           ; field
           }
-        
     )
   in
   let method_params = get_params_string_list proc_name in
@@ -183,4 +180,3 @@ let get_nullsafe_extra
     ; field
     ; annotation_graph= None
     }
-  
diff --git a/infer/src/nullsafe/typeCheck.ml b/infer/src/nullsafe/typeCheck.ml
index fcbd2f9e1..dc2d9a963 100644
--- a/infer/src/nullsafe/typeCheck.ml
+++ b/infer/src/nullsafe/typeCheck.ml
@@ -1204,7 +1204,6 @@ let calc_typestate_after_call
     in
     EradicateChecks.
       {param_index; formal= formal_param; actual; is_formal_propagates_nullable}
-    
   in
   (* Infer nullability of function call result based on its signature *)
   let preliminary_resolved_ret =
diff --git a/infer/src/pulse/Pulse.ml b/infer/src/pulse/Pulse.ml
index 6bf2a5535..84b110c34 100644
--- a/infer/src/pulse/Pulse.ml
+++ b/infer/src/pulse/Pulse.ml
@@ -167,7 +167,6 @@ module PulseTransferFunctions = struct
           ( astate
           , ProcnameDispatcher.Call.FuncArg.
               {exp= actual_exp; arg_payload= actual_evaled; typ= actual_typ}
-            
             :: rev_func_args
           )
       )
diff --git a/infer/src/unit/JavaProfilerSamplesTest.ml b/infer/src/unit/JavaProfilerSamplesTest.ml
index f802f36b3..26d5366c4 100644
--- a/infer/src/unit/JavaProfilerSamplesTest.ml
+++ b/infer/src/unit/JavaProfilerSamplesTest.ml
@@ -96,7 +96,6 @@ let test_jni_parse_str_with_valid_input =
             , Array Char
             )
         ]
-      
     )
   ; ( "test_jni_parse_str_with_multiple_separate_types"
     , "I[[[CIJ(I)[C"
diff --git a/sledge/report/sledge_report.ml b/sledge/report/sledge_report.ml
index 94e13c892..52c624919 100644
--- a/sledge/report/sledge_report.ml
+++ b/sledge/report/sledge_report.ml
@@ -78,7 +78,6 @@ let add_gc base_gcs gc row =
           ; promoted= gc.promoted -. bgc.promoted
           ; peak_size= gc.peak_size -. bgc.peak_size
           }
-        
         :: gcs_deltas
     )
   in
@@ -101,7 +100,6 @@ let add_cov base_cov cov row =
               ; fraction= cov.fraction -. base_cov.fraction
               ; solver_steps= cov.solver_steps - base_cov.solver_steps
               }
-            
           in
           Some (covd :: Option.value row.cov_deltas ~default:[])
       | _ ->
@@ -197,7 +195,6 @@ let combine name b_result c_result =
                 ; promoted= ave_floats promos
                 ; peak_size= ave_floats peaks
                 }
-              
         in
         let covs = if List.is_empty covs then None else Some covs in
         let status =
@@ -629,7 +626,6 @@ let average row =
           ; promoted= ave_floats promo
           ; peak_size= ave_floats peak
           }
-        
   in
   let gcs = ave_gcs row.gcs in
   let gcs_deltas = ave_gcs row.gcs_deltas in
@@ -681,7 +677,6 @@ let add_total rows =
                   ; promoted= total_gcs.promoted +. row_gcs.promoted
                   ; peak_size= total_gcs.peak_size +. row_gcs.peak_size
                   }
-                
           | _ ->
               total.gcs
         in
@@ -694,7 +689,6 @@ let add_total rows =
                   ; promoted= total_deltas.promoted +. row_deltas.promoted
                   ; peak_size= total_deltas.peak_size +. row_deltas.peak_size
                   }
-                
           | _ ->
               total.gcs_deltas
         in
diff --git a/compiler/lib-runtime/jsoo_runtime.ml b/compiler/lib-runtime/jsoo_runtime.ml
index 41fc732331..ad0816f2f7 100644
--- a/compiler/lib-runtime/jsoo_runtime.ml
+++ b/compiler/lib-runtime/jsoo_runtime.ml
@@ -53,6 +53,5 @@ let runtime =
     ; unix
     ; weak
     ]
-  
 
 include Files
diff --git a/src/dune_engine/action_exec.ml b/src/dune_engine/action_exec.ml
index a77f30734..d7f3f07a3 100644
--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -137,7 +137,6 @@ let exec_run_dynamic_client ~ectx ~eenv prog args =
     in
     DAP.Run_arguments.
       {prepared_dependencies= eenv.prepared_dependencies; targets}
-    
   in
   Io.write_file run_arguments_fn (DAP.Run_arguments.serialize run_arguments) ;
   let env =
```

</details>

# `conventional` profile:

<details>

```diff
diff --git a/infer/src/backend/ondemand.ml b/infer/src/backend/ondemand.ml
index db18ad538..b04307073 100644
--- a/infer/src/backend/ondemand.ml
+++ b/infer/src/backend/ondemand.ml
@@ -206,7 +206,6 @@ let run_proc_analysis exe_env ~caller_pdesc callee_pdesc =
               preposts = [];
               phase = summary.payloads.biabduction |> opt_get_phase;
             }
-          
       in
 
       { summary.payloads with biabduction }
diff --git a/infer/src/base/Config.ml b/infer/src/base/Config.ml
index d15c0377b..49dd8211e 100644
--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -1195,7 +1195,6 @@ and ( biabduction_write_dotty,
             (Report, manual_generic);
             (ReportDiff, manual_generic);
           ]
-        
       "Apply issue-specific deduplication during analysis and/or reporting."
   and debug_level_analysis =
     CLOpt.mk_int ~long:"debug-level-analysis" ~default:0
@@ -1335,7 +1334,6 @@ and ( biabduction_write_dotty,
             (Run, manual_generic);
             (Report, manual_generic);
           ]
-        
       "Also log messages to stdout and stderr"
   in
   let linters_developer_mode =
@@ -1554,7 +1552,6 @@ and force_delete_results_dir =
           (Compile, manual_generic);
           (Run, manual_generic);
         ]
-      
     "Do not refuse to delete the results directory if it doesn't look like an \
      infer results directory."
 
@@ -1711,7 +1708,6 @@ and issues_tests_fields =
           BugTrace;
           NullsafeExtra;
         ]
-      
     ~symbols:IssuesTestField.all_symbols ~eq:IssuesTestField.equal
     "Fields to emit with $(b,--issues-tests)"
 
@@ -2095,7 +2091,6 @@ and project_root =
           (Run, manual_generic);
           (Report, manual_generic);
         ]
-      
     ~meta:"dir" "Specify the root directory of the project"
 
 and pulse_cut_to_one_path_procedures_pattern =
@@ -2397,7 +2392,6 @@ and results_dir =
           (Run, manual_generic);
           (Report, manual_generic);
         ]
-      
     ~meta:"dir" "Write results and internal files in the specified directory"
 
 and scheduler =
@@ -2566,7 +2560,6 @@ and sqlite_cache_size =
           (Capture, manual_generic);
           (Run, manual_generic);
         ]
-      
     "SQLite cache size in pages (if positive) or kB (if negative), follows \
      formal of corresponding SQLite PRAGMA."
 
@@ -2579,7 +2572,6 @@ and sqlite_page_size =
           (Capture, manual_generic);
           (Run, manual_generic);
         ]
-      
     "SQLite page size in bytes, must be a power of two between 512 and 65536."
 
 and sqlite_lock_timeout =
@@ -2596,7 +2588,6 @@ and sqlite_lock_timeout =
           (Capture, manual_generic);
           (Run, manual_generic);
         ]
-      
     "Timeout for SQLite results database operations, in milliseconds."
 
 and sqlite_vfs =
diff --git a/infer/src/biabduction/Tabulation.ml b/infer/src/biabduction/Tabulation.ml
index 32457a4bd..c54593743 100644
--- a/infer/src/biabduction/Tabulation.ml
+++ b/infer/src/biabduction/Tabulation.ml
@@ -105,7 +105,6 @@ let spec_rename_vars pname spec =
   in
   BiabductionSummary.
     { pre = pre''; posts = posts''; visited = spec.BiabductionSummary.visited }
-  
 
 (** Find and number the specs for [proc_attrs], after renaming their vars, and also return the
     parameters *)
diff --git a/infer/src/biabduction/interproc.ml b/infer/src/biabduction/interproc.ml
index 77c678d87..4bb0affa1 100644
--- a/infer/src/biabduction/interproc.ml
+++ b/infer/src/biabduction/interproc.ml
@@ -601,7 +601,6 @@ let extract_specs ({ InterproceduralAnalysis.tenv; _ } as analysis_data) pdesc
   let mk_spec (pre, posts) =
     BiabductionSummary.
       { pre = Jprop.Prop (1, pre); posts; visited = Visitedset.empty }
-    
   in
 
   List.map ~f:mk_spec pre_post_list
diff --git a/infer/src/clang/cField_decl.ml b/infer/src/clang/cField_decl.ml
index bfc3aa9d0..df92be378 100644
--- a/infer/src/clang/cField_decl.ml
+++ b/infer/src/clang/cField_decl.ml
@@ -47,7 +47,6 @@ let build_sil_field qual_type_to_sil_type tenv class_tname ni_name qual_type
             name = None;
             value = Str (Clang_ast_j.string_of_property_attribute att);
           }
-        
       )
       prop_attributes
   in
diff --git a/infer/src/clang/cTrans.ml b/infer/src/clang/cTrans.ml
index a70d254ca..9fa598905 100644
--- a/infer/src/clang/cTrans.ml
+++ b/infer/src/clang/cTrans.ml
@@ -231,7 +231,6 @@ struct
           is_constexpr = false;
           is_declared_unused = false;
         }
-      
     in
 
     Procdesc.append_locals procdesc [ var_data ];
@@ -1771,7 +1770,6 @@ struct
                     is_constexpr = false;
                     is_declared_unused = false;
                   }
-                
               in
 
               Procdesc.append_locals context.procdesc [ var_data ];
@@ -2686,7 +2684,6 @@ struct
                 is_constexpr = false;
                 is_declared_unused = false;
               }
-            
           in
 
           Procdesc.append_locals procdesc [ var_data ];
diff --git a/infer/src/concurrency/starvation.ml b/infer/src/concurrency/starvation.ml
index de958829b..d340b7b6a 100644
--- a/infer/src/concurrency/starvation.ml
+++ b/infer/src/concurrency/starvation.ml
@@ -605,7 +605,6 @@ end = struct
         strict_mode_violation;
         arbitrary_code_execution_under_lock;
       ]
-    
 
   let issue_log_of loc_map =
     let log_report loc issue_log { issue_type; pname; ltr; message } =
diff --git a/infer/src/cost/ConfigImpactAnalysis.ml b/infer/src/cost/ConfigImpactAnalysis.ml
index d02b57a01..d2a398b4c 100644
--- a/infer/src/cost/ConfigImpactAnalysis.ml
+++ b/infer/src/cost/ConfigImpactAnalysis.ml
@@ -868,7 +868,6 @@ module TransferFunctions = struct
                   args;
                   ret;
                 }
-              
             in
 
             let instantiated_cost = get_instantiated_cost call in
diff --git a/infer/src/infer.ml b/infer/src/infer.ml
index 9721fc2a3..cd01c8776 100644
--- a/infer/src/infer.ml
+++ b/infer/src/infer.ml
@@ -242,7 +242,6 @@ let () =
               config_impact_current,
               config_impact_previous
             )
-          
         with
       | None, None, None, None, None, None ->
           L.die UserError
diff --git a/infer/src/nullsafe/ClassLevelAnalysis.ml b/infer/src/nullsafe/ClassLevelAnalysis.ml
index 440ca52bc..068a7f3bd 100644
--- a/infer/src/nullsafe/ClassLevelAnalysis.ml
+++ b/infer/src/nullsafe/ClassLevelAnalysis.ml
@@ -17,7 +17,6 @@ let log_issue ?proc_name ~issue_log ~loc ~severity ~nullsafe_extra issue_type
         cost_polynomial = None;
         cost_degree = None;
       }
-    
   in
 
   let proc_name =
@@ -117,7 +116,6 @@ let make_meta_issue modes_and_issues top_level_class_mode top_level_class_name =
         curr_nullsafe_mode = mode_to_json top_level_class_mode;
         can_be_promoted_to = Option.map mode_to_promote_to ~f:mode_to_json;
       }
-    
   in
 
   let issue_type, description, severity =
@@ -219,7 +217,6 @@ let report_meta_issue_for_top_level_class tenv source_file class_name
           field = None;
           annotation_graph = None;
         }
-      
     in
 
     log_issue ~issue_log ~loc:class_loc ~severity ~nullsafe_extra issue_type
@@ -258,7 +255,6 @@ let analyze_nullsafe_annotations tenv source_file class_name class_struct
         field = None;
         annotation_graph = None;
       }
-    
   in
 
   match NullsafeMode.check_problematic_class_annotation tenv class_name with
@@ -316,7 +312,6 @@ let report_annotation_graph source_file class_name class_struct annotation_graph
         field = None;
         annotation_graph = Some annotation_graph;
       }
-    
   in
 
   log_issue ~issue_log ~loc:class_loc ~severity:IssueType.Info ~nullsafe_extra
diff --git a/infer/src/nullsafe/NullsafeIssue.ml b/infer/src/nullsafe/NullsafeIssue.ml
index dcd47bc49..50151fac4 100644
--- a/infer/src/nullsafe/NullsafeIssue.ml
+++ b/infer/src/nullsafe/NullsafeIssue.ml
@@ -105,7 +105,6 @@ let to_nullable_method_json nullable_methods =
           package = Procname.Java.get_package pname |> Option.value ~default:"";
           call_line = call_loc.Location.line;
         }
-      
   )
 
 let java_type_to_string java_type =
@@ -124,7 +123,6 @@ let parameter_not_nullable_info_to_json { param_index; proc_name } :
         name = Procname.Java.get_method proc_name;
         params = get_params_string_list proc_name;
       }
-    
   in
 
   Jsonbug_t.{ class_name; package_name; method_info; param_index }
@@ -165,14 +163,12 @@ let get_nullsafe_extra
             package_name = JavaClassName.package java_class_name;
             field;
           }
-        
     )
   in
   let method_params = get_params_string_list proc_name in
   let method_info =
     Jsonbug_t.
       { name = Procname.Java.get_method proc_name; params = method_params }
-    
   in
 
   let parameter_not_nullable_info =
@@ -192,4 +188,3 @@ let get_nullsafe_extra
       field;
       annotation_graph = None;
     }
-  
diff --git a/infer/src/nullsafe/typeCheck.ml b/infer/src/nullsafe/typeCheck.ml
index b19eee481..3f5d75892 100644
--- a/infer/src/nullsafe/typeCheck.ml
+++ b/infer/src/nullsafe/typeCheck.ml
@@ -1153,7 +1153,6 @@ let calc_typestate_after_call
         actual;
         is_formal_propagates_nullable;
       }
-    
   in
 
   (* Infer nullability of function call result based on its signature *)
diff --git a/infer/src/pulse/Pulse.ml b/infer/src/pulse/Pulse.ml
index 4a2b2db30..cc94ff40b 100644
--- a/infer/src/pulse/Pulse.ml
+++ b/infer/src/pulse/Pulse.ml
@@ -159,7 +159,6 @@ module PulseTransferFunctions = struct
                 arg_payload = actual_evaled;
                 typ = actual_typ;
               }
-            
             :: rev_func_args
           )
       )
diff --git a/infer/src/unit/JavaProfilerSamplesTest.ml b/infer/src/unit/JavaProfilerSamplesTest.ml
index 87402c0a3..57066ee2a 100644
--- a/infer/src/unit/JavaProfilerSamplesTest.ml
+++ b/infer/src/unit/JavaProfilerSamplesTest.ml
@@ -102,7 +102,6 @@ let test_jni_parse_str_with_valid_input =
               Array Char
             );
         ]
-      
     );
     ( "test_jni_parse_str_with_multiple_separate_types",
       "I[[[CIJ(I)[C",
@@ -114,7 +113,6 @@ let test_jni_parse_str_with_valid_input =
           Long;
           Method ([ Int ], Array Char);
         ]
-      
     );
     ( "test_jni_parse_str_with_multiple_fully_qualified_classes",
       "(Laaa/bbb/Ccc;Laaa/bbb/Ccc;)V",
diff --git a/sledge/report/sledge_report.ml b/sledge/report/sledge_report.ml
index 9cfb34142..8f29689bd 100644
--- a/sledge/report/sledge_report.ml
+++ b/sledge/report/sledge_report.ml
@@ -77,7 +77,6 @@ let add_gc base_gcs gc row =
             promoted = gc.promoted -. bgc.promoted;
             peak_size = gc.peak_size -. bgc.peak_size;
           }
-        
         :: gcs_deltas
     )
   in
@@ -101,7 +100,6 @@ let add_cov base_cov cov row =
                 fraction = cov.fraction -. base_cov.fraction;
                 solver_steps = cov.solver_steps - base_cov.solver_steps;
               }
-            
           in
 
           Some (covd :: Option.value row.cov_deltas ~default:[])
@@ -199,7 +197,6 @@ let combine name b_result c_result =
                   promoted = ave_floats promos;
                   peak_size = ave_floats peaks;
                 }
-              
         in
 
         let covs = if List.is_empty covs then None else Some covs in
@@ -631,7 +628,6 @@ let average row =
             promoted = ave_floats promo;
             peak_size = ave_floats peak;
           }
-        
   in
 
   let gcs = ave_gcs row.gcs in
@@ -686,7 +682,6 @@ let add_total rows =
                     promoted = total_gcs.promoted +. row_gcs.promoted;
                     peak_size = total_gcs.peak_size +. row_gcs.peak_size;
                   }
-                
           | _ -> total.gcs
         in
         let gcs_deltas =
@@ -699,7 +694,6 @@ let add_total rows =
                     promoted = total_deltas.promoted +. row_deltas.promoted;
                     peak_size = total_deltas.peak_size +. row_deltas.peak_size;
                   }
-                
           | _ -> total.gcs_deltas
         in
         let status_deltas =
diff --git a/compiler/lib-runtime/jsoo_runtime.ml b/compiler/lib-runtime/jsoo_runtime.ml
index acf4b25cf2..f733ef75e9 100644
--- a/compiler/lib-runtime/jsoo_runtime.ml
+++ b/compiler/lib-runtime/jsoo_runtime.ml
@@ -54,6 +54,5 @@ let runtime =
       unix;
       weak;
     ]
-  
 
 include Files
diff --git a/src/dune_engine/action_exec.ml b/src/dune_engine/action_exec.ml
index 1eb48ffd3..e2949e1fd 100644
--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -128,7 +128,6 @@ let exec_run_dynamic_client ~ectx ~eenv prog args =
     in
     DAP.Run_arguments.
       { prepared_dependencies = eenv.prepared_dependencies; targets }
-    
   in
 
   Io.write_file run_arguments_fn (DAP.Run_arguments.serialize run_arguments);
```

</details>

# `janestreet` profile:

<details>

```diff
diff --git a/infer/src/backend/ondemand.ml b/infer/src/backend/ondemand.ml
index 6ef4de3e6..a814b1c61 100644
--- a/infer/src/backend/ondemand.ml
+++ b/infer/src/backend/ondemand.ml
@@ -218,7 +218,6 @@ let run_proc_analysis exe_env ~caller_pdesc callee_pdesc =
         Some
           BiabductionSummary.
             { preposts = []; phase = summary.payloads.biabduction |> opt_get_phase }
-          
       in
       { summary.payloads with biabduction }
     in
diff --git a/infer/src/base/Config.ml b/infer/src/base/Config.ml
index 38c276230..cd787b606 100644
--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -1294,7 +1294,6 @@ and ( biabduction_write_dotty
       ~in_help:
         InferCommand.
           [ Analyze, manual_generic; Report, manual_generic; ReportDiff, manual_generic ]
-        
       "Apply issue-specific deduplication during analysis and/or reporting."
   and debug_level_analysis =
     CLOpt.mk_int
@@ -1451,7 +1450,6 @@ and ( biabduction_write_dotty
           ; Run, manual_generic
           ; Report, manual_generic
           ]
-        
       "Also log messages to stdout and stderr"
   in
   let linters_developer_mode =
@@ -1683,7 +1681,6 @@ and force_delete_results_dir =
     ~in_help:
       InferCommand.
         [ Capture, manual_generic; Compile, manual_generic; Run, manual_generic ]
-      
     "Do not refuse to delete the results directory if it doesn't look like an infer \
      results directory."
 
@@ -1863,7 +1860,6 @@ and issues_tests_fields =
         ; BugTrace
         ; NullsafeExtra
         ]
-      
     ~symbols:IssuesTestField.all_symbols
     ~eq:IssuesTestField.equal
     "Fields to emit with $(b,--issues-tests)"
@@ -2333,7 +2329,6 @@ and project_root =
         ; Run, manual_generic
         ; Report, manual_generic
         ]
-      
     ~meta:"dir"
     "Specify the root directory of the project"
 
@@ -2695,7 +2690,6 @@ and results_dir =
         ; Run, manual_generic
         ; Report, manual_generic
         ]
-      
     ~meta:"dir"
     "Write results and internal files in the specified directory"
 
@@ -2879,7 +2873,6 @@ and sqlite_cache_size =
     ~in_help:
       InferCommand.
         [ Analyze, manual_generic; Capture, manual_generic; Run, manual_generic ]
-      
     "SQLite cache size in pages (if positive) or kB (if negative), follows formal of \
      corresponding SQLite PRAGMA."
 
@@ -2890,7 +2883,6 @@ and sqlite_page_size =
     ~in_help:
       InferCommand.
         [ Analyze, manual_generic; Capture, manual_generic; Run, manual_generic ]
-      
     "SQLite page size in bytes, must be a power of two between 512 and 65536."
 
 and sqlite_lock_timeout =
@@ -2905,7 +2897,6 @@ and sqlite_lock_timeout =
     ~in_help:
       InferCommand.
         [ Analyze, manual_generic; Capture, manual_generic; Run, manual_generic ]
-      
     "Timeout for SQLite results database operations, in milliseconds."
 
 and sqlite_vfs =
diff --git a/infer/src/biabduction/Tabulation.ml b/infer/src/biabduction/Tabulation.ml
index 06370ca9d..b0a14ee48 100644
--- a/infer/src/biabduction/Tabulation.ml
+++ b/infer/src/biabduction/Tabulation.ml
@@ -100,7 +100,6 @@ let spec_rename_vars pname spec =
   let posts'' = List.map ~f:(fun (p, path) -> prop_add_callee_suffix p, path) posts' in
   BiabductionSummary.
     { pre = pre''; posts = posts''; visited = spec.BiabductionSummary.visited }
-  
 ;;
 
 (** Find and number the specs for [proc_attrs], after renaming their vars, and also return the
diff --git a/infer/src/clang/cTrans.ml b/infer/src/clang/cTrans.ml
index 26e5003c0..8b60b9b54 100644
--- a/infer/src/clang/cTrans.ml
+++ b/infer/src/clang/cTrans.ml
@@ -257,7 +257,6 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
         ; is_constexpr = false
         ; is_declared_unused = false
         }
-      
     in
     Procdesc.append_locals procdesc [ var_data ];
     Exp.Lvar pvar, typ
@@ -1762,7 +1761,6 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
               ; is_constexpr = false
               ; is_declared_unused = false
               }
-            
           in
           Procdesc.append_locals context.procdesc [ var_data ];
           `Temp pvar
@@ -2765,7 +2763,6 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
             ; is_constexpr = false
             ; is_declared_unused = false
             }
-          
         in
         Procdesc.append_locals procdesc [ var_data ];
         `Temp pvar
diff --git a/infer/src/concurrency/starvation.ml b/infer/src/concurrency/starvation.ml
index c3278fe9d..38430cab9 100644
--- a/infer/src/concurrency/starvation.ml
+++ b/infer/src/concurrency/starvation.ml
@@ -610,7 +610,6 @@ end = struct
       ; strict_mode_violation
       ; arbitrary_code_execution_under_lock
       ]
-    
   ;;
 
   let issue_log_of loc_map =
diff --git a/infer/src/cost/ConfigImpactAnalysis.ml b/infer/src/cost/ConfigImpactAnalysis.ml
index 2e0911d96..57e8b3239 100644
--- a/infer/src/cost/ConfigImpactAnalysis.ml
+++ b/infer/src/cost/ConfigImpactAnalysis.ml
@@ -933,7 +933,6 @@ module TransferFunctions = struct
             ; args
             ; ret
             }
-          
         in
         let instantiated_cost = get_instantiated_cost call in
         Dom.call tenv analyze_dependency ~instantiated_cost ~callee args location astate
diff --git a/infer/src/nullsafe/ClassLevelAnalysis.ml b/infer/src/nullsafe/ClassLevelAnalysis.ml
index 2f9c004ca..183af1ea7 100644
--- a/infer/src/nullsafe/ClassLevelAnalysis.ml
+++ b/infer/src/nullsafe/ClassLevelAnalysis.ml
@@ -20,7 +20,6 @@ let log_issue
   let extras =
     Jsonbug_t.
       { nullsafe_extra = Some nullsafe_extra; cost_polynomial = None; cost_degree = None }
-    
   in
   let proc_name = Option.value proc_name ~default:Procname.Linters_dummy_method in
   let trace = [ Errlog.make_trace_element 0 loc error_message [] ] in
@@ -132,7 +131,6 @@ let make_meta_issue modes_and_issues top_level_class_mode top_level_class_name =
       ; curr_nullsafe_mode = mode_to_json top_level_class_mode
       ; can_be_promoted_to = Option.map mode_to_promote_to ~f:mode_to_json
       }
-    
   in
   let issue_type, description, severity =
     if NullsafeMode.equal top_level_class_mode Default
@@ -238,7 +236,6 @@ let report_meta_issue_for_top_level_class
         ; field = None
         ; annotation_graph = None
         }
-      
     in
     log_issue ~issue_log ~loc:class_loc ~severity ~nullsafe_extra issue_type description
   )
@@ -289,7 +286,6 @@ let analyze_nullsafe_annotations tenv source_file class_name class_struct issue_
       ; field = None
       ; annotation_graph = None
       }
-    
   in
   match NullsafeMode.check_problematic_class_annotation tenv class_name with
   | Ok () -> issue_log
@@ -357,7 +353,6 @@ let report_annotation_graph source_file class_name class_struct annotation_graph
       ; field = None
       ; annotation_graph = Some annotation_graph
       }
-    
   in
   log_issue
     ~issue_log
diff --git a/infer/src/nullsafe/NullsafeIssue.ml b/infer/src/nullsafe/NullsafeIssue.ml
index 1f7973630..7690fc352 100644
--- a/infer/src/nullsafe/NullsafeIssue.ml
+++ b/infer/src/nullsafe/NullsafeIssue.ml
@@ -103,7 +103,6 @@ let to_nullable_method_json nullable_methods =
         ; package = Procname.Java.get_package pname |> Option.value ~default:""
         ; call_line = call_loc.Location.line
         }
-      
   )
 ;;
 
@@ -123,7 +122,6 @@ let parameter_not_nullable_info_to_json { param_index; proc_name }
       { name = Procname.Java.get_method proc_name
       ; params = get_params_string_list proc_name
       }
-    
   in
   Jsonbug_t.{ class_name; package_name; method_info; param_index }
 ;;
@@ -163,7 +161,6 @@ let get_nullsafe_extra
           ; package_name = JavaClassName.package java_class_name
           ; field
           }
-        
     )
   in
   let method_params = get_params_string_list proc_name in
@@ -185,5 +182,4 @@ let get_nullsafe_extra
     ; field
     ; annotation_graph = None
     }
-  
 ;;
diff --git a/infer/src/nullsafe/typeCheck.ml b/infer/src/nullsafe/typeCheck.ml
index 1375f8649..939a1af1d 100644
--- a/infer/src/nullsafe/typeCheck.ml
+++ b/infer/src/nullsafe/typeCheck.ml
@@ -1499,7 +1499,6 @@ let calc_typestate_after_call
     in
     EradicateChecks.
       { param_index; formal = formal_param; actual; is_formal_propagates_nullable }
-    
   in
   (* Infer nullability of function call result based on its signature *)
   let preliminary_resolved_ret =
diff --git a/infer/src/pulse/Pulse.ml b/infer/src/pulse/Pulse.ml
index c5286e587..f55cd2f0d 100644
--- a/infer/src/pulse/Pulse.ml
+++ b/infer/src/pulse/Pulse.ml
@@ -206,7 +206,6 @@ module PulseTransferFunctions = struct
           ( astate
           , ProcnameDispatcher.Call.FuncArg.
               { exp = actual_exp; arg_payload = actual_evaled; typ = actual_typ }
-            
             :: rev_func_args )
       )
     in
diff --git a/infer/src/unit/JavaProfilerSamplesTest.ml b/infer/src/unit/JavaProfilerSamplesTest.ml
index 40d0f05c1..70a9f2722 100644
--- a/infer/src/unit/JavaProfilerSamplesTest.ml
+++ b/infer/src/unit/JavaProfilerSamplesTest.ml
@@ -88,7 +88,6 @@ let test_jni_parse_str_with_valid_input =
         [ Method
             ([ Int; Boolean; FullyQualifiedClass ("java.lang", "String") ], Array Char)
         ]
-      
     )
   ; ( "test_jni_parse_str_with_multiple_separate_types"
     , "I[[[CIJ(I)[C"
diff --git a/sledge/report/sledge_report.ml b/sledge/report/sledge_report.ml
index 8f0da2be0..0abf7e6f4 100644
--- a/sledge/report/sledge_report.ml
+++ b/sledge/report/sledge_report.ml
@@ -88,7 +88,6 @@ let add_gc base_gcs gc row =
           ; promoted = gc.promoted -. bgc.promoted
           ; peak_size = gc.peak_size -. bgc.peak_size
           }
-        
         :: gcs_deltas
     )
   in
@@ -115,7 +114,6 @@ let add_cov base_cov cov row =
             ; fraction = cov.fraction -. base_cov.fraction
             ; solver_steps = cov.solver_steps - base_cov.solver_steps
             }
-          
         in
         Some (covd :: Option.value row.cov_deltas ~default:[])
       | _ -> None
@@ -218,7 +216,6 @@ let combine name b_result c_result =
               ; promoted = ave_floats promos
               ; peak_size = ave_floats peaks
               }
-            
         )
       in
       let covs = if List.is_empty covs then None else Some covs in
@@ -678,7 +675,6 @@ let average row =
           ; promoted = ave_floats promo
           ; peak_size = ave_floats peak
           }
-        
     )
   in
   let gcs = ave_gcs row.gcs in
@@ -730,7 +726,7 @@ let add_total rows =
                 ; promoted = total_gcs.promoted +. row_gcs.promoted
                 ; peak_size = total_gcs.peak_size +. row_gcs.peak_size
                 }
-              | _ -> total.gcs
+          | _ -> total.gcs
         in
         let gcs_deltas =
           match total.gcs_deltas, row.gcs_deltas with
@@ -741,7 +737,7 @@ let add_total rows =
                 ; promoted = total_deltas.promoted +. row_deltas.promoted
                 ; peak_size = total_deltas.peak_size +. row_deltas.peak_size
                 }
-              | _ -> total.gcs_deltas
+          | _ -> total.gcs_deltas
         in
         let status_deltas =
           if Option.is_some total.status_deltas || Option.is_some row.status_deltas
diff --git a/compiler/lib-runtime/jsoo_runtime.ml b/compiler/lib-runtime/jsoo_runtime.ml
index 5501914e9c..67648127a0 100644
--- a/compiler/lib-runtime/jsoo_runtime.ml
+++ b/compiler/lib-runtime/jsoo_runtime.ml
@@ -53,7 +53,6 @@ let runtime =
     ; unix
     ; weak
     ]
-  
 ;;
```

</details>

All changes are improvements.

@nojb I didn't reproduce the "linebreak after the `in`" bug in the testbase, can you try that this PRs also fixes that in your codebase?