### PR TITLE
Remove the bisect_ppx dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -56,10 +56,6 @@
   (ocaml-version
    (>= 3.2.0))
   ocp-indent
-  (bisect_ppx
-   (and
-    :with-test
-    (>= 2.5.0)))
   (odoc-parser
    (>= 0.9.0))
   (re
@@ -102,10 +98,6 @@
   (ocaml-version
    (>= 3.2.0))
   ocp-indent
-  (bisect_ppx
-   (and
-    :with-test
-    (>= 2.5.0)))
   (odoc-parser
    (>= 0.9.0))
   (re

--- a/ocamlformat-rpc.opam
+++ b/ocamlformat-rpc.opam
@@ -24,7 +24,6 @@ depends: [
   "menhirSdk" {>= "20201216"}
   "ocaml-version" {>= "3.2.0"}
   "ocp-indent"
-  "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc-parser" {>= "0.9.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.15"}

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -23,7 +23,6 @@ depends: [
   "menhirSdk" {>= "20201216"}
   "ocaml-version" {>= "3.2.0"}
   "ocp-indent"
-  "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc-parser" {>= "0.9.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.15"}


### PR DESCRIPTION
As noted in https://github.com/ocaml/opam-repository/pull/19694 there is a circular dependency between
ocamlformat and bisect_ppx, bisect_ppx depends on ocamlformat.0.16.0 since `bisect_ppx.2.6.0`.

We could also update the dependency to bisect_ppx to:
`"bisect_ppx" {with-test & = "2.5.0"}` but I think we can just remove the dependency, and people that want to use `make coverage` will get the following error message anyway:
```
dune runtest --instrument-with bisect_ppx --force
File "bin/ocamlformat-rpc/dune", line 19, characters 11-21:
19 |   (backend bisect_ppx))
                ^^^^^^^^^^
Error: Library "bisect_ppx" not found.
```