### PR TITLE
Allow configuration options to have deprecated values 

### DIFF
--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -215,12 +215,12 @@ module Formatting = struct
     let doc = "Position of the assignment operator." in
     let names = ["assignment-operator"] in
     let all =
-      [ C.Value.valid ~name:"end-line" `End_line
+      [ C.Value.make ~name:"end-line" `End_line
           ~doc:
             "$(b,end-line) positions assignment operators (`:=` and `<-`) \
              at the end of the line and breaks after it if the whole \
              assignment expression does not fit on a single line."
-      ; C.Value.valid ~name:"begin-line" `Begin_line
+      ; C.Value.make ~name:"begin-line" `Begin_line
           ~doc:
             "$(b,begin-line) positions assignment operators (`:=` and `<-`) \
              at the beginning of the line and breaks before it if the whole \
@@ -237,12 +237,12 @@ module Formatting = struct
     in
     let names = ["break-before-in"] in
     let all =
-      [ C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      [ C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) will always break the line before the \
              $(i,in) keyword if the whole $(i,let) binding does not fit on \
              a single line."
-      ; C.Value.valid ~name:"auto" `Auto
+      ; C.Value.make ~name:"auto" `Auto
           ~doc:
             "$(b,auto) will only break the line if the $(i,in) keyword does \
              not fit on the previous line." ]
@@ -255,26 +255,26 @@ module Formatting = struct
     let doc = "Break pattern match cases." in
     let names = ["break-cases"] in
     let all =
-      [ C.Value.valid ~name:"fit" `Fit
+      [ C.Value.make ~name:"fit" `Fit
           ~doc:
             "Specifying $(b,fit) lets pattern matches break at the margin \
              naturally."
-      ; C.Value.valid ~name:"nested" `Nested
+      ; C.Value.make ~name:"nested" `Nested
           ~doc:
             "$(b,nested) forces a break after nested or-patterns to \
              highlight the case body. Note that with $(b,nested), the \
              $(b,indicate-nested-or-patterns) option is not needed, and so \
              ignored."
-      ; C.Value.valid ~name:"toplevel" `Toplevel
+      ; C.Value.make ~name:"toplevel" `Toplevel
           ~doc:
             "$(b,toplevel) forces top-level cases (i.e. not nested \
              or-patterns) to break across lines, otherwise break naturally \
              at the margin."
-      ; C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      ; C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) tries to fit all or-patterns on the same \
              line, otherwise breaks."
-      ; C.Value.valid ~name:"all" `All
+      ; C.Value.make ~name:"all" `All
           ~doc:"$(b,all) forces all pattern matches to break across lines."
       ]
     in
@@ -288,11 +288,11 @@ module Formatting = struct
     in
     let names = ["break-collection-expressions"] in
     let all =
-      [ C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      [ C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) vertically breaks expressions if they do \
              not fit on a single line."
-      ; C.Value.valid ~name:"wrap" `Wrap
+      ; C.Value.make ~name:"wrap" `Wrap
           ~doc:
             "$(b,wrap) will group simple expressions and try to format them \
              in a single line." ]
@@ -305,13 +305,13 @@ module Formatting = struct
     let doc = "Style for function declarations and types." in
     let names = ["break-fun-decl"] in
     let all =
-      [ C.Value.valid ~name:"wrap" `Wrap
+      [ C.Value.make ~name:"wrap" `Wrap
           ~doc:"$(b,wrap) breaks only if necessary."
-      ; C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      ; C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) vertically breaks arguments if they do \
              not fit on a single line."
-      ; C.Value.valid ~name:"smart" `Smart
+      ; C.Value.make ~name:"smart" `Smart
           ~doc:
             "$(b,smart) is like $(b,fit-or-vertical) but try to fit \
              arguments on their line if they fit." ]
@@ -324,13 +324,13 @@ module Formatting = struct
     let doc = "Style for function signatures." in
     let names = ["break-fun-sig"] in
     let all =
-      [ C.Value.valid ~name:"wrap" `Wrap
+      [ C.Value.make ~name:"wrap" `Wrap
           ~doc:"$(b,wrap) breaks only if necessary."
-      ; C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      ; C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) vertically breaks arguments if they do \
              not fit on a single line."
-      ; C.Value.valid ~name:"smart" `Smart
+      ; C.Value.make ~name:"smart" `Smart
           ~doc:
             "$(b,smart) is like $(b,fit-or-vertical) but try to fit \
              arguments on their line if they fit." ]
@@ -343,11 +343,11 @@ module Formatting = struct
     let doc = "Break sequence of infix operators." in
     let names = ["break-infix"] in
     let all =
-      [ C.Value.valid ~name:"wrap" `Wrap
+      [ C.Value.make ~name:"wrap" `Wrap
           ~doc:
             "$(b,wrap) will group simple expressions and try to format them \
              in a single line."
-      ; C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      ; C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) vertically breaks expressions if they do \
              not fit on a single line." ]
@@ -374,14 +374,14 @@ module Formatting = struct
     in
     let names = ["break-separators"] in
     let all =
-      [ C.Value.valid ~name:"after" `After
+      [ C.Value.make ~name:"after" `After
           ~doc:"$(b,after) breaks the expressions after the separator."
-      ; C.Value.valid ~name:"before" `Before
+      ; C.Value.make ~name:"before" `Before
           ~doc:"$(b,before) breaks the expressions before the separator." ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
-        [ C.Value_removed.mk ~name:"after-and-docked" ~version:"0.12"
+        [ C.Value_removed.make ~name:"after-and-docked" ~version:"0.12"
             ~msg:
               "One can get a similar behaviour by setting \
                `break-separators=after`, `space-around-lists=false`, and \
@@ -402,18 +402,18 @@ module Formatting = struct
     let doc = "Break string literals." in
     let names = ["break-string-literals"] in
     let all =
-      [ C.Value.valid ~name:"auto" `Auto
+      [ C.Value.make ~name:"auto" `Auto
           ~doc:
             "$(b,auto) mode breaks lines at newlines and wraps string \
              literals at the margin."
-      ; C.Value.valid ~name:"never" `Never
+      ; C.Value.make ~name:"never" `Never
           ~doc:
             "$(b,never) mode formats string literals as they are parsed, in \
              particular, with escape sequences expanded." ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
-        (C.Value_removed.mk_list
+        (C.Value_removed.make_list
            ~names:["newlines"; "newlines-and-wrap"; "wrap"]
            ~version:"0.12"
            ~msg:
@@ -427,9 +427,9 @@ module Formatting = struct
     let doc = "Break struct-end module items." in
     let names = ["break-struct"] in
     let all =
-      [ C.Value.valid ~name:"force" `Force
+      [ C.Value.make ~name:"force" `Force
           ~doc:"$(b,force) will break struct-end phrases unconditionally."
-      ; C.Value.valid ~name:"natural" `Natural
+      ; C.Value.make ~name:"natural" `Natural
           ~doc:
             "$(b,natural) will break struct-end phrases naturally at the \
              margin." ]
@@ -456,9 +456,9 @@ module Formatting = struct
     in
     let names = ["cases-matching-exp-indent"] in
     let all =
-      [ C.Value.valid ~name:"normal" `Normal
+      [ C.Value.make ~name:"normal" `Normal
           ~doc:"$(b,normal) indents as it would any other expression."
-      ; C.Value.valid ~name:"compact" `Compact
+      ; C.Value.make ~name:"compact" `Compact
           ~doc:
             "$(b,compact) forces an indentation of 2, unless \
              $(b,nested-match) is set to $(b,align) and we're on the last \
@@ -493,24 +493,24 @@ module Formatting = struct
     let doc = "Doc comments position." in
     let names = ["doc-comments"] in
     let all =
-      [ C.Value.valid ~name:"after-when-possible" `After_when_possible
+      [ C.Value.make ~name:"after-when-possible" `After_when_possible
           ~doc:
             "$(b,after-when-possible) puts doc comments after the \
              corresponding code. This option has no effect on variant \
              declarations because that would change their meaning and on \
              structures, signatures and objects for readability."
-      ; C.Value.valid ~name:"before-except-val" `Before_except_val
+      ; C.Value.make ~name:"before-except-val" `Before_except_val
           ~doc:
             "$(b,before-except-val) puts doc comments before the \
              corresponding code, but puts doc comments of $(b,val) and \
              $(b,external) declarations after the corresponding \
              declarations."
-      ; C.Value.valid ~name:"before" `Before
+      ; C.Value.make ~name:"before" `Before
           ~doc:"$(b,before) puts comments before the corresponding code." ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
-        [ C.Value_removed.mk ~name:"after" ~version:"0.14.2"
+        [ C.Value_removed.make ~name:"after" ~version:"0.14.2"
             ~msg:
               "This value has been renamed `after-when-possible` to take \
                into account the technical limitations of ocamlformat, the \
@@ -532,9 +532,9 @@ module Formatting = struct
     let doc = "Position of doc comments with only tags." in
     let names = ["doc-comments-tag-only"] in
     let all =
-      [ C.Value.valid ~name:"default" `Default
+      [ C.Value.make ~name:"default" `Default
           ~doc:"$(b,default) means no special treatment."
-      ; C.Value.valid ~name:"fit" `Fit
+      ; C.Value.make ~name:"fit" `Fit
           ~doc:"$(b,fit) puts doc comments on the same line." ]
     in
     C.choice ~names ~all ~doc ~kind
@@ -590,9 +590,9 @@ module Formatting = struct
     let doc = "Style of expression grouping." in
     let names = ["exp-grouping"] in
     let all =
-      [ C.Value.valid ~name:"parens" `Parens
+      [ C.Value.make ~name:"parens" `Parens
           ~doc:"$(b,parens) groups expressions using parentheses."
-      ; C.Value.valid ~name:"preserve" `Preserve
+      ; C.Value.make ~name:"preserve" `Preserve
           ~doc:
             "$(b,preserve) preserves the original grouping syntax \
              (parentheses or $(i,begin)/$(i,end))." ]
@@ -624,12 +624,12 @@ module Formatting = struct
     in
     let names = ["field-space"] in
     let all =
-      [ C.Value.valid ~name:"loose" `Loose ~doc:"$(b,loose) does."
-      ; C.Value.valid ~name:"tight" `Tight
+      [ C.Value.make ~name:"loose" `Loose ~doc:"$(b,loose) does."
+      ; C.Value.make ~name:"tight" `Tight
           ~doc:
             "$(b,tight) does not use a space between a field name and the \
              punctuation symbol (`:` or `=`)."
-      ; C.Value.valid ~name:"tight-decl" `Tight_decl
+      ; C.Value.make ~name:"tight-decl" `Tight_decl
           ~doc:
             "$(b,tight-decl) is $(b,tight) for declarations and $(b,loose) \
              for instantiations." ]
@@ -653,13 +653,13 @@ module Formatting = struct
     in
     let names = ["function-indent-nested"] in
     let all =
-      [ C.Value.valid ~name:"never" `Never
+      [ C.Value.make ~name:"never" `Never
           ~doc:
             "$(b,never) only applies $(b,function-indent) if the function \
              block starts a line."
-      ; C.Value.valid ~name:"always" `Always
+      ; C.Value.make ~name:"always" `Always
           ~doc:"$(b,always) always apply $(b,function-indent)."
-      ; C.Value.valid ~name:"auto" `Auto
+      ; C.Value.make ~name:"auto" `Auto
           ~doc:"$(b,auto) applies $(b,function-indent) when seen fit." ]
     in
     C.choice ~names ~all ~doc ~kind
@@ -670,19 +670,19 @@ module Formatting = struct
     let doc = "If-then-else formatting." in
     let names = ["if-then-else"] in
     let all =
-      [ C.Value.valid ~name:"compact" `Compact
+      [ C.Value.make ~name:"compact" `Compact
           ~doc:
             "$(b,compact) tries to format an if-then-else expression on a \
              single line."
-      ; C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      ; C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) vertically breaks branches if they do not \
              fit on a single line."
-      ; C.Value.valid ~name:"keyword-first" `Keyword_first
+      ; C.Value.make ~name:"keyword-first" `Keyword_first
           ~doc:
             "$(b,keyword-first) formats if-then-else expressions such that \
              the if-then-else keywords are the first on the line."
-      ; C.Value.valid ~name:"k-r" `K_R
+      ; C.Value.make ~name:"k-r" `K_R
           ~doc:
             "$(b,k-r) formats if-then-else expressions with parentheses \
              that match the K&R style." ]
@@ -708,15 +708,15 @@ module Formatting = struct
     in
     let names = ["indicate-multiline-delimiters"] in
     let all =
-      [ C.Value.valid ~name:"no" `No
+      [ C.Value.make ~name:"no" `No
           ~doc:
             "$(b, no) doesn't do anything special to indicate the closing \
              delimiter."
-      ; C.Value.valid ~name:"space" `Space
+      ; C.Value.make ~name:"space" `Space
           ~doc:
             "$(b,space) prints a space inside the delimiter to indicate the \
              matching one is on a different line."
-      ; C.Value.valid ~name:"closing-on-separate-line"
+      ; C.Value.make ~name:"closing-on-separate-line"
           `Closing_on_separate_line
           ~doc:
             "$(b, closing-on-separate-line) makes sure that the closing \
@@ -733,13 +733,13 @@ module Formatting = struct
     in
     let names = ["indicate-nested-or-patterns"] in
     let all =
-      [ C.Value.valid ~name:"unsafe-no" `Unsafe_no
+      [ C.Value.make ~name:"unsafe-no" `Unsafe_no
           ~doc:
             "$(b,unsafe-no) does not indicate nested or-patterns. Warning: \
              this can produce confusing code where a short body of a match \
              case is visually hidden by surrounding long patterns, leading \
              to misassociation between patterns and body expressions."
-      ; C.Value.valid ~name:"space" `Space
+      ; C.Value.make ~name:"space" `Space
           ~doc:
             "$(b,space) starts lines of nested or-patterns with \" |\" \
              rather than \"| \"." ]
@@ -755,11 +755,11 @@ module Formatting = struct
     in
     let names = ["infix-precedence"] in
     let all =
-      [ C.Value.valid ~name:"indent" `Indent
+      [ C.Value.make ~name:"indent" `Indent
           ~doc:
             "$(b,indent) uses indentation to explicitly disambiguate \
              precedences of infix operators."
-      ; C.Value.valid ~name:"parens" `Parens
+      ; C.Value.make ~name:"parens" `Parens
           ~doc:
             "$(b,parens) uses parentheses to explicitly disambiguate \
              precedences of infix operators." ]
@@ -779,11 +779,11 @@ module Formatting = struct
     let doc = "Style of let_and." in
     let names = ["let-and"] in
     let all =
-      [ C.Value.valid ~name:"compact" `Compact
+      [ C.Value.make ~name:"compact" `Compact
           ~doc:
             "$(b,compact) will try to format `let p = e and p = e` in a \
              single line."
-      ; C.Value.valid ~name:"sparse" `Sparse
+      ; C.Value.make ~name:"sparse" `Sparse
           ~doc:"$(b,sparse) will always break between them." ]
     in
     C.choice ~names ~all ~doc ~kind
@@ -805,15 +805,15 @@ module Formatting = struct
     let doc = "Spacing between let binding." in
     let names = ["let-binding-spacing"] in
     let all =
-      [ C.Value.valid ~name:"compact" `Compact
+      [ C.Value.make ~name:"compact" `Compact
           ~doc:
             "$(b,compact) spacing separates adjacent let bindings in a \
              module according to module-item-spacing."
-      ; C.Value.valid ~name:"sparse" `Sparse
+      ; C.Value.make ~name:"sparse" `Sparse
           ~doc:
             "$(b,sparse) places two open lines between a multi-line \
              module-level let binding and the next."
-      ; C.Value.valid ~name:"double-semicolon" `Double_semicolon
+      ; C.Value.make ~name:"double-semicolon" `Double_semicolon
           ~doc:
             "$(b,double-semicolon) places double semicolons and an open \
              line between a multi-line module-level let binding and the \
@@ -826,12 +826,12 @@ module Formatting = struct
   let let_module =
     let doc = "Module binding formatting." in
     let all =
-      [ C.Value.valid ~name:"compact" `Compact
+      [ C.Value.make ~name:"compact" `Compact
           ~doc:
             "$(b,compact) does not break a line after the $(i,let module \
              ... =) and before the $(i,in) if the module declaration does \
              not fit on a single line."
-      ; C.Value.valid ~name:"sparse" `Sparse
+      ; C.Value.make ~name:"sparse" `Sparse
           ~doc:
             "$(b,sparse) breaks a line after $(i,let module ... =) and \
              before the $(i,in) if the module declaration does not fit on a \
@@ -850,8 +850,8 @@ module Formatting = struct
   let line_endings =
     let doc = "Line endings used." in
     let all =
-      [ C.Value.valid ~name:"lf" `Lf ~doc:"$(b,lf) uses Unix line endings."
-      ; C.Value.valid ~name:"crlf" `Crlf
+      [ C.Value.make ~name:"lf" `Lf ~doc:"$(b,lf) uses Unix line endings."
+      ; C.Value.make ~name:"crlf" `Crlf
           ~doc:"$(b,crlf) uses Windows line endings." ]
     in
     C.choice ~names:["line-endings"] ~all ~doc ~allow_inline:false ~kind
@@ -881,13 +881,13 @@ module Formatting = struct
     in
     let names = ["match-indent-nested"] in
     let all =
-      [ C.Value.valid ~name:"never" `Never
+      [ C.Value.make ~name:"never" `Never
           ~doc:
             "$(b,never) only applies $(b,match-indent) if the match block \
              starts a line."
-      ; C.Value.valid ~name:"always" `Always
+      ; C.Value.make ~name:"always" `Always
           ~doc:"$(b,always) always apply $(b,match-indent)."
-      ; C.Value.valid ~name:"auto" `Auto
+      ; C.Value.make ~name:"auto" `Auto
           ~doc:"$(b,auto) applies $(b,match-indent) when seen fit." ]
     in
     C.choice ~names ~all ~doc ~kind
@@ -917,13 +917,13 @@ module Formatting = struct
     let doc = "Spacing between items of structures and signatures." in
     let names = ["module-item-spacing"] in
     let all =
-      [ C.Value.valid ~name:"sparse" `Sparse
+      [ C.Value.make ~name:"sparse" `Sparse
           ~doc:"$(b,sparse) will always break a line between two items."
-      ; C.Value.valid ~name:"preserve" `Preserve
+      ; C.Value.make ~name:"preserve" `Preserve
           ~doc:
             "$(b,preserve) will not leave open lines between one-liners of \
              similar sorts unless there is an open line in the input."
-      ; C.Value.valid ~name:"compact" `Compact
+      ; C.Value.make ~name:"compact" `Compact
           ~doc:
             "$(b,compact) will not leave open lines between one-liners of \
              similar sorts." ]
@@ -939,11 +939,11 @@ module Formatting = struct
     in
     let names = ["nested-match"] in
     let all =
-      [ C.Value.valid ~name:"wrap" `Wrap
+      [ C.Value.make ~name:"wrap" `Wrap
           ~doc:
             "$(b,wrap) wraps the nested pattern-matching with parentheses \
              and adds indentation."
-      ; C.Value.valid ~name:"align" `Align
+      ; C.Value.make ~name:"align" `Align
           ~doc:
             "$(b,align) vertically aligns the nested pattern-matching under \
              the encompassing pattern-matching." ]
@@ -986,9 +986,9 @@ module Formatting = struct
     let doc = "Parens tuple expressions." in
     let names = ["parens-tuple"] in
     let all =
-      [ C.Value.valid ~name:"always" `Always
+      [ C.Value.make ~name:"always" `Always
           ~doc:"$(b,always) always uses parentheses around tuples."
-      ; C.Value.valid ~name:"multi-line-only" `Multi_line_only
+      ; C.Value.make ~name:"multi-line-only" `Multi_line_only
           ~doc:
             "$(b,multi-line-only) mode will try to skip parens for \
              single-line tuples." ]
@@ -1001,11 +1001,11 @@ module Formatting = struct
     let doc = "Parens tuple patterns." in
     let names = ["parens-tuple-patterns"] in
     let all =
-      [ C.Value.valid ~name:"multi-line-only" `Multi_line_only
+      [ C.Value.make ~name:"multi-line-only" `Multi_line_only
           ~doc:
             "$(b,multi-line-only) mode will try to skip parens for \
              single-line tuple patterns."
-      ; C.Value.valid ~name:"always" `Always
+      ; C.Value.make ~name:"always" `Always
           ~doc:"$(b,always) always uses parentheses around tuples patterns."
       ]
     in
@@ -1024,11 +1024,11 @@ module Formatting = struct
     let doc = "Blank line between expressions of a sequence." in
     let names = ["sequence-blank-line"] in
     let all =
-      [ C.Value.valid ~name:"preserve-one" `Preserve_one
+      [ C.Value.make ~name:"preserve-one" `Preserve_one
           ~doc:
             "$(b,preserve) will keep a blank line between two expressions \
              of a sequence if the input contains at least one."
-      ; C.Value.valid ~name:"compact" `Compact
+      ; C.Value.make ~name:"compact" `Compact
           ~doc:
             "$(b,compact) will not keep any blank line between expressions \
              of a sequence." ]
@@ -1041,11 +1041,11 @@ module Formatting = struct
     let doc = "Style of sequence." in
     let names = ["sequence-style"] in
     let all =
-      [ C.Value.valid ~name:"terminator" `Terminator
+      [ C.Value.make ~name:"terminator" `Terminator
           ~doc:"$(b,terminator) only puts spaces after semicolons."
-      ; C.Value.valid ~name:"separator" `Separator
+      ; C.Value.make ~name:"separator" `Separator
           ~doc:"$(b,separator) puts spaces before and after semicolons."
-      ; C.Value.valid ~name:"before" `Before
+      ; C.Value.make ~name:"before" `Before
           ~doc:"$(b,before) breaks the sequence before semicolons." ]
     in
     C.choice ~names ~all ~doc ~kind
@@ -1058,10 +1058,10 @@ module Formatting = struct
     in
     let names = ["single-case"] in
     let all =
-      [ C.Value.valid ~name:"compact" `Compact
+      [ C.Value.make ~name:"compact" `Compact
           ~doc:
             "$(b,compact) will try to format a single case on a single line."
-      ; C.Value.valid ~name:"sparse" `Sparse
+      ; C.Value.make ~name:"sparse" `Sparse
           ~doc:"$(b,sparse) will always break the line before a single case."
       ]
     in
@@ -1112,11 +1112,11 @@ module Formatting = struct
     let doc = "Style of type declaration." in
     let names = ["type-decl"] in
     let all =
-      [ C.Value.valid ~name:"compact" `Compact
+      [ C.Value.make ~name:"compact" `Compact
           ~doc:
             "$(b,compact) will try to format constructors and records \
              definition in a single line."
-      ; C.Value.valid ~name:"sparse" `Sparse
+      ; C.Value.make ~name:"sparse" `Sparse
           ~doc:
             "$(b,sparse) will always break between constructors and record \
              fields." ]
@@ -1706,21 +1706,21 @@ let (_profile : t option C.t) =
   in
   let names = profile_option_names in
   let all =
-    [ C.Value.valid ~name:"conventional" (Some conventional_profile)
+    [ C.Value.make ~name:"conventional" (Some conventional_profile)
         ~doc:
           "The $(b,conventional) profile aims to be as familiar and \
            \"conventional\" appearing as the available options allow."
-    ; C.Value.valid ~name:"default" (Some default_profile)
+    ; C.Value.make ~name:"default" (Some default_profile)
         ~doc:"$(b,default) is an alias for the $(b,conventional) profile."
-    ; C.Value.valid ~name:"compact" (Some compact_profile)
+    ; C.Value.make ~name:"compact" (Some compact_profile)
         ~doc:
           "The $(b,compact) profile is similar to $(b,ocamlformat) but opts \
            for a generally more compact code style."
-    ; C.Value.valid ~name:"sparse" (Some sparse_profile)
+    ; C.Value.make ~name:"sparse" (Some sparse_profile)
         ~doc:
           "The $(b,sparse) profile is similar to $(b,ocamlformat) but opts \
            for a generally more sparse code style."
-    ; C.Value.valid ~name:"ocamlformat" (Some ocamlformat_profile)
+    ; C.Value.make ~name:"ocamlformat" (Some ocamlformat_profile)
         ~doc:
           "The $(b,ocamlformat) profile aims to take advantage of the \
            strengths of a parsetree-based auto-formatter, and to limit the \
@@ -1739,7 +1739,7 @@ let (_profile : t option C.t) =
            or white space is avoided unless it helps legibility; Attention \
            has been given to making some syntactic gotchas visually \
            obvious."
-    ; C.Value.valid ~name:"janestreet" (Some janestreet_profile)
+    ; C.Value.make ~name:"janestreet" (Some janestreet_profile)
         ~doc:"The $(b,janestreet) profile is used at Jane Street." ]
   in
   C.choice ~names ~all ~doc ~kind:C.Formatting

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -215,18 +215,16 @@ module Formatting = struct
     let doc = "Position of the assignment operator." in
     let names = ["assignment-operator"] in
     let all =
-      [ ( "end-line"
-        , `End_line
-        , "$(b,end-line) positions assignment operators (`:=` and `<-`) at \
-           the end of the line and breaks after it if the whole assignment \
-           expression does not fit on a single line."
-        , `Valid )
-      ; ( "begin-line"
-        , `Begin_line
-        , "$(b,begin-line) positions assignment operators (`:=` and `<-`) \
-           at the beginning of the line and breaks before it if the whole \
-           assignment expression does not fit on a single line."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"end-line" `End_line
+          ~doc:
+            "$(b,end-line) positions assignment operators (`:=` and `<-`) \
+             at the end of the line and breaks after it if the whole \
+             assignment expression does not fit on a single line."
+      ; C.Value.Ok.valid ~name:"begin-line" `Begin_line
+          ~doc:
+            "$(b,begin-line) positions assignment operators (`:=` and `<-`) \
+             at the beginning of the line and breaks before it if the whole \
+             assignment expression does not fit on a single line." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with assignment_operator= x})
@@ -239,17 +237,15 @@ module Formatting = struct
     in
     let names = ["break-before-in"] in
     let all =
-      [ ( "fit-or-vertical"
-        , `Fit_or_vertical
-        , "$(b,fit-or-vertical) will always break the line before the \
-           $(i,in) keyword if the whole $(i,let) binding does not fit on a \
-           single line."
-        , `Valid )
-      ; ( "auto"
-        , `Auto
-        , "$(b,auto) will only break the line if the $(i,in) keyword does \
-           not fit on the previous line."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+          ~doc:
+            "$(b,fit-or-vertical) will always break the line before the \
+             $(i,in) keyword if the whole $(i,let) binding does not fit on \
+             a single line."
+      ; C.Value.Ok.valid ~name:"auto" `Auto
+          ~doc:
+            "$(b,auto) will only break the line if the $(i,in) keyword does \
+             not fit on the previous line." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_before_in= x})
@@ -259,33 +255,28 @@ module Formatting = struct
     let doc = "Break pattern match cases." in
     let names = ["break-cases"] in
     let all =
-      [ ( "fit"
-        , `Fit
-        , "Specifying $(b,fit) lets pattern matches break at the margin \
-           naturally."
-        , `Valid )
-      ; ( "nested"
-        , `Nested
-        , "$(b,nested) forces a break after nested or-patterns to highlight \
-           the case body. Note that with $(b,nested), the \
-           $(b,indicate-nested-or-patterns) option is not needed, and so \
-           ignored."
-        , `Valid )
-      ; ( "toplevel"
-        , `Toplevel
-        , "$(b,toplevel) forces top-level cases (i.e. not nested \
-           or-patterns) to break across lines, otherwise break naturally at \
-           the margin."
-        , `Valid )
-      ; ( "fit-or-vertical"
-        , `Fit_or_vertical
-        , "$(b,fit-or-vertical) tries to fit all or-patterns on the same \
-           line, otherwise breaks."
-        , `Valid )
-      ; ( "all"
-        , `All
-        , "$(b,all) forces all pattern matches to break across lines."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"fit" `Fit
+          ~doc:
+            "Specifying $(b,fit) lets pattern matches break at the margin \
+             naturally."
+      ; C.Value.Ok.valid ~name:"nested" `Nested
+          ~doc:
+            "$(b,nested) forces a break after nested or-patterns to \
+             highlight the case body. Note that with $(b,nested), the \
+             $(b,indicate-nested-or-patterns) option is not needed, and so \
+             ignored."
+      ; C.Value.Ok.valid ~name:"toplevel" `Toplevel
+          ~doc:
+            "$(b,toplevel) forces top-level cases (i.e. not nested \
+             or-patterns) to break across lines, otherwise break naturally \
+             at the margin."
+      ; C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+          ~doc:
+            "$(b,fit-or-vertical) tries to fit all or-patterns on the same \
+             line, otherwise breaks."
+      ; C.Value.Ok.valid ~name:"all" `All
+          ~doc:"$(b,all) forces all pattern matches to break across lines."
+      ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_cases= x})
@@ -297,16 +288,14 @@ module Formatting = struct
     in
     let names = ["break-collection-expressions"] in
     let all =
-      [ ( "fit-or-vertical"
-        , `Fit_or_vertical
-        , "$(b,fit-or-vertical) vertically breaks expressions if they do \
-           not fit on a single line."
-        , `Valid )
-      ; ( "wrap"
-        , `Wrap
-        , "$(b,wrap) will group simple expressions and try to format them \
-           in a single line."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+          ~doc:
+            "$(b,fit-or-vertical) vertically breaks expressions if they do \
+             not fit on a single line."
+      ; C.Value.Ok.valid ~name:"wrap" `Wrap
+          ~doc:
+            "$(b,wrap) will group simple expressions and try to format them \
+             in a single line." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_collection_expressions= x})
@@ -316,17 +305,16 @@ module Formatting = struct
     let doc = "Style for function declarations and types." in
     let names = ["break-fun-decl"] in
     let all =
-      [ ("wrap", `Wrap, "$(b,wrap) breaks only if necessary.", `Valid)
-      ; ( "fit-or-vertical"
-        , `Fit_or_vertical
-        , "$(b,fit-or-vertical) vertically breaks arguments if they do not \
-           fit on a single line."
-        , `Valid )
-      ; ( "smart"
-        , `Smart
-        , "$(b,smart) is like $(b,fit-or-vertical) but try to fit arguments \
-           on their line if they fit."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"wrap" `Wrap
+          ~doc:"$(b,wrap) breaks only if necessary."
+      ; C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+          ~doc:
+            "$(b,fit-or-vertical) vertically breaks arguments if they do \
+             not fit on a single line."
+      ; C.Value.Ok.valid ~name:"smart" `Smart
+          ~doc:
+            "$(b,smart) is like $(b,fit-or-vertical) but try to fit \
+             arguments on their line if they fit." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_fun_decl= x})
@@ -336,17 +324,16 @@ module Formatting = struct
     let doc = "Style for function signatures." in
     let names = ["break-fun-sig"] in
     let all =
-      [ ("wrap", `Wrap, "$(b,wrap) breaks only if necessary.", `Valid)
-      ; ( "fit-or-vertical"
-        , `Fit_or_vertical
-        , "$(b,fit-or-vertical) vertically breaks arguments if they do not \
-           fit on a single line."
-        , `Valid )
-      ; ( "smart"
-        , `Smart
-        , "$(b,smart) is like $(b,fit-or-vertical) but try to fit arguments \
-           on their line if they fit."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"wrap" `Wrap
+          ~doc:"$(b,wrap) breaks only if necessary."
+      ; C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+          ~doc:
+            "$(b,fit-or-vertical) vertically breaks arguments if they do \
+             not fit on a single line."
+      ; C.Value.Ok.valid ~name:"smart" `Smart
+          ~doc:
+            "$(b,smart) is like $(b,fit-or-vertical) but try to fit \
+             arguments on their line if they fit." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_fun_sig= x})
@@ -356,16 +343,14 @@ module Formatting = struct
     let doc = "Break sequence of infix operators." in
     let names = ["break-infix"] in
     let all =
-      [ ( "wrap"
-        , `Wrap
-        , "$(b,wrap) will group simple expressions and try to format them \
-           in a single line."
-        , `Valid )
-      ; ( "fit-or-vertical"
-        , `Fit_or_vertical
-        , "$(b,fit-or-vertical) vertically breaks expressions if they do \
-           not fit on a single line."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"wrap" `Wrap
+          ~doc:
+            "$(b,wrap) will group simple expressions and try to format them \
+             in a single line."
+      ; C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+          ~doc:
+            "$(b,fit-or-vertical) vertically breaks expressions if they do \
+             not fit on a single line." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_infix= x})
@@ -389,14 +374,10 @@ module Formatting = struct
     in
     let names = ["break-separators"] in
     let all =
-      [ ( "after"
-        , `After
-        , "$(b,after) breaks the expressions after the separator."
-        , `Valid )
-      ; ( "before"
-        , `Before
-        , "$(b,before) breaks the expressions before the separator."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"after" `After
+          ~doc:"$(b,after) breaks the expressions after the separator."
+      ; C.Value.Ok.valid ~name:"before" `Before
+          ~doc:"$(b,before) breaks the expressions before the separator." ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
@@ -421,16 +402,14 @@ module Formatting = struct
     let doc = "Break string literals." in
     let names = ["break-string-literals"] in
     let all =
-      [ ( "auto"
-        , `Auto
-        , "$(b,auto) mode breaks lines at newlines and wraps string \
-           literals at the margin."
-        , `Valid )
-      ; ( "never"
-        , `Never
-        , "$(b,never) mode formats string literals as they are parsed, in \
-           particular, with escape sequences expanded."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"auto" `Auto
+          ~doc:
+            "$(b,auto) mode breaks lines at newlines and wraps string \
+             literals at the margin."
+      ; C.Value.Ok.valid ~name:"never" `Never
+          ~doc:
+            "$(b,never) mode formats string literals as they are parsed, in \
+             particular, with escape sequences expanded." ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
@@ -448,15 +427,12 @@ module Formatting = struct
     let doc = "Break struct-end module items." in
     let names = ["break-struct"] in
     let all =
-      [ ( "force"
-        , `Force
-        , "$(b,force) will break struct-end phrases unconditionally."
-        , `Valid )
-      ; ( "natural"
-        , `Natural
-        , "$(b,natural) will break struct-end phrases naturally at the \
-           margin."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"force" `Force
+          ~doc:"$(b,force) will break struct-end phrases unconditionally."
+      ; C.Value.Ok.valid ~name:"natural" `Natural
+          ~doc:
+            "$(b,natural) will break struct-end phrases naturally at the \
+             margin." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_struct= Poly.(x = `Force)})
@@ -480,16 +456,13 @@ module Formatting = struct
     in
     let names = ["cases-matching-exp-indent"] in
     let all =
-      [ ( "normal"
-        , `Normal
-        , "$(b,normal) indents as it would any other expression."
-        , `Valid )
-      ; ( "compact"
-        , `Compact
-        , "$(b,compact) forces an indentation of 2, unless \
-           $(b,nested-match) is set to $(b,align) and we're on the last \
-           case."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"normal" `Normal
+          ~doc:"$(b,normal) indents as it would any other expression."
+      ; C.Value.Ok.valid ~name:"compact" `Compact
+          ~doc:
+            "$(b,compact) forces an indentation of 2, unless \
+             $(b,nested-match) is set to $(b,align) and we're on the last \
+             case." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with cases_matching_exp_indent= x})
@@ -520,23 +493,20 @@ module Formatting = struct
     let doc = "Doc comments position." in
     let names = ["doc-comments"] in
     let all =
-      [ ( "after-when-possible"
-        , `After_when_possible
-        , "$(b,after-when-possible) puts doc comments after the \
-           corresponding code. This option has no effect on variant \
-           declarations because that would change their meaning and on \
-           structures, signatures and objects for readability."
-        , `Valid )
-      ; ( "before-except-val"
-        , `Before_except_val
-        , "$(b,before-except-val) puts doc comments before the \
-           corresponding code, but puts doc comments of $(b,val) and \
-           $(b,external) declarations after the corresponding declarations."
-        , `Valid )
-      ; ( "before"
-        , `Before
-        , "$(b,before) puts comments before the corresponding code."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"after-when-possible" `After_when_possible
+          ~doc:
+            "$(b,after-when-possible) puts doc comments after the \
+             corresponding code. This option has no effect on variant \
+             declarations because that would change their meaning and on \
+             structures, signatures and objects for readability."
+      ; C.Value.Ok.valid ~name:"before-except-val" `Before_except_val
+          ~doc:
+            "$(b,before-except-val) puts doc comments before the \
+             corresponding code, but puts doc comments of $(b,val) and \
+             $(b,external) declarations after the corresponding \
+             declarations."
+      ; C.Value.Ok.valid ~name:"before" `Before
+          ~doc:"$(b,before) puts comments before the corresponding code." ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
@@ -562,12 +532,10 @@ module Formatting = struct
     let doc = "Position of doc comments with only tags." in
     let names = ["doc-comments-tag-only"] in
     let all =
-      [ ( "default"
-        , `Default
-        , "$(b,default) means no special treatment."
-        , `Valid )
-      ; ("fit", `Fit, "$(b,fit) puts doc comments on the same line.", `Valid)
-      ]
+      [ C.Value.Ok.valid ~name:"default" `Default
+          ~doc:"$(b,default) means no special treatment."
+      ; C.Value.Ok.valid ~name:"fit" `Fit
+          ~doc:"$(b,fit) puts doc comments on the same line." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with doc_comments_tag_only= x})
@@ -622,15 +590,12 @@ module Formatting = struct
     let doc = "Style of expression grouping." in
     let names = ["exp-grouping"] in
     let all =
-      [ ( "parens"
-        , `Parens
-        , "$(b,parens) groups expressions using parentheses."
-        , `Valid )
-      ; ( "preserve"
-        , `Preserve
-        , "$(b,preserve) preserves the original grouping syntax \
-           (parentheses or $(i,begin)/$(i,end))."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"parens" `Parens
+          ~doc:"$(b,parens) groups expressions using parentheses."
+      ; C.Value.Ok.valid ~name:"preserve" `Preserve
+          ~doc:
+            "$(b,preserve) preserves the original grouping syntax \
+             (parentheses or $(i,begin)/$(i,end))." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with exp_grouping= x})
@@ -659,17 +624,15 @@ module Formatting = struct
     in
     let names = ["field-space"] in
     let all =
-      [ ("loose", `Loose, "$(b,loose) does.", `Valid)
-      ; ( "tight"
-        , `Tight
-        , "$(b,tight) does not use a space between a field name and the \
-           punctuation symbol (`:` or `=`)."
-        , `Valid )
-      ; ( "tight-decl"
-        , `Tight_decl
-        , "$(b,tight-decl) is $(b,tight) for declarations and $(b,loose) \
-           for instantiations."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"loose" `Loose ~doc:"$(b,loose) does."
+      ; C.Value.Ok.valid ~name:"tight" `Tight
+          ~doc:
+            "$(b,tight) does not use a space between a field name and the \
+             punctuation symbol (`:` or `=`)."
+      ; C.Value.Ok.valid ~name:"tight-decl" `Tight_decl
+          ~doc:
+            "$(b,tight-decl) is $(b,tight) for declarations and $(b,loose) \
+             for instantiations." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with field_space= x})
@@ -690,19 +653,14 @@ module Formatting = struct
     in
     let names = ["function-indent-nested"] in
     let all =
-      [ ( "never"
-        , `Never
-        , "$(b,never) only applies $(b,function-indent) if the function \
-           block starts a line."
-        , `Valid )
-      ; ( "always"
-        , `Always
-        , "$(b,always) always apply $(b,function-indent)."
-        , `Valid )
-      ; ( "auto"
-        , `Auto
-        , "$(b,auto) applies $(b,function-indent) when seen fit."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"never" `Never
+          ~doc:
+            "$(b,never) only applies $(b,function-indent) if the function \
+             block starts a line."
+      ; C.Value.Ok.valid ~name:"always" `Always
+          ~doc:"$(b,always) always apply $(b,function-indent)."
+      ; C.Value.Ok.valid ~name:"auto" `Auto
+          ~doc:"$(b,auto) applies $(b,function-indent) when seen fit." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with function_indent_nested= x})
@@ -712,26 +670,22 @@ module Formatting = struct
     let doc = "If-then-else formatting." in
     let names = ["if-then-else"] in
     let all =
-      [ ( "compact"
-        , `Compact
-        , "$(b,compact) tries to format an if-then-else expression on a \
-           single line."
-        , `Valid )
-      ; ( "fit-or-vertical"
-        , `Fit_or_vertical
-        , "$(b,fit-or-vertical) vertically breaks branches if they do not \
-           fit on a single line."
-        , `Valid )
-      ; ( "keyword-first"
-        , `Keyword_first
-        , "$(b,keyword-first) formats if-then-else expressions such that \
-           the if-then-else keywords are the first on the line."
-        , `Valid )
-      ; ( "k-r"
-        , `K_R
-        , "$(b,k-r) formats if-then-else expressions with parentheses that \
-           match the K&R style."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"compact" `Compact
+          ~doc:
+            "$(b,compact) tries to format an if-then-else expression on a \
+             single line."
+      ; C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+          ~doc:
+            "$(b,fit-or-vertical) vertically breaks branches if they do not \
+             fit on a single line."
+      ; C.Value.Ok.valid ~name:"keyword-first" `Keyword_first
+          ~doc:
+            "$(b,keyword-first) formats if-then-else expressions such that \
+             the if-then-else keywords are the first on the line."
+      ; C.Value.Ok.valid ~name:"k-r" `K_R
+          ~doc:
+            "$(b,k-r) formats if-then-else expressions with parentheses \
+             that match the K&R style." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with if_then_else= x})
@@ -754,21 +708,19 @@ module Formatting = struct
     in
     let names = ["indicate-multiline-delimiters"] in
     let all =
-      [ ( "no"
-        , `No
-        , "$(b, no) doesn't do anything special to indicate the closing \
-           delimiter."
-        , `Valid )
-      ; ( "space"
-        , `Space
-        , "$(b,space) prints a space inside the delimiter to indicate the \
-           matching one is on a different line."
-        , `Valid )
-      ; ( "closing-on-separate-line"
-        , `Closing_on_separate_line
-        , "$(b, closing-on-separate-line) makes sure that the closing \
-           delimiter is on its own line."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"no" `No
+          ~doc:
+            "$(b, no) doesn't do anything special to indicate the closing \
+             delimiter."
+      ; C.Value.Ok.valid ~name:"space" `Space
+          ~doc:
+            "$(b,space) prints a space inside the delimiter to indicate the \
+             matching one is on a different line."
+      ; C.Value.Ok.valid ~name:"closing-on-separate-line"
+          `Closing_on_separate_line
+          ~doc:
+            "$(b, closing-on-separate-line) makes sure that the closing \
+             delimiter is on its own line." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with indicate_multiline_delimiters= x})
@@ -781,18 +733,16 @@ module Formatting = struct
     in
     let names = ["indicate-nested-or-patterns"] in
     let all =
-      [ ( "unsafe-no"
-        , `Unsafe_no
-        , "$(b,unsafe-no) does not indicate nested or-patterns. Warning: \
-           this can produce confusing code where a short body of a match \
-           case is visually hidden by surrounding long patterns, leading to \
-           misassociation between patterns and body expressions."
-        , `Valid )
-      ; ( "space"
-        , `Space
-        , "$(b,space) starts lines of nested or-patterns with \" |\" rather \
-           than \"| \"."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"unsafe-no" `Unsafe_no
+          ~doc:
+            "$(b,unsafe-no) does not indicate nested or-patterns. Warning: \
+             this can produce confusing code where a short body of a match \
+             case is visually hidden by surrounding long patterns, leading \
+             to misassociation between patterns and body expressions."
+      ; C.Value.Ok.valid ~name:"space" `Space
+          ~doc:
+            "$(b,space) starts lines of nested or-patterns with \" |\" \
+             rather than \"| \"." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with indicate_nested_or_patterns= x})
@@ -805,16 +755,14 @@ module Formatting = struct
     in
     let names = ["infix-precedence"] in
     let all =
-      [ ( "indent"
-        , `Indent
-        , "$(b,indent) uses indentation to explicitly disambiguate \
-           precedences of infix operators."
-        , `Valid )
-      ; ( "parens"
-        , `Parens
-        , "$(b,parens) uses parentheses to explicitly disambiguate \
-           precedences of infix operators."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"indent" `Indent
+          ~doc:
+            "$(b,indent) uses indentation to explicitly disambiguate \
+             precedences of infix operators."
+      ; C.Value.Ok.valid ~name:"parens" `Parens
+          ~doc:
+            "$(b,parens) uses parentheses to explicitly disambiguate \
+             precedences of infix operators." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with infix_precedence= x})
@@ -831,15 +779,12 @@ module Formatting = struct
     let doc = "Style of let_and." in
     let names = ["let-and"] in
     let all =
-      [ ( "compact"
-        , `Compact
-        , "$(b,compact) will try to format `let p = e and p = e` in a \
-           single line."
-        , `Valid )
-      ; ( "sparse"
-        , `Sparse
-        , "$(b,sparse) will always break between them."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"compact" `Compact
+          ~doc:
+            "$(b,compact) will try to format `let p = e and p = e` in a \
+             single line."
+      ; C.Value.Ok.valid ~name:"sparse" `Sparse
+          ~doc:"$(b,sparse) will always break between them." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with let_and= x})
@@ -860,21 +805,19 @@ module Formatting = struct
     let doc = "Spacing between let binding." in
     let names = ["let-binding-spacing"] in
     let all =
-      [ ( "compact"
-        , `Compact
-        , "$(b,compact) spacing separates adjacent let bindings in a module \
-           according to module-item-spacing."
-        , `Valid )
-      ; ( "sparse"
-        , `Sparse
-        , "$(b,sparse) places two open lines between a multi-line \
-           module-level let binding and the next."
-        , `Valid )
-      ; ( "double-semicolon"
-        , `Double_semicolon
-        , "$(b,double-semicolon) places double semicolons and an open line \
-           between a multi-line module-level let binding and the next."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"compact" `Compact
+          ~doc:
+            "$(b,compact) spacing separates adjacent let bindings in a \
+             module according to module-item-spacing."
+      ; C.Value.Ok.valid ~name:"sparse" `Sparse
+          ~doc:
+            "$(b,sparse) places two open lines between a multi-line \
+             module-level let binding and the next."
+      ; C.Value.Ok.valid ~name:"double-semicolon" `Double_semicolon
+          ~doc:
+            "$(b,double-semicolon) places double semicolons and an open \
+             line between a multi-line module-level let binding and the \
+             next." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with let_binding_spacing= x})
@@ -883,18 +826,16 @@ module Formatting = struct
   let let_module =
     let doc = "Module binding formatting." in
     let all =
-      [ ( "compact"
-        , `Compact
-        , "$(b,compact) does not break a line after the $(i,let module ... \
-           =) and before the $(i,in) if the module declaration does not fit \
-           on a single line."
-        , `Valid )
-      ; ( "sparse"
-        , `Sparse
-        , "$(b,sparse) breaks a line after $(i,let module ... =) and before \
-           the $(i,in) if the module declaration does not fit on a single \
-           line."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"compact" `Compact
+          ~doc:
+            "$(b,compact) does not break a line after the $(i,let module \
+             ... =) and before the $(i,in) if the module declaration does \
+             not fit on a single line."
+      ; C.Value.Ok.valid ~name:"sparse" `Sparse
+          ~doc:
+            "$(b,sparse) breaks a line after $(i,let module ... =) and \
+             before the $(i,in) if the module declaration does not fit on a \
+             single line." ]
     in
     C.choice ~names:["let-module"] ~all ~doc ~kind
       (fun conf x -> {conf with let_module= x})
@@ -909,8 +850,9 @@ module Formatting = struct
   let line_endings =
     let doc = "Line endings used." in
     let all =
-      [ ("lf", `Lf, "$(b,lf) uses Unix line endings.", `Valid)
-      ; ("crlf", `Crlf, "$(b,crlf) uses Windows line endings.", `Valid) ]
+      [ C.Value.Ok.valid ~name:"lf" `Lf ~doc:"$(b,lf) uses Unix line endings."
+      ; C.Value.Ok.valid ~name:"crlf" `Crlf
+          ~doc:"$(b,crlf) uses Windows line endings." ]
     in
     C.choice ~names:["line-endings"] ~all ~doc ~allow_inline:false ~kind
       (fun conf x -> {conf with line_endings= x})
@@ -939,19 +881,14 @@ module Formatting = struct
     in
     let names = ["match-indent-nested"] in
     let all =
-      [ ( "never"
-        , `Never
-        , "$(b,never) only applies $(b,match-indent) if the match block \
-           starts a line."
-        , `Valid )
-      ; ( "always"
-        , `Always
-        , "$(b,always) always apply $(b,match-indent)."
-        , `Valid )
-      ; ( "auto"
-        , `Auto
-        , "$(b,auto) applies $(b,match-indent) when seen fit."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"never" `Never
+          ~doc:
+            "$(b,never) only applies $(b,match-indent) if the match block \
+             starts a line."
+      ; C.Value.Ok.valid ~name:"always" `Always
+          ~doc:"$(b,always) always apply $(b,match-indent)."
+      ; C.Value.Ok.valid ~name:"auto" `Auto
+          ~doc:"$(b,auto) applies $(b,match-indent) when seen fit." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with match_indent_nested= x})
@@ -980,20 +917,16 @@ module Formatting = struct
     let doc = "Spacing between items of structures and signatures." in
     let names = ["module-item-spacing"] in
     let all =
-      [ ( "sparse"
-        , `Sparse
-        , "$(b,sparse) will always break a line between two items."
-        , `Valid )
-      ; ( "preserve"
-        , `Preserve
-        , "$(b,preserve) will not leave open lines between one-liners of \
-           similar sorts unless there is an open line in the input."
-        , `Valid )
-      ; ( "compact"
-        , `Compact
-        , "$(b,compact) will not leave open lines between one-liners of \
-           similar sorts."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"sparse" `Sparse
+          ~doc:"$(b,sparse) will always break a line between two items."
+      ; C.Value.Ok.valid ~name:"preserve" `Preserve
+          ~doc:
+            "$(b,preserve) will not leave open lines between one-liners of \
+             similar sorts unless there is an open line in the input."
+      ; C.Value.Ok.valid ~name:"compact" `Compact
+          ~doc:
+            "$(b,compact) will not leave open lines between one-liners of \
+             similar sorts." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with module_item_spacing= x})
@@ -1006,16 +939,14 @@ module Formatting = struct
     in
     let names = ["nested-match"] in
     let all =
-      [ ( "wrap"
-        , `Wrap
-        , "$(b,wrap) wraps the nested pattern-matching with parentheses and \
-           adds indentation."
-        , `Valid )
-      ; ( "align"
-        , `Align
-        , "$(b,align) vertically aligns the nested pattern-matching under \
-           the encompassing pattern-matching."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"wrap" `Wrap
+          ~doc:
+            "$(b,wrap) wraps the nested pattern-matching with parentheses \
+             and adds indentation."
+      ; C.Value.Ok.valid ~name:"align" `Align
+          ~doc:
+            "$(b,align) vertically aligns the nested pattern-matching under \
+             the encompassing pattern-matching." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with nested_match= x})
@@ -1055,15 +986,12 @@ module Formatting = struct
     let doc = "Parens tuple expressions." in
     let names = ["parens-tuple"] in
     let all =
-      [ ( "always"
-        , `Always
-        , "$(b,always) always uses parentheses around tuples."
-        , `Valid )
-      ; ( "multi-line-only"
-        , `Multi_line_only
-        , "$(b,multi-line-only) mode will try to skip parens for \
-           single-line tuples."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"always" `Always
+          ~doc:"$(b,always) always uses parentheses around tuples."
+      ; C.Value.Ok.valid ~name:"multi-line-only" `Multi_line_only
+          ~doc:
+            "$(b,multi-line-only) mode will try to skip parens for \
+             single-line tuples." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with parens_tuple= x})
@@ -1073,15 +1001,13 @@ module Formatting = struct
     let doc = "Parens tuple patterns." in
     let names = ["parens-tuple-patterns"] in
     let all =
-      [ ( "multi-line-only"
-        , `Multi_line_only
-        , "$(b,multi-line-only) mode will try to skip parens for \
-           single-line tuple patterns."
-        , `Valid )
-      ; ( "always"
-        , `Always
-        , "$(b,always) always uses parentheses around tuples patterns."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"multi-line-only" `Multi_line_only
+          ~doc:
+            "$(b,multi-line-only) mode will try to skip parens for \
+             single-line tuple patterns."
+      ; C.Value.Ok.valid ~name:"always" `Always
+          ~doc:"$(b,always) always uses parentheses around tuples patterns."
+      ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with parens_tuple_patterns= x})
@@ -1098,16 +1024,14 @@ module Formatting = struct
     let doc = "Blank line between expressions of a sequence." in
     let names = ["sequence-blank-line"] in
     let all =
-      [ ( "preserve-one"
-        , `Preserve_one
-        , "$(b,preserve) will keep a blank line between two expressions of \
-           a sequence if the input contains at least one."
-        , `Valid )
-      ; ( "compact"
-        , `Compact
-        , "$(b,compact) will not keep any blank line between expressions of \
-           a sequence."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"preserve-one" `Preserve_one
+          ~doc:
+            "$(b,preserve) will keep a blank line between two expressions \
+             of a sequence if the input contains at least one."
+      ; C.Value.Ok.valid ~name:"compact" `Compact
+          ~doc:
+            "$(b,compact) will not keep any blank line between expressions \
+             of a sequence." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with sequence_blank_line= x})
@@ -1117,18 +1041,12 @@ module Formatting = struct
     let doc = "Style of sequence." in
     let names = ["sequence-style"] in
     let all =
-      [ ( "terminator"
-        , `Terminator
-        , "$(b,terminator) only puts spaces after semicolons."
-        , `Valid )
-      ; ( "separator"
-        , `Separator
-        , "$(b,separator) puts spaces before and after semicolons."
-        , `Valid )
-      ; ( "before"
-        , `Before
-        , "$(b,before) breaks the sequence before semicolons."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"terminator" `Terminator
+          ~doc:"$(b,terminator) only puts spaces after semicolons."
+      ; C.Value.Ok.valid ~name:"separator" `Separator
+          ~doc:"$(b,separator) puts spaces before and after semicolons."
+      ; C.Value.Ok.valid ~name:"before" `Before
+          ~doc:"$(b,before) breaks the sequence before semicolons." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with sequence_style= x})
@@ -1140,14 +1058,12 @@ module Formatting = struct
     in
     let names = ["single-case"] in
     let all =
-      [ ( "compact"
-        , `Compact
-        , "$(b,compact) will try to format a single case on a single line."
-        , `Valid )
-      ; ( "sparse"
-        , `Sparse
-        , "$(b,sparse) will always break the line before a single case."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"compact" `Compact
+          ~doc:
+            "$(b,compact) will try to format a single case on a single line."
+      ; C.Value.Ok.valid ~name:"sparse" `Sparse
+          ~doc:"$(b,sparse) will always break the line before a single case."
+      ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with single_case= x})
@@ -1196,16 +1112,14 @@ module Formatting = struct
     let doc = "Style of type declaration." in
     let names = ["type-decl"] in
     let all =
-      [ ( "compact"
-        , `Compact
-        , "$(b,compact) will try to format constructors and records \
-           definition in a single line."
-        , `Valid )
-      ; ( "sparse"
-        , `Sparse
-        , "$(b,sparse) will always break between constructors and record \
-           fields."
-        , `Valid ) ]
+      [ C.Value.Ok.valid ~name:"compact" `Compact
+          ~doc:
+            "$(b,compact) will try to format constructors and records \
+             definition in a single line."
+      ; C.Value.Ok.valid ~name:"sparse" `Sparse
+          ~doc:
+            "$(b,sparse) will always break between constructors and record \
+             fields." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with type_decl= x})
@@ -1792,48 +1706,41 @@ let (_profile : t option C.t) =
   in
   let names = profile_option_names in
   let all =
-    [ ( "conventional"
-      , Some conventional_profile
-      , "The $(b,conventional) profile aims to be as familiar and \
-         \"conventional\" appearing as the available options allow."
-      , `Valid )
-    ; ( "default"
-      , Some default_profile
-      , "$(b,default) is an alias for the $(b,conventional) profile."
-      , `Valid )
-    ; ( "compact"
-      , Some compact_profile
-      , "The $(b,compact) profile is similar to $(b,ocamlformat) but opts \
-         for a generally more compact code style."
-      , `Valid )
-    ; ( "sparse"
-      , Some sparse_profile
-      , "The $(b,sparse) profile is similar to $(b,ocamlformat) but opts \
-         for a generally more sparse code style."
-      , `Valid )
-    ; ( "ocamlformat"
-      , Some ocamlformat_profile
-      , "The $(b,ocamlformat) profile aims to take advantage of the \
-         strengths of a parsetree-based auto-formatter, and to limit the \
-         consequences of the weaknesses imposed by the current \
-         implementation. This is a style which optimizes for what the \
-         formatter can do best, rather than to match the style of any \
-         existing code. General guidelines that have directed the design \
-         include: Legibility, in the sense of making it as hard as possible \
-         for quick visual parsing to give the wrong interpretation, is of \
-         highest priority; Whenever possible the high-level structure of \
-         the code should be obvious by looking only at the left margin, in \
-         particular, it should not be necessary to visually jump from left \
-         to right hunting for critical keywords, tokens, etc; All else \
-         equal compact code is preferred as reading without scrolling is \
-         easier, so indentation or white space is avoided unless it helps \
-         legibility; Attention has been given to making some syntactic \
-         gotchas visually obvious."
-      , `Valid )
-    ; ( "janestreet"
-      , Some janestreet_profile
-      , "The $(b,janestreet) profile is used at Jane Street."
-      , `Valid ) ]
+    [ C.Value.Ok.valid ~name:"conventional" (Some conventional_profile)
+        ~doc:
+          "The $(b,conventional) profile aims to be as familiar and \
+           \"conventional\" appearing as the available options allow."
+    ; C.Value.Ok.valid ~name:"default" (Some default_profile)
+        ~doc:"$(b,default) is an alias for the $(b,conventional) profile."
+    ; C.Value.Ok.valid ~name:"compact" (Some compact_profile)
+        ~doc:
+          "The $(b,compact) profile is similar to $(b,ocamlformat) but opts \
+           for a generally more compact code style."
+    ; C.Value.Ok.valid ~name:"sparse" (Some sparse_profile)
+        ~doc:
+          "The $(b,sparse) profile is similar to $(b,ocamlformat) but opts \
+           for a generally more sparse code style."
+    ; C.Value.Ok.valid ~name:"ocamlformat" (Some ocamlformat_profile)
+        ~doc:
+          "The $(b,ocamlformat) profile aims to take advantage of the \
+           strengths of a parsetree-based auto-formatter, and to limit the \
+           consequences of the weaknesses imposed by the current \
+           implementation. This is a style which optimizes for what the \
+           formatter can do best, rather than to match the style of any \
+           existing code. General guidelines that have directed the design \
+           include: Legibility, in the sense of making it as hard as \
+           possible for quick visual parsing to give the wrong \
+           interpretation, is of highest priority; Whenever possible the \
+           high-level structure of the code should be obvious by looking \
+           only at the left margin, in particular, it should not be \
+           necessary to visually jump from left to right hunting for \
+           critical keywords, tokens, etc; All else equal compact code is \
+           preferred as reading without scrolling is easier, so indentation \
+           or white space is avoided unless it helps legibility; Attention \
+           has been given to making some syntactic gotchas visually \
+           obvious."
+    ; C.Value.Ok.valid ~name:"janestreet" (Some janestreet_profile)
+        ~doc:"The $(b,janestreet) profile is used at Jane Street." ]
   in
   C.choice ~names ~all ~doc ~kind:C.Formatting
     (fun conf p ->

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -219,12 +219,14 @@ module Formatting = struct
         , `End_line
         , "$(b,end-line) positions assignment operators (`:=` and `<-`) at \
            the end of the line and breaks after it if the whole assignment \
-           expression does not fit on a single line." )
+           expression does not fit on a single line."
+        , `Valid )
       ; ( "begin-line"
         , `Begin_line
         , "$(b,begin-line) positions assignment operators (`:=` and `<-`) \
            at the beginning of the line and breaks before it if the whole \
-           assignment expression does not fit on a single line." ) ]
+           assignment expression does not fit on a single line."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with assignment_operator= x})
@@ -241,11 +243,13 @@ module Formatting = struct
         , `Fit_or_vertical
         , "$(b,fit-or-vertical) will always break the line before the \
            $(i,in) keyword if the whole $(i,let) binding does not fit on a \
-           single line." )
+           single line."
+        , `Valid )
       ; ( "auto"
         , `Auto
         , "$(b,auto) will only break the line if the $(i,in) keyword does \
-           not fit on the previous line." ) ]
+           not fit on the previous line."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_before_in= x})
@@ -258,25 +262,30 @@ module Formatting = struct
       [ ( "fit"
         , `Fit
         , "Specifying $(b,fit) lets pattern matches break at the margin \
-           naturally." )
+           naturally."
+        , `Valid )
       ; ( "nested"
         , `Nested
         , "$(b,nested) forces a break after nested or-patterns to highlight \
            the case body. Note that with $(b,nested), the \
            $(b,indicate-nested-or-patterns) option is not needed, and so \
-           ignored." )
+           ignored."
+        , `Valid )
       ; ( "toplevel"
         , `Toplevel
         , "$(b,toplevel) forces top-level cases (i.e. not nested \
            or-patterns) to break across lines, otherwise break naturally at \
-           the margin." )
+           the margin."
+        , `Valid )
       ; ( "fit-or-vertical"
         , `Fit_or_vertical
         , "$(b,fit-or-vertical) tries to fit all or-patterns on the same \
-           line, otherwise breaks." )
+           line, otherwise breaks."
+        , `Valid )
       ; ( "all"
         , `All
-        , "$(b,all) forces all pattern matches to break across lines." ) ]
+        , "$(b,all) forces all pattern matches to break across lines."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_cases= x})
@@ -291,11 +300,13 @@ module Formatting = struct
       [ ( "fit-or-vertical"
         , `Fit_or_vertical
         , "$(b,fit-or-vertical) vertically breaks expressions if they do \
-           not fit on a single line." )
+           not fit on a single line."
+        , `Valid )
       ; ( "wrap"
         , `Wrap
         , "$(b,wrap) will group simple expressions and try to format them \
-           in a single line." ) ]
+           in a single line."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_collection_expressions= x})
@@ -305,15 +316,17 @@ module Formatting = struct
     let doc = "Style for function declarations and types." in
     let names = ["break-fun-decl"] in
     let all =
-      [ ("wrap", `Wrap, "$(b,wrap) breaks only if necessary.")
+      [ ("wrap", `Wrap, "$(b,wrap) breaks only if necessary.", `Valid)
       ; ( "fit-or-vertical"
         , `Fit_or_vertical
         , "$(b,fit-or-vertical) vertically breaks arguments if they do not \
-           fit on a single line." )
+           fit on a single line."
+        , `Valid )
       ; ( "smart"
         , `Smart
         , "$(b,smart) is like $(b,fit-or-vertical) but try to fit arguments \
-           on their line if they fit." ) ]
+           on their line if they fit."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_fun_decl= x})
@@ -323,15 +336,17 @@ module Formatting = struct
     let doc = "Style for function signatures." in
     let names = ["break-fun-sig"] in
     let all =
-      [ ("wrap", `Wrap, "$(b,wrap) breaks only if necessary.")
+      [ ("wrap", `Wrap, "$(b,wrap) breaks only if necessary.", `Valid)
       ; ( "fit-or-vertical"
         , `Fit_or_vertical
         , "$(b,fit-or-vertical) vertically breaks arguments if they do not \
-           fit on a single line." )
+           fit on a single line."
+        , `Valid )
       ; ( "smart"
         , `Smart
         , "$(b,smart) is like $(b,fit-or-vertical) but try to fit arguments \
-           on their line if they fit." ) ]
+           on their line if they fit."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_fun_sig= x})
@@ -344,11 +359,13 @@ module Formatting = struct
       [ ( "wrap"
         , `Wrap
         , "$(b,wrap) will group simple expressions and try to format them \
-           in a single line." )
+           in a single line."
+        , `Valid )
       ; ( "fit-or-vertical"
         , `Fit_or_vertical
         , "$(b,fit-or-vertical) vertically breaks expressions if they do \
-           not fit on a single line." ) ]
+           not fit on a single line."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_infix= x})
@@ -374,14 +391,16 @@ module Formatting = struct
     let all =
       [ ( "after"
         , `After
-        , "$(b,after) breaks the expressions after the separator." )
+        , "$(b,after) breaks the expressions after the separator."
+        , `Valid )
       ; ( "before"
         , `Before
-        , "$(b,before) breaks the expressions before the separator." ) ]
+        , "$(b,before) breaks the expressions before the separator."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
-        [ C.removed_value ~name:"after-and-docked" ~version:"0.12"
+        [ C.Value.Removed.mk ~name:"after-and-docked" ~version:"0.12"
             ~msg:
               "One can get a similar behaviour by setting \
                `break-separators=after`, `space-around-lists=false`, and \
@@ -405,15 +424,17 @@ module Formatting = struct
       [ ( "auto"
         , `Auto
         , "$(b,auto) mode breaks lines at newlines and wraps string \
-           literals at the margin." )
+           literals at the margin."
+        , `Valid )
       ; ( "never"
         , `Never
         , "$(b,never) mode formats string literals as they are parsed, in \
-           particular, with escape sequences expanded." ) ]
+           particular, with escape sequences expanded."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
-        (C.removed_values
+        (C.Value.Removed.mk_list
            ~names:["newlines"; "newlines-and-wrap"; "wrap"]
            ~version:"0.12"
            ~msg:
@@ -429,11 +450,13 @@ module Formatting = struct
     let all =
       [ ( "force"
         , `Force
-        , "$(b,force) will break struct-end phrases unconditionally." )
+        , "$(b,force) will break struct-end phrases unconditionally."
+        , `Valid )
       ; ( "natural"
         , `Natural
         , "$(b,natural) will break struct-end phrases naturally at the \
-           margin." ) ]
+           margin."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_struct= Poly.(x = `Force)})
@@ -459,12 +482,14 @@ module Formatting = struct
     let all =
       [ ( "normal"
         , `Normal
-        , "$(b,normal) indents as it would any other expression." )
+        , "$(b,normal) indents as it would any other expression."
+        , `Valid )
       ; ( "compact"
         , `Compact
         , "$(b,compact) forces an indentation of 2, unless \
            $(b,nested-match) is set to $(b,align) and we're on the last \
-           case." ) ]
+           case."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with cases_matching_exp_indent= x})
@@ -500,20 +525,22 @@ module Formatting = struct
         , "$(b,after-when-possible) puts doc comments after the \
            corresponding code. This option has no effect on variant \
            declarations because that would change their meaning and on \
-           structures, signatures and objects for readability." )
+           structures, signatures and objects for readability."
+        , `Valid )
       ; ( "before-except-val"
         , `Before_except_val
         , "$(b,before-except-val) puts doc comments before the \
            corresponding code, but puts doc comments of $(b,val) and \
            $(b,external) declarations after the corresponding declarations."
-        )
+        , `Valid )
       ; ( "before"
         , `Before
-        , "$(b,before) puts comments before the corresponding code." ) ]
+        , "$(b,before) puts comments before the corresponding code."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
-        [ C.removed_value ~name:"after" ~version:"0.14.2"
+        [ C.Value.Removed.mk ~name:"after" ~version:"0.14.2"
             ~msg:
               "This value has been renamed `after-when-possible` to take \
                into account the technical limitations of ocamlformat, the \
@@ -535,8 +562,12 @@ module Formatting = struct
     let doc = "Position of doc comments with only tags." in
     let names = ["doc-comments-tag-only"] in
     let all =
-      [ ("default", `Default, "$(b,default) means no special treatment.")
-      ; ("fit", `Fit, "$(b,fit) puts doc comments on the same line.") ]
+      [ ( "default"
+        , `Default
+        , "$(b,default) means no special treatment."
+        , `Valid )
+      ; ("fit", `Fit, "$(b,fit) puts doc comments on the same line.", `Valid)
+      ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with doc_comments_tag_only= x})
@@ -593,11 +624,13 @@ module Formatting = struct
     let all =
       [ ( "parens"
         , `Parens
-        , "$(b,parens) groups expressions using parentheses." )
+        , "$(b,parens) groups expressions using parentheses."
+        , `Valid )
       ; ( "preserve"
         , `Preserve
         , "$(b,preserve) preserves the original grouping syntax \
-           (parentheses or $(i,begin)/$(i,end))." ) ]
+           (parentheses or $(i,begin)/$(i,end))."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with exp_grouping= x})
@@ -626,15 +659,17 @@ module Formatting = struct
     in
     let names = ["field-space"] in
     let all =
-      [ ("loose", `Loose, "$(b,loose) does.")
+      [ ("loose", `Loose, "$(b,loose) does.", `Valid)
       ; ( "tight"
         , `Tight
         , "$(b,tight) does not use a space between a field name and the \
-           punctuation symbol (`:` or `=`)." )
+           punctuation symbol (`:` or `=`)."
+        , `Valid )
       ; ( "tight-decl"
         , `Tight_decl
         , "$(b,tight-decl) is $(b,tight) for declarations and $(b,loose) \
-           for instantiations." ) ]
+           for instantiations."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with field_space= x})
@@ -658,11 +693,16 @@ module Formatting = struct
       [ ( "never"
         , `Never
         , "$(b,never) only applies $(b,function-indent) if the function \
-           block starts a line." )
-      ; ("always", `Always, "$(b,always) always apply $(b,function-indent).")
+           block starts a line."
+        , `Valid )
+      ; ( "always"
+        , `Always
+        , "$(b,always) always apply $(b,function-indent)."
+        , `Valid )
       ; ( "auto"
         , `Auto
-        , "$(b,auto) applies $(b,function-indent) when seen fit." ) ]
+        , "$(b,auto) applies $(b,function-indent) when seen fit."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with function_indent_nested= x})
@@ -675,19 +715,23 @@ module Formatting = struct
       [ ( "compact"
         , `Compact
         , "$(b,compact) tries to format an if-then-else expression on a \
-           single line." )
+           single line."
+        , `Valid )
       ; ( "fit-or-vertical"
         , `Fit_or_vertical
         , "$(b,fit-or-vertical) vertically breaks branches if they do not \
-           fit on a single line." )
+           fit on a single line."
+        , `Valid )
       ; ( "keyword-first"
         , `Keyword_first
         , "$(b,keyword-first) formats if-then-else expressions such that \
-           the if-then-else keywords are the first on the line." )
+           the if-then-else keywords are the first on the line."
+        , `Valid )
       ; ( "k-r"
         , `K_R
         , "$(b,k-r) formats if-then-else expressions with parentheses that \
-           match the K&R style." ) ]
+           match the K&R style."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with if_then_else= x})
@@ -713,15 +757,18 @@ module Formatting = struct
       [ ( "no"
         , `No
         , "$(b, no) doesn't do anything special to indicate the closing \
-           delimiter." )
+           delimiter."
+        , `Valid )
       ; ( "space"
         , `Space
         , "$(b,space) prints a space inside the delimiter to indicate the \
-           matching one is on a different line." )
+           matching one is on a different line."
+        , `Valid )
       ; ( "closing-on-separate-line"
         , `Closing_on_separate_line
         , "$(b, closing-on-separate-line) makes sure that the closing \
-           delimiter is on its own line." ) ]
+           delimiter is on its own line."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with indicate_multiline_delimiters= x})
@@ -739,11 +786,13 @@ module Formatting = struct
         , "$(b,unsafe-no) does not indicate nested or-patterns. Warning: \
            this can produce confusing code where a short body of a match \
            case is visually hidden by surrounding long patterns, leading to \
-           misassociation between patterns and body expressions." )
+           misassociation between patterns and body expressions."
+        , `Valid )
       ; ( "space"
         , `Space
         , "$(b,space) starts lines of nested or-patterns with \" |\" rather \
-           than \"| \"." ) ]
+           than \"| \"."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with indicate_nested_or_patterns= x})
@@ -759,11 +808,13 @@ module Formatting = struct
       [ ( "indent"
         , `Indent
         , "$(b,indent) uses indentation to explicitly disambiguate \
-           precedences of infix operators." )
+           precedences of infix operators."
+        , `Valid )
       ; ( "parens"
         , `Parens
         , "$(b,parens) uses parentheses to explicitly disambiguate \
-           precedences of infix operators." ) ]
+           precedences of infix operators."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with infix_precedence= x})
@@ -783,8 +834,12 @@ module Formatting = struct
       [ ( "compact"
         , `Compact
         , "$(b,compact) will try to format `let p = e and p = e` in a \
-           single line." )
-      ; ("sparse", `Sparse, "$(b,sparse) will always break between them.") ]
+           single line."
+        , `Valid )
+      ; ( "sparse"
+        , `Sparse
+        , "$(b,sparse) will always break between them."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with let_and= x})
@@ -808,15 +863,18 @@ module Formatting = struct
       [ ( "compact"
         , `Compact
         , "$(b,compact) spacing separates adjacent let bindings in a module \
-           according to module-item-spacing." )
+           according to module-item-spacing."
+        , `Valid )
       ; ( "sparse"
         , `Sparse
         , "$(b,sparse) places two open lines between a multi-line \
-           module-level let binding and the next." )
+           module-level let binding and the next."
+        , `Valid )
       ; ( "double-semicolon"
         , `Double_semicolon
         , "$(b,double-semicolon) places double semicolons and an open line \
-           between a multi-line module-level let binding and the next." ) ]
+           between a multi-line module-level let binding and the next."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with let_binding_spacing= x})
@@ -829,12 +887,14 @@ module Formatting = struct
         , `Compact
         , "$(b,compact) does not break a line after the $(i,let module ... \
            =) and before the $(i,in) if the module declaration does not fit \
-           on a single line." )
+           on a single line."
+        , `Valid )
       ; ( "sparse"
         , `Sparse
         , "$(b,sparse) breaks a line after $(i,let module ... =) and before \
            the $(i,in) if the module declaration does not fit on a single \
-           line." ) ]
+           line."
+        , `Valid ) ]
     in
     C.choice ~names:["let-module"] ~all ~doc ~kind
       (fun conf x -> {conf with let_module= x})
@@ -849,8 +909,8 @@ module Formatting = struct
   let line_endings =
     let doc = "Line endings used." in
     let all =
-      [ ("lf", `Lf, "$(b,lf) uses Unix line endings.")
-      ; ("crlf", `Crlf, "$(b,crlf) uses Windows line endings.") ]
+      [ ("lf", `Lf, "$(b,lf) uses Unix line endings.", `Valid)
+      ; ("crlf", `Crlf, "$(b,crlf) uses Windows line endings.", `Valid) ]
     in
     C.choice ~names:["line-endings"] ~all ~doc ~allow_inline:false ~kind
       (fun conf x -> {conf with line_endings= x})
@@ -882,10 +942,16 @@ module Formatting = struct
       [ ( "never"
         , `Never
         , "$(b,never) only applies $(b,match-indent) if the match block \
-           starts a line." )
-      ; ("always", `Always, "$(b,always) always apply $(b,match-indent).")
-      ; ("auto", `Auto, "$(b,auto) applies $(b,match-indent) when seen fit.")
-      ]
+           starts a line."
+        , `Valid )
+      ; ( "always"
+        , `Always
+        , "$(b,always) always apply $(b,match-indent)."
+        , `Valid )
+      ; ( "auto"
+        , `Auto
+        , "$(b,auto) applies $(b,match-indent) when seen fit."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with match_indent_nested= x})
@@ -916,15 +982,18 @@ module Formatting = struct
     let all =
       [ ( "sparse"
         , `Sparse
-        , "$(b,sparse) will always break a line between two items." )
+        , "$(b,sparse) will always break a line between two items."
+        , `Valid )
       ; ( "preserve"
         , `Preserve
         , "$(b,preserve) will not leave open lines between one-liners of \
-           similar sorts unless there is an open line in the input." )
+           similar sorts unless there is an open line in the input."
+        , `Valid )
       ; ( "compact"
         , `Compact
         , "$(b,compact) will not leave open lines between one-liners of \
-           similar sorts." ) ]
+           similar sorts."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with module_item_spacing= x})
@@ -940,11 +1009,13 @@ module Formatting = struct
       [ ( "wrap"
         , `Wrap
         , "$(b,wrap) wraps the nested pattern-matching with parentheses and \
-           adds indentation." )
+           adds indentation."
+        , `Valid )
       ; ( "align"
         , `Align
         , "$(b,align) vertically aligns the nested pattern-matching under \
-           the encompassing pattern-matching." ) ]
+           the encompassing pattern-matching."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with nested_match= x})
@@ -986,11 +1057,13 @@ module Formatting = struct
     let all =
       [ ( "always"
         , `Always
-        , "$(b,always) always uses parentheses around tuples." )
+        , "$(b,always) always uses parentheses around tuples."
+        , `Valid )
       ; ( "multi-line-only"
         , `Multi_line_only
         , "$(b,multi-line-only) mode will try to skip parens for \
-           single-line tuples." ) ]
+           single-line tuples."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with parens_tuple= x})
@@ -1003,10 +1076,12 @@ module Formatting = struct
       [ ( "multi-line-only"
         , `Multi_line_only
         , "$(b,multi-line-only) mode will try to skip parens for \
-           single-line tuple patterns." )
+           single-line tuple patterns."
+        , `Valid )
       ; ( "always"
         , `Always
-        , "$(b,always) always uses parentheses around tuples patterns." ) ]
+        , "$(b,always) always uses parentheses around tuples patterns."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with parens_tuple_patterns= x})
@@ -1026,11 +1101,13 @@ module Formatting = struct
       [ ( "preserve-one"
         , `Preserve_one
         , "$(b,preserve) will keep a blank line between two expressions of \
-           a sequence if the input contains at least one." )
+           a sequence if the input contains at least one."
+        , `Valid )
       ; ( "compact"
         , `Compact
         , "$(b,compact) will not keep any blank line between expressions of \
-           a sequence." ) ]
+           a sequence."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with sequence_blank_line= x})
@@ -1042,13 +1119,16 @@ module Formatting = struct
     let all =
       [ ( "terminator"
         , `Terminator
-        , "$(b,terminator) only puts spaces after semicolons." )
+        , "$(b,terminator) only puts spaces after semicolons."
+        , `Valid )
       ; ( "separator"
         , `Separator
-        , "$(b,separator) puts spaces before and after semicolons." )
+        , "$(b,separator) puts spaces before and after semicolons."
+        , `Valid )
       ; ( "before"
         , `Before
-        , "$(b,before) breaks the sequence before semicolons." ) ]
+        , "$(b,before) breaks the sequence before semicolons."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with sequence_style= x})
@@ -1063,10 +1143,11 @@ module Formatting = struct
       [ ( "compact"
         , `Compact
         , "$(b,compact) will try to format a single case on a single line."
-        )
+        , `Valid )
       ; ( "sparse"
         , `Sparse
-        , "$(b,sparse) will always break the line before a single case." ) ]
+        , "$(b,sparse) will always break the line before a single case."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with single_case= x})
@@ -1118,11 +1199,13 @@ module Formatting = struct
       [ ( "compact"
         , `Compact
         , "$(b,compact) will try to format constructors and records \
-           definition in a single line." )
+           definition in a single line."
+        , `Valid )
       ; ( "sparse"
         , `Sparse
         , "$(b,sparse) will always break between constructors and record \
-           fields." ) ]
+           fields."
+        , `Valid ) ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with type_decl= x})
@@ -1712,18 +1795,22 @@ let (_profile : t option C.t) =
     [ ( "conventional"
       , Some conventional_profile
       , "The $(b,conventional) profile aims to be as familiar and \
-         \"conventional\" appearing as the available options allow." )
+         \"conventional\" appearing as the available options allow."
+      , `Valid )
     ; ( "default"
       , Some default_profile
-      , "$(b,default) is an alias for the $(b,conventional) profile." )
+      , "$(b,default) is an alias for the $(b,conventional) profile."
+      , `Valid )
     ; ( "compact"
       , Some compact_profile
       , "The $(b,compact) profile is similar to $(b,ocamlformat) but opts \
-         for a generally more compact code style." )
+         for a generally more compact code style."
+      , `Valid )
     ; ( "sparse"
       , Some sparse_profile
       , "The $(b,sparse) profile is similar to $(b,ocamlformat) but opts \
-         for a generally more sparse code style." )
+         for a generally more sparse code style."
+      , `Valid )
     ; ( "ocamlformat"
       , Some ocamlformat_profile
       , "The $(b,ocamlformat) profile aims to take advantage of the \
@@ -1741,10 +1828,12 @@ let (_profile : t option C.t) =
          equal compact code is preferred as reading without scrolling is \
          easier, so indentation or white space is avoided unless it helps \
          legibility; Attention has been given to making some syntactic \
-         gotchas visually obvious." )
+         gotchas visually obvious."
+      , `Valid )
     ; ( "janestreet"
       , Some janestreet_profile
-      , "The $(b,janestreet) profile is used at Jane Street." ) ]
+      , "The $(b,janestreet) profile is used at Jane Street."
+      , `Valid ) ]
   in
   C.choice ~names ~all ~doc ~kind:C.Formatting
     (fun conf p ->

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -216,15 +216,13 @@ module Formatting = struct
     let names = ["assignment-operator"] in
     let all =
       [ C.Value.make ~name:"end-line" `End_line
-          ~doc:
-            "$(b,end-line) positions assignment operators (`:=` and `<-`) \
-             at the end of the line and breaks after it if the whole \
-             assignment expression does not fit on a single line."
+          "$(b,end-line) positions assignment operators (`:=` and `<-`) at \
+           the end of the line and breaks after it if the whole assignment \
+           expression does not fit on a single line."
       ; C.Value.make ~name:"begin-line" `Begin_line
-          ~doc:
-            "$(b,begin-line) positions assignment operators (`:=` and `<-`) \
-             at the beginning of the line and breaks before it if the whole \
-             assignment expression does not fit on a single line." ]
+          "$(b,begin-line) positions assignment operators (`:=` and `<-`) \
+           at the beginning of the line and breaks before it if the whole \
+           assignment expression does not fit on a single line." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with assignment_operator= x})
@@ -238,14 +236,12 @@ module Formatting = struct
     let names = ["break-before-in"] in
     let all =
       [ C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
-          ~doc:
-            "$(b,fit-or-vertical) will always break the line before the \
-             $(i,in) keyword if the whole $(i,let) binding does not fit on \
-             a single line."
+          "$(b,fit-or-vertical) will always break the line before the \
+           $(i,in) keyword if the whole $(i,let) binding does not fit on a \
+           single line."
       ; C.Value.make ~name:"auto" `Auto
-          ~doc:
-            "$(b,auto) will only break the line if the $(i,in) keyword does \
-             not fit on the previous line." ]
+          "$(b,auto) will only break the line if the $(i,in) keyword does \
+           not fit on the previous line." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_before_in= x})
@@ -256,27 +252,22 @@ module Formatting = struct
     let names = ["break-cases"] in
     let all =
       [ C.Value.make ~name:"fit" `Fit
-          ~doc:
-            "Specifying $(b,fit) lets pattern matches break at the margin \
-             naturally."
+          "Specifying $(b,fit) lets pattern matches break at the margin \
+           naturally."
       ; C.Value.make ~name:"nested" `Nested
-          ~doc:
-            "$(b,nested) forces a break after nested or-patterns to \
-             highlight the case body. Note that with $(b,nested), the \
-             $(b,indicate-nested-or-patterns) option is not needed, and so \
-             ignored."
+          "$(b,nested) forces a break after nested or-patterns to highlight \
+           the case body. Note that with $(b,nested), the \
+           $(b,indicate-nested-or-patterns) option is not needed, and so \
+           ignored."
       ; C.Value.make ~name:"toplevel" `Toplevel
-          ~doc:
-            "$(b,toplevel) forces top-level cases (i.e. not nested \
-             or-patterns) to break across lines, otherwise break naturally \
-             at the margin."
+          "$(b,toplevel) forces top-level cases (i.e. not nested \
+           or-patterns) to break across lines, otherwise break naturally at \
+           the margin."
       ; C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
-          ~doc:
-            "$(b,fit-or-vertical) tries to fit all or-patterns on the same \
-             line, otherwise breaks."
+          "$(b,fit-or-vertical) tries to fit all or-patterns on the same \
+           line, otherwise breaks."
       ; C.Value.make ~name:"all" `All
-          ~doc:"$(b,all) forces all pattern matches to break across lines."
-      ]
+          "$(b,all) forces all pattern matches to break across lines." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_cases= x})
@@ -289,13 +280,11 @@ module Formatting = struct
     let names = ["break-collection-expressions"] in
     let all =
       [ C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
-          ~doc:
-            "$(b,fit-or-vertical) vertically breaks expressions if they do \
-             not fit on a single line."
+          "$(b,fit-or-vertical) vertically breaks expressions if they do \
+           not fit on a single line."
       ; C.Value.make ~name:"wrap" `Wrap
-          ~doc:
-            "$(b,wrap) will group simple expressions and try to format them \
-             in a single line." ]
+          "$(b,wrap) will group simple expressions and try to format them \
+           in a single line." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_collection_expressions= x})
@@ -305,16 +294,13 @@ module Formatting = struct
     let doc = "Style for function declarations and types." in
     let names = ["break-fun-decl"] in
     let all =
-      [ C.Value.make ~name:"wrap" `Wrap
-          ~doc:"$(b,wrap) breaks only if necessary."
+      [ C.Value.make ~name:"wrap" `Wrap "$(b,wrap) breaks only if necessary."
       ; C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
-          ~doc:
-            "$(b,fit-or-vertical) vertically breaks arguments if they do \
-             not fit on a single line."
+          "$(b,fit-or-vertical) vertically breaks arguments if they do not \
+           fit on a single line."
       ; C.Value.make ~name:"smart" `Smart
-          ~doc:
-            "$(b,smart) is like $(b,fit-or-vertical) but try to fit \
-             arguments on their line if they fit." ]
+          "$(b,smart) is like $(b,fit-or-vertical) but try to fit arguments \
+           on their line if they fit." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_fun_decl= x})
@@ -324,16 +310,13 @@ module Formatting = struct
     let doc = "Style for function signatures." in
     let names = ["break-fun-sig"] in
     let all =
-      [ C.Value.make ~name:"wrap" `Wrap
-          ~doc:"$(b,wrap) breaks only if necessary."
+      [ C.Value.make ~name:"wrap" `Wrap "$(b,wrap) breaks only if necessary."
       ; C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
-          ~doc:
-            "$(b,fit-or-vertical) vertically breaks arguments if they do \
-             not fit on a single line."
+          "$(b,fit-or-vertical) vertically breaks arguments if they do not \
+           fit on a single line."
       ; C.Value.make ~name:"smart" `Smart
-          ~doc:
-            "$(b,smart) is like $(b,fit-or-vertical) but try to fit \
-             arguments on their line if they fit." ]
+          "$(b,smart) is like $(b,fit-or-vertical) but try to fit arguments \
+           on their line if they fit." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_fun_sig= x})
@@ -344,13 +327,11 @@ module Formatting = struct
     let names = ["break-infix"] in
     let all =
       [ C.Value.make ~name:"wrap" `Wrap
-          ~doc:
-            "$(b,wrap) will group simple expressions and try to format them \
-             in a single line."
+          "$(b,wrap) will group simple expressions and try to format them \
+           in a single line."
       ; C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
-          ~doc:
-            "$(b,fit-or-vertical) vertically breaks expressions if they do \
-             not fit on a single line." ]
+          "$(b,fit-or-vertical) vertically breaks expressions if they do \
+           not fit on a single line." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_infix= x})
@@ -375,9 +356,9 @@ module Formatting = struct
     let names = ["break-separators"] in
     let all =
       [ C.Value.make ~name:"after" `After
-          ~doc:"$(b,after) breaks the expressions after the separator."
+          "$(b,after) breaks the expressions after the separator."
       ; C.Value.make ~name:"before" `Before
-          ~doc:"$(b,before) breaks the expressions before the separator." ]
+          "$(b,before) breaks the expressions before the separator." ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
@@ -403,13 +384,11 @@ module Formatting = struct
     let names = ["break-string-literals"] in
     let all =
       [ C.Value.make ~name:"auto" `Auto
-          ~doc:
-            "$(b,auto) mode breaks lines at newlines and wraps string \
-             literals at the margin."
+          "$(b,auto) mode breaks lines at newlines and wraps string \
+           literals at the margin."
       ; C.Value.make ~name:"never" `Never
-          ~doc:
-            "$(b,never) mode formats string literals as they are parsed, in \
-             particular, with escape sequences expanded." ]
+          "$(b,never) mode formats string literals as they are parsed, in \
+           particular, with escape sequences expanded." ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
@@ -428,11 +407,10 @@ module Formatting = struct
     let names = ["break-struct"] in
     let all =
       [ C.Value.make ~name:"force" `Force
-          ~doc:"$(b,force) will break struct-end phrases unconditionally."
+          "$(b,force) will break struct-end phrases unconditionally."
       ; C.Value.make ~name:"natural" `Natural
-          ~doc:
-            "$(b,natural) will break struct-end phrases naturally at the \
-             margin." ]
+          "$(b,natural) will break struct-end phrases naturally at the \
+           margin." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with break_struct= Poly.(x = `Force)})
@@ -457,12 +435,11 @@ module Formatting = struct
     let names = ["cases-matching-exp-indent"] in
     let all =
       [ C.Value.make ~name:"normal" `Normal
-          ~doc:"$(b,normal) indents as it would any other expression."
+          "$(b,normal) indents as it would any other expression."
       ; C.Value.make ~name:"compact" `Compact
-          ~doc:
-            "$(b,compact) forces an indentation of 2, unless \
-             $(b,nested-match) is set to $(b,align) and we're on the last \
-             case." ]
+          "$(b,compact) forces an indentation of 2, unless \
+           $(b,nested-match) is set to $(b,align) and we're on the last \
+           case." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with cases_matching_exp_indent= x})
@@ -494,19 +471,16 @@ module Formatting = struct
     let names = ["doc-comments"] in
     let all =
       [ C.Value.make ~name:"after-when-possible" `After_when_possible
-          ~doc:
-            "$(b,after-when-possible) puts doc comments after the \
-             corresponding code. This option has no effect on variant \
-             declarations because that would change their meaning and on \
-             structures, signatures and objects for readability."
+          "$(b,after-when-possible) puts doc comments after the \
+           corresponding code. This option has no effect on variant \
+           declarations because that would change their meaning and on \
+           structures, signatures and objects for readability."
       ; C.Value.make ~name:"before-except-val" `Before_except_val
-          ~doc:
-            "$(b,before-except-val) puts doc comments before the \
-             corresponding code, but puts doc comments of $(b,val) and \
-             $(b,external) declarations after the corresponding \
-             declarations."
+          "$(b,before-except-val) puts doc comments before the \
+           corresponding code, but puts doc comments of $(b,val) and \
+           $(b,external) declarations after the corresponding declarations."
       ; C.Value.make ~name:"before" `Before
-          ~doc:"$(b,before) puts comments before the corresponding code." ]
+          "$(b,before) puts comments before the corresponding code." ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
@@ -533,9 +507,9 @@ module Formatting = struct
     let names = ["doc-comments-tag-only"] in
     let all =
       [ C.Value.make ~name:"default" `Default
-          ~doc:"$(b,default) means no special treatment."
+          "$(b,default) means no special treatment."
       ; C.Value.make ~name:"fit" `Fit
-          ~doc:"$(b,fit) puts doc comments on the same line." ]
+          "$(b,fit) puts doc comments on the same line." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with doc_comments_tag_only= x})
@@ -591,11 +565,10 @@ module Formatting = struct
     let names = ["exp-grouping"] in
     let all =
       [ C.Value.make ~name:"parens" `Parens
-          ~doc:"$(b,parens) groups expressions using parentheses."
+          "$(b,parens) groups expressions using parentheses."
       ; C.Value.make ~name:"preserve" `Preserve
-          ~doc:
-            "$(b,preserve) preserves the original grouping syntax \
-             (parentheses or $(i,begin)/$(i,end))." ]
+          "$(b,preserve) preserves the original grouping syntax \
+           (parentheses or $(i,begin)/$(i,end))." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with exp_grouping= x})
@@ -624,15 +597,13 @@ module Formatting = struct
     in
     let names = ["field-space"] in
     let all =
-      [ C.Value.make ~name:"loose" `Loose ~doc:"$(b,loose) does."
+      [ C.Value.make ~name:"loose" `Loose "$(b,loose) does."
       ; C.Value.make ~name:"tight" `Tight
-          ~doc:
-            "$(b,tight) does not use a space between a field name and the \
-             punctuation symbol (`:` or `=`)."
+          "$(b,tight) does not use a space between a field name and the \
+           punctuation symbol (`:` or `=`)."
       ; C.Value.make ~name:"tight-decl" `Tight_decl
-          ~doc:
-            "$(b,tight-decl) is $(b,tight) for declarations and $(b,loose) \
-             for instantiations." ]
+          "$(b,tight-decl) is $(b,tight) for declarations and $(b,loose) \
+           for instantiations." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with field_space= x})
@@ -654,13 +625,12 @@ module Formatting = struct
     let names = ["function-indent-nested"] in
     let all =
       [ C.Value.make ~name:"never" `Never
-          ~doc:
-            "$(b,never) only applies $(b,function-indent) if the function \
-             block starts a line."
+          "$(b,never) only applies $(b,function-indent) if the function \
+           block starts a line."
       ; C.Value.make ~name:"always" `Always
-          ~doc:"$(b,always) always apply $(b,function-indent)."
+          "$(b,always) always apply $(b,function-indent)."
       ; C.Value.make ~name:"auto" `Auto
-          ~doc:"$(b,auto) applies $(b,function-indent) when seen fit." ]
+          "$(b,auto) applies $(b,function-indent) when seen fit." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with function_indent_nested= x})
@@ -671,21 +641,17 @@ module Formatting = struct
     let names = ["if-then-else"] in
     let all =
       [ C.Value.make ~name:"compact" `Compact
-          ~doc:
-            "$(b,compact) tries to format an if-then-else expression on a \
-             single line."
+          "$(b,compact) tries to format an if-then-else expression on a \
+           single line."
       ; C.Value.make ~name:"fit-or-vertical" `Fit_or_vertical
-          ~doc:
-            "$(b,fit-or-vertical) vertically breaks branches if they do not \
-             fit on a single line."
+          "$(b,fit-or-vertical) vertically breaks branches if they do not \
+           fit on a single line."
       ; C.Value.make ~name:"keyword-first" `Keyword_first
-          ~doc:
-            "$(b,keyword-first) formats if-then-else expressions such that \
-             the if-then-else keywords are the first on the line."
+          "$(b,keyword-first) formats if-then-else expressions such that \
+           the if-then-else keywords are the first on the line."
       ; C.Value.make ~name:"k-r" `K_R
-          ~doc:
-            "$(b,k-r) formats if-then-else expressions with parentheses \
-             that match the K&R style." ]
+          "$(b,k-r) formats if-then-else expressions with parentheses that \
+           match the K&R style." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with if_then_else= x})
@@ -709,18 +675,15 @@ module Formatting = struct
     let names = ["indicate-multiline-delimiters"] in
     let all =
       [ C.Value.make ~name:"no" `No
-          ~doc:
-            "$(b, no) doesn't do anything special to indicate the closing \
-             delimiter."
+          "$(b, no) doesn't do anything special to indicate the closing \
+           delimiter."
       ; C.Value.make ~name:"space" `Space
-          ~doc:
-            "$(b,space) prints a space inside the delimiter to indicate the \
-             matching one is on a different line."
+          "$(b,space) prints a space inside the delimiter to indicate the \
+           matching one is on a different line."
       ; C.Value.make ~name:"closing-on-separate-line"
           `Closing_on_separate_line
-          ~doc:
-            "$(b, closing-on-separate-line) makes sure that the closing \
-             delimiter is on its own line." ]
+          "$(b, closing-on-separate-line) makes sure that the closing \
+           delimiter is on its own line." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with indicate_multiline_delimiters= x})
@@ -734,15 +697,13 @@ module Formatting = struct
     let names = ["indicate-nested-or-patterns"] in
     let all =
       [ C.Value.make ~name:"unsafe-no" `Unsafe_no
-          ~doc:
-            "$(b,unsafe-no) does not indicate nested or-patterns. Warning: \
-             this can produce confusing code where a short body of a match \
-             case is visually hidden by surrounding long patterns, leading \
-             to misassociation between patterns and body expressions."
+          "$(b,unsafe-no) does not indicate nested or-patterns. Warning: \
+           this can produce confusing code where a short body of a match \
+           case is visually hidden by surrounding long patterns, leading to \
+           misassociation between patterns and body expressions."
       ; C.Value.make ~name:"space" `Space
-          ~doc:
-            "$(b,space) starts lines of nested or-patterns with \" |\" \
-             rather than \"| \"." ]
+          "$(b,space) starts lines of nested or-patterns with \" |\" rather \
+           than \"| \"." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with indicate_nested_or_patterns= x})
@@ -756,13 +717,11 @@ module Formatting = struct
     let names = ["infix-precedence"] in
     let all =
       [ C.Value.make ~name:"indent" `Indent
-          ~doc:
-            "$(b,indent) uses indentation to explicitly disambiguate \
-             precedences of infix operators."
+          "$(b,indent) uses indentation to explicitly disambiguate \
+           precedences of infix operators."
       ; C.Value.make ~name:"parens" `Parens
-          ~doc:
-            "$(b,parens) uses parentheses to explicitly disambiguate \
-             precedences of infix operators." ]
+          "$(b,parens) uses parentheses to explicitly disambiguate \
+           precedences of infix operators." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with infix_precedence= x})
@@ -780,11 +739,10 @@ module Formatting = struct
     let names = ["let-and"] in
     let all =
       [ C.Value.make ~name:"compact" `Compact
-          ~doc:
-            "$(b,compact) will try to format `let p = e and p = e` in a \
-             single line."
+          "$(b,compact) will try to format `let p = e and p = e` in a \
+           single line."
       ; C.Value.make ~name:"sparse" `Sparse
-          ~doc:"$(b,sparse) will always break between them." ]
+          "$(b,sparse) will always break between them." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with let_and= x})
@@ -806,18 +764,14 @@ module Formatting = struct
     let names = ["let-binding-spacing"] in
     let all =
       [ C.Value.make ~name:"compact" `Compact
-          ~doc:
-            "$(b,compact) spacing separates adjacent let bindings in a \
-             module according to module-item-spacing."
+          "$(b,compact) spacing separates adjacent let bindings in a module \
+           according to module-item-spacing."
       ; C.Value.make ~name:"sparse" `Sparse
-          ~doc:
-            "$(b,sparse) places two open lines between a multi-line \
-             module-level let binding and the next."
+          "$(b,sparse) places two open lines between a multi-line \
+           module-level let binding and the next."
       ; C.Value.make ~name:"double-semicolon" `Double_semicolon
-          ~doc:
-            "$(b,double-semicolon) places double semicolons and an open \
-             line between a multi-line module-level let binding and the \
-             next." ]
+          "$(b,double-semicolon) places double semicolons and an open line \
+           between a multi-line module-level let binding and the next." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with let_binding_spacing= x})
@@ -827,15 +781,13 @@ module Formatting = struct
     let doc = "Module binding formatting." in
     let all =
       [ C.Value.make ~name:"compact" `Compact
-          ~doc:
-            "$(b,compact) does not break a line after the $(i,let module \
-             ... =) and before the $(i,in) if the module declaration does \
-             not fit on a single line."
+          "$(b,compact) does not break a line after the $(i,let module ... \
+           =) and before the $(i,in) if the module declaration does not fit \
+           on a single line."
       ; C.Value.make ~name:"sparse" `Sparse
-          ~doc:
-            "$(b,sparse) breaks a line after $(i,let module ... =) and \
-             before the $(i,in) if the module declaration does not fit on a \
-             single line." ]
+          "$(b,sparse) breaks a line after $(i,let module ... =) and before \
+           the $(i,in) if the module declaration does not fit on a single \
+           line." ]
     in
     C.choice ~names:["let-module"] ~all ~doc ~kind
       (fun conf x -> {conf with let_module= x})
@@ -850,9 +802,9 @@ module Formatting = struct
   let line_endings =
     let doc = "Line endings used." in
     let all =
-      [ C.Value.make ~name:"lf" `Lf ~doc:"$(b,lf) uses Unix line endings."
+      [ C.Value.make ~name:"lf" `Lf "$(b,lf) uses Unix line endings."
       ; C.Value.make ~name:"crlf" `Crlf
-          ~doc:"$(b,crlf) uses Windows line endings." ]
+          "$(b,crlf) uses Windows line endings." ]
     in
     C.choice ~names:["line-endings"] ~all ~doc ~allow_inline:false ~kind
       (fun conf x -> {conf with line_endings= x})
@@ -882,13 +834,12 @@ module Formatting = struct
     let names = ["match-indent-nested"] in
     let all =
       [ C.Value.make ~name:"never" `Never
-          ~doc:
-            "$(b,never) only applies $(b,match-indent) if the match block \
-             starts a line."
+          "$(b,never) only applies $(b,match-indent) if the match block \
+           starts a line."
       ; C.Value.make ~name:"always" `Always
-          ~doc:"$(b,always) always apply $(b,match-indent)."
+          "$(b,always) always apply $(b,match-indent)."
       ; C.Value.make ~name:"auto" `Auto
-          ~doc:"$(b,auto) applies $(b,match-indent) when seen fit." ]
+          "$(b,auto) applies $(b,match-indent) when seen fit." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with match_indent_nested= x})
@@ -918,15 +869,13 @@ module Formatting = struct
     let names = ["module-item-spacing"] in
     let all =
       [ C.Value.make ~name:"sparse" `Sparse
-          ~doc:"$(b,sparse) will always break a line between two items."
+          "$(b,sparse) will always break a line between two items."
       ; C.Value.make ~name:"preserve" `Preserve
-          ~doc:
-            "$(b,preserve) will not leave open lines between one-liners of \
-             similar sorts unless there is an open line in the input."
+          "$(b,preserve) will not leave open lines between one-liners of \
+           similar sorts unless there is an open line in the input."
       ; C.Value.make ~name:"compact" `Compact
-          ~doc:
-            "$(b,compact) will not leave open lines between one-liners of \
-             similar sorts." ]
+          "$(b,compact) will not leave open lines between one-liners of \
+           similar sorts." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with module_item_spacing= x})
@@ -940,13 +889,11 @@ module Formatting = struct
     let names = ["nested-match"] in
     let all =
       [ C.Value.make ~name:"wrap" `Wrap
-          ~doc:
-            "$(b,wrap) wraps the nested pattern-matching with parentheses \
-             and adds indentation."
+          "$(b,wrap) wraps the nested pattern-matching with parentheses and \
+           adds indentation."
       ; C.Value.make ~name:"align" `Align
-          ~doc:
-            "$(b,align) vertically aligns the nested pattern-matching under \
-             the encompassing pattern-matching." ]
+          "$(b,align) vertically aligns the nested pattern-matching under \
+           the encompassing pattern-matching." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with nested_match= x})
@@ -987,11 +934,10 @@ module Formatting = struct
     let names = ["parens-tuple"] in
     let all =
       [ C.Value.make ~name:"always" `Always
-          ~doc:"$(b,always) always uses parentheses around tuples."
+          "$(b,always) always uses parentheses around tuples."
       ; C.Value.make ~name:"multi-line-only" `Multi_line_only
-          ~doc:
-            "$(b,multi-line-only) mode will try to skip parens for \
-             single-line tuples." ]
+          "$(b,multi-line-only) mode will try to skip parens for \
+           single-line tuples." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with parens_tuple= x})
@@ -1002,12 +948,10 @@ module Formatting = struct
     let names = ["parens-tuple-patterns"] in
     let all =
       [ C.Value.make ~name:"multi-line-only" `Multi_line_only
-          ~doc:
-            "$(b,multi-line-only) mode will try to skip parens for \
-             single-line tuple patterns."
+          "$(b,multi-line-only) mode will try to skip parens for \
+           single-line tuple patterns."
       ; C.Value.make ~name:"always" `Always
-          ~doc:"$(b,always) always uses parentheses around tuples patterns."
-      ]
+          "$(b,always) always uses parentheses around tuples patterns." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with parens_tuple_patterns= x})
@@ -1025,13 +969,11 @@ module Formatting = struct
     let names = ["sequence-blank-line"] in
     let all =
       [ C.Value.make ~name:"preserve-one" `Preserve_one
-          ~doc:
-            "$(b,preserve) will keep a blank line between two expressions \
-             of a sequence if the input contains at least one."
+          "$(b,preserve) will keep a blank line between two expressions of \
+           a sequence if the input contains at least one."
       ; C.Value.make ~name:"compact" `Compact
-          ~doc:
-            "$(b,compact) will not keep any blank line between expressions \
-             of a sequence." ]
+          "$(b,compact) will not keep any blank line between expressions of \
+           a sequence." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with sequence_blank_line= x})
@@ -1042,11 +984,11 @@ module Formatting = struct
     let names = ["sequence-style"] in
     let all =
       [ C.Value.make ~name:"terminator" `Terminator
-          ~doc:"$(b,terminator) only puts spaces after semicolons."
+          "$(b,terminator) only puts spaces after semicolons."
       ; C.Value.make ~name:"separator" `Separator
-          ~doc:"$(b,separator) puts spaces before and after semicolons."
+          "$(b,separator) puts spaces before and after semicolons."
       ; C.Value.make ~name:"before" `Before
-          ~doc:"$(b,before) breaks the sequence before semicolons." ]
+          "$(b,before) breaks the sequence before semicolons." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with sequence_style= x})
@@ -1059,11 +1001,9 @@ module Formatting = struct
     let names = ["single-case"] in
     let all =
       [ C.Value.make ~name:"compact" `Compact
-          ~doc:
-            "$(b,compact) will try to format a single case on a single line."
+          "$(b,compact) will try to format a single case on a single line."
       ; C.Value.make ~name:"sparse" `Sparse
-          ~doc:"$(b,sparse) will always break the line before a single case."
-      ]
+          "$(b,sparse) will always break the line before a single case." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with single_case= x})
@@ -1113,13 +1053,11 @@ module Formatting = struct
     let names = ["type-decl"] in
     let all =
       [ C.Value.make ~name:"compact" `Compact
-          ~doc:
-            "$(b,compact) will try to format constructors and records \
-             definition in a single line."
+          "$(b,compact) will try to format constructors and records \
+           definition in a single line."
       ; C.Value.make ~name:"sparse" `Sparse
-          ~doc:
-            "$(b,sparse) will always break between constructors and record \
-             fields." ]
+          "$(b,sparse) will always break between constructors and record \
+           fields." ]
     in
     C.choice ~names ~all ~doc ~kind
       (fun conf x -> {conf with type_decl= x})
@@ -1707,40 +1645,35 @@ let (_profile : t option C.t) =
   let names = profile_option_names in
   let all =
     [ C.Value.make ~name:"conventional" (Some conventional_profile)
-        ~doc:
-          "The $(b,conventional) profile aims to be as familiar and \
-           \"conventional\" appearing as the available options allow."
+        "The $(b,conventional) profile aims to be as familiar and \
+         \"conventional\" appearing as the available options allow."
     ; C.Value.make ~name:"default" (Some default_profile)
-        ~doc:"$(b,default) is an alias for the $(b,conventional) profile."
+        "$(b,default) is an alias for the $(b,conventional) profile."
     ; C.Value.make ~name:"compact" (Some compact_profile)
-        ~doc:
-          "The $(b,compact) profile is similar to $(b,ocamlformat) but opts \
-           for a generally more compact code style."
+        "The $(b,compact) profile is similar to $(b,ocamlformat) but opts \
+         for a generally more compact code style."
     ; C.Value.make ~name:"sparse" (Some sparse_profile)
-        ~doc:
-          "The $(b,sparse) profile is similar to $(b,ocamlformat) but opts \
-           for a generally more sparse code style."
+        "The $(b,sparse) profile is similar to $(b,ocamlformat) but opts \
+         for a generally more sparse code style."
     ; C.Value.make ~name:"ocamlformat" (Some ocamlformat_profile)
-        ~doc:
-          "The $(b,ocamlformat) profile aims to take advantage of the \
-           strengths of a parsetree-based auto-formatter, and to limit the \
-           consequences of the weaknesses imposed by the current \
-           implementation. This is a style which optimizes for what the \
-           formatter can do best, rather than to match the style of any \
-           existing code. General guidelines that have directed the design \
-           include: Legibility, in the sense of making it as hard as \
-           possible for quick visual parsing to give the wrong \
-           interpretation, is of highest priority; Whenever possible the \
-           high-level structure of the code should be obvious by looking \
-           only at the left margin, in particular, it should not be \
-           necessary to visually jump from left to right hunting for \
-           critical keywords, tokens, etc; All else equal compact code is \
-           preferred as reading without scrolling is easier, so indentation \
-           or white space is avoided unless it helps legibility; Attention \
-           has been given to making some syntactic gotchas visually \
-           obvious."
+        "The $(b,ocamlformat) profile aims to take advantage of the \
+         strengths of a parsetree-based auto-formatter, and to limit the \
+         consequences of the weaknesses imposed by the current \
+         implementation. This is a style which optimizes for what the \
+         formatter can do best, rather than to match the style of any \
+         existing code. General guidelines that have directed the design \
+         include: Legibility, in the sense of making it as hard as possible \
+         for quick visual parsing to give the wrong interpretation, is of \
+         highest priority; Whenever possible the high-level structure of \
+         the code should be obvious by looking only at the left margin, in \
+         particular, it should not be necessary to visually jump from left \
+         to right hunting for critical keywords, tokens, etc; All else \
+         equal compact code is preferred as reading without scrolling is \
+         easier, so indentation or white space is avoided unless it helps \
+         legibility; Attention has been given to making some syntactic \
+         gotchas visually obvious."
     ; C.Value.make ~name:"janestreet" (Some janestreet_profile)
-        ~doc:"The $(b,janestreet) profile is used at Jane Street." ]
+        "The $(b,janestreet) profile is used at Jane Street." ]
   in
   C.choice ~names ~all ~doc ~kind:C.Formatting
     (fun conf p ->

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -215,12 +215,12 @@ module Formatting = struct
     let doc = "Position of the assignment operator." in
     let names = ["assignment-operator"] in
     let all =
-      [ C.Value.Ok.valid ~name:"end-line" `End_line
+      [ C.Value.valid ~name:"end-line" `End_line
           ~doc:
             "$(b,end-line) positions assignment operators (`:=` and `<-`) \
              at the end of the line and breaks after it if the whole \
              assignment expression does not fit on a single line."
-      ; C.Value.Ok.valid ~name:"begin-line" `Begin_line
+      ; C.Value.valid ~name:"begin-line" `Begin_line
           ~doc:
             "$(b,begin-line) positions assignment operators (`:=` and `<-`) \
              at the beginning of the line and breaks before it if the whole \
@@ -237,12 +237,12 @@ module Formatting = struct
     in
     let names = ["break-before-in"] in
     let all =
-      [ C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      [ C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) will always break the line before the \
              $(i,in) keyword if the whole $(i,let) binding does not fit on \
              a single line."
-      ; C.Value.Ok.valid ~name:"auto" `Auto
+      ; C.Value.valid ~name:"auto" `Auto
           ~doc:
             "$(b,auto) will only break the line if the $(i,in) keyword does \
              not fit on the previous line." ]
@@ -255,26 +255,26 @@ module Formatting = struct
     let doc = "Break pattern match cases." in
     let names = ["break-cases"] in
     let all =
-      [ C.Value.Ok.valid ~name:"fit" `Fit
+      [ C.Value.valid ~name:"fit" `Fit
           ~doc:
             "Specifying $(b,fit) lets pattern matches break at the margin \
              naturally."
-      ; C.Value.Ok.valid ~name:"nested" `Nested
+      ; C.Value.valid ~name:"nested" `Nested
           ~doc:
             "$(b,nested) forces a break after nested or-patterns to \
              highlight the case body. Note that with $(b,nested), the \
              $(b,indicate-nested-or-patterns) option is not needed, and so \
              ignored."
-      ; C.Value.Ok.valid ~name:"toplevel" `Toplevel
+      ; C.Value.valid ~name:"toplevel" `Toplevel
           ~doc:
             "$(b,toplevel) forces top-level cases (i.e. not nested \
              or-patterns) to break across lines, otherwise break naturally \
              at the margin."
-      ; C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      ; C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) tries to fit all or-patterns on the same \
              line, otherwise breaks."
-      ; C.Value.Ok.valid ~name:"all" `All
+      ; C.Value.valid ~name:"all" `All
           ~doc:"$(b,all) forces all pattern matches to break across lines."
       ]
     in
@@ -288,11 +288,11 @@ module Formatting = struct
     in
     let names = ["break-collection-expressions"] in
     let all =
-      [ C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      [ C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) vertically breaks expressions if they do \
              not fit on a single line."
-      ; C.Value.Ok.valid ~name:"wrap" `Wrap
+      ; C.Value.valid ~name:"wrap" `Wrap
           ~doc:
             "$(b,wrap) will group simple expressions and try to format them \
              in a single line." ]
@@ -305,13 +305,13 @@ module Formatting = struct
     let doc = "Style for function declarations and types." in
     let names = ["break-fun-decl"] in
     let all =
-      [ C.Value.Ok.valid ~name:"wrap" `Wrap
+      [ C.Value.valid ~name:"wrap" `Wrap
           ~doc:"$(b,wrap) breaks only if necessary."
-      ; C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      ; C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) vertically breaks arguments if they do \
              not fit on a single line."
-      ; C.Value.Ok.valid ~name:"smart" `Smart
+      ; C.Value.valid ~name:"smart" `Smart
           ~doc:
             "$(b,smart) is like $(b,fit-or-vertical) but try to fit \
              arguments on their line if they fit." ]
@@ -324,13 +324,13 @@ module Formatting = struct
     let doc = "Style for function signatures." in
     let names = ["break-fun-sig"] in
     let all =
-      [ C.Value.Ok.valid ~name:"wrap" `Wrap
+      [ C.Value.valid ~name:"wrap" `Wrap
           ~doc:"$(b,wrap) breaks only if necessary."
-      ; C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      ; C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) vertically breaks arguments if they do \
              not fit on a single line."
-      ; C.Value.Ok.valid ~name:"smart" `Smart
+      ; C.Value.valid ~name:"smart" `Smart
           ~doc:
             "$(b,smart) is like $(b,fit-or-vertical) but try to fit \
              arguments on their line if they fit." ]
@@ -343,11 +343,11 @@ module Formatting = struct
     let doc = "Break sequence of infix operators." in
     let names = ["break-infix"] in
     let all =
-      [ C.Value.Ok.valid ~name:"wrap" `Wrap
+      [ C.Value.valid ~name:"wrap" `Wrap
           ~doc:
             "$(b,wrap) will group simple expressions and try to format them \
              in a single line."
-      ; C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      ; C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) vertically breaks expressions if they do \
              not fit on a single line." ]
@@ -374,14 +374,14 @@ module Formatting = struct
     in
     let names = ["break-separators"] in
     let all =
-      [ C.Value.Ok.valid ~name:"after" `After
+      [ C.Value.valid ~name:"after" `After
           ~doc:"$(b,after) breaks the expressions after the separator."
-      ; C.Value.Ok.valid ~name:"before" `Before
+      ; C.Value.valid ~name:"before" `Before
           ~doc:"$(b,before) breaks the expressions before the separator." ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
-        [ C.Value.Removed.mk ~name:"after-and-docked" ~version:"0.12"
+        [ C.Value_removed.mk ~name:"after-and-docked" ~version:"0.12"
             ~msg:
               "One can get a similar behaviour by setting \
                `break-separators=after`, `space-around-lists=false`, and \
@@ -402,18 +402,18 @@ module Formatting = struct
     let doc = "Break string literals." in
     let names = ["break-string-literals"] in
     let all =
-      [ C.Value.Ok.valid ~name:"auto" `Auto
+      [ C.Value.valid ~name:"auto" `Auto
           ~doc:
             "$(b,auto) mode breaks lines at newlines and wraps string \
              literals at the margin."
-      ; C.Value.Ok.valid ~name:"never" `Never
+      ; C.Value.valid ~name:"never" `Never
           ~doc:
             "$(b,never) mode formats string literals as they are parsed, in \
              particular, with escape sequences expanded." ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
-        (C.Value.Removed.mk_list
+        (C.Value_removed.mk_list
            ~names:["newlines"; "newlines-and-wrap"; "wrap"]
            ~version:"0.12"
            ~msg:
@@ -427,9 +427,9 @@ module Formatting = struct
     let doc = "Break struct-end module items." in
     let names = ["break-struct"] in
     let all =
-      [ C.Value.Ok.valid ~name:"force" `Force
+      [ C.Value.valid ~name:"force" `Force
           ~doc:"$(b,force) will break struct-end phrases unconditionally."
-      ; C.Value.Ok.valid ~name:"natural" `Natural
+      ; C.Value.valid ~name:"natural" `Natural
           ~doc:
             "$(b,natural) will break struct-end phrases naturally at the \
              margin." ]
@@ -456,9 +456,9 @@ module Formatting = struct
     in
     let names = ["cases-matching-exp-indent"] in
     let all =
-      [ C.Value.Ok.valid ~name:"normal" `Normal
+      [ C.Value.valid ~name:"normal" `Normal
           ~doc:"$(b,normal) indents as it would any other expression."
-      ; C.Value.Ok.valid ~name:"compact" `Compact
+      ; C.Value.valid ~name:"compact" `Compact
           ~doc:
             "$(b,compact) forces an indentation of 2, unless \
              $(b,nested-match) is set to $(b,align) and we're on the last \
@@ -493,24 +493,24 @@ module Formatting = struct
     let doc = "Doc comments position." in
     let names = ["doc-comments"] in
     let all =
-      [ C.Value.Ok.valid ~name:"after-when-possible" `After_when_possible
+      [ C.Value.valid ~name:"after-when-possible" `After_when_possible
           ~doc:
             "$(b,after-when-possible) puts doc comments after the \
              corresponding code. This option has no effect on variant \
              declarations because that would change their meaning and on \
              structures, signatures and objects for readability."
-      ; C.Value.Ok.valid ~name:"before-except-val" `Before_except_val
+      ; C.Value.valid ~name:"before-except-val" `Before_except_val
           ~doc:
             "$(b,before-except-val) puts doc comments before the \
              corresponding code, but puts doc comments of $(b,val) and \
              $(b,external) declarations after the corresponding \
              declarations."
-      ; C.Value.Ok.valid ~name:"before" `Before
+      ; C.Value.valid ~name:"before" `Before
           ~doc:"$(b,before) puts comments before the corresponding code." ]
     in
     C.choice ~names ~all ~doc ~kind
       ~removed_values:
-        [ C.Value.Removed.mk ~name:"after" ~version:"0.14.2"
+        [ C.Value_removed.mk ~name:"after" ~version:"0.14.2"
             ~msg:
               "This value has been renamed `after-when-possible` to take \
                into account the technical limitations of ocamlformat, the \
@@ -532,9 +532,9 @@ module Formatting = struct
     let doc = "Position of doc comments with only tags." in
     let names = ["doc-comments-tag-only"] in
     let all =
-      [ C.Value.Ok.valid ~name:"default" `Default
+      [ C.Value.valid ~name:"default" `Default
           ~doc:"$(b,default) means no special treatment."
-      ; C.Value.Ok.valid ~name:"fit" `Fit
+      ; C.Value.valid ~name:"fit" `Fit
           ~doc:"$(b,fit) puts doc comments on the same line." ]
     in
     C.choice ~names ~all ~doc ~kind
@@ -590,9 +590,9 @@ module Formatting = struct
     let doc = "Style of expression grouping." in
     let names = ["exp-grouping"] in
     let all =
-      [ C.Value.Ok.valid ~name:"parens" `Parens
+      [ C.Value.valid ~name:"parens" `Parens
           ~doc:"$(b,parens) groups expressions using parentheses."
-      ; C.Value.Ok.valid ~name:"preserve" `Preserve
+      ; C.Value.valid ~name:"preserve" `Preserve
           ~doc:
             "$(b,preserve) preserves the original grouping syntax \
              (parentheses or $(i,begin)/$(i,end))." ]
@@ -624,12 +624,12 @@ module Formatting = struct
     in
     let names = ["field-space"] in
     let all =
-      [ C.Value.Ok.valid ~name:"loose" `Loose ~doc:"$(b,loose) does."
-      ; C.Value.Ok.valid ~name:"tight" `Tight
+      [ C.Value.valid ~name:"loose" `Loose ~doc:"$(b,loose) does."
+      ; C.Value.valid ~name:"tight" `Tight
           ~doc:
             "$(b,tight) does not use a space between a field name and the \
              punctuation symbol (`:` or `=`)."
-      ; C.Value.Ok.valid ~name:"tight-decl" `Tight_decl
+      ; C.Value.valid ~name:"tight-decl" `Tight_decl
           ~doc:
             "$(b,tight-decl) is $(b,tight) for declarations and $(b,loose) \
              for instantiations." ]
@@ -653,13 +653,13 @@ module Formatting = struct
     in
     let names = ["function-indent-nested"] in
     let all =
-      [ C.Value.Ok.valid ~name:"never" `Never
+      [ C.Value.valid ~name:"never" `Never
           ~doc:
             "$(b,never) only applies $(b,function-indent) if the function \
              block starts a line."
-      ; C.Value.Ok.valid ~name:"always" `Always
+      ; C.Value.valid ~name:"always" `Always
           ~doc:"$(b,always) always apply $(b,function-indent)."
-      ; C.Value.Ok.valid ~name:"auto" `Auto
+      ; C.Value.valid ~name:"auto" `Auto
           ~doc:"$(b,auto) applies $(b,function-indent) when seen fit." ]
     in
     C.choice ~names ~all ~doc ~kind
@@ -670,19 +670,19 @@ module Formatting = struct
     let doc = "If-then-else formatting." in
     let names = ["if-then-else"] in
     let all =
-      [ C.Value.Ok.valid ~name:"compact" `Compact
+      [ C.Value.valid ~name:"compact" `Compact
           ~doc:
             "$(b,compact) tries to format an if-then-else expression on a \
              single line."
-      ; C.Value.Ok.valid ~name:"fit-or-vertical" `Fit_or_vertical
+      ; C.Value.valid ~name:"fit-or-vertical" `Fit_or_vertical
           ~doc:
             "$(b,fit-or-vertical) vertically breaks branches if they do not \
              fit on a single line."
-      ; C.Value.Ok.valid ~name:"keyword-first" `Keyword_first
+      ; C.Value.valid ~name:"keyword-first" `Keyword_first
           ~doc:
             "$(b,keyword-first) formats if-then-else expressions such that \
              the if-then-else keywords are the first on the line."
-      ; C.Value.Ok.valid ~name:"k-r" `K_R
+      ; C.Value.valid ~name:"k-r" `K_R
           ~doc:
             "$(b,k-r) formats if-then-else expressions with parentheses \
              that match the K&R style." ]
@@ -708,15 +708,15 @@ module Formatting = struct
     in
     let names = ["indicate-multiline-delimiters"] in
     let all =
-      [ C.Value.Ok.valid ~name:"no" `No
+      [ C.Value.valid ~name:"no" `No
           ~doc:
             "$(b, no) doesn't do anything special to indicate the closing \
              delimiter."
-      ; C.Value.Ok.valid ~name:"space" `Space
+      ; C.Value.valid ~name:"space" `Space
           ~doc:
             "$(b,space) prints a space inside the delimiter to indicate the \
              matching one is on a different line."
-      ; C.Value.Ok.valid ~name:"closing-on-separate-line"
+      ; C.Value.valid ~name:"closing-on-separate-line"
           `Closing_on_separate_line
           ~doc:
             "$(b, closing-on-separate-line) makes sure that the closing \
@@ -733,13 +733,13 @@ module Formatting = struct
     in
     let names = ["indicate-nested-or-patterns"] in
     let all =
-      [ C.Value.Ok.valid ~name:"unsafe-no" `Unsafe_no
+      [ C.Value.valid ~name:"unsafe-no" `Unsafe_no
           ~doc:
             "$(b,unsafe-no) does not indicate nested or-patterns. Warning: \
              this can produce confusing code where a short body of a match \
              case is visually hidden by surrounding long patterns, leading \
              to misassociation between patterns and body expressions."
-      ; C.Value.Ok.valid ~name:"space" `Space
+      ; C.Value.valid ~name:"space" `Space
           ~doc:
             "$(b,space) starts lines of nested or-patterns with \" |\" \
              rather than \"| \"." ]
@@ -755,11 +755,11 @@ module Formatting = struct
     in
     let names = ["infix-precedence"] in
     let all =
-      [ C.Value.Ok.valid ~name:"indent" `Indent
+      [ C.Value.valid ~name:"indent" `Indent
           ~doc:
             "$(b,indent) uses indentation to explicitly disambiguate \
              precedences of infix operators."
-      ; C.Value.Ok.valid ~name:"parens" `Parens
+      ; C.Value.valid ~name:"parens" `Parens
           ~doc:
             "$(b,parens) uses parentheses to explicitly disambiguate \
              precedences of infix operators." ]
@@ -779,11 +779,11 @@ module Formatting = struct
     let doc = "Style of let_and." in
     let names = ["let-and"] in
     let all =
-      [ C.Value.Ok.valid ~name:"compact" `Compact
+      [ C.Value.valid ~name:"compact" `Compact
           ~doc:
             "$(b,compact) will try to format `let p = e and p = e` in a \
              single line."
-      ; C.Value.Ok.valid ~name:"sparse" `Sparse
+      ; C.Value.valid ~name:"sparse" `Sparse
           ~doc:"$(b,sparse) will always break between them." ]
     in
     C.choice ~names ~all ~doc ~kind
@@ -805,15 +805,15 @@ module Formatting = struct
     let doc = "Spacing between let binding." in
     let names = ["let-binding-spacing"] in
     let all =
-      [ C.Value.Ok.valid ~name:"compact" `Compact
+      [ C.Value.valid ~name:"compact" `Compact
           ~doc:
             "$(b,compact) spacing separates adjacent let bindings in a \
              module according to module-item-spacing."
-      ; C.Value.Ok.valid ~name:"sparse" `Sparse
+      ; C.Value.valid ~name:"sparse" `Sparse
           ~doc:
             "$(b,sparse) places two open lines between a multi-line \
              module-level let binding and the next."
-      ; C.Value.Ok.valid ~name:"double-semicolon" `Double_semicolon
+      ; C.Value.valid ~name:"double-semicolon" `Double_semicolon
           ~doc:
             "$(b,double-semicolon) places double semicolons and an open \
              line between a multi-line module-level let binding and the \
@@ -826,12 +826,12 @@ module Formatting = struct
   let let_module =
     let doc = "Module binding formatting." in
     let all =
-      [ C.Value.Ok.valid ~name:"compact" `Compact
+      [ C.Value.valid ~name:"compact" `Compact
           ~doc:
             "$(b,compact) does not break a line after the $(i,let module \
              ... =) and before the $(i,in) if the module declaration does \
              not fit on a single line."
-      ; C.Value.Ok.valid ~name:"sparse" `Sparse
+      ; C.Value.valid ~name:"sparse" `Sparse
           ~doc:
             "$(b,sparse) breaks a line after $(i,let module ... =) and \
              before the $(i,in) if the module declaration does not fit on a \
@@ -850,8 +850,8 @@ module Formatting = struct
   let line_endings =
     let doc = "Line endings used." in
     let all =
-      [ C.Value.Ok.valid ~name:"lf" `Lf ~doc:"$(b,lf) uses Unix line endings."
-      ; C.Value.Ok.valid ~name:"crlf" `Crlf
+      [ C.Value.valid ~name:"lf" `Lf ~doc:"$(b,lf) uses Unix line endings."
+      ; C.Value.valid ~name:"crlf" `Crlf
           ~doc:"$(b,crlf) uses Windows line endings." ]
     in
     C.choice ~names:["line-endings"] ~all ~doc ~allow_inline:false ~kind
@@ -881,13 +881,13 @@ module Formatting = struct
     in
     let names = ["match-indent-nested"] in
     let all =
-      [ C.Value.Ok.valid ~name:"never" `Never
+      [ C.Value.valid ~name:"never" `Never
           ~doc:
             "$(b,never) only applies $(b,match-indent) if the match block \
              starts a line."
-      ; C.Value.Ok.valid ~name:"always" `Always
+      ; C.Value.valid ~name:"always" `Always
           ~doc:"$(b,always) always apply $(b,match-indent)."
-      ; C.Value.Ok.valid ~name:"auto" `Auto
+      ; C.Value.valid ~name:"auto" `Auto
           ~doc:"$(b,auto) applies $(b,match-indent) when seen fit." ]
     in
     C.choice ~names ~all ~doc ~kind
@@ -917,13 +917,13 @@ module Formatting = struct
     let doc = "Spacing between items of structures and signatures." in
     let names = ["module-item-spacing"] in
     let all =
-      [ C.Value.Ok.valid ~name:"sparse" `Sparse
+      [ C.Value.valid ~name:"sparse" `Sparse
           ~doc:"$(b,sparse) will always break a line between two items."
-      ; C.Value.Ok.valid ~name:"preserve" `Preserve
+      ; C.Value.valid ~name:"preserve" `Preserve
           ~doc:
             "$(b,preserve) will not leave open lines between one-liners of \
              similar sorts unless there is an open line in the input."
-      ; C.Value.Ok.valid ~name:"compact" `Compact
+      ; C.Value.valid ~name:"compact" `Compact
           ~doc:
             "$(b,compact) will not leave open lines between one-liners of \
              similar sorts." ]
@@ -939,11 +939,11 @@ module Formatting = struct
     in
     let names = ["nested-match"] in
     let all =
-      [ C.Value.Ok.valid ~name:"wrap" `Wrap
+      [ C.Value.valid ~name:"wrap" `Wrap
           ~doc:
             "$(b,wrap) wraps the nested pattern-matching with parentheses \
              and adds indentation."
-      ; C.Value.Ok.valid ~name:"align" `Align
+      ; C.Value.valid ~name:"align" `Align
           ~doc:
             "$(b,align) vertically aligns the nested pattern-matching under \
              the encompassing pattern-matching." ]
@@ -986,9 +986,9 @@ module Formatting = struct
     let doc = "Parens tuple expressions." in
     let names = ["parens-tuple"] in
     let all =
-      [ C.Value.Ok.valid ~name:"always" `Always
+      [ C.Value.valid ~name:"always" `Always
           ~doc:"$(b,always) always uses parentheses around tuples."
-      ; C.Value.Ok.valid ~name:"multi-line-only" `Multi_line_only
+      ; C.Value.valid ~name:"multi-line-only" `Multi_line_only
           ~doc:
             "$(b,multi-line-only) mode will try to skip parens for \
              single-line tuples." ]
@@ -1001,11 +1001,11 @@ module Formatting = struct
     let doc = "Parens tuple patterns." in
     let names = ["parens-tuple-patterns"] in
     let all =
-      [ C.Value.Ok.valid ~name:"multi-line-only" `Multi_line_only
+      [ C.Value.valid ~name:"multi-line-only" `Multi_line_only
           ~doc:
             "$(b,multi-line-only) mode will try to skip parens for \
              single-line tuple patterns."
-      ; C.Value.Ok.valid ~name:"always" `Always
+      ; C.Value.valid ~name:"always" `Always
           ~doc:"$(b,always) always uses parentheses around tuples patterns."
       ]
     in
@@ -1024,11 +1024,11 @@ module Formatting = struct
     let doc = "Blank line between expressions of a sequence." in
     let names = ["sequence-blank-line"] in
     let all =
-      [ C.Value.Ok.valid ~name:"preserve-one" `Preserve_one
+      [ C.Value.valid ~name:"preserve-one" `Preserve_one
           ~doc:
             "$(b,preserve) will keep a blank line between two expressions \
              of a sequence if the input contains at least one."
-      ; C.Value.Ok.valid ~name:"compact" `Compact
+      ; C.Value.valid ~name:"compact" `Compact
           ~doc:
             "$(b,compact) will not keep any blank line between expressions \
              of a sequence." ]
@@ -1041,11 +1041,11 @@ module Formatting = struct
     let doc = "Style of sequence." in
     let names = ["sequence-style"] in
     let all =
-      [ C.Value.Ok.valid ~name:"terminator" `Terminator
+      [ C.Value.valid ~name:"terminator" `Terminator
           ~doc:"$(b,terminator) only puts spaces after semicolons."
-      ; C.Value.Ok.valid ~name:"separator" `Separator
+      ; C.Value.valid ~name:"separator" `Separator
           ~doc:"$(b,separator) puts spaces before and after semicolons."
-      ; C.Value.Ok.valid ~name:"before" `Before
+      ; C.Value.valid ~name:"before" `Before
           ~doc:"$(b,before) breaks the sequence before semicolons." ]
     in
     C.choice ~names ~all ~doc ~kind
@@ -1058,10 +1058,10 @@ module Formatting = struct
     in
     let names = ["single-case"] in
     let all =
-      [ C.Value.Ok.valid ~name:"compact" `Compact
+      [ C.Value.valid ~name:"compact" `Compact
           ~doc:
             "$(b,compact) will try to format a single case on a single line."
-      ; C.Value.Ok.valid ~name:"sparse" `Sparse
+      ; C.Value.valid ~name:"sparse" `Sparse
           ~doc:"$(b,sparse) will always break the line before a single case."
       ]
     in
@@ -1112,11 +1112,11 @@ module Formatting = struct
     let doc = "Style of type declaration." in
     let names = ["type-decl"] in
     let all =
-      [ C.Value.Ok.valid ~name:"compact" `Compact
+      [ C.Value.valid ~name:"compact" `Compact
           ~doc:
             "$(b,compact) will try to format constructors and records \
              definition in a single line."
-      ; C.Value.Ok.valid ~name:"sparse" `Sparse
+      ; C.Value.valid ~name:"sparse" `Sparse
           ~doc:
             "$(b,sparse) will always break between constructors and record \
              fields." ]
@@ -1706,21 +1706,21 @@ let (_profile : t option C.t) =
   in
   let names = profile_option_names in
   let all =
-    [ C.Value.Ok.valid ~name:"conventional" (Some conventional_profile)
+    [ C.Value.valid ~name:"conventional" (Some conventional_profile)
         ~doc:
           "The $(b,conventional) profile aims to be as familiar and \
            \"conventional\" appearing as the available options allow."
-    ; C.Value.Ok.valid ~name:"default" (Some default_profile)
+    ; C.Value.valid ~name:"default" (Some default_profile)
         ~doc:"$(b,default) is an alias for the $(b,conventional) profile."
-    ; C.Value.Ok.valid ~name:"compact" (Some compact_profile)
+    ; C.Value.valid ~name:"compact" (Some compact_profile)
         ~doc:
           "The $(b,compact) profile is similar to $(b,ocamlformat) but opts \
            for a generally more compact code style."
-    ; C.Value.Ok.valid ~name:"sparse" (Some sparse_profile)
+    ; C.Value.valid ~name:"sparse" (Some sparse_profile)
         ~doc:
           "The $(b,sparse) profile is similar to $(b,ocamlformat) but opts \
            for a generally more sparse code style."
-    ; C.Value.Ok.valid ~name:"ocamlformat" (Some ocamlformat_profile)
+    ; C.Value.valid ~name:"ocamlformat" (Some ocamlformat_profile)
         ~doc:
           "The $(b,ocamlformat) profile aims to take advantage of the \
            strengths of a parsetree-based auto-formatter, and to limit the \
@@ -1739,7 +1739,7 @@ let (_profile : t option C.t) =
            or white space is avoided unless it helps legibility; Attention \
            has been given to making some syntactic gotchas visually \
            obvious."
-    ; C.Value.Ok.valid ~name:"janestreet" (Some janestreet_profile)
+    ; C.Value.valid ~name:"janestreet" (Some janestreet_profile)
         ~doc:"The $(b,janestreet) profile is used at Jane Street." ]
   in
   C.choice ~names ~all ~doc ~kind:C.Formatting

--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -191,10 +191,10 @@ module Make (C : CONFIG) = struct
   module Value = struct
     type 'a t = string * 'a * string * [`Valid | `Deprecated of deprecated]
 
-    let valid ~name ~doc value = (name, value, doc, `Valid)
-
-    let deprecated ~name ~doc ~deprecated value =
-      (name, value, doc, `Deprecated deprecated)
+    let make ?deprecated ~name ~doc value =
+      match deprecated with
+      | None -> (name, value, doc, `Valid)
+      | Some x -> (name, value, doc, `Deprecated x)
 
     let pp_deprecated s ppf {dmsg= msg; dversion= v} =
       Format.fprintf ppf "Value `%s` is deprecated since version %s. %s" s v
@@ -220,10 +220,10 @@ module Make (C : CONFIG) = struct
   module Value_removed = struct
     type t = {name: string; version: string; msg: string}
 
-    let mk ~name ~version ~msg = {name; version; msg}
+    let make ~name ~version ~msg = {name; version; msg}
 
-    let mk_list ~names ~version ~msg =
-      List.map names ~f:(fun name -> mk ~name ~version ~msg)
+    let make_list ~names ~version ~msg =
+      List.map names ~f:(fun name -> make ~name ~version ~msg)
 
     let add_parse_errors values conv =
       let parse s =

--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -189,8 +189,13 @@ module Make (C : CONFIG) = struct
     opt
 
   module Value = struct
-    module Valid = struct
+    module Ok = struct
       type 'a t = string * 'a * string * [`Valid | `Deprecated of deprecated]
+
+      let valid ~name ~doc value = (name, value, doc, `Valid)
+
+      let deprecated ~name ~doc ~deprecated value =
+        (name, value, doc, `Deprecated deprecated)
 
       let pp_deprecated s ppf {dmsg= msg; dversion= v} =
         Format.fprintf ppf "Value `%s` is deprecated since version %s. %s" s
@@ -244,7 +249,7 @@ module Make (C : CONFIG) = struct
         (pp_print_list
            ~pp_sep:(fun fs () -> fprintf fs "@,")
            (fun fs (s, _, d, st) ->
-             fprintf fs "%s%a" d (Value.Valid.status_doc s) st ) )
+             fprintf fs "%s%a" d (Value.Ok.status_doc s) st ) )
         all
     in
     let docv =
@@ -257,7 +262,7 @@ module Make (C : CONFIG) = struct
     in
     let update conf x =
       ( match List.find all ~f:(fun (_, v, _, _) -> Poly.(x = v)) with
-      | Some opt -> Value.Valid.warn_if_deprecated conf opt
+      | Some opt -> Value.Ok.warn_if_deprecated conf opt
       | None -> () ) ;
       update conf x
     in

--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -244,7 +244,8 @@ module Make (C : CONFIG) = struct
 
   let choice ~all ?(removed_values = []) ~names ~doc ~kind
       ?(allow_inline = Poly.(kind = Formatting)) ?status update =
-    let name, default, _, _ = List.hd_exn all in
+    let _, default, _, _ = List.hd_exn all in
+    let name = List.hd_exn names in
     let opt_names = List.map all ~f:(fun (x, y, _, _) -> (x, y)) in
     let conv =
       Value.Removed.add_parse_errors removed_values (Arg.enum opt_names)

--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -202,8 +202,8 @@ module Make (C : CONFIG) = struct
 
     let pp_deprecated_with_name ~opt ~val_ ppf {dmsg= msg; dversion= v} =
       Format.fprintf ppf
-        "Value `%s` of option `%s` is deprecated since version %s. %s" val_
-        opt v msg
+        "option `%s`: value `%s` is deprecated since version %s. %s" opt val_
+        v msg
 
     let status_doc s ppf = function
       | `Valid -> ()

--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -191,7 +191,7 @@ module Make (C : CONFIG) = struct
   module Value = struct
     type 'a t = string * 'a * string * [`Valid | `Deprecated of deprecated]
 
-    let make ?deprecated ~name ~doc value =
+    let make ?deprecated ~name value doc =
       match deprecated with
       | None -> (name, value, doc, `Valid)
       | Some x -> (name, value, doc, `Deprecated x)

--- a/lib/Config_option.mli
+++ b/lib/Config_option.mli
@@ -53,8 +53,7 @@ module Make (C : CONFIG) : sig
   module Value : sig
     type 'a t
 
-    val make :
-      ?deprecated:deprecated -> name:string -> doc:string -> 'a -> 'a t
+    val make : ?deprecated:deprecated -> name:string -> 'a -> string -> 'a t
   end
 
   module Value_removed : sig

--- a/lib/Config_option.mli
+++ b/lib/Config_option.mli
@@ -53,10 +53,8 @@ module Make (C : CONFIG) : sig
   module Value : sig
     type 'a t
 
-    val valid : name:string -> doc:string -> 'a -> 'a t
-
-    val deprecated :
-      name:string -> doc:string -> deprecated:deprecated -> 'a -> 'a t
+    val make :
+      ?deprecated:deprecated -> name:string -> doc:string -> 'a -> 'a t
   end
 
   module Value_removed : sig
@@ -65,11 +63,12 @@ module Make (C : CONFIG) : sig
         displayed. *)
     type t
 
-    val mk : name:string -> version:string -> msg:string -> t
+    val make : name:string -> version:string -> msg:string -> t
     (** [name] is the configuration value that was removed in version
         [version]. [msg] explains how to get the former behaviour. *)
 
-    val mk_list : names:string list -> version:string -> msg:string -> t list
+    val make_list :
+      names:string list -> version:string -> msg:string -> t list
     (** Shorthand for [mk] when [version] and [msg] are shared. This can be
         used when multiple values are removed at the same time. *)
   end

--- a/lib/Config_option.mli
+++ b/lib/Config_option.mli
@@ -50,23 +50,31 @@ module Make (C : CONFIG) : sig
 
   val removed : since_version:string -> string -> removed
 
-  (** Indicate that a configuration value has been removed in an ocamlformat
-      release. A message indicating how to migrate will be displayed. *)
-  type removed_value
+  module Value : sig
+    module Valid : sig
+      type 'a t = string * 'a * string * [`Valid | `Deprecated of deprecated]
+    end
 
-  val removed_value :
-    name:string -> version:string -> msg:string -> removed_value
-  (** [name] is the configuration value that was removed in version
-      [version]. [msg] explains how to get the former behaviour. *)
+    module Removed : sig
+      (** Indicate that a configuration value has been removed in an
+          ocamlformat release. A message indicating how to migrate will be
+          displayed. *)
+      type t
 
-  val removed_values :
-    names:string list -> version:string -> msg:string -> removed_value list
-  (** Shorthand for [removed_value] when [version] and [msg] are shared. This
-      can be used when multiple values are removed at the same time. *)
+      val mk : name:string -> version:string -> msg:string -> t
+      (** [name] is the configuration value that was removed in version
+          [version]. [msg] explains how to get the former behaviour. *)
+
+      val mk_list :
+        names:string list -> version:string -> msg:string -> t list
+      (** Shorthand for [mk] when [version] and [msg] are shared. This can be
+          used when multiple values are removed at the same time. *)
+    end
+  end
 
   val choice :
-       all:(string * 'a * string) list
-    -> ?removed_values:removed_value list
+       all:'a Value.Valid.t list
+    -> ?removed_values:Value.Removed.t list
     -> 'a option_decl
 
   val flag : default:bool -> bool option_decl

--- a/lib/Config_option.mli
+++ b/lib/Config_option.mli
@@ -51,35 +51,32 @@ module Make (C : CONFIG) : sig
   val removed : since_version:string -> string -> removed
 
   module Value : sig
-    module Ok : sig
-      type 'a t
+    type 'a t
 
-      val valid : name:string -> doc:string -> 'a -> 'a t
+    val valid : name:string -> doc:string -> 'a -> 'a t
 
-      val deprecated :
-        name:string -> doc:string -> deprecated:deprecated -> 'a -> 'a t
-    end
+    val deprecated :
+      name:string -> doc:string -> deprecated:deprecated -> 'a -> 'a t
+  end
 
-    module Removed : sig
-      (** Indicate that a configuration value has been removed in an
-          ocamlformat release. A message indicating how to migrate will be
-          displayed. *)
-      type t
+  module Value_removed : sig
+    (** Indicate that a configuration value has been removed in an
+        ocamlformat release. A message indicating how to migrate will be
+        displayed. *)
+    type t
 
-      val mk : name:string -> version:string -> msg:string -> t
-      (** [name] is the configuration value that was removed in version
-          [version]. [msg] explains how to get the former behaviour. *)
+    val mk : name:string -> version:string -> msg:string -> t
+    (** [name] is the configuration value that was removed in version
+        [version]. [msg] explains how to get the former behaviour. *)
 
-      val mk_list :
-        names:string list -> version:string -> msg:string -> t list
-      (** Shorthand for [mk] when [version] and [msg] are shared. This can be
-          used when multiple values are removed at the same time. *)
-    end
+    val mk_list : names:string list -> version:string -> msg:string -> t list
+    (** Shorthand for [mk] when [version] and [msg] are shared. This can be
+        used when multiple values are removed at the same time. *)
   end
 
   val choice :
-       all:'a Value.Ok.t list
-    -> ?removed_values:Value.Removed.t list
+       all:'a Value.t list
+    -> ?removed_values:Value_removed.t list
     -> 'a option_decl
 
   val flag : default:bool -> bool option_decl

--- a/lib/Config_option.mli
+++ b/lib/Config_option.mli
@@ -51,8 +51,13 @@ module Make (C : CONFIG) : sig
   val removed : since_version:string -> string -> removed
 
   module Value : sig
-    module Valid : sig
-      type 'a t = string * 'a * string * [`Valid | `Deprecated of deprecated]
+    module Ok : sig
+      type 'a t
+
+      val valid : name:string -> doc:string -> 'a -> 'a t
+
+      val deprecated :
+        name:string -> doc:string -> deprecated:deprecated -> 'a -> 'a t
     end
 
     module Removed : sig
@@ -73,7 +78,7 @@ module Make (C : CONFIG) : sig
   end
 
   val choice :
-       all:'a Value.Valid.t list
+       all:'a Value.Ok.t list
     -> ?removed_values:Value.Removed.t list
     -> 'a option_decl
 


### PR DESCRIPTION
Here is what is produced when deprecating the value of some option:

```diff
diff --git a/ocamlformat-help.txt b/ocamlformat-help.actual
index 29694e95..abcc9a03 100644
--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.actual
@@ -105,8 +105,9 @@ OPTIONS (CODE FORMATTING STYLE)
        --break-separators={after|before}
            Break before or after separators such as `;` in list or record
            expressions. after breaks the expressions after the separator.
-           before breaks the expressions before the separator. The default
-           value is after.
+           before breaks the expressions before the separator. Warning: Value
+           `before` is deprecated since version 0.20.0. Deprecation message.
+           The default value is after.

diff --git a/test/passing/tests/break_separators-before_docked_wrap.ml.err b/test/passing/break_separators-before_docked_wrap.ml.stderr
index 8cec0959..f2a39eff 100644
--- a/test/passing/tests/break_separators-before_docked_wrap.ml.err
+++ b/test/passing/break_separators-before_docked_wrap.ml.stderr
@@ -1 +1,2 @@
+Warning: Value `before` of option `after` is deprecated since version 0.20.0. Deprecation message.
 Warning: tests/break_separators.ml:212 exceeds the margin
```

A warning is printed in the ocamlformat documentation, and when using a deprecated value explicitly.