### PR TITLE
Define cmt_checker type to simplify break_between functions

### DIFF
--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -118,6 +118,11 @@ val doc_atrs :
   -> attributes
   -> (string Location.loc * bool) list option * attributes
 
+type cmt_checker =
+  { cmts_before: Location.t -> bool
+  ; cmts_within: Location.t -> bool
+  ; cmts_after: Location.t -> bool }
+
 module Pat : sig
   val is_simple : pattern -> bool
 end
@@ -166,13 +171,7 @@ type t =
 val is_top : t -> bool
 
 val break_between :
-     Source.t
-  -> cmts:'a
-  -> has_cmts_before:('a -> Location.t -> bool)
-  -> has_cmts_after:('a -> Location.t -> bool)
-  -> t * Conf.t
-  -> t * Conf.t
-  -> bool
+  Source.t -> cmt_checker -> t * Conf.t -> t * Conf.t -> bool
 
 val attributes : t -> attributes
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -54,9 +54,12 @@ module Cmts = struct
   end
 end
 
-let break_between {source; cmts; _} =
-  Ast.break_between source ~cmts ~has_cmts_before:Cmts.has_before
-    ~has_cmts_after:Cmts.has_after
+let cmt_checker {cmts; _} =
+  { cmts_before= Cmts.has_before cmts
+  ; cmts_within= Cmts.has_within cmts
+  ; cmts_after= Cmts.has_after cmts }
+
+let break_between c = Ast.break_between c.source (cmt_checker c)
 
 type block =
   { opn: Fmt.t


### PR DESCRIPTION
Some refactoring to reduce the diff of #1743, no behavioral change.