### PR TITLE
Only sugarize RHS of sequences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 
 #### Bug fixes
 
-  + Fix normalization of sequences of expressions (#1731, @gpetiot)
+  + Fix normalization of sequences of expressions (#1731, #1815, @gpetiot)
 
   + Type constrained patterns are now always parenthesized, parentheses were missing in a class context (#1734, @gpetiot)
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2205,6 +2205,8 @@ end = struct
     in
     let exp_in_sequence lhs rhs exp =
       match (lhs.pexp_desc, exp.pexp_attributes) with
+      (* already parenthesized if attributes are attached *)
+      | Pexp_sequence _, [] when lhs == exp -> true
       | (Pexp_match _ | Pexp_try _), _ :: _ when lhs == exp -> true
       | _, _ :: _ -> false
       | ( Pexp_extension

--- a/lib/Normalize.ml
+++ b/lib/Normalize.ml
@@ -251,21 +251,11 @@ let make_mapper conf ~ignore_doc_comments =
   in
   let expr (m : Ast_mapper.mapper) exp =
     let exp = {exp with pexp_loc_stack= []} in
-    let {pexp_desc; pexp_loc= loc1; pexp_attributes= attrs1; _} = exp in
+    let {pexp_desc; _} = exp in
     match pexp_desc with
     | Pexp_poly ({pexp_desc= Pexp_constraint (e, t); _}, None) ->
         m.expr m {exp with pexp_desc= Pexp_poly (e, Some t)}
     | Pexp_constraint (e, {ptyp_desc= Ptyp_poly ([], _t); _}) -> m.expr m e
-    | Pexp_sequence
-        ( exp1
-        , { pexp_desc= Pexp_sequence (exp2, exp3)
-          ; pexp_loc= loc2
-          ; pexp_attributes= attrs2
-          ; _ } ) ->
-        m.expr m
-          (Exp.sequence ~loc:loc1 ~attrs:attrs1
-             (Exp.sequence ~loc:loc2 ~attrs:attrs2 exp1 exp2)
-             exp3 )
     | _ -> Ast_mapper.default_mapper.expr m exp
   in
   let pat (m : Ast_mapper.mapper) pat =

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -230,27 +230,28 @@ let sequence cmts xexp =
           ~after:e2.pexp_loc ;
         if (not allow_attribute) && not (List.is_empty exp.pexp_attributes)
         then [(None, xexp)]
-        else if Ast.exposed_right_exp Ast.Let_match e1 then
-          [(None, sub_exp ~ctx e1); (Some ext, sub_exp ~ctx e2)]
         else
-          let l1 = sequence_ ~allow_attribute:false (sub_exp ~ctx e1) in
           let l2 =
-            match sequence_ ~allow_attribute:false (sub_exp ~ctx e2) with
-            | [] -> []
-            | (_, e2) :: l2 -> (Some ext, e2) :: l2
+            if Ast.exposed_right_exp Ast.Let_match e1 then
+              [(Some ext, sub_exp ~ctx e2)]
+            else
+              match sequence_ ~allow_attribute:false (sub_exp ~ctx e2) with
+              | [] -> []
+              | (_, e2) :: l2 -> (Some ext, e2) :: l2
           in
-          List.append l1 l2
+          (None, sub_exp ~ctx e1) :: l2
     | Pexp_sequence (e1, e2) ->
         Cmts.relocate cmts ~src:pexp_loc ~before:e1.pexp_loc
           ~after:e2.pexp_loc ;
         if (not allow_attribute) && not (List.is_empty exp.pexp_attributes)
         then [(None, xexp)]
-        else if Ast.exposed_right_exp Ast.Let_match e1 then
-          [(None, sub_exp ~ctx e1); (None, sub_exp ~ctx e2)]
         else
-          List.append
-            (sequence_ ~allow_attribute:false (sub_exp ~ctx e1))
-            (sequence_ ~allow_attribute:false (sub_exp ~ctx e2))
+          let l2 =
+            if Ast.exposed_right_exp Ast.Let_match e1 then
+              [(None, sub_exp ~ctx e2)]
+            else sequence_ ~allow_attribute:false (sub_exp ~ctx e2)
+          in
+          (None, sub_exp ~ctx e1) :: l2
     | _ -> [(None, xexp)]
   in
   sequence_ xexp

--- a/test/passing/tests/sequence-preserve.ml.ref
+++ b/test/passing/tests/sequence-preserve.ml.ref
@@ -1,8 +1,8 @@
 let read_traces filename =
   let ic = open_in_bin filename in
-  read_hashtable ~t:[%t: contracts_trace] 0 40 ic tbl1 ;
-  read_hashtable ~t:[%t: variables_trace] 40 70 ic tbl2 ;
-  read_hashtable ~t:[%t: expressions_trace] 70 100 ic tbl3 ;
+  ( read_hashtable ~t:[%t: contracts_trace] 0 40 ic tbl1 ;
+    read_hashtable ~t:[%t: variables_trace] 40 70 ic tbl2 ;
+    read_hashtable ~t:[%t: expressions_trace] 70 100 ic tbl3 ) ;
   close_in ic
 
 let foo x y =

--- a/test/passing/tests/sequence.ml.ref
+++ b/test/passing/tests/sequence.ml.ref
@@ -1,8 +1,8 @@
 let read_traces filename =
   let ic = open_in_bin filename in
-  read_hashtable ~t:[%t: contracts_trace] 0 40 ic tbl1 ;
-  read_hashtable ~t:[%t: variables_trace] 40 70 ic tbl2 ;
-  read_hashtable ~t:[%t: expressions_trace] 70 100 ic tbl3 ;
+  ( read_hashtable ~t:[%t: contracts_trace] 0 40 ic tbl1 ;
+    read_hashtable ~t:[%t: variables_trace] 40 70 ic tbl2 ;
+    read_hashtable ~t:[%t: expressions_trace] 70 100 ic tbl3 ) ;
   close_in ic
 
 let foo x y =


### PR DESCRIPTION
Fix #1787, better fix of #1728 and #1730.
No diff with test_branch.sh.
To not break the AST we should only sugarize the RHS of sequences, LHS should be parenthesized if it's also a sequence.