### PR TITLE
Handle let operator punning uniformly with other punning forms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,9 @@
 
   + Allow disambiguated global identifiers (like t/2) so they can be formatted by tools like OCaml-LSP (#1716, @let-def)
 
+  + Handle let operator punning uniformly with other punning forms.
+    Normalizes let operator to the punned form where possible, if output syntax version is at least OCaml 4.13. (#1834, @jberdine)
+
 ### 0.19.0 (2021-07-16)
 
 #### Bug fixes

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -139,11 +139,9 @@ module Let_binding : sig
     ; lb_loc: Location.t }
 
   val of_value_binding :
-    Cmts.t -> Source.t -> ctx:Ast.t -> first:bool -> value_binding -> t
+    Cmts.t -> ctx:Ast.t -> first:bool -> value_binding -> t
 
-  val of_value_bindings :
-    Cmts.t -> Source.t -> ctx:Ast.t -> value_binding list -> t list
+  val of_value_bindings : Cmts.t -> ctx:Ast.t -> value_binding list -> t list
 
-  val of_binding_ops :
-    Cmts.t -> Source.t -> ctx:Ast.t -> binding_op list -> t list
+  val of_binding_ops : Cmts.t -> ctx:Ast.t -> binding_op list -> t list
 end

--- a/test/passing/tests/let_punning.ml
+++ b/test/passing/tests/let_punning.ml
@@ -13,5 +13,5 @@ let p =
   (x, y, z)
 
 let q =
-  let%foo x and y and z in
+  let%foo x = x and y = y and z = z in
   (x, y, z)


### PR DESCRIPTION
Other sorts of punning, such as record fields, normalize to the punned
form. For example `{x = x}` normalizes to `{x}`. This patch brings let
operator punning in line by normalizing e.g. `let* x = x` to `let* x`.