### PR TITLE
Set option 'enable-outside-detected-project' for test_branch.sh

### DIFF
--- a/test-extra/Makefile
+++ b/test-extra/Makefile
@@ -111,11 +111,11 @@ FIND_ARGS= \
 
 .PHONY: test_inplace
 test_inplace:
-	@find $(DIRS) $(FIND_ARGS) | parallel --bar "$(OCAMLFORMAT_EXE)" --no-version-check -i
+	@find $(DIRS) $(FIND_ARGS) | parallel --bar "$(OCAMLFORMAT_EXE)" --no-version-check --enable-outside-detected-project -i
 
 .PHONY: test_extra
 test_extra:
-	@find $(XDIRS) $(FIND_ARGS) | parallel --bar "$(OCAMLFORMAT_EXE)" --no-version-check --quiet -i
+	@find $(XDIRS) $(FIND_ARGS) | parallel --bar "$(OCAMLFORMAT_EXE)" --no-version-check --enable-outside-detected-project --quiet -i
 
 .PHONY: test_margins
 test_margins:


### PR DESCRIPTION
I got a lot of errors while running `test_branch.sh` because this option was not set, but what's funny is that it didn't appear after I updated my `test-extra` directory, just out of nowhere.
Maybe someone could double check before I merge.