### PR TITLE
Deprecate option 'disambiguate-non-breaking-match'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
   + Options `--align-cases`, `--align-constructors-decl` and `--align-variants-decl` are now deprecated and will be removed by version 1.0 (#1793, @gpetiot)
 
+  + Option `disambiguate-non-breaking-match` is now deprecated and will be removed by version 1.0 (#1805, @gpetiot)
+
 #### Bug fixes
 
   + Fix normalization of sequences of expressions (#1731, @gpetiot)

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -484,9 +484,10 @@ module Formatting = struct
     let doc =
       "Add parentheses around matching constructs that fit on a single line."
     in
+    let deprecated = C.deprecated ~since_version:"0.20.0" removed_by_v1_0 in
     C.flag
       ~names:["disambiguate-non-breaking-match"]
-      ~default:false ~doc ~section
+      ~default:false ~doc ~section ~deprecated
       (fun conf x -> {conf with disambiguate_non_breaking_match= x})
       (fun conf -> conf.disambiguate_non_breaking_match)
 

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -157,7 +157,9 @@ OPTIONS (CODE FORMATTING STYLE)
 
        --disambiguate-non-breaking-match
            Add parentheses around matching constructs that fit on a single
-           line. The flag is unset by default.
+           line. The flag is unset by default. Warning: This option is
+           deprecated since version 0.20.0. It will be removed by version
+           1.0.
 
        --doc-comments={after-when-possible|before-except-val|before}
            Doc comments position. after-when-possible puts doc comments after

--- a/test/passing/tests/disambiguate.ml.err
+++ b/test/passing/tests/disambiguate.ml.err
@@ -1,0 +1,1 @@
+Warning: disambiguate-non-breaking-match: This option is deprecated since version 0.20.0. It will be removed by version 1.0.


### PR DESCRIPTION
This option is not set by any major project, and from Jules' script only transept.0.1.0 and preface.0.1.0 use it.

Maybe we can even remove it without deprecating it first?