### PR TITLE
Take the 'in' location into consideration to decide whether there is a blank line after a let-binding

### DIFF
--- a/test/passing/tests/sequence-preserve.ml.ref
+++ b/test/passing/tests/sequence-preserve.ml.ref
@@ -131,6 +131,16 @@ let _ =
   in
   ()
 
+let _ =
+  let _ =
+    Fooooooooo.
+      [ (swap_1_c, {minimum_transfert_amount= 0.})
+      ; (swap_2_c, {minimum_transfert_amount= 0.})
+      ; (swap_3_c, {minimum_transfert_amount= 0.}) ]
+    (* foooooooooooooooooooo *)
+  in
+  ()
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/tests/sequence-preserve.ml.ref
+++ b/test/passing/tests/sequence-preserve.ml.ref
@@ -129,7 +129,6 @@ let _ =
       ; (swap_2_c, {minimum_transfert_amount= 0.})
       ; (swap_3_c, {minimum_transfert_amount= 0.}) ]
   in
-
   ()
 
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]

--- a/test/passing/tests/sequence-preserve.ml.ref
+++ b/test/passing/tests/sequence-preserve.ml.ref
@@ -122,6 +122,16 @@ let _ =
   (* some comment *)
   next statement
 
+let _ =
+  let _ =
+    Fooooooooo.
+      [ (swap_1_c, {minimum_transfert_amount= 0.})
+      ; (swap_2_c, {minimum_transfert_amount= 0.})
+      ; (swap_3_c, {minimum_transfert_amount= 0.}) ]
+  in
+
+  ()
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/tests/sequence.ml
+++ b/test/passing/tests/sequence.ml
@@ -128,6 +128,18 @@ let _ =
   (* some comment *)
   next statement
 
+let _ =
+  let _ =
+    Fooooooooo.
+      [
+        (swap_1_c, { minimum_transfert_amount = 0. });
+        (swap_2_c, { minimum_transfert_amount = 0. });
+        (swap_3_c, { minimum_transfert_amount = 0. });
+      ]
+    
+  in
+  ()
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/tests/sequence.ml
+++ b/test/passing/tests/sequence.ml
@@ -140,6 +140,19 @@ let _ =
   in
   ()
 
+let _ =
+  let _ =
+    Fooooooooo.
+      [
+        (swap_1_c, { minimum_transfert_amount = 0. });
+        (swap_2_c, { minimum_transfert_amount = 0. });
+        (swap_3_c, { minimum_transfert_amount = 0. });
+      ]
+    (* foooooooooooooooooooo *)
+    
+  in
+  ()
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/tests/sequence.ml.ref
+++ b/test/passing/tests/sequence.ml.ref
@@ -107,6 +107,15 @@ let _ =
   (* some comment *)
   next statement
 
+let _ =
+  let _ =
+    Fooooooooo.
+      [ (swap_1_c, {minimum_transfert_amount= 0.})
+      ; (swap_2_c, {minimum_transfert_amount= 0.})
+      ; (swap_3_c, {minimum_transfert_amount= 0.}) ]
+  in
+  ()
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =

--- a/test/passing/tests/sequence.ml.ref
+++ b/test/passing/tests/sequence.ml.ref
@@ -116,6 +116,16 @@ let _ =
   in
   ()
 
+let _ =
+  let _ =
+    Fooooooooo.
+      [ (swap_1_c, {minimum_transfert_amount= 0.})
+      ; (swap_2_c, {minimum_transfert_amount= 0.})
+      ; (swap_3_c, {minimum_transfert_amount= 0.}) ]
+    (* foooooooooooooooooooo *)
+  in
+  ()
+
 [@@@ocamlformat "indicate-multiline-delimiters=closing-on-separate-line"]
 
 let foo x y =


### PR DESCRIPTION
Fix #1796, no diff with test_branch.sh

The issue lies with the option `sequence-blank-line=preserve-one` that didn't take the location of `in` into consideration, so the linebreak before `in` (that should not be preserved) was confused with a linebreak after `in` (that should be preserved when this option is set)