### PR TITLE
Format comments of the form (*= xx *) as docstrings when parse-docstrings is set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,8 @@
   + Handle let operator punning uniformly with other punning forms.
     Normalizes let operator to the punned form where possible, if output syntax version is at least OCaml 4.13.0. (#1834, #1846, @jberdine)
 
+  + Format comments of the form `(*= xx *)` as docstrings when `parse-docstrings` is set (#1810, @gpetiot)
+
 ### 0.19.0 (2021-07-16)
 
 #### Bug fixes

--- a/lib/Cmt.mli
+++ b/lib/Cmt.mli
@@ -27,6 +27,7 @@ val fmt :
      t
   -> wrap:bool
   -> ocp_indent_compat:bool
+  -> parse_docstrings:bool
   -> fmt_code:(string -> (Fmt.t, unit) Result.t)
   -> pos
   -> Fmt.t

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -261,12 +261,5 @@ let fmt_block_element c = function
 let fmt ~fmt_code (docs : t) =
   vbox 0 (list_block_elem docs (fmt_block_element {fmt_code}))
 
-let diff c x y =
-  let norm z =
-    let f Cmt.{txt; _} = Normalize.docstring c txt in
-    Set.of_list (module String) (List.map ~f z)
-  in
-  Set.symmetric_diff (norm x) (norm y)
-
 let is_tag_only =
   List.for_all ~f:(function {Loc.value= `Tag _; _} -> true | _ -> false)

--- a/lib/Fmt_odoc.mli
+++ b/lib/Fmt_odoc.mli
@@ -12,9 +12,5 @@
 val fmt :
   fmt_code:(string -> (Fmt.t, unit) Result.t) -> Odoc_parser.Ast.t -> Fmt.t
 
-val diff :
-  Conf.t -> Cmt.t list -> Cmt.t list -> (string, string) Either.t Sequence.t
-(** Difference between two lists of doc comments. *)
-
 val is_tag_only : Odoc_parser.Ast.t -> bool
 (** [true] if the documentation only contains tags *)

--- a/lib/Normalize.mli
+++ b/lib/Normalize.mli
@@ -16,7 +16,7 @@ val dedup_cmts : 'a Extended_ast.t -> 'a -> Cmt.t list -> Cmt.t list
 val comment : string -> string
 (** Normalize a comment. *)
 
-val docstring : Conf.t -> string -> string
+val docstring : Conf.t -> Location.t -> string -> string
 (** Normalize a docstring. *)
 
 val normalize : 'a Std_ast.t -> Conf.t -> 'a -> 'a
@@ -34,3 +34,7 @@ type docstring_error =
 
 val moved_docstrings :
   'a Std_ast.t -> Conf.t -> 'a -> 'a -> docstring_error list
+
+val diff_docstrings :
+  Conf.t -> Cmt.t list -> Cmt.t list -> (string, string) Either.t Sequence.t
+(** Difference between two lists of doc comments. *)

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -402,7 +402,7 @@ let format (type a b) (fg : a Extended_ast.t) (std_fg : b Std_ast.t)
         let diff_cmts =
           Sequence.append
             (Cmts.diff conf old_comments t_newcomments)
-            (Fmt_odoc.diff conf old_docstrings t_newdocstrings)
+            (Normalize.diff_docstrings conf old_docstrings t_newdocstrings)
         in
         if not (Sequence.is_empty diff_cmts) then
           let old_ast = dump_ast std_fg ~suffix:".old" std_t.ast in

--- a/test/passing/tests/comments.ml
+++ b/test/passing/tests/comments.ml
@@ -295,3 +295,24 @@ let _ =
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
   #= (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
+
+let _ =
+  if something then
+(*= {[
+      let _ =
+       f
+       @@
+       { aaa= aaa bbb ccc  
+         ; bbb= aaa bbb ccc
+
+       ; ccc= aaa bbb ccc }
+       >>= fun () ->
+       let _ = x in
+       f @@ g @@ h @@ fun x -> y
+    ]} *)
+    fooooooo (*= {v We need this
+                    to stay verbatim! v} *)
+  else
+    { fooo : int (*= [f] [x] *) (*= [k] [zz] [zz] *)
+    ; fooo : k (*= {[ f x y ]} *)
+    ; fooo : k (*= {[ f x y ]} *) }

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -388,3 +388,23 @@ let _ =
           blah *)
     foooooooooooooooooooooooo
     foooooooooooooooo fooooooooooooooo
+
+let _ =
+  if something then
+    (*= {[
+          let _ =
+            f @@ {aaa= aaa bbb ccc; bbb= aaa bbb ccc; ccc= aaa bbb ccc}
+            >>= fun () ->
+            let _ = x in
+            f @@ g @@ h @@ fun x -> y
+        ]} *)
+    fooooooo (*= {v
+We need this
+                    to stay verbatim!
+                 v} *)
+  else
+    { fooo: int
+      (*= [f] [x] *)
+      (*= [k] [zz] [zz] *)
+    ; fooo: k (*= {[ f x y ]} *)
+    ; fooo: k (*= {[ f x y ]} *) }


### PR DESCRIPTION
This is more of a RFC, based on the discussion started in https://github.com/ocaml-ppx/ocamlformat/pull/1804, as I sitll think removing `wrap-comments` in the long run is a good idea.
Should replace https://github.com/ocaml-ppx/ocamlformat/pull/1747

The idea is:
- if `wrap-comments` is set, it has the priority (until it is removed), so the comments are wrapped (same behavior as `main` branch)
- if `parse-docstrings` is set, parse comments as docstrings if they are valid docstrings, otherwise wrap each paragraph
- otherwise wrap each paragraph

Running test_branch.sh with `parse-docstrings=true` shows that a lot of comments should be fixed, but there is some issue with the fallback, characters are not properly escaped, I didn't have time to have a look yet.

I didn't like the idea of introducing a new syntax to format a comment as docstring, as maybe some people will ask us later to keep maitaining this syntax if we want to remove it. To me it sounds good to have it enabled with `parse-docstrings` as long as the paragraph formatting is a good fallback.

For the record, `wrap-comments` and `parse-docstrings` are both disabled by default on all profiles.

What do you think?

cc @ceastlund as this is a feature you have been interested in