### PR TITLE
Deprecate --align-* options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 #### Deprecated
 
+  + Options `--align-cases`, `--align-constructors-decl` and `--align-variants-decl` are now deprecated (#1793, @gpetiot)
+
 #### Bug fixes
 
   + Fix normalization of sequences of expressions (#1731, @gpetiot)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 #### Deprecated
 
-  + Options `--align-cases`, `--align-constructors-decl` and `--align-variants-decl` are now deprecated (#1793, @gpetiot)
+  + Options `--align-cases`, `--align-constructors-decl` and `--align-variants-decl` are now deprecated and will be removed by version 1.0 (#1793, @gpetiot)
 
 #### Bug fixes
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -185,24 +185,29 @@ let ocaml_version_conv =
 module Formatting = struct
   let section = `Formatting
 
+  let no_align = "Vertical alignment is no longer a promoted behavior."
+
   let align_cases =
     let doc = "Align match/try cases vertically." in
     let names = ["align-cases"] in
-    C.flag ~default:false ~names ~doc ~section
+    let deprecated = C.deprecated ~since_version:"0.20.0" no_align in
+    C.flag ~default:false ~names ~doc ~section ~deprecated
       (fun conf x -> {conf with align_cases= x})
       (fun conf -> conf.align_cases)
 
   let align_constructors_decl =
     let doc = "Align type declarations vertically." in
     let names = ["align-constructors-decl"] in
-    C.flag ~default:false ~names ~doc ~section
+    let deprecated = C.deprecated ~since_version:"0.20.0" no_align in
+    C.flag ~default:false ~names ~doc ~section ~deprecated
       (fun conf x -> {conf with align_constructors_decl= x})
       (fun conf -> conf.align_constructors_decl)
 
   let align_variants_decl =
     let doc = "Align type variants declarations vertically." in
     let names = ["align-variants-decl"] in
-    C.flag ~default:false ~names ~doc ~section
+    let deprecated = C.deprecated ~since_version:"0.20.0" no_align in
+    C.flag ~default:false ~names ~doc ~section ~deprecated
       (fun conf x -> {conf with align_variants_decl= x})
       (fun conf -> conf.align_variants_decl)
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -185,12 +185,12 @@ let ocaml_version_conv =
 module Formatting = struct
   let section = `Formatting
 
-  let no_align = "Vertical alignment is no longer a promoted behavior."
+  let removed_by_v1_0 = "It will be removed by version 1.0."
 
   let align_cases =
     let doc = "Align match/try cases vertically." in
     let names = ["align-cases"] in
-    let deprecated = C.deprecated ~since_version:"0.20.0" no_align in
+    let deprecated = C.deprecated ~since_version:"0.20.0" removed_by_v1_0 in
     C.flag ~default:false ~names ~doc ~section ~deprecated
       (fun conf x -> {conf with align_cases= x})
       (fun conf -> conf.align_cases)
@@ -198,7 +198,7 @@ module Formatting = struct
   let align_constructors_decl =
     let doc = "Align type declarations vertically." in
     let names = ["align-constructors-decl"] in
-    let deprecated = C.deprecated ~since_version:"0.20.0" no_align in
+    let deprecated = C.deprecated ~since_version:"0.20.0" removed_by_v1_0 in
     C.flag ~default:false ~names ~doc ~section ~deprecated
       (fun conf x -> {conf with align_constructors_decl= x})
       (fun conf -> conf.align_constructors_decl)
@@ -206,7 +206,7 @@ module Formatting = struct
   let align_variants_decl =
     let doc = "Align type variants declarations vertically." in
     let names = ["align-variants-decl"] in
-    let deprecated = C.deprecated ~since_version:"0.20.0" no_align in
+    let deprecated = C.deprecated ~since_version:"0.20.0" removed_by_v1_0 in
     C.flag ~default:false ~names ~doc ~section ~deprecated
       (fun conf x -> {conf with align_variants_decl= x})
       (fun conf -> conf.align_variants_decl)

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -45,18 +45,18 @@ OPTIONS (CODE FORMATTING STYLE)
 
        --align-cases
            Align match/try cases vertically. The flag is unset by default.
-           Warning: This option is deprecated since version 0.20.0. Vertical
-           alignment is no longer a promoted behavior.
+           Warning: This option is deprecated since version 0.20.0. It will
+           be removed by version 1.0.
 
        --align-constructors-decl
            Align type declarations vertically. The flag is unset by default.
-           Warning: This option is deprecated since version 0.20.0. Vertical
-           alignment is no longer a promoted behavior.
+           Warning: This option is deprecated since version 0.20.0. It will
+           be removed by version 1.0.
 
        --align-variants-decl
            Align type variants declarations vertically. The flag is unset by
            default. Warning: This option is deprecated since version 0.20.0.
-           Vertical alignment is no longer a promoted behavior.
+           It will be removed by version 1.0.
 
        --assignment-operator={end-line|begin-line}
            Position of the assignment operator. end-line positions assignment

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -45,13 +45,18 @@ OPTIONS (CODE FORMATTING STYLE)
 
        --align-cases
            Align match/try cases vertically. The flag is unset by default.
+           Warning: This option is deprecated since version 0.20.0. Vertical
+           alignment is no longer a promoted behavior.
 
        --align-constructors-decl
            Align type declarations vertically. The flag is unset by default.
+           Warning: This option is deprecated since version 0.20.0. Vertical
+           alignment is no longer a promoted behavior.
 
        --align-variants-decl
            Align type variants declarations vertically. The flag is unset by
-           default.
+           default. Warning: This option is deprecated since version 0.20.0.
+           Vertical alignment is no longer a promoted behavior.
 
        --assignment-operator={end-line|begin-line}
            Position of the assignment operator. end-line positions assignment

--- a/test/passing/tests/align_cases-break_all.ml.err
+++ b/test/passing/tests/align_cases-break_all.ml.err
@@ -1,0 +1,3 @@
+Warning: align-variants-decl: This option is deprecated since version 0.20.0. Vertical alignment is no longer a promoted behavior.
+Warning: align-constructors-decl: This option is deprecated since version 0.20.0. Vertical alignment is no longer a promoted behavior.
+Warning: align-cases: This option is deprecated since version 0.20.0. Vertical alignment is no longer a promoted behavior.

--- a/test/passing/tests/align_cases-break_all.ml.err
+++ b/test/passing/tests/align_cases-break_all.ml.err
@@ -1,3 +1,3 @@
-Warning: align-variants-decl: This option is deprecated since version 0.20.0. Vertical alignment is no longer a promoted behavior.
-Warning: align-constructors-decl: This option is deprecated since version 0.20.0. Vertical alignment is no longer a promoted behavior.
-Warning: align-cases: This option is deprecated since version 0.20.0. Vertical alignment is no longer a promoted behavior.
+Warning: align-variants-decl: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
+Warning: align-constructors-decl: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
+Warning: align-cases: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/align_cases.ml.err
+++ b/test/passing/tests/align_cases.ml.err
@@ -1,0 +1,3 @@
+Warning: align-variants-decl: This option is deprecated since version 0.20.0. Vertical alignment is no longer a promoted behavior.
+Warning: align-constructors-decl: This option is deprecated since version 0.20.0. Vertical alignment is no longer a promoted behavior.
+Warning: align-cases: This option is deprecated since version 0.20.0. Vertical alignment is no longer a promoted behavior.

--- a/test/passing/tests/align_cases.ml.err
+++ b/test/passing/tests/align_cases.ml.err
@@ -1,3 +1,3 @@
-Warning: align-variants-decl: This option is deprecated since version 0.20.0. Vertical alignment is no longer a promoted behavior.
-Warning: align-constructors-decl: This option is deprecated since version 0.20.0. Vertical alignment is no longer a promoted behavior.
-Warning: align-cases: This option is deprecated since version 0.20.0. Vertical alignment is no longer a promoted behavior.
+Warning: align-variants-decl: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
+Warning: align-constructors-decl: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
+Warning: align-cases: This option is deprecated since version 0.20.0. It will be removed by version 1.0.


### PR DESCRIPTION
Deprecate options `--align-cases`, `--align-constructors-decl` and `--align-variants-decl` for ocamlformat.0.20.0