### PR TITLE
Emacs: only hook ocamlformat mode on tuareg/caml modes when ocamlformat is not disabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,8 @@
     Fix formatting of labelled arguments containing comments.
     (#1797, @gpetiot)
 
+  + Emacs: only hook ocamlformat mode on tuareg/caml modes when ocamlformat is not disabled (#1814, @gpetiot)
+
 #### Changes
 
   + Preserve bracketed lists in the Parsetree (#1694, @gpetiot)

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -411,10 +411,23 @@ With ARG, perform this action that many times."
     t
     split-string-default-separators)))
 
-(add-hook 'tuareg-mode-hook 'ocamlformat-setup-indent t)
-(add-hook 'tuareg-mode-hook 'ocamlformat-set-newline-and-indent)
-(add-hook 'caml-mode-hook 'ocamlformat-caml-mode-setup t)
-(add-hook 'caml-mode-hook 'ocamlformat-set-newline-and-indent)
+(defun ocamlformat--add-hooks ()
+  "Link ocamlformat with tuareg-mode and caml-mode."
+  (progn
+    (add-hook 'tuareg-mode-hook 'ocamlformat-setup-indent t)
+    (add-hook 'tuareg-mode-hook 'ocamlformat-set-newline-and-indent)
+    (add-hook 'caml-mode-hook 'ocamlformat-caml-mode-setup t)
+    (add-hook 'caml-mode-hook 'ocamlformat-set-newline-and-indent)))
+
+(pcase ocamlformat-enable
+  ;; never hook
+  ('disable '())
+  ;; always hook
+  ('enable-outside-detected-project (ocamlformat--add-hooks))
+  ;; only hook if there is an .ocamlformat file at the root of the project
+  ('enable
+   (if (file-exists-p (concat default-directory ".ocamlformat"))
+    (ocamlformat--add-hooks))))
 
 (provide 'ocamlformat)
 

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -44,6 +44,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'vc)
 
 (defcustom ocamlformat-command "ocamlformat"
   "The 'ocamlformat' command."
@@ -426,7 +427,7 @@ With ARG, perform this action that many times."
   ('enable-outside-detected-project (ocamlformat--add-hooks))
   ;; only hook if there is an .ocamlformat file at the root of the project
   ('enable
-   (if (file-exists-p (concat default-directory ".ocamlformat"))
+   (if (vc-find-root default-directory ".ocamlformat")
     (ocamlformat--add-hooks))))
 
 (provide 'ocamlformat)


### PR DESCRIPTION
Trying to fix #1792, this should be improved to also take into account the value of `--root`. For now it just looks up the `.ocamlformat` file in the current directory, but it allows some basic testing to at least confirm if this is going in the right direction.
(This will be so much better once all this plumbing will be taken care of by dune)

cc @bobot let us know if it improves the situation