### PR TITLE
Fix documentation of option 'use-file', it should not be deprecated

### DIFF
--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1234,7 +1234,7 @@ let kind : Syntax.t option ref =
   let impl = (Some Syntax.Use_file, Arg.info ["impl"] ~doc ~docs) in
   let doc = "Parse file with unrecognized extension as an interface." in
   let intf = (Some Syntax.Signature, Arg.info ["intf"] ~doc ~docs) in
-  let doc = "Deprecated. Same as $(b,impl)." in
+  let doc = "Parse file with unrecognized extension as toplevel phrases." in
   let use_file = (Some Syntax.Use_file, Arg.info ["use-file"] ~doc ~docs) in
   let default = None in
   mk ~default Arg.(value & vflag default [impl; intf; use_file])

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -629,7 +629,7 @@ OPTIONS
            subdirectories.
 
        --use-file
-           Deprecated. Same as impl.
+           Parse file with unrecognized extension as toplevel phrases.
 
        --version
            Show version information.


### PR DESCRIPTION
`--use-file` and `--impl` are not treated the same, contrary to what the documentation says, calling different functions from `Parse`, and also different formatting functions.
Maybe it was the case before we had rewritten the code to use fragment types, but not anymore.