### PR TITLE
Update documentation of deprecated option 'disable-outside-detected-project'

### DIFF
--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1128,10 +1128,12 @@ let disable_conf_files =
 let disable_outside_detected_project =
   let doc =
     Format.sprintf
-      "$(b,Warning:) this option is $(b,deprecated) and will be removed in \
+      "$(b,Warning:) this option is $(b,deprecated) and will be removed by \
        OCamlFormat v1.0."
   in
   let default = false in
+  let deprecated = C.deprecated ~since_version:"0.10.0" removed_by_v1_0 in
+  let docs = C.section_name Operational (`Deprecated deprecated) in
   mk ~default
     Arg.(value & flag & info ["disable-outside-detected-project"] ~doc ~docs)
 

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -501,6 +501,10 @@ OPTIONS (DEPRECATED)
            default. Warning: This option is deprecated since version 0.20.0.
            It will be removed by version 1.0.
 
+       --disable-outside-detected-project
+           Warning: this option is deprecated and will be removed by
+           OCamlFormat v1.0.
+
        --disambiguate-non-breaking-match
            Add parentheses around matching constructs that fit on a single
            line. The flag is unset by default. Warning: This option is
@@ -538,10 +542,6 @@ OPTIONS
 
        --disable-conf-files
            Disable .ocamlformat configuration files.
-
-       --disable-outside-detected-project
-           Warning: this option is deprecated and will be removed in
-           OCamlFormat v1.0.
 
        --enable-outside-detected-project
            Read .ocamlformat config files outside the current project. The


### PR DESCRIPTION
This option has been deprecated since 0.10.0, moving it with the other deprecated options.