### PR TITLE
Deprecate option 'wrap-comments'

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -2,5 +2,4 @@ profile = ocamlformat
 break-cases = fit
 margin = 77
 parse-docstrings = true
-wrap-comments = true
 line-endings = lf

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1147,7 +1147,8 @@ module Formatting = struct
        wrapped. Consecutive comments with both left and right margin \
        aligned are not wrapped either."
     in
-    C.flag ~default:false ~names:["wrap-comments"] ~doc ~section
+    let deprecated = C.deprecated ~since_version:"0.20.0" removed_by_v1_0 in
+    C.flag ~default:false ~names:["wrap-comments"] ~doc ~section ~deprecated
       (fun conf x -> {conf with wrap_comments= x})
       (fun conf -> conf.wrap_comments)
 

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -451,6 +451,8 @@ OPTIONS (CODE FORMATTING STYLE)
            with vertically-aligned asterisks on the left margin are not
            wrapped. Consecutive comments with both left and right margin
            aligned are not wrapped either. The flag is unset by default.
+           Warning: This option is deprecated since version 0.20.0. It will
+           be removed by version 1.0.
 
        --wrap-fun-args
            Style for function call. The flag is set by default.

--- a/test/failing/tests/comments.ml.broken-ref
+++ b/test/failing/tests/comments.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/comments.ml" (syntax error)
 File "tests/comments.ml", line 64, characters 0-6:
 64 | module M_ok : sig

--- a/test/failing/tests/core_failing.ml.broken-ref
+++ b/test/failing/tests/core_failing.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/core_failing.ml" (syntax error)
 File "tests/core_failing.ml", line 18, characters 6-7:
 18 |     (A)

--- a/test/failing/tests/core_passing.ml.broken-ref
+++ b/test/failing/tests/core_passing.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/core_passing.ml" (syntax error)
 File "tests/core_passing.ml", line 27, characters 0-3:
 27 | let error_string message = error message () <:sexp_of< unit >>

--- a/test/failing/tests/edge_cases.ml.broken-ref
+++ b/test/failing/tests/edge_cases.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/edge_cases.ml" (syntax error)
 File "tests/edge_cases.ml", line 90, characters 4-12:
 90 |     function (_ : [ `c ]) -> d

--- a/test/failing/tests/escaped_nl.ml.broken-ref
+++ b/test/failing/tests/escaped_nl.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/escaped_nl.ml" (syntax error)
 File "tests/escaped_nl.ml", line 33, characters 9-10:
 33 | let c1 = '

--- a/test/failing/tests/exprs.ml.broken-ref
+++ b/test/failing/tests/exprs.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/exprs.ml" (syntax error)
 File "tests/exprs.ml", line 19, characters 5-6:
 19 |     x:x

--- a/test/failing/tests/indent_empty.ml.broken-ref
+++ b/test/failing/tests/indent_empty.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/indent_empty.ml" (syntax error)
 File "tests/indent_empty.ml", line 5, characters 0-3:
 5 | end

--- a/test/failing/tests/js_2018.ml.broken-ref
+++ b/test/failing/tests/js_2018.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/js_2018.ml" (syntax error)
 File "tests/js_2018.ml", line 14, characters 0-3:
 14 | let _ =

--- a/test/failing/tests/js_bench.ml.broken-ref
+++ b/test/failing/tests/js_bench.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/js_bench.ml" (syntax error)
 File "tests/js_bench.ml", line 13, characters 28-34:
 13 | BENCH_MODULE "Blit tests" = struct

--- a/test/failing/tests/js_comment.ml.broken-ref
+++ b/test/failing/tests/js_comment.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/js_comment.ml" (syntax error)
 File "tests/js_comment.ml", line 165, characters 2-4:
 165 |   -> bar_snoo : a b

--- a/test/failing/tests/js_default.ml.broken-ref
+++ b/test/failing/tests/js_default.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/js_default.ml" (syntax error)
 File "tests/js_default.ml", line 5, characters 6-10:
 5 |       with default(Year_month.Map.empty);

--- a/test/failing/tests/js_functor.ml.broken-ref
+++ b/test/failing/tests/js_functor.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/js_functor.ml" (syntax error)
 File "tests/js_functor.ml", line 10, characters 4-7:
 10 |     end)

--- a/test/failing/tests/js_low_priority.ml.broken-ref
+++ b/test/failing/tests/js_low_priority.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/js_low_priority.ml" (syntax error)
 File "tests/js_low_priority.ml", line 32, characters 0-2:
 32 | (* Maybe add:

--- a/test/failing/tests/js_test.ml.broken-ref
+++ b/test/failing/tests/js_test.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/js_test.ml" (syntax error)
 File "tests/js_test.ml", line 1, characters 9-10:
 1 | let%test =

--- a/test/failing/tests/lwt.ml.broken-ref
+++ b/test/failing/tests/lwt.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/lwt.ml" (syntax error)
 File "tests/lwt.ml", line 5, characters 22-26:
 5 | let f x = match_lwt x with

--- a/test/failing/tests/macro.ml.broken-ref
+++ b/test/failing/tests/macro.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/macro.ml" (syntax error)
 File "tests/macro.ml", line 3, characters 0-7:
 3 | INCLUDE "bar"

--- a/test/failing/tests/match_fun.ml.broken-ref
+++ b/test/failing/tests/match_fun.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/match_fun.ml" (syntax error)
 File "tests/match_fun.ml", line 5, characters 0-0:
 Error: Syntax error

--- a/test/failing/tests/misc_2019.ml.broken-ref
+++ b/test/failing/tests/misc_2019.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/misc_2019.ml" (syntax error)
 File "tests/misc_2019.ml", line 15, characters 2-8:
 15 |   module type of struct

--- a/test/failing/tests/module.ml.broken-ref
+++ b/test/failing/tests/module.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/module.ml" (syntax error)
 File "tests/module.ml", line 5, characters 18-22:
 5 |       include Foo with type t := t

--- a/test/failing/tests/nesting.ml.broken-ref
+++ b/test/failing/tests/nesting.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/nesting.ml" (syntax error)
 File "tests/nesting.ml", line 35, characters 0-0:
 Error: Syntax error: 'end' expected

--- a/test/failing/tests/never_align.ml.broken-ref
+++ b/test/failing/tests/never_align.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/never_align.ml" (syntax error)
 File "tests/never_align.ml", line 13, characters 4-5:
 13 |     b

--- a/test/failing/tests/ocamldoc.ml.broken-ref
+++ b/test/failing/tests/ocamldoc.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/ocamldoc.ml" (syntax error)
 File "tests/ocamldoc.ml", line 75, characters 0-5:
 75 | class type my_class_type =

--- a/test/failing/tests/partial2.ml.broken-ref
+++ b/test/failing/tests/partial2.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/partial2.ml" (syntax error)
 File "tests/partial2.ml", line 4, characters 0-0:
 Error: Syntax error

--- a/test/failing/tests/pattern.ml.broken-ref
+++ b/test/failing/tests/pattern.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/pattern.ml" (syntax error)
 File "tests/pattern.ml", line 68, characters 11-12:
 68 |    with bli)

--- a/test/failing/tests/ppx_stritem_ext.ml.broken-ref
+++ b/test/failing/tests/ppx_stritem_ext.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/ppx_stritem_ext.ml" (syntax error)
 File "tests/ppx_stritem_ext.ml", line 10, characters 11-14:
 10 | module S = sig

--- a/test/failing/tests/quotations2.ml.broken-ref
+++ b/test/failing/tests/quotations2.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/quotations2.ml" (syntax error)
 File "tests/quotations2.ml", line 19, characters 6-8:
 19 |       <:xhtml<<li class="current"><a href=$str:url$>$str:long$</a></li>&>>

--- a/test/failing/tests/record_with.ml.broken-ref
+++ b/test/failing/tests/record_with.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/record_with.ml" (syntax error)
 File "tests/record_with.ml", line 28, characters 0-3:
 28 | let b =

--- a/test/failing/tests/unit_classes.ml.broken-ref
+++ b/test/failing/tests/unit_classes.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/unit_classes.ml" (syntax error)
 File "tests/unit_classes.ml", line 23, characters 24-25:
 23 |     method private bar1 x ~y : bool

--- a/test/failing/tests/unit_expr.ml.broken-ref
+++ b/test/failing/tests/unit_expr.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/unit_expr.ml" (syntax error)
 File "tests/unit_expr.ml", line 33, characters 3-4:
 33 |   `_

--- a/test/failing/tests/unit_extensions.ml.broken-ref
+++ b/test/failing/tests/unit_extensions.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/unit_extensions.ml" (syntax error)
 File "tests/unit_extensions.ml", line 101, characters 8-11:
 101 |       M.sig

--- a/test/failing/tests/unit_lex.ml.broken-ref
+++ b/test/failing/tests/unit_lex.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 File "tests/unit_lex.ml", line 18, characters 4-10:
 18 |     йзижща (* this file must be iso-8859-1 *)
          ^^^^^^

--- a/test/failing/tests/unit_modtypes.ml.broken-ref
+++ b/test/failing/tests/unit_modtypes.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/unit_modtypes.ml" (syntax error)
 File "tests/unit_modtypes.ml", line 66, characters 13-14:
 66 |   module M (X) (Y):

--- a/test/failing/tests/unit_typedefs.ml.broken-ref
+++ b/test/failing/tests/unit_typedefs.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/unit_typedefs.ml" (syntax error)
 File "tests/unit_typedefs.ml", line 20, characters 3-4:
 20 |    (-'c,-'d))

--- a/test/failing/tests/unit_types.ml.broken-ref
+++ b/test/failing/tests/unit_types.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/unit_types.ml" (syntax error)
 File "tests/unit_types.ml", line 32, characters 7-8:
 32 |     ( ?_ : int -> t )

--- a/test/failing/tests/unit_values.ml.broken-ref
+++ b/test/failing/tests/unit_values.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 File "tests/unit_values.ml", line 6, characters 10-11:
 6 | let i32 = −1073741824, 1073741823
               ^

--- a/test/failing/tests/unstable_docstrings.mli.broken-ref
+++ b/test/failing/tests/unstable_docstrings.mli.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: Cannot process "tests/unstable_docstrings.mli".
   Please report this bug at https://github.com/ocaml-ppx/ocamlformat/issues.
   BUG: doc comments changed.

--- a/test/failing/tests/with_2.ml.broken-ref
+++ b/test/failing/tests/with_2.ml.broken-ref
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/with_2.ml" (syntax error)
 File "tests/with_2.ml", line 37, characters 0-0:
 Error: Syntax error

--- a/test/passing/tests/align_cases-break_all.ml.err
+++ b/test/passing/tests/align_cases-break_all.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: align-variants-decl: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: align-constructors-decl: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: align-cases: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/align_cases.ml.err
+++ b/test/passing/tests/align_cases.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: align-variants-decl: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: align-constructors-decl: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: align-cases: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/align_infix.ml.err
+++ b/test/passing/tests/align_infix.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/alignment.ml.err
+++ b/test/passing/tests/alignment.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/apply.ml.err
+++ b/test/passing/tests/apply.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/apply.ml:26 exceeds the margin

--- a/test/passing/tests/apply_functor.ml.err
+++ b/test/passing/tests/apply_functor.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/args_grouped.ml.err
+++ b/test/passing/tests/args_grouped.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/array.ml.err
+++ b/test/passing/tests/array.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/assignment_operator-op_begin_line.ml.err
+++ b/test/passing/tests/assignment_operator-op_begin_line.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/assignment_operator.ml:13 exceeds the margin
 Warning: tests/assignment_operator.ml:15 exceeds the margin
 Warning: tests/assignment_operator.ml:19 exceeds the margin

--- a/test/passing/tests/assignment_operator.ml.err
+++ b/test/passing/tests/assignment_operator.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/attribute_and_expression.ml.err
+++ b/test/passing/tests/attribute_and_expression.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/attributes.ml.err
+++ b/test/passing/tests/attributes.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/attributes.ml:340 exceeds the margin

--- a/test/passing/tests/attributes.mli.err
+++ b/test/passing/tests/attributes.mli.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/binders.ml.err
+++ b/test/passing/tests/binders.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_before_in-auto.ml.err
+++ b/test/passing/tests/break_before_in-auto.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_before_in.ml.err
+++ b/test/passing/tests/break_before_in.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_cases-align.ml.err
+++ b/test/passing/tests/break_cases-align.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_cases.ml:68 exceeds the margin
 Warning: tests/break_cases.ml:141 exceeds the margin
 Warning: tests/break_cases.ml:242 exceeds the margin

--- a/test/passing/tests/break_cases-all.ml.err
+++ b/test/passing/tests/break_cases-all.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_cases.ml:68 exceeds the margin
 Warning: tests/break_cases.ml:141 exceeds the margin
 Warning: tests/break_cases.ml:242 exceeds the margin

--- a/test/passing/tests/break_cases-closing_on_separate_line.ml.err
+++ b/test/passing/tests/break_cases-closing_on_separate_line.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_cases.ml:76 exceeds the margin
 Warning: tests/break_cases.ml:151 exceeds the margin
 Warning: tests/break_cases.ml:255 exceeds the margin

--- a/test/passing/tests/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.err
+++ b/test/passing/tests/break_cases-closing_on_separate_line_leading_nested_match_parens.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_cases.ml:76 exceeds the margin
 Warning: tests/break_cases.ml:151 exceeds the margin
 Warning: tests/break_cases.ml:255 exceeds the margin

--- a/test/passing/tests/break_cases-cosl_lnmp_cmei.ml.err
+++ b/test/passing/tests/break_cases-cosl_lnmp_cmei.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_cases.ml:76 exceeds the margin
 Warning: tests/break_cases.ml:151 exceeds the margin
 Warning: tests/break_cases.ml:255 exceeds the margin

--- a/test/passing/tests/break_cases-fit_or_vertical.ml.err
+++ b/test/passing/tests/break_cases-fit_or_vertical.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_cases.ml:57 exceeds the margin
 Warning: tests/break_cases.ml:119 exceeds the margin
 Warning: tests/break_cases.ml:204 exceeds the margin

--- a/test/passing/tests/break_cases-nested.ml.err
+++ b/test/passing/tests/break_cases-nested.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_cases.ml:53 exceeds the margin
 Warning: tests/break_cases.ml:116 exceeds the margin
 Warning: tests/break_cases.ml:206 exceeds the margin

--- a/test/passing/tests/break_cases-normal_indent.ml.err
+++ b/test/passing/tests/break_cases-normal_indent.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_cases.ml:68 exceeds the margin
 Warning: tests/break_cases.ml:141 exceeds the margin
 Warning: tests/break_cases.ml:242 exceeds the margin

--- a/test/passing/tests/break_cases-toplevel.ml.err
+++ b/test/passing/tests/break_cases-toplevel.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_cases.ml:59 exceeds the margin
 Warning: tests/break_cases.ml:122 exceeds the margin
 Warning: tests/break_cases.ml:208 exceeds the margin

--- a/test/passing/tests/break_cases.ml.err
+++ b/test/passing/tests/break_cases.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_cases.ml:47 exceeds the margin
 Warning: tests/break_cases.ml:104 exceeds the margin
 Warning: tests/break_cases.ml:180 exceeds the margin

--- a/test/passing/tests/break_fun_decl-fit_or_vertical.ml.err
+++ b/test/passing/tests/break_fun_decl-fit_or_vertical.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_fun_decl-smart.ml.err
+++ b/test/passing/tests/break_fun_decl-smart.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_fun_decl-wrap.ml.err
+++ b/test/passing/tests/break_fun_decl-wrap.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_fun_decl.ml.err
+++ b/test/passing/tests/break_fun_decl.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_record.ml.err
+++ b/test/passing/tests/break_record.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_separators-after.ml.err
+++ b/test/passing/tests/break_separators-after.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_separators-after_docked.ml.err
+++ b/test/passing/tests/break_separators-after_docked.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_separators.ml:571 exceeds the margin

--- a/test/passing/tests/break_separators-after_docked_wrap.ml.err
+++ b/test/passing/tests/break_separators-after_docked_wrap.ml.err
@@ -1,2 +1,3 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_separators.ml:193 exceeds the margin
 Warning: tests/break_separators.ml:366 exceeds the margin

--- a/test/passing/tests/break_separators-after_wrap.ml.err
+++ b/test/passing/tests/break_separators-after_wrap.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_separators-before_docked.ml.err
+++ b/test/passing/tests/break_separators-before_docked.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_separators-before_docked_wrap.ml.err
+++ b/test/passing/tests/break_separators-before_docked_wrap.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_separators.ml:212 exceeds the margin

--- a/test/passing/tests/break_separators-wrap.ml.err
+++ b/test/passing/tests/break_separators-wrap.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_separators.ml:185 exceeds the margin

--- a/test/passing/tests/break_separators.ml.err
+++ b/test/passing/tests/break_separators.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_sequence_before.ml.err
+++ b/test/passing/tests/break_sequence_before.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_string_literals-never.ml.err
+++ b/test/passing/tests/break_string_literals-never.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/break_string_literals.ml:4 exceeds the margin
 Warning: tests/break_string_literals.ml:7 exceeds the margin
 Warning: tests/break_string_literals.ml:11 exceeds the margin

--- a/test/passing/tests/break_string_literals.ml.err
+++ b/test/passing/tests/break_string_literals.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/break_struct.ml.err
+++ b/test/passing/tests/break_struct.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/cinaps.ml.err
+++ b/test/passing/tests/cinaps.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/cmdline_override.ml.err
+++ b/test/passing/tests/cmdline_override.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/cmdline_override2.ml.err
+++ b/test/passing/tests/cmdline_override2.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/coerce.ml.err
+++ b/test/passing/tests/coerce.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/comment_breaking.ml.err
+++ b/test/passing/tests/comment_breaking.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/comment_header.ml.err
+++ b/test/passing/tests/comment_header.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/comment_in_empty.ml.err
+++ b/test/passing/tests/comment_in_empty.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/comment_in_modules.ml.err
+++ b/test/passing/tests/comment_in_modules.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/comment_last.ml.err
+++ b/test/passing/tests/comment_last.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/comment_sparse.ml.err
+++ b/test/passing/tests/comment_sparse.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/comments.ml.err
+++ b/test/passing/tests/comments.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/comments.ml:252 exceeds the margin

--- a/test/passing/tests/comments_args.ml.err
+++ b/test/passing/tests/comments_args.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/comments_around_disabled.ml.err
+++ b/test/passing/tests/comments_around_disabled.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/comments_in_record.ml.err
+++ b/test/passing/tests/comments_in_record.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/comments_in_record.ml:21 exceeds the margin

--- a/test/passing/tests/compact_lists_arrays.ml.err
+++ b/test/passing/tests/compact_lists_arrays.ml.err
@@ -1,2 +1,3 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/compact_lists_arrays.ml:20 exceeds the margin
 Warning: tests/compact_lists_arrays.ml:48 exceeds the margin

--- a/test/passing/tests/crlf_to_crlf.ml.err
+++ b/test/passing/tests/crlf_to_crlf.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/crlf_to_lf.ml.err
+++ b/test/passing/tests/crlf_to_lf.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/custom_list.ml.err
+++ b/test/passing/tests/custom_list.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/directives.mlt.err
+++ b/test/passing/tests/directives.mlt.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/disabled.ml.err
+++ b/test/passing/tests/disabled.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/disambiguate.ml.err
+++ b/test/passing/tests/disambiguate.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/disambiguated_types.ml.err
+++ b/test/passing/tests/disambiguated_types.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/doc_comments-after.ml.err
+++ b/test/passing/tests/doc_comments-after.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/doc_comments.ml:299 exceeds the margin

--- a/test/passing/tests/doc_comments-before-except-val.ml.err
+++ b/test/passing/tests/doc_comments-before-except-val.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/doc_comments.ml:299 exceeds the margin

--- a/test/passing/tests/doc_comments-before.ml.err
+++ b/test/passing/tests/doc_comments-before.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/doc_comments.ml:299 exceeds the margin

--- a/test/passing/tests/doc_comments-no-parse-docstrings.mli.err
+++ b/test/passing/tests/doc_comments-no-parse-docstrings.mli.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/doc_comments.mli:10 exceeds the margin
 Warning: tests/doc_comments.mli:90 exceeds the margin
 Warning: tests/doc_comments.mli:96 exceeds the margin

--- a/test/passing/tests/doc_comments-no-wrap.mli.err
+++ b/test/passing/tests/doc_comments-no-wrap.mli.err
@@ -1,3 +1,5 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/doc_comments.mli:10 exceeds the margin
 Warning: tests/doc_comments.mli:78 exceeds the margin
 Warning: tests/doc_comments.mli:80 exceeds the margin

--- a/test/passing/tests/doc_comments.ml.err
+++ b/test/passing/tests/doc_comments.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/doc_comments.ml:299 exceeds the margin

--- a/test/passing/tests/doc_comments.mli.err
+++ b/test/passing/tests/doc_comments.mli.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/doc_comments.mli:10 exceeds the margin
 Warning: tests/doc_comments.mli:78 exceeds the margin
 Warning: tests/doc_comments.mli:80 exceeds the margin

--- a/test/passing/tests/doc_comments_padding.ml.err
+++ b/test/passing/tests/doc_comments_padding.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/eliom_ext.eliom.err
+++ b/test/passing/tests/eliom_ext.eliom.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/empty.ml.err
+++ b/test/passing/tests/empty.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/empty_ml.ml.err
+++ b/test/passing/tests/empty_ml.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/empty_mli.mli.err
+++ b/test/passing/tests/empty_mli.mli.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/empty_mlt.mlt.err
+++ b/test/passing/tests/empty_mlt.mlt.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/error1.ml.err
+++ b/test/passing/tests/error1.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/error1.ml" (syntax error)
 File "tests/error1.ml", line 2, characters 0-0:
 Error: Syntax error

--- a/test/passing/tests/error2.ml.err
+++ b/test/passing/tests/error2.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/error2.ml" (syntax error)
 File "tests/error2.ml", line 1, characters 0-1:
 1 | "asdd

--- a/test/passing/tests/error3.ml.err
+++ b/test/passing/tests/error3.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: ignoring "tests/error3.ml" (misplaced documentation comments - warning 50)
 File "tests/error3.ml", line 2, characters 0-13:
 2 | (** a or b *)

--- a/test/passing/tests/error4.ml.err
+++ b/test/passing/tests/error4.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 File "tests/error4.ml", line 2, characters 0-13:
 2 | (** a or b *)
     ^^^^^^^^^^^^^

--- a/test/passing/tests/escaped_nl.ml.err
+++ b/test/passing/tests/escaped_nl.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/exceptions.ml.err
+++ b/test/passing/tests/exceptions.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/exp_grouping-parens.ml.err
+++ b/test/passing/tests/exp_grouping-parens.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/exp_grouping.ml.err
+++ b/test/passing/tests/exp_grouping.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/exp_record.ml.err
+++ b/test/passing/tests/exp_record.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/expect_test.ml.err
+++ b/test/passing/tests/expect_test.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/expect_test.ml:9 exceeds the margin
 Warning: tests/expect_test.ml:15 exceeds the margin
 Warning: tests/expect_test.ml:24 exceeds the margin

--- a/test/passing/tests/extensions-indent.ml.err
+++ b/test/passing/tests/extensions-indent.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/extensions-indent.mli.err
+++ b/test/passing/tests/extensions-indent.mli.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/extensions.ml.err
+++ b/test/passing/tests/extensions.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/extensions.mli.err
+++ b/test/passing/tests/extensions.mli.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/field-op_begin_line.ml.err
+++ b/test/passing/tests/field-op_begin_line.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/field.ml:13 exceeds the margin
 Warning: tests/field.ml:15 exceeds the margin
 Warning: tests/field.ml:19 exceeds the margin

--- a/test/passing/tests/field.ml.err
+++ b/test/passing/tests/field.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/first_class_module.ml.err
+++ b/test/passing/tests/first_class_module.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/first_class_module.ml:73 exceeds the margin

--- a/test/passing/tests/floating_doc.ml.err
+++ b/test/passing/tests/floating_doc.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/for_while.ml.err
+++ b/test/passing/tests/for_while.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/format_invalid_files-0.ml.err
+++ b/test/passing/tests/format_invalid_files-0.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/format_invalid_files.ml.err
+++ b/test/passing/tests/format_invalid_files.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/format_invalid_files_with_locations.ml.err
+++ b/test/passing/tests/format_invalid_files_with_locations.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/fun_decl.ml.err
+++ b/test/passing/tests/fun_decl.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/fun_function.ml.err
+++ b/test/passing/tests/fun_function.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/function_indent-never.ml.err
+++ b/test/passing/tests/function_indent-never.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/function_indent.ml.err
+++ b/test/passing/tests/function_indent.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/functor.ml.err
+++ b/test/passing/tests/functor.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/funsig.ml.err
+++ b/test/passing/tests/funsig.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/gadt.ml.err
+++ b/test/passing/tests/gadt.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/generative.ml.err
+++ b/test/passing/tests/generative.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/hash_types.ml.err
+++ b/test/passing/tests/hash_types.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/holes.ml.err
+++ b/test/passing/tests/holes.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/ifand.ml.err
+++ b/test/passing/tests/ifand.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/index_op.ml.err
+++ b/test/passing/tests/index_op.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/indicate_multiline_delimiters-cosl.ml.err
+++ b/test/passing/tests/indicate_multiline_delimiters-cosl.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/indicate_multiline_delimiters-space.ml.err
+++ b/test/passing/tests/indicate_multiline_delimiters-space.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/indicate_multiline_delimiters.ml.err
+++ b/test/passing/tests/indicate_multiline_delimiters.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/infix_arg_grouping.ml.err
+++ b/test/passing/tests/infix_arg_grouping.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/infix_bind-break.ml.err
+++ b/test/passing/tests/infix_bind-break.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/infix_bind-fit_or_vertical-break.ml.err
+++ b/test/passing/tests/infix_bind-fit_or_vertical-break.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/infix_bind-fit_or_vertical.ml.err
+++ b/test/passing/tests/infix_bind-fit_or_vertical.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/infix_bind.ml.err
+++ b/test/passing/tests/infix_bind.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/infix_precedence.ml.err
+++ b/test/passing/tests/infix_precedence.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/injectivity.ml.err
+++ b/test/passing/tests/injectivity.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/invalid.ml.err
+++ b/test/passing/tests/invalid.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/invalid_docstring.ml.err
+++ b/test/passing/tests/invalid_docstring.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: Invalid documentation comment:
 File "tests/invalid_docstring.ml", line 1, characters 5-5:
 End of text is not allowed in '{v ... v}' (verbatim text).

--- a/test/passing/tests/issue114.ml.err
+++ b/test/passing/tests/issue114.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/issue1750.ml.err
+++ b/test/passing/tests/issue1750.ml.err
@@ -1,2 +1,3 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/issue1750.ml:20 exceeds the margin
 Warning: tests/issue1750.ml:60 exceeds the margin

--- a/test/passing/tests/issue289.ml.err
+++ b/test/passing/tests/issue289.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/issue289.ml:4 exceeds the margin

--- a/test/passing/tests/issue48.ml.err
+++ b/test/passing/tests/issue48.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/issue51.ml.err
+++ b/test/passing/tests/issue51.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/issue57.ml.err
+++ b/test/passing/tests/issue57.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/issue60.ml.err
+++ b/test/passing/tests/issue60.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/issue77.ml.err
+++ b/test/passing/tests/issue77.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/issue85.ml.err
+++ b/test/passing/tests/issue85.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/issue89.ml.err
+++ b/test/passing/tests/issue89.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/ite-compact.ml.err
+++ b/test/passing/tests/ite-compact.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/ite.ml:30 exceeds the margin

--- a/test/passing/tests/ite-compact_closing.ml.err
+++ b/test/passing/tests/ite-compact_closing.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/ite.ml:35 exceeds the margin

--- a/test/passing/tests/ite-fit_or_vertical.ml.err
+++ b/test/passing/tests/ite-fit_or_vertical.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/ite-fit_or_vertical_closing.ml.err
+++ b/test/passing/tests/ite-fit_or_vertical_closing.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/ite-fit_or_vertical_no_indicate.ml.err
+++ b/test/passing/tests/ite-fit_or_vertical_no_indicate.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/ite-kr.ml.err
+++ b/test/passing/tests/ite-kr.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/ite-kr_closing.ml.err
+++ b/test/passing/tests/ite-kr_closing.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/ite-kw_first.ml.err
+++ b/test/passing/tests/ite-kw_first.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/ite-kw_first_closing.ml.err
+++ b/test/passing/tests/ite-kw_first_closing.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/ite-kw_first_no_indicate.ml.err
+++ b/test/passing/tests/ite-kw_first_no_indicate.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/ite-no_indicate.ml.err
+++ b/test/passing/tests/ite-no_indicate.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/ite.ml.err
+++ b/test/passing/tests/ite.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/ite.ml:30 exceeds the margin

--- a/test/passing/tests/js_args.ml.err
+++ b/test/passing/tests/js_args.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/js_begin.ml.err
+++ b/test/passing/tests/js_begin.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/js_bind.ml.err
+++ b/test/passing/tests/js_bind.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/js_fun.ml.err
+++ b/test/passing/tests/js_fun.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/js_map.ml.err
+++ b/test/passing/tests/js_map.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/js_pattern.ml.err
+++ b/test/passing/tests/js_pattern.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/js_poly.ml.err
+++ b/test/passing/tests/js_poly.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/js_record.ml.err
+++ b/test/passing/tests/js_record.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/js_sig.mli.err
+++ b/test/passing/tests/js_sig.mli.err
@@ -1,0 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/js_source.ml:154 exceeds the margin
 Warning: tests/js_source.ml:3578 exceeds the margin
 Warning: tests/js_source.ml:9582 exceeds the margin

--- a/test/passing/tests/js_syntax.ml.err
+++ b/test/passing/tests/js_syntax.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/js_to_do.ml.err
+++ b/test/passing/tests/js_to_do.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/js_upon.ml.err
+++ b/test/passing/tests/js_upon.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/kw_extentions.ml.err
+++ b/test/passing/tests/kw_extentions.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/label_option_default_args.ml.err
+++ b/test/passing/tests/label_option_default_args.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/labelled_args-414.ml.err
+++ b/test/passing/tests/labelled_args-414.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/labelled_args.ml.err
+++ b/test/passing/tests/labelled_args.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/lazy.ml.err
+++ b/test/passing/tests/lazy.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/let_binding-in_indent.ml.err
+++ b/test/passing/tests/let_binding-in_indent.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/let_binding-indent.ml.err
+++ b/test/passing/tests/let_binding-indent.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/let_binding.ml.err
+++ b/test/passing/tests/let_binding.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/let_binding_spacing-double-semicolon.ml.err
+++ b/test/passing/tests/let_binding_spacing-double-semicolon.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/let_binding_spacing-sparse.ml.err
+++ b/test/passing/tests/let_binding_spacing-sparse.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/let_binding_spacing.ml.err
+++ b/test/passing/tests/let_binding_spacing.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/let_in_constr.ml.err
+++ b/test/passing/tests/let_in_constr.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/let_module-sparse.ml.err
+++ b/test/passing/tests/let_module-sparse.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/let_module.ml.err
+++ b/test/passing/tests/let_module.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/let_punning.ml.err
+++ b/test/passing/tests/let_punning.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/list-space_around.ml.err
+++ b/test/passing/tests/list-space_around.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/list.ml.err
+++ b/test/passing/tests/list.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/list_and_comments.ml.err
+++ b/test/passing/tests/list_and_comments.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/loc_stack.ml.err
+++ b/test/passing/tests/loc_stack.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/locally_abtract_types.ml.err
+++ b/test/passing/tests/locally_abtract_types.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/margin_80.ml.err
+++ b/test/passing/tests/margin_80.ml.err
@@ -1,2 +1,3 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/margin_80.ml:7 exceeds the margin
 Warning: tests/margin_80.ml:11 exceeds the margin

--- a/test/passing/tests/match.ml.err
+++ b/test/passing/tests/match.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/match2.ml.err
+++ b/test/passing/tests/match2.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/match_indent-never.ml.err
+++ b/test/passing/tests/match_indent-never.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/match_indent.ml.err
+++ b/test/passing/tests/match_indent.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/max_indent.ml.err
+++ b/test/passing/tests/max_indent.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/mod_type_subst.ml.err
+++ b/test/passing/tests/mod_type_subst.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/module.ml.err
+++ b/test/passing/tests/module.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/module_anonymous.ml.err
+++ b/test/passing/tests/module_anonymous.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/module_attributes.ml.err
+++ b/test/passing/tests/module_attributes.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/module_attributes.ml:23 exceeds the margin

--- a/test/passing/tests/module_item_spacing-preserve.ml.err
+++ b/test/passing/tests/module_item_spacing-preserve.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/module_item_spacing-sparse.ml.err
+++ b/test/passing/tests/module_item_spacing-sparse.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/module_item_spacing.ml.err
+++ b/test/passing/tests/module_item_spacing.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/module_item_spacing.mli.err
+++ b/test/passing/tests/module_item_spacing.mli.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/module_type.ml.err
+++ b/test/passing/tests/module_type.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/monadic_binding.ml.err
+++ b/test/passing/tests/monadic_binding.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/multi_index_op.ml.err
+++ b/test/passing/tests/multi_index_op.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/named_existentials.ml.err
+++ b/test/passing/tests/named_existentials.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/need_format.ml.err
+++ b/test/passing/tests/need_format.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 ocamlformat: "tests/need_format.ml" was not already formatted. ([max-iters = 1])

--- a/test/passing/tests/new.ml.err
+++ b/test/passing/tests/new.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/object.ml.err
+++ b/test/passing/tests/object.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/object.ml:56 exceeds the margin

--- a/test/passing/tests/object2.ml.err
+++ b/test/passing/tests/object2.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/object_type.ml.err
+++ b/test/passing/tests/object_type.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/obuild.ml.err
+++ b/test/passing/tests/obuild.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/ocp_indent_compat.ml.err
+++ b/test/passing/tests/ocp_indent_compat.ml.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/ocp_indent_compat.ml:134 exceeds the margin

--- a/test/passing/tests/ocp_indent_options.ml.err
+++ b/test/passing/tests/ocp_indent_options.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/open-closing-on-separate-line.ml.err
+++ b/test/passing/tests/open-closing-on-separate-line.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/open.ml.err
+++ b/test/passing/tests/open.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/open_types.ml.err
+++ b/test/passing/tests/open_types.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/option.ml.err
+++ b/test/passing/tests/option.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 File "tests/option.ml", line 63, characters 17-28:
 63 |              [@@@ocamlformat "margin=90"]
                       ^^^^^^^^^^^

--- a/test/passing/tests/override.ml.err
+++ b/test/passing/tests/override.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/parens_tuple_patterns.ml.err
+++ b/test/passing/tests/parens_tuple_patterns.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/partial.ml.err
+++ b/test/passing/tests/partial.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/partial_double_quotes.ml.err
+++ b/test/passing/tests/partial_double_quotes.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/polytypes-default.ml.err
+++ b/test/passing/tests/polytypes-default.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/polytypes-janestreet.ml.err
+++ b/test/passing/tests/polytypes-janestreet.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/polytypes.ml.err
+++ b/test/passing/tests/polytypes.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/pre_post_extensions.ml.err
+++ b/test/passing/tests/pre_post_extensions.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/precedence.ml.err
+++ b/test/passing/tests/precedence.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/prefix_infix.ml.err
+++ b/test/passing/tests/prefix_infix.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/print_config.ml.err
+++ b/test/passing/tests/print_config.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 profile=ocamlformat (file tests/.ocamlformat:1)
 quiet=false (profile ocamlformat (file tests/.ocamlformat:1))
 max-iters=2 (environment variable)

--- a/test/passing/tests/profiles.ml.err
+++ b/test/passing/tests/profiles.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/profiles2.ml.err
+++ b/test/passing/tests/profiles2.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/protected_object_types.ml.err
+++ b/test/passing/tests/protected_object_types.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/quoted_strings.ml.err
+++ b/test/passing/tests/quoted_strings.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/recmod.mli.err
+++ b/test/passing/tests/recmod.mli.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/record-loose.ml.err
+++ b/test/passing/tests/record-loose.ml.err
@@ -1,2 +1,3 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/record.ml:9 exceeds the margin
 Warning: tests/record.ml:15 exceeds the margin

--- a/test/passing/tests/record-tight_decl.ml.err
+++ b/test/passing/tests/record-tight_decl.ml.err
@@ -1,2 +1,3 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/record.ml:9 exceeds the margin
 Warning: tests/record.ml:15 exceeds the margin

--- a/test/passing/tests/record.ml.err
+++ b/test/passing/tests/record.ml.err
@@ -1,2 +1,3 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/record.ml:9 exceeds the margin
 Warning: tests/record.ml:15 exceeds the margin

--- a/test/passing/tests/record_punning.ml.err
+++ b/test/passing/tests/record_punning.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/reformat_string.ml.err
+++ b/test/passing/tests/reformat_string.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/refs.ml.err
+++ b/test/passing/tests/refs.ml.err
@@ -1,2 +1,3 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/refs.ml:2 exceeds the margin
 Warning: tests/refs.ml:4 exceeds the margin

--- a/test/passing/tests/remove_extra_parens.ml.err
+++ b/test/passing/tests/remove_extra_parens.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/revapply_ext.ml.err
+++ b/test/passing/tests/revapply_ext.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/send.ml.err
+++ b/test/passing/tests/send.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/sequence-preserve.ml.err
+++ b/test/passing/tests/sequence-preserve.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/sequence.ml.err
+++ b/test/passing/tests/sequence.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/shebang.ml.err
+++ b/test/passing/tests/shebang.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/shortcut_ext_attr.ml.err
+++ b/test/passing/tests/shortcut_ext_attr.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/sig_value.mli.err
+++ b/test/passing/tests/sig_value.mli.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/single_line.mli.err
+++ b/test/passing/tests/single_line.mli.err
@@ -1,1 +1,2 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/single_line.mli:4 exceeds the margin

--- a/test/passing/tests/skip.ml.err
+++ b/test/passing/tests/skip.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/source.ml.err
+++ b/test/passing/tests/source.ml.err
@@ -1,2 +1,3 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/source.ml:700 exceeds the margin
 Warning: tests/source.ml:2318 exceeds the margin

--- a/test/passing/tests/str_value.ml.err
+++ b/test/passing/tests/str_value.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/string.ml.err
+++ b/test/passing/tests/string.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/string_array.ml.err
+++ b/test/passing/tests/string_array.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/string_wrapping.ml.err
+++ b/test/passing/tests/string_wrapping.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/symbol.ml.err
+++ b/test/passing/tests/symbol.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/tag_only.ml.err
+++ b/test/passing/tests/tag_only.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/tag_only.mli.err
+++ b/test/passing/tests/tag_only.mli.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/try_with_or_pattern.ml.err
+++ b/test/passing/tests/try_with_or_pattern.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/tuple.ml.err
+++ b/test/passing/tests/tuple.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/tuple.ml:15 exceeds the margin
 Warning: tests/tuple.ml:25 exceeds the margin
 Warning: tests/tuple.ml:31 exceeds the margin

--- a/test/passing/tests/tuple_less_parens.ml.err
+++ b/test/passing/tests/tuple_less_parens.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/tuple_less_parens.ml:15 exceeds the margin
 Warning: tests/tuple_less_parens.ml:25 exceeds the margin
 Warning: tests/tuple_less_parens.ml:31 exceeds the margin

--- a/test/passing/tests/tuple_type_parens.ml.err
+++ b/test/passing/tests/tuple_type_parens.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/type_and_constraint.ml.err
+++ b/test/passing/tests/type_and_constraint.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/type_annotations.ml.err
+++ b/test/passing/tests/type_annotations.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/types-compact-space_around-docked.ml.err
+++ b/test/passing/tests/types-compact-space_around-docked.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/types-compact-space_around.ml.err
+++ b/test/passing/tests/types-compact-space_around.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/types-compact.ml.err
+++ b/test/passing/tests/types-compact.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/types-indent.ml.err
+++ b/test/passing/tests/types-indent.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/types-sparse-space_around.ml.err
+++ b/test/passing/tests/types-sparse-space_around.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/types-sparse.ml.err
+++ b/test/passing/tests/types-sparse.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/types.ml.err
+++ b/test/passing/tests/types.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/unary.ml.err
+++ b/test/passing/tests/unary.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/unary_hash.ml.err
+++ b/test/passing/tests/unary_hash.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/unicode.ml.err
+++ b/test/passing/tests/unicode.ml.err
@@ -1,2 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/unicode.ml:5 exceeds the margin
 Warning: tests/unicode.ml:11 exceeds the margin

--- a/test/passing/tests/use_file.mlt.err
+++ b/test/passing/tests/use_file.mlt.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/verbose1.ml.err
+++ b/test/passing/tests/verbose1.ml.err
@@ -1,3 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 profile=ocamlformat (file tests/.ocamlformat:1)
 quiet=false (profile ocamlformat (file tests/.ocamlformat:1))
 max-iters=2 (file tests/.ocamlformat:6)

--- a/test/passing/tests/wrap_comments.ml.err
+++ b/test/passing/tests/wrap_comments.ml.err
@@ -1,1 +1,4 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.
 Warning: tests/wrap_comments.ml:35 exceeds the margin

--- a/test/passing/tests/wrap_comments_break.ml.err
+++ b/test/passing/tests/wrap_comments_break.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.

--- a/test/passing/tests/wrapping_functor_args.ml.err
+++ b/test/passing/tests/wrapping_functor_args.ml.err
@@ -1,0 +1,1 @@
+Warning: wrap-comments: This option is deprecated since version 0.20.0. It will be removed by version 1.0.


### PR DESCRIPTION
This option prevents people from organizing their comments as they want, so most people don't use it.