### PR TITLE
Revert "Do not use ghost locations for type constraints (ocaml#10555)"

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -595,7 +595,7 @@ and fmt_payload c ctx pld =
       in
       fmt "?@ " $ fmt_pattern c (sub_pat ~ctx pat) $ opt exp fmt_when
 
-and fmt_record_field c ?typ ?rhs ?constraint_loc lid1 =
+and fmt_record_field c ?typ ?rhs ?(type_first = false) lid1 =
   let fmt_type ?(parens = false) t =
     str ": " $ fmt_core_type c t $ fmt_if parens ")"
   in
@@ -609,20 +609,11 @@ and fmt_record_field c ?typ ?rhs ?constraint_loc lid1 =
   in
   let fmt_type_rhs =
     match (typ, rhs) with
-    | Some t, Some r -> (
-      match constraint_loc with
-      | Some (`Constraint_lid loc) ->
-          field_space
-          $ Cmts.fmt_before c loc ~pro:(Fmt.break 1 0) ~epi:noop
-          $ fmt_type t $ fmt "@ " $ fmt_rhs r $ Cmts.fmt_after c loc
-      | Some (`Constraint_exp loc) ->
-          field_space $ fmt "=@;<1 2>"
-          $ hvbox 0
-            @@ Cmts.fmt c loc
-                 (str "(" $ cbox 0 r $ str " " $ fmt_type ~parens:true t)
-      | None ->
+    | Some t, Some r ->
+        if type_first then field_space $ fmt_type t $ fmt "@ " $ fmt_rhs r
+        else
           field_space $ fmt_rhs ~parens:true r $ str " "
-          $ fmt_type ~parens:true t )
+          $ fmt_type ~parens:true t
     | Some t, None -> field_space $ fmt_type t
     | None, Some r -> field_space $ fmt_rhs r
     | None, None -> noop
@@ -1032,12 +1023,11 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
           | Ppat_constraint (p, t) when List.is_empty ppat_attributes ->
               let typ = sub_typ ~ctx:(Pat pat) t
               and rhs = fmt_rhs ~ctx:(Pat pat) p in
-              let constraint_loc =
-                if Source.type_constraint_is_first t p.ppat_loc then
-                  `Constraint_lid ppat_loc
-                else `Constraint_exp ppat_loc
+              let type_first =
+                Source.type_constraint_is_first t p.ppat_loc
               in
-              fmt_record_field c ~typ ~rhs ~constraint_loc lid1
+              Cmts.fmt c p.ppat_loc
+              @@ fmt_record_field c ~typ ~rhs ~type_first lid1
           | _ -> fmt_record_field c ~rhs:(fmt_rhs ~ctx pat) lid1 )
       in
       let p1, p2 = Params.get_record_pat c.conf ~ctx:ctx0 in
@@ -2350,13 +2340,12 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
               Cmts.fmt c f.pexp_loc
               @@ fmt_record_field c ~rhs:(fmt_rhs f) lid1
           | Pexp_constraint (e, t) when List.is_empty f.pexp_attributes ->
-              let constraint_loc =
-                if Source.type_constraint_is_first t e.pexp_loc then
-                  `Constraint_lid f.pexp_loc
-                else `Constraint_exp f.pexp_loc
+              let type_first =
+                Source.type_constraint_is_first t e.pexp_loc
               in
-              fmt_record_field c ~typ:(sub_typ ~ctx t) ~rhs:(fmt_rhs e)
-                ~constraint_loc lid1
+              Cmts.fmt c f.pexp_loc
+              @@ fmt_record_field c ~typ:(sub_typ ~ctx t) ~rhs:(fmt_rhs e)
+                   ~type_first lid1
           | _ ->
               Cmts.fmt c f.pexp_loc
               @@ fmt_record_field c ~rhs:(fmt_rhs f) lid1 )

--- a/test/passing/tests/comments_in_record.ml.ref
+++ b/test/passing/tests/comments_in_record.ml.ref
@@ -23,8 +23,8 @@ let { (* cmts *)
     ; a
     ; (* b *) b
     ; (* c *) c
-    ; d=
-        (* d *)
+    ; (* d *)
+      d=
         (D : loooooooooooooooooooooooooooooooooooooooooooooooooooooooong_int)
     ; (* e *)
       e: loooooooooooooooooooooooooooooooooooooooooooooooooooooooong_int } =
@@ -65,12 +65,14 @@ let _ =
   { (* a *) a (* a' *)= (* b *) b (* b' *)
   ; (* c *) c (* c' *): (* d *) d (* d' *) = (* e *) e (* e' *)
   ; (* f *) f (* f' *)
-  ; (* g *) g (* g' *)=
-      (* j *) ((* h *) h (* h' *) : (* i *) i (* i' *)) (* j' *) }
+  ; (* j *)
+    (* g *) g (* g' *)= ((* h *) h (* h' *) : (* i *) i (* i' *))
+    (* j' *) }
 
 let { (* a *) a (* a' *)= (* b *) b (* b' *)
     ; (* c *) c (* c' *): (* d *) d (* d' *) = (* e *) e (* e' *)
     ; (* f *) f (* f' *)
-    ; (* g *) g (* g' *)=
-        (* j *) ((* h *) h (* h' *) : (* i *) i (* i' *)) (* j' *) } =
+    ; (* j *)
+      (* g *) g (* g' *)= ((* h *) h (* h' *) : (* i *) i (* i' *))
+      (* j' *) } =
   x

--- a/vendor/ocaml-4.13-extended/parser.mly
+++ b/vendor/ocaml-4.13-extended/parser.mly
@@ -183,8 +183,8 @@ let mkstrexp e attrs =
 
 let mkexp_constraint ~loc e (t1, t2) =
   match t1, t2 with
-  | Some t, None -> mkexp ~loc (Pexp_constraint(e, t))
-  | _, Some t -> mkexp ~loc (Pexp_coerce(e, t1, t))
+  | Some t, None -> ghexp ~loc (Pexp_constraint(e, t))
+  | _, Some t -> ghexp ~loc (Pexp_coerce(e, t1, t))
   | None, None -> assert false
 
 let mkexp_opt_constraint ~loc e = function
@@ -193,7 +193,7 @@ let mkexp_opt_constraint ~loc e = function
 
 let mkpat_opt_constraint ~loc p = function
   | None -> p
-  | Some typ -> mkpat ~loc (Ppat_constraint(p, typ))
+  | Some typ -> ghpat ~loc (Ppat_constraint(p, typ))
 
 let syntax_error () =
   raise Syntaxerr.Escape_error
@@ -364,12 +364,12 @@ let loc_last (id : Longident.t Location.loc) : string Location.loc =
 let loc_lident (id : string Location.loc) : Longident.t Location.loc =
   loc_map (fun x -> Lident x) id
 
-let exp_of_longident lid =
-  let lid = loc_map (fun id -> Lident (Longident.last id)) lid in
-  Exp.mk ~loc:lid.loc (Pexp_ident lid)
+let exp_of_longident ~loc lid =
+  let lid = make_ghost (loc_map (fun id -> Lident (Longident.last id)) lid) in
+  ghexp ~loc (Pexp_ident lid)
 
-let exp_of_label lbl =
-  Exp.mk ~loc:lbl.loc (Pexp_ident (loc_lident lbl))
+let exp_of_label ~loc lbl =
+  mkexp ~loc (Pexp_ident (loc_lident lbl))
 
 let pat_of_label lbl =
   Pat.mk ~loc:lbl.loc  (Ppat_var (loc_last lbl))
@@ -2615,15 +2615,15 @@ record_expr_content:
   | label = mkrhs(label_longident)
     c = type_constraint?
     eo = preceded(EQUAL, expr)?
-      { let constraint_loc, label, e =
+      { let e =
           match eo with
           | None ->
               (* No pattern; this is a pun. Desugar it. *)
-              $sloc, make_ghost label, exp_of_longident label
+              exp_of_longident ~loc:$sloc label
           | Some e ->
-              ($startpos(c), $endpos), label, e
+              e
         in
-        label, mkexp_opt_constraint ~loc:constraint_loc e c }
+        label, mkexp_opt_constraint ~loc:$sloc e c }
 ;
 %inline object_expr_content:
   xs = separated_or_terminated_nonempty_list(SEMI, object_expr_field)
@@ -2632,13 +2632,13 @@ record_expr_content:
 %inline object_expr_field:
     label = mkrhs(label)
     oe = preceded(EQUAL, expr)?
-      { let label, e =
+      { let e =
           match oe with
           | None ->
               (* No expression; this is a pun. Desugar it. *)
-              make_ghost label, exp_of_label label
+              exp_of_label ~loc:$sloc label
           | Some e ->
-              label, e
+              e
         in
         label, e }
 ;
@@ -2828,18 +2828,18 @@ pattern_comma_list(self):
   label = mkrhs(label_longident)
   octy = preceded(COLON, core_type)?
   opat = preceded(EQUAL, pattern)?
-    { let constraint_loc, label, pat =
+    { let label, pat =
         match opat with
         | None ->
             (* No pattern; this is a pun. Desugar it.
                But that the pattern was there and the label reconstructed (which
                piece of AST is marked as ghost is important for warning
                emission). *)
-            $sloc, make_ghost label, pat_of_label label
+            make_ghost label, pat_of_label label
         | Some pat ->
-            ($startpos(octy), $endpos), label, pat
+            label, pat
       in
-      label, mkpat_opt_constraint ~loc:constraint_loc pat octy
+      label, mkpat_opt_constraint ~loc:$sloc pat octy
     }
 ;
 

--- a/vendor/ocaml-4.13/parser.mly
+++ b/vendor/ocaml-4.13/parser.mly
@@ -208,8 +208,8 @@ let mkstrexp e attrs =
 
 let mkexp_constraint ~loc e (t1, t2) =
   match t1, t2 with
-  | Some t, None -> mkexp ~loc (Pexp_constraint(e, t))
-  | _, Some t -> mkexp ~loc (Pexp_coerce(e, t1, t))
+  | Some t, None -> ghexp ~loc (Pexp_constraint(e, t))
+  | _, Some t -> ghexp ~loc (Pexp_coerce(e, t1, t))
   | None, None -> assert false
 
 let mkexp_opt_constraint ~loc e = function
@@ -218,7 +218,7 @@ let mkexp_opt_constraint ~loc e = function
 
 let mkpat_opt_constraint ~loc p = function
   | None -> p
-  | Some typ -> mkpat ~loc (Ppat_constraint(p, typ))
+  | Some typ -> ghpat ~loc (Ppat_constraint(p, typ))
 
 let syntax_error () =
   raise Syntaxerr.Escape_error
@@ -389,12 +389,12 @@ let loc_last (id : Longident.t Location.loc) : string Location.loc =
 let loc_lident (id : string Location.loc) : Longident.t Location.loc =
   loc_map (fun x -> Lident x) id
 
-let exp_of_longident lid =
-  let lid = loc_map (fun id -> Lident (Longident.last id)) lid in
-  Exp.mk ~loc:lid.loc (Pexp_ident lid)
+let exp_of_longident ~loc lid =
+  let lid = make_ghost (loc_map (fun id -> Lident (Longident.last id)) lid) in
+  ghexp ~loc (Pexp_ident lid)
 
-let exp_of_label lbl =
-  Exp.mk ~loc:lbl.loc (Pexp_ident (loc_lident lbl))
+let exp_of_label ~loc lbl =
+  mkexp ~loc (Pexp_ident (loc_lident lbl))
 
 let pat_of_label lbl =
   Pat.mk ~loc:lbl.loc  (Ppat_var (loc_last lbl))
@@ -2642,15 +2642,15 @@ record_expr_content:
   | label = mkrhs(label_longident)
     c = type_constraint?
     eo = preceded(EQUAL, expr)?
-      { let constraint_loc, label, e =
+      { let e =
           match eo with
           | None ->
               (* No pattern; this is a pun. Desugar it. *)
-              $sloc, make_ghost label, exp_of_longident label
+              exp_of_longident ~loc:$sloc label
           | Some e ->
-              ($startpos(c), $endpos), label, e
+              e
         in
-        label, mkexp_opt_constraint ~loc:constraint_loc e c }
+        label, mkexp_opt_constraint ~loc:$sloc e c }
 ;
 %inline object_expr_content:
   xs = separated_or_terminated_nonempty_list(SEMI, object_expr_field)
@@ -2659,13 +2659,13 @@ record_expr_content:
 %inline object_expr_field:
     label = mkrhs(label)
     oe = preceded(EQUAL, expr)?
-      { let label, e =
+      { let e =
           match oe with
           | None ->
               (* No expression; this is a pun. Desugar it. *)
-              make_ghost label, exp_of_label label
+              exp_of_label ~loc:$sloc label
           | Some e ->
-              label, e
+              e
         in
         label, e }
 ;
@@ -2853,18 +2853,18 @@ pattern_comma_list(self):
   label = mkrhs(label_longident)
   octy = preceded(COLON, core_type)?
   opat = preceded(EQUAL, pattern)?
-    { let constraint_loc, label, pat =
+    { let label, pat =
         match opat with
         | None ->
             (* No pattern; this is a pun. Desugar it.
                But that the pattern was there and the label reconstructed (which
                piece of AST is marked as ghost is important for warning
                emission). *)
-            $sloc, make_ghost label, pat_of_label label
+            make_ghost label, pat_of_label label
         | Some pat ->
-            ($startpos(octy), $endpos), label, pat
+            label, pat
       in
-      label, mkpat_opt_constraint ~loc:constraint_loc pat octy
+      label, mkpat_opt_constraint ~loc:$sloc pat octy
     }
 ;
 

--- a/vendor/parse-wyc/lib/parser.mly
+++ b/vendor/parse-wyc/lib/parser.mly
@@ -191,8 +191,8 @@ let mkstrexp e attrs =
 
 let mkexp_constraint ~loc e (t1, t2) =
   match t1, t2 with
-  | Some t, None -> mkexp ~loc (Pexp_constraint(e, t))
-  | _, Some t -> mkexp ~loc (Pexp_coerce(e, t1, t))
+  | Some t, None -> ghexp ~loc (Pexp_constraint(e, t))
+  | _, Some t -> ghexp ~loc (Pexp_coerce(e, t1, t))
   | None, None -> assert false
 
 let mkexp_opt_constraint ~loc e = function
@@ -201,7 +201,7 @@ let mkexp_opt_constraint ~loc e = function
 
 let mkpat_opt_constraint ~loc p = function
   | None -> p
-  | Some typ -> mkpat ~loc (Ppat_constraint(p, typ))
+  | Some typ -> ghpat ~loc (Ppat_constraint(p, typ))
 
 (*let syntax_error () =
   raise Syntaxerr.Escape_error*)
@@ -372,12 +372,12 @@ let loc_last (id : Longident.t Location.loc) : string Location.loc =
 let loc_lident (id : string Location.loc) : Longident.t Location.loc =
   loc_map (fun x -> Lident x) id
 
-let exp_of_longident lid =
-  let lid = loc_map (fun id -> Lident (Longident.last id)) lid in
-  Exp.mk ~loc:lid.loc (Pexp_ident lid)
+let exp_of_longident ~loc lid =
+  let lid = make_ghost (loc_map (fun id -> Lident (Longident.last id)) lid) in
+  ghexp ~loc (Pexp_ident lid)
 
-let exp_of_label lbl =
-  Exp.mk ~loc:lbl.loc (Pexp_ident (loc_lident lbl))
+let exp_of_label ~loc lbl =
+  mkexp ~loc (Pexp_ident (loc_lident lbl))
 
 let pat_of_label lbl =
   Pat.mk ~loc:lbl.loc  (Ppat_var (loc_last lbl))
@@ -2614,15 +2614,15 @@ record_expr_content:
   | label = mkrhs(label_longident)
     c = type_constraint?
     eo = preceded(EQUAL, expr)?
-      { let constraint_loc, label, e =
+      { let e =
           match eo with
           | None ->
               (* No pattern; this is a pun. Desugar it. *)
-              $sloc, make_ghost label, exp_of_longident label
+              exp_of_longident ~loc:$sloc label
           | Some e ->
-              ($startpos(c), $endpos), label, e
+              e
         in
-        label, mkexp_opt_constraint ~loc:constraint_loc e c }
+        label, mkexp_opt_constraint ~loc:$sloc e c }
 ;
 %inline object_expr_content:
   xs = separated_or_terminated_nonempty_list(SEMI, object_expr_field)
@@ -2631,13 +2631,13 @@ record_expr_content:
 %inline object_expr_field:
     label = mkrhs(label)
     oe = preceded(EQUAL, expr)?
-      { let label, e =
+      { let e =
           match oe with
           | None ->
               (* No expression; this is a pun. Desugar it. *)
-              make_ghost label, exp_of_label label
+              exp_of_label ~loc:$sloc label
           | Some e ->
-              label, e
+              e
         in
         label, e }
 ;
@@ -2827,18 +2827,18 @@ pattern_comma_list(self):
   label = mkrhs(label_longident)
   octy = preceded(COLON, core_type)?
   opat = preceded(EQUAL, pattern)?
-    { let constraint_loc, label, pat =
+    { let label, pat =
         match opat with
         | None ->
             (* No pattern; this is a pun. Desugar it.
                But that the pattern was there and the label reconstructed (which
                piece of AST is marked as ghost is important for warning
                emission). *)
-            $sloc, make_ghost label, pat_of_label label
+            make_ghost label, pat_of_label label
         | Some pat ->
-            ($startpos(octy), $endpos), label, pat
+            label, pat
       in
-      label, mkpat_opt_constraint ~loc:constraint_loc pat octy
+      label, mkpat_opt_constraint ~loc:$sloc pat octy
     }
 ;
 


### PR DESCRIPTION
Reverts ocaml-ppx/ocamlformat#1779