### PR TITLE
Apply option 'field-space' to values in signatures for more consistency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 #### Changes
 
+  + Apply option 'field-space' to values in signatures for more consistency (#1855, @gpetiot)
+
 #### New features
 
 ### 0.20.1 (2021-12-13)

--- a/lib-rpc/ocamlformat_rpc_lib.ml
+++ b/lib-rpc/ocamlformat_rpc_lib.ml
@@ -14,11 +14,11 @@ open Sexplib0
 module type Command_S = sig
   type t
 
-  val read_input : Stdlib.in_channel -> t
+  val read_input: Stdlib.in_channel -> t
 
-  val to_sexp : t -> Sexp.t
+  val to_sexp: t -> Sexp.t
 
-  val output : Stdlib.out_channel -> t -> unit
+  val output: Stdlib.out_channel -> t -> unit
 end
 
 module type Client_S = sig
@@ -26,18 +26,18 @@ module type Client_S = sig
 
   type cmd
 
-  val pid : t -> int
+  val pid: t -> int
 
-  val mk : pid:int -> in_channel -> out_channel -> t
+  val mk: pid:int -> in_channel -> out_channel -> t
 
-  val query : cmd -> t -> cmd
+  val query: cmd -> t -> cmd
 
-  val halt : t -> (unit, [> `Msg of string]) result
+  val halt: t -> (unit, [> `Msg of string]) result
 
-  val config :
+  val config:
     (string * string) list -> t -> (unit, [> `Msg of string]) result
 
-  val format : string -> t -> (string, [> `Msg of string]) result
+  val format: string -> t -> (string, [> `Msg of string]) result
 end
 
 module type V = sig

--- a/lib-rpc/ocamlformat_rpc_lib.mli
+++ b/lib-rpc/ocamlformat_rpc_lib.mli
@@ -12,11 +12,11 @@
 module type Command_S = sig
   type t
 
-  val read_input : Stdlib.in_channel -> t
+  val read_input: Stdlib.in_channel -> t
 
-  val to_sexp : t -> Sexplib0.Sexp.t
+  val to_sexp: t -> Sexplib0.Sexp.t
 
-  val output : Stdlib.out_channel -> t -> unit
+  val output: Stdlib.out_channel -> t -> unit
 end
 
 module type Client_S = sig
@@ -24,18 +24,18 @@ module type Client_S = sig
 
   type cmd
 
-  val pid : t -> int
+  val pid: t -> int
 
-  val mk : pid:int -> in_channel -> out_channel -> t
+  val mk: pid:int -> in_channel -> out_channel -> t
 
-  val query : cmd -> t -> cmd
+  val query: cmd -> t -> cmd
 
-  val halt : t -> (unit, [> `Msg of string]) result
+  val halt: t -> (unit, [> `Msg of string]) result
 
-  val config :
+  val config:
     (string * string) list -> t -> (unit, [> `Msg of string]) result
 
-  val format : string -> t -> (string, [> `Msg of string]) result
+  val format: string -> t -> (string, [> `Msg of string]) result
 end
 
 module type V = sig
@@ -58,7 +58,7 @@ module V1 :
 
 type client = [`V1 of V1.Client.t]
 
-val pick_client :
+val pick_client:
      pid:int
   -> in_channel
   -> out_channel
@@ -68,11 +68,11 @@ val pick_client :
     according to a list of [versions], that is a list ordered from the most
     to the least wished version. *)
 
-val pid : client -> int
+val pid: client -> int
 
-val halt : client -> (unit, [> `Msg of string]) result
+val halt: client -> (unit, [> `Msg of string]) result
 
-val config :
+val config:
   (string * string) list -> client -> (unit, [> `Msg of string]) result
 
-val format : string -> client -> (string, [> `Msg of string]) result
+val format: string -> client -> (string, [> `Msg of string]) result

--- a/lib/Assoc.mli
+++ b/lib/Assoc.mli
@@ -12,10 +12,10 @@
 (** Associativities of Ast terms *)
 type t = Left | Non | Right
 
-val to_string : t -> string
+val to_string: t -> string
 
-val equal : t -> t -> bool
+val equal: t -> t -> bool
 
-val of_prec : Prec.t -> t
+val of_prec: Prec.t -> t
 (** [of_prec prec] is the associativity of Ast terms with precedence [prec].
     (Associativity is uniform across precedence levels.) *)

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -825,25 +825,25 @@ let break_between s cc (i1, c1) (i2, c2) =
 module rec In_ctx : sig
   type 'a xt = private {ctx: T.t; ast: 'a}
 
-  val sub_ast : ctx:T.t -> T.t -> T.t xt
+  val sub_ast: ctx:T.t -> T.t -> T.t xt
 
-  val sub_typ : ctx:T.t -> core_type -> core_type xt
+  val sub_typ: ctx:T.t -> core_type -> core_type xt
 
-  val sub_cty : ctx:T.t -> class_type -> class_type xt
+  val sub_cty: ctx:T.t -> class_type -> class_type xt
 
-  val sub_pat : ctx:T.t -> pattern -> pattern xt
+  val sub_pat: ctx:T.t -> pattern -> pattern xt
 
-  val sub_exp : ctx:T.t -> expression -> expression xt
+  val sub_exp: ctx:T.t -> expression -> expression xt
 
-  val sub_cl : ctx:T.t -> class_expr -> class_expr xt
+  val sub_cl: ctx:T.t -> class_expr -> class_expr xt
 
-  val sub_mty : ctx:T.t -> module_type -> module_type xt
+  val sub_mty: ctx:T.t -> module_type -> module_type xt
 
-  val sub_mod : ctx:T.t -> module_expr -> module_expr xt
+  val sub_mod: ctx:T.t -> module_expr -> module_expr xt
 
-  val sub_sig : ctx:T.t -> signature_item -> signature_item xt
+  val sub_sig: ctx:T.t -> signature_item -> signature_item xt
 
-  val sub_str : ctx:T.t -> structure_item -> structure_item xt
+  val sub_str: ctx:T.t -> structure_item -> structure_item xt
 end = struct
   open Requires_sub_terms
 
@@ -873,30 +873,30 @@ end
 (** Operations determining precedence and necessary parenthesization of terms
     based on their super-terms. *)
 and Requires_sub_terms : sig
-  val is_simple :
+  val is_simple:
     Conf.t -> (expression In_ctx.xt -> int) -> expression In_ctx.xt -> bool
 
-  val exposed_right_exp : cls -> expression -> bool
+  val exposed_right_exp: cls -> expression -> bool
 
-  val prec_ast : T.t -> Prec.t option
+  val prec_ast: T.t -> Prec.t option
 
-  val parenze_typ : core_type In_ctx.xt -> bool
+  val parenze_typ: core_type In_ctx.xt -> bool
 
-  val parenze_mty : module_type In_ctx.xt -> bool
+  val parenze_mty: module_type In_ctx.xt -> bool
 
-  val parenze_mod : module_expr In_ctx.xt -> bool
+  val parenze_mod: module_expr In_ctx.xt -> bool
 
-  val parenze_cty : class_type In_ctx.xt -> bool
+  val parenze_cty: class_type In_ctx.xt -> bool
 
-  val parenze_cl : class_expr In_ctx.xt -> bool
+  val parenze_cl: class_expr In_ctx.xt -> bool
 
-  val parenze_pat : pattern In_ctx.xt -> bool
+  val parenze_pat: pattern In_ctx.xt -> bool
 
-  val parenze_exp : expression In_ctx.xt -> bool
+  val parenze_exp: expression In_ctx.xt -> bool
 
-  val parenze_nested_exp : expression In_ctx.xt -> bool
+  val parenze_nested_exp: expression In_ctx.xt -> bool
 
-  val is_displaced_infix_op : expression In_ctx.xt -> bool
+  val is_displaced_infix_op: expression In_ctx.xt -> bool
 end = struct
   open In_ctx
 

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -14,7 +14,7 @@
 open Migrate_ast
 open Extended_ast
 
-val init : Conf.t -> unit
+val init: Conf.t -> unit
 (** Initialize internal state *)
 
 module Attr : sig
@@ -24,10 +24,10 @@ module Attr : sig
       | Item  (** [@@attr] *)
       | Floating  (** [@@@attr] *)
 
-    val to_string : t -> string
+    val to_string: t -> string
   end
 
-  val is_doc : attribute -> bool
+  val is_doc: attribute -> bool
   (** Holds for docstrings, that are attributes of the form [(** ... *)]. *)
 end
 
@@ -35,31 +35,31 @@ module Ext : sig
   module Key : sig
     type t = Regular  (** [%ext] *) | Item  (** [%%ext] *)
 
-    val to_string : t -> string
+    val to_string: t -> string
   end
 end
 
 module Token : sig
-  val is_infix : Parser.token -> bool
+  val is_infix: Parser.token -> bool
   (** Holds for infix symbols. *)
 end
 
 module String_id : sig
-  val is_prefix : string -> bool
+  val is_prefix: string -> bool
   (** Holds for prefix symbols. *)
 
-  val is_infix : string -> bool
+  val is_infix: string -> bool
   (** Holds for infix symbols. *)
 
-  val is_symbol : string -> bool
+  val is_symbol: string -> bool
   (** Holds for prefix or infix symbols. *)
 
-  val is_hash_getter : string -> bool
+  val is_hash_getter: string -> bool
   (** [is_hash_getter id] returns whether [id] is considered a hash-getter
       operator, of the form [#**#] or [#**.] where [**] can be 0 or more
       operator chars. *)
 
-  val is_monadic_binding : string -> bool
+  val is_monadic_binding: string -> bool
   (** [is_monadic_binding id] returns whether [id] is a monadic binding
       operator of the form [let**] or [and**] where [**] can be 1 or more
       operator chars. *)
@@ -68,33 +68,33 @@ end
 module Longident : sig
   include module type of Longident
 
-  val is_infix : t -> bool
+  val is_infix: t -> bool
   (** Holds for infix identifiers. *)
 
-  val is_hash_getter : t -> bool
+  val is_hash_getter: t -> bool
   (** [is_hash_getter id] returns whether [id] is considered a hash-getter
       operator, of the form [#**#] or [#**.] where [**] can be 0 or more
       operator chars. *)
 
-  val is_monadic_binding : t -> bool
+  val is_monadic_binding: t -> bool
   (** [is_monadic_binding id] returns whether [id] is a monadic binding
       operator of the form [let**] or [and**] where [**] can be 1 or more
       operator chars. *)
 end
 
 module Exp : sig
-  val is_prefix : expression -> bool
+  val is_prefix: expression -> bool
   (** Holds for prefix symbol expressions. *)
 
-  val is_symbol : expression -> bool
+  val is_symbol: expression -> bool
   (** Holds for prefix or infix expressions. *)
 
-  val is_monadic_binding : expression -> bool
+  val is_monadic_binding: expression -> bool
   (** [is_monadic_binding id] returns whether [id] is a monadic binding
       operator of the form [let**] or [and**] where [**] can be 1 or more
       operator chars. *)
 
-  val exposed_left : expression -> bool
+  val exposed_left: expression -> bool
   (** [exposed_left exp] holds if the left-most subexpression of [exp] is a
       prefix operators. *)
 end
@@ -122,7 +122,7 @@ module Indexing_op : sig
     ; rhs: expression option  (** eg. [a.*{b} <- exp] *)
     ; loc: Location.t }
 
-  val get_sugar :
+  val get_sugar:
     expression -> (Asttypes.arg_label * expression) list -> t option
   (** [get_sugar e args] is [Some all] if [e] is an identifier that is an
       indexing operator and if the sugar syntax is already used in the
@@ -130,7 +130,7 @@ module Indexing_op : sig
       corresponding [Pexp_apply]. *)
 end
 
-val doc_atrs :
+val doc_atrs:
      ?acc:(string Location.loc * bool) list
   -> attributes
   -> (string Location.loc * bool) list option * attributes
@@ -141,27 +141,27 @@ type cmt_checker =
   ; cmts_after: Location.t -> bool }
 
 module Pat : sig
-  val is_simple : pattern -> bool
+  val is_simple: pattern -> bool
 end
 
 module Mod : sig
-  val is_simple : module_expr -> bool
+  val is_simple: module_expr -> bool
 end
 
 module Mty : sig
-  val is_simple : module_type -> bool
+  val is_simple: module_type -> bool
 end
 
 module Cl : sig
-  val is_simple : class_expr -> bool
+  val is_simple: class_expr -> bool
 end
 
 module Cty : sig
-  val is_simple : class_type -> bool
+  val is_simple: class_type -> bool
 end
 
 module Tyd : sig
-  val is_simple : type_declaration -> bool
+  val is_simple: type_declaration -> bool
 end
 
 type toplevel_item =
@@ -186,96 +186,96 @@ type t =
   | Tli of toplevel_item
   | Top
 
-val is_top : t -> bool
+val is_top: t -> bool
 
-val break_between :
+val break_between:
   Source.t -> cmt_checker -> t * Conf.t -> t * Conf.t -> bool
 
-val attributes : t -> attributes
+val attributes: t -> attributes
 
-val location : t -> Location.t
+val location: t -> Location.t
 
-val dump : Format.formatter -> t -> unit
+val dump: Format.formatter -> t -> unit
 (** Debug: Dump the representation of an Ast term. *)
 
 (** Term-in-context [{ctx; ast}] records that [ast] is (considered to be) an
     immediate sub-term of [ctx]. *)
 type 'a xt = private {ctx: t; ast: 'a}
 
-val sub_typ : ctx:t -> core_type -> core_type xt
+val sub_typ: ctx:t -> core_type -> core_type xt
 (** Construct a core_type-in-context. *)
 
-val sub_cty : ctx:t -> class_type -> class_type xt
+val sub_cty: ctx:t -> class_type -> class_type xt
 (** Construct a class_type-in-context. *)
 
-val sub_pat : ctx:t -> pattern -> pattern xt
+val sub_pat: ctx:t -> pattern -> pattern xt
 (** Construct a pattern-in-context. *)
 
-val sub_exp : ctx:t -> expression -> expression xt
+val sub_exp: ctx:t -> expression -> expression xt
 (** Construct a expression-in-context. *)
 
-val sub_cl : ctx:t -> class_expr -> class_expr xt
+val sub_cl: ctx:t -> class_expr -> class_expr xt
 (** Construct a class_expr-in-context. *)
 
-val sub_mty : ctx:t -> module_type -> module_type xt
+val sub_mty: ctx:t -> module_type -> module_type xt
 (** Construct a module_type-in-context. *)
 
-val sub_mod : ctx:t -> module_expr -> module_expr xt
+val sub_mod: ctx:t -> module_expr -> module_expr xt
 (** Construct a module_expr-in-context. *)
 
-val sub_sig : ctx:t -> signature_item -> signature_item xt
+val sub_sig: ctx:t -> signature_item -> signature_item xt
 (** Construct a signature_item-in-context. *)
 
-val sub_str : ctx:t -> structure_item -> structure_item xt
+val sub_str: ctx:t -> structure_item -> structure_item xt
 (** Construct a structure_item-in-context. *)
 
-val is_simple : Conf.t -> (expression xt -> int) -> expression xt -> bool
+val is_simple: Conf.t -> (expression xt -> int) -> expression xt -> bool
 (** Holds of "simple" expressions: constants and constructor and function
     applications of other simple expressions. *)
 
 (** 'Classes' of expressions which are parenthesized differently. *)
 type cls = Let_match | Match | Non_apply | Sequence | Then | ThenElse
 
-val exposed_right_exp : cls -> expression -> bool
+val exposed_right_exp: cls -> expression -> bool
 (** [exposed_right_exp cls exp] holds if there is a right-most subexpression
     of [exp] which is of class [cls] and is not parenthesized. *)
 
-val prec_ast : t -> Prec.t option
+val prec_ast: t -> Prec.t option
 (** [prec_ast ast] is the precedence of [ast]. Meaningful for binary
     operators, otherwise returns [None]. *)
 
-val parenze_typ : core_type xt -> bool
+val parenze_typ: core_type xt -> bool
 (** [parenze_typ xtyp] holds when core_type-in-context [xtyp] should be
     parenthesized. *)
 
-val parenze_cty : class_type xt -> bool
+val parenze_cty: class_type xt -> bool
 (** [parenze_cty xcty] holds when class_type-in-context [xcty] should be
     parenthesized. *)
 
-val parenze_cl : class_expr xt -> bool
+val parenze_cl: class_expr xt -> bool
 (** [parenze_cl xcl] holds when class-in-context [xcl] should be
     parenthesized. *)
 
-val parenze_pat : pattern xt -> bool
+val parenze_pat: pattern xt -> bool
 (** [parenze_pat xpat] holds when pattern-in-context [xpat] should be
     parenthesized. *)
 
-val parenze_exp : expression xt -> bool
+val parenze_exp: expression xt -> bool
 (** [parenze_exp xexp] holds when expression-in-context [xexp] should be
     parenthesized. *)
 
-val parenze_nested_exp : expression xt -> bool
+val parenze_nested_exp: expression xt -> bool
 (** [parenze_nested_exp xexp] holds when nested expression-in-context [xexp]
     should be parenthesized. *)
 
-val parenze_mty : module_type xt -> bool
+val parenze_mty: module_type xt -> bool
 (** [parenze_mty xmty] holds when module_type-in-context [xmty] should be
     parenthesized. *)
 
-val parenze_mod : module_expr xt -> bool
+val parenze_mod: module_expr xt -> bool
 (** [parenze_mod xmod] holds when module_expr-in-context [xmod] should be
     parenthesized. *)
 
-val is_displaced_infix_op : expression xt -> bool
+val is_displaced_infix_op: expression xt -> bool
 (** [is_displaced_infix_op xexp] holds if an expression-in-context [xexp] is
     an infix op that is not fully applied. *)

--- a/lib/Cmt.mli
+++ b/lib/Cmt.mli
@@ -13,11 +13,11 @@ open Migrate_ast
 
 type t = private {txt: string; loc: Location.t}
 
-val create : string -> Location.t -> t
+val create: string -> Location.t -> t
 
-val loc : t -> Location.t
+val loc: t -> Location.t
 
-val txt : t -> string
+val txt: t -> string
 
 include Comparator.S with type t := t
 

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -138,20 +138,19 @@ let infix_symbol_before src (loc : Location.t) =
 module CmtSet : sig
   type t
 
-  val of_list : Cmt.t list -> t
+  val of_list: Cmt.t list -> t
 
-  val to_list : t -> Cmt.t list
+  val to_list: t -> Cmt.t list
   (** ordered by start location *)
 
-  val is_empty : t -> bool
+  val is_empty: t -> bool
 
-  val split : t -> Location.t -> t * t * t
+  val split: t -> Location.t -> t * t * t
   (** [split s {loc_start; loc_end}] splits [s] into the subset of comments
       that end before [loc_start], those that start after [loc_end], and
       those within the loc. *)
 
-  val partition :
-    Source.t -> prev:Location.t -> next:Location.t -> t -> t * t
+  val partition: Source.t -> prev:Location.t -> next:Location.t -> t -> t * t
   (** Heuristic to choose between placing a comment after the previous
       location or before the next one. *)
 end = struct

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -27,26 +27,26 @@ module Format = Format_
 
 type t
 
-val init :
+val init:
   'a Extended_ast.t -> debug:bool -> Source.t -> 'a -> Cmt.t list -> t
 (** [init fragment source x comments] associates each comment in [comments]
     with a source location appearing in [x]. It uses [Source] to help resolve
     ambiguities. Initializes the state used by the [fmt] functions. *)
 
-val relocate :
+val relocate:
   t -> src:Location.t -> before:Location.t -> after:Location.t -> unit
 (** [relocate src before after] moves (changes the association with
     locations) comments before [src] to [before] and comments after [src] to
     [after]. *)
 
-val relocate_wrongfully_attached_cmts :
+val relocate_wrongfully_attached_cmts:
   t -> Source.t -> Extended_ast.expression -> unit
 (** [relocate_wrongfully_attached_cmts] relocates wrongfully attached
     comments, e.g. comments that should be attached to the whole
     pattern-matching expressions ([match-with] or [try-with] expressions) but
     are wrongfully attached to the matched expression. *)
 
-val fmt_before :
+val fmt_before:
      t
   -> Conf.t
   -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
@@ -59,7 +59,7 @@ val fmt_before :
 (** [fmt_before loc] formats the comments associated with [loc] that appear
     before [loc]. *)
 
-val fmt_after :
+val fmt_after:
      t
   -> Conf.t
   -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
@@ -70,7 +70,7 @@ val fmt_after :
 (** [fmt_after loc] formats the comments associated with [loc] that appear
     after [loc]. *)
 
-val fmt_within :
+val fmt_within:
      t
   -> Conf.t
   -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
@@ -82,7 +82,7 @@ val fmt_within :
     within [loc]. *)
 
 module Toplevel : sig
-  val fmt_before :
+  val fmt_before:
        t
     -> Conf.t
     -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
@@ -91,7 +91,7 @@ module Toplevel : sig
   (** [fmt_before loc] formats the comments associated with [loc] that appear
       before [loc]. *)
 
-  val fmt_after :
+  val fmt_after:
        t
     -> Conf.t
     -> fmt_code:(Conf.t -> string -> (Fmt.t, unit) Result.t)
@@ -101,25 +101,25 @@ module Toplevel : sig
       after [loc]. *)
 end
 
-val drop_inside : t -> Location.t -> unit
+val drop_inside: t -> Location.t -> unit
 
-val drop_before : t -> Location.t -> t
+val drop_before: t -> Location.t -> t
 
-val has_before : t -> Location.t -> bool
+val has_before: t -> Location.t -> bool
 (** [has_before t loc] holds if [t] contains some comment before [loc]. *)
 
-val has_within : t -> Location.t -> bool
+val has_within: t -> Location.t -> bool
 (** [has_within t loc] holds if [t] contains some comment within [loc]. *)
 
-val has_after : t -> Location.t -> bool
+val has_after: t -> Location.t -> bool
 (** [has_after t loc] holds if [t] contains some comment after [loc]. *)
 
-val remaining_comments : t -> Cmt.t list
+val remaining_comments: t -> Cmt.t list
 (** Returns comments that have not been formatted yet. *)
 
-val remaining_locs : t -> Location.t list
+val remaining_locs: t -> Location.t list
 
-val remaining_before : t -> Location.t -> Cmt.t list
+val remaining_before: t -> Location.t -> Cmt.t list
 (** [remaining_before c loc] returns the comments before [loc] *)
 
 type layout_cache_key =
@@ -127,6 +127,6 @@ type layout_cache_key =
   | Pattern of Parsetree.pattern
   | Expression of Parsetree.expression
 
-val preserve : cache_key:layout_cache_key -> (unit -> Fmt.t) -> t -> string
+val preserve: cache_key:layout_cache_key -> (unit -> Fmt.t) -> t -> string
 (** [preserve f t] formats like [f ()] but returns a string and does not
     consume comments from [t]. *)

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -83,7 +83,7 @@ type t =
   ; wrap_comments: bool  (** Wrap comments at margin. *)
   ; wrap_fun_args: bool }
 
-val default_profile : t
+val default_profile: t
 
 type file = Stdin | File of string
 
@@ -105,14 +105,14 @@ type opts =
   ; margin_check: bool
         (** Check whether the formatted output exceeds the margin. *) }
 
-val action : unit -> (action * opts) Cmdliner.Term.result
+val action: unit -> (action * opts) Cmdliner.Term.result
 (** Formatting action: input type and source, and output destination. *)
 
-val update : ?quiet:bool -> t -> Extended_ast.attribute -> t
+val update: ?quiet:bool -> t -> Extended_ast.attribute -> t
 (** [update ?quiet c a] updates configuration [c] after reading attribute
     [a]. [quiet] is false by default. *)
 
-val update_value :
+val update_value:
   t -> name:string -> value:string -> (t, Config_option.Error.t) Result.t
 
-val print_config : t -> unit
+val print_config: t -> unit

--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -28,9 +28,9 @@ end
 module type CONFIG = sig
   type config
 
-  val profile_option_names : string list
+  val profile_option_names: string list
 
-  val warn : config -> ('a, Format.formatter, unit, unit) format4 -> 'a
+  val warn: config -> ('a, Format.formatter, unit, unit) format4 -> 'a
 end
 
 module Make (C : CONFIG) = struct

--- a/lib/Config_option.mli
+++ b/lib/Config_option.mli
@@ -16,15 +16,15 @@ module Error : sig
     | Misplaced of string * string
     | Unknown of string * [`Msg of string] option
 
-  val to_string : t -> string
+  val to_string: t -> string
 end
 
 module type CONFIG = sig
   type config
 
-  val profile_option_names : string list
+  val profile_option_names: string list
 
-  val warn : config -> ('a, Format.formatter, unit, unit) format4 -> 'a
+  val warn: config -> ('a, Format.formatter, unit, unit) format4 -> 'a
 end
 
 module Make (C : CONFIG) : sig
@@ -54,16 +54,16 @@ module Make (C : CONFIG) : sig
     -> (config -> 'a)
     -> 'a t
 
-  val section_name : kind -> status -> string
+  val section_name: kind -> status -> string
 
-  val deprecated : since:Version.t -> string -> deprecated
+  val deprecated: since:Version.t -> string -> deprecated
 
-  val removed : since:Version.t -> string -> removed
+  val removed: since:Version.t -> string -> removed
 
   module Value : sig
     type 'a t
 
-    val make : ?deprecated:deprecated -> name:string -> 'a -> string -> 'a t
+    val make: ?deprecated:deprecated -> name:string -> 'a -> string -> 'a t
   end
 
   module Value_removed : sig
@@ -72,40 +72,40 @@ module Make (C : CONFIG) : sig
         displayed. *)
     type t
 
-    val make : name:string -> since:Version.t -> msg:string -> t
+    val make: name:string -> since:Version.t -> msg:string -> t
     (** [name] is the configuration value that was removed in version
         [since]. [msg] explains how to get the former behaviour. *)
 
-    val make_list :
+    val make_list:
       names:string list -> since:Version.t -> msg:string -> t list
     (** Shorthand for [mk] when [since] and [msg] are shared. This can be
         used when multiple values are removed at the same time. *)
   end
 
-  val choice :
+  val choice:
        all:'a Value.t list
     -> ?removed_values:Value_removed.t list
     -> 'a option_decl
 
-  val flag : default:bool -> bool option_decl
+  val flag: default:bool -> bool option_decl
 
-  val any :
+  val any:
        ?default_doc:string
     -> 'a Cmdliner.Arg.conv
     -> default:'a
     -> docv:string
     -> 'a option_decl
 
-  val removed_option :
+  val removed_option:
     names:string list -> since:Version.t -> msg:string -> unit
   (** Declare an option as removed. Using such an option will result in an
       helpful error including [msg] and [since]. *)
 
-  val default : 'a t -> 'a
+  val default: 'a t -> 'a
 
-  val update_using_cmdline : config -> config
+  val update_using_cmdline: config -> config
 
-  val update :
+  val update:
        config:config
     -> from:updated_from
     -> name:string
@@ -113,5 +113,5 @@ module Make (C : CONFIG) : sig
     -> inline:bool
     -> (config, Error.t) Result.t
 
-  val print_config : config -> unit
+  val print_config: config -> unit
 end

--- a/lib/Docstring.mli
+++ b/lib/Docstring.mli
@@ -9,12 +9,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val parse :
+val parse:
      loc:Warnings.loc
   -> string
   -> (Odoc_parser.Ast.t, Odoc_parser.Warning.t list) Result.t
 
-val warn : Format.formatter -> Odoc_parser.Warning.t -> unit
+val warn: Format.formatter -> Odoc_parser.Warning.t -> unit
 
 type error =
   | Moved of Location.t * Location.t * string
@@ -22,13 +22,13 @@ type error =
   | Added of Location.t * string
   | Removed of Location.t * string
 
-val is_tag_only : Odoc_parser.Ast.t -> bool
+val is_tag_only: Odoc_parser.Ast.t -> bool
 (** [true] if the documentation only contains tags *)
 
-val normalize :
+val normalize:
      parse_docstrings:bool
   -> normalize_code:(string -> string)
   -> string
   -> string
 
-val normalize_text : string -> string
+val normalize_text: string -> string

--- a/lib/Exposed.mli
+++ b/lib/Exposed.mli
@@ -19,21 +19,21 @@ open Extended_ast
 
 (** Predicates for [<] on the LHS of printed AST nodes. *)
 module Left : sig
-  val core_type : core_type -> bool
+  val core_type: core_type -> bool
 end
 
 module Right : sig
   (** Predicates for [>] on the RHS of printed AST nodes. *)
 
-  val core_type : core_type -> bool
+  val core_type: core_type -> bool
 
-  val label_declaration : label_declaration -> bool
+  val label_declaration: label_declaration -> bool
 
-  val row_field : row_field -> bool
+  val row_field: row_field -> bool
 
-  val payload : payload -> bool
+  val payload: payload -> bool
 
-  val list : elt:('a -> bool) -> 'a list -> bool
+  val list: elt:('a -> bool) -> 'a list -> bool
   (** [list ~elt l] holds iff [elt] holds of the {i last} element in [l], and
       is [false] if [l] is empty. *)
 end

--- a/lib/Extended_ast.mli
+++ b/lib/Extended_ast.mli
@@ -24,33 +24,33 @@ type 'a t =
   | Expression : expression t
 
 module Parse : sig
-  val ast : 'a t -> Lexing.lexbuf -> 'a
+  val ast: 'a t -> Lexing.lexbuf -> 'a
 end
 
-val equal_core_type : core_type -> core_type -> bool
+val equal_core_type: core_type -> core_type -> bool
 
-val map : 'a t -> Ast_mapper.mapper -> 'a -> 'a
+val map: 'a t -> Ast_mapper.mapper -> 'a -> 'a
 
 module Pprintast : sig
   include module type of Pprintast
 
-  val ast : 'a t -> Format.formatter -> 'a -> unit
+  val ast: 'a t -> Format.formatter -> 'a -> unit
 end
 
 module Printast : sig
-  val ast : 'a t -> Format.formatter -> 'a -> unit
+  val ast: 'a t -> Format.formatter -> 'a -> unit
 end
 
 module Asttypes : sig
   include module type of Asttypes
 
-  val is_private : private_flag -> bool
+  val is_private: private_flag -> bool
 
-  val is_open : closed_flag -> bool
+  val is_open: closed_flag -> bool
 
-  val is_override : override_flag -> bool
+  val is_override: override_flag -> bool
 
-  val is_mutable : mutable_flag -> bool
+  val is_mutable: mutable_flag -> bool
 
-  val is_recursive : rec_flag -> bool
+  val is_recursive: rec_flag -> bool
 end

--- a/lib/File_system.mli
+++ b/lib/File_system.mli
@@ -9,13 +9,13 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val project_root_witness : string list
+val project_root_witness: string list
 
 type configuration_file = Ocamlformat of Fpath.t | Ocp_indent of Fpath.t
 
-val is_ocp_indent_file : configuration_file -> bool
+val is_ocp_indent_file: configuration_file -> bool
 
-val root_ocamlformat_file : root:Fpath.t option -> Fpath.t
+val root_ocamlformat_file: root:Fpath.t option -> Fpath.t
 
 type t =
   { ignore_files: Fpath.t list
@@ -23,7 +23,7 @@ type t =
   ; configuration_files: configuration_file list
   ; project_root: Fpath.t option }
 
-val make :
+val make:
      enable_outside_detected_project:bool
   -> disable_conf_files:bool
   -> root:Fpath.t option

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -21,16 +21,16 @@ module Format = Format_
 module T : sig
   type t
 
-  val ( $ ) : t -> t -> t
+  val ( $ ): t -> t -> t
   (** Sequence *)
 
-  val with_pp : (Format.formatter -> unit) -> t
+  val with_pp: (Format.formatter -> unit) -> t
   (** Use an arbitrary pretty-printing function *)
 
-  val protect : t -> on_error:(exn -> unit) -> t
+  val protect: t -> on_error:(exn -> unit) -> t
   (** Exception handler *)
 
-  val lazy_ : (unit -> t) -> t
+  val lazy_: (unit -> t) -> t
   (** Defer the evaluation of some side effects until formatting happens.
 
       This can matter if for example a list of [t] is built, and then only
@@ -39,7 +39,7 @@ module T : sig
 
       See [tests_lazy] in [Test_fmt]. *)
 
-  val eval : Format.formatter -> t -> unit
+  val eval: Format.formatter -> t -> unit
   (** Main function to evaluate a term using an actual formatter. *)
 end = struct
   type t = (Format.formatter -> unit) Staged.t

--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -25,38 +25,38 @@ type sp =
   | Space  (** [@ ] *)
   | Break of int * int  (** [@;] *)
 
-val sp : sp -> t
+val sp: sp -> t
 
-val ( $ ) : t -> t -> t
+val ( $ ): t -> t -> t
 (** Format concatenation: [a $ b] formats [a], then [b]. *)
 
-val sequence : t list -> t
+val sequence: t list -> t
 (** Format concatenation of n elements. *)
 
-val ( >$ ) : t -> ('b -> t) -> 'b -> t
+val ( >$ ): t -> ('b -> t) -> 'b -> t
 (** Pre-compose a format thunk onto a function returning a format thunk. *)
 
-val lazy_ : (unit -> t) -> t
+val lazy_: (unit -> t) -> t
 (** Defer the evaluation of some side effects until formatting happens. *)
 
-val set_margin : int -> t
+val set_margin: int -> t
 (** Set the margin. *)
 
-val set_max_indent : int -> t
+val set_max_indent: int -> t
 (** Set the maximum indentation. *)
 
-val eval : Format.formatter -> t -> unit
+val eval: Format.formatter -> t -> unit
 (** [eval fs t] runs format thunk [t] outputting to [fs] *)
 
-val protect : t -> on_error:(exn -> unit) -> t
+val protect: t -> on_error:(exn -> unit) -> t
 (** Catch exceptions raised while formatting. *)
 
 (** Break hints and format strings --------------------------------------*)
 
-val break : int -> int -> t
+val break: int -> int -> t
 (** Format a break hint. *)
 
-val cbreak : fits:string * int * string -> breaks:string * int * string -> t
+val cbreak: fits:string * int * string -> breaks:string * int * string -> t
 (** Format a custom break.
 
     - [fits = (a, b, c)] formats a string [a], [b] spaces and a string [c] if
@@ -64,78 +64,78 @@ val cbreak : fits:string * int * string -> breaks:string * int * string -> t
     - [breaks = (d, e, f)] formats a string [d], [e] spaces and a string [f]
       if the line breaks. *)
 
-val noop : t
+val noop: t
 (** Format nothing. *)
 
-val fmt : s -> t
+val fmt: s -> t
 (** Format a format string. *)
 
 (** Primitive types -----------------------------------------------------*)
 
-val char : char -> t
+val char: char -> t
 (** Format a char. *)
 
-val str : string -> t
+val str: string -> t
 (** Format a string. *)
 
 (** Primitive containers ------------------------------------------------*)
 
-val opt : 'a option -> ('a -> t) -> t
+val opt: 'a option -> ('a -> t) -> t
 (** Format an option using provided formatter for the element. *)
 
-val list : 'a list -> s -> ('a -> t) -> t
+val list: 'a list -> s -> ('a -> t) -> t
 (** Format a list separated by a format string using provided function for
     the elements. *)
 
-val list_fl : 'a list -> (first:bool -> last:bool -> 'a -> t) -> t
+val list_fl: 'a list -> (first:bool -> last:bool -> 'a -> t) -> t
 (** Format a list using provided function for the elements, which is passed
     the flags indicating if the element is the first or last. *)
 
-val list_pn : 'a list -> (prev:'a option -> 'a -> next:'a option -> t) -> t
+val list_pn: 'a list -> (prev:'a option -> 'a -> next:'a option -> t) -> t
 (** Format a list using provided function for the elements, which is passed
     the previous and next elements, if any. *)
 
-val list_k : 'a list -> t -> ('a -> t) -> t
+val list_k: 'a list -> t -> ('a -> t) -> t
 (** Format a list using the format thunk for the separators between elements. *)
 
 (** Conditional formatting ----------------------------------------------*)
 
-val fmt_if : bool -> s -> t
+val fmt_if: bool -> s -> t
 (** Conditionally format. *)
 
-val fmt_if_k : bool -> t -> t
+val fmt_if_k: bool -> t -> t
 (** Conditionally format thunk. *)
 
-val fmt_or : bool -> s -> s -> t
+val fmt_or: bool -> s -> s -> t
 (** Conditionally select between two format strings. *)
 
-val fmt_or_k : bool -> t -> t -> t
+val fmt_or_k: bool -> t -> t -> t
 (** Conditionally select between two format thunks. *)
 
-val fmt_opt : t option -> t
+val fmt_opt: t option -> t
 (** Optionally format. [fmt_opt (Some t)] is [t] and [fmt_opt None] is
     [noop]. *)
 
 (** Conditional on immediately following a line break -------------------*)
 
-val if_newline : string -> t
+val if_newline: string -> t
 (** Format a string if the line has just been broken. *)
 
-val break_unless_newline : int -> int -> t
+val break_unless_newline: int -> int -> t
 (** Format a break unless the line has just been broken. *)
 
 (** Conditional on breaking of enclosing box ----------------------------*)
 
 type behavior = Fit | Break
 
-val fits_breaks :
+val fits_breaks:
   ?force:behavior -> ?hint:int * int -> ?level:int -> string -> string -> t
 (** [fits_breaks fits nspaces offset breaks] prints [fits] if the enclosing
     box fits on one line, and otherwise prints [breaks], which is a string
     that optionally follows a break [hint] (that is a pair
     [(nspaces, offset)] equivalent to the break hint ["@;<nspaces offset>"]). *)
 
-val fits_breaks_if :
+val fits_breaks_if:
      ?force:behavior
   -> ?hint:int * int
   -> ?level:int
@@ -147,81 +147,81 @@ val fits_breaks_if :
 
 (** Wrapping ------------------------------------------------------------*)
 
-val wrap : s -> s -> t -> t
+val wrap: s -> s -> t -> t
 (** [wrap prologue epilogue body] formats [prologue] then [body] then
     [epilogue]. *)
 
-val wrap_k : t -> t -> t -> t
+val wrap_k: t -> t -> t -> t
 (** As [wrap], but prologue and epilogue may be arbitrary format thunks. *)
 
-val wrap_if : bool -> s -> s -> t -> t
+val wrap_if: bool -> s -> s -> t -> t
 (** As [wrap], but prologue and epilogue are only formatted conditionally. *)
 
-val wrap_if_k : bool -> t -> t -> t -> t
+val wrap_if_k: bool -> t -> t -> t -> t
 (** As [wrap_if], but prologue and epilogue may be arbitrary format thunks. *)
 
-val wrap_if_fits_or : bool -> string -> string -> t -> t
+val wrap_if_fits_or: bool -> string -> string -> t -> t
 (** As [wrap_if_fits], but prologue and epilogue can be forced by the
     additional condition. *)
 
-val wrap_fits_breaks : ?space:bool -> Conf.t -> string -> string -> t -> t
+val wrap_fits_breaks: ?space:bool -> Conf.t -> string -> string -> t -> t
 (** As [wrap], but if [space] is provided, a space is added after prologue
     and a space hint is added before epilogue in case the enclosing box
     breaks. *)
 
-val wrap_fits_breaks_if :
+val wrap_fits_breaks_if:
   ?space:bool -> Conf.t -> bool -> string -> string -> t -> t
 (** As [wrap_fits_breaks], but prologue and epilogue are formatted subject to
     the additional condition. *)
 
 (** Boxes ---------------------------------------------------------------*)
 
-val with_box_debug : t -> t
+val with_box_debug: t -> t
 (** Represent boxes inside a format thunk with colored brackets. For debug
     purposes *)
 
-val open_vbox : ?name:string -> int -> t
+val open_vbox: ?name:string -> int -> t
 (** Open an vbox with specified indentation. *)
 
-val open_hvbox : ?name:string -> int -> t
+val open_hvbox: ?name:string -> int -> t
 (** Open an hvbox with specified indentation. *)
 
-val open_hovbox : ?name:string -> int -> t
+val open_hovbox: ?name:string -> int -> t
 (** Open an hovbox with specified indentation. *)
 
-val close_box : t
+val close_box: t
 (** Close an arbitrary box. *)
 
 (** Wrapping boxes ------------------------------------------------------*)
 
-val cbox : ?name:string -> int -> t -> t
+val cbox: ?name:string -> int -> t -> t
 (** Wrap a format thunk with a compacting box with specified indentation. *)
 
-val vbox : ?name:string -> int -> t -> t
+val vbox: ?name:string -> int -> t -> t
 (** Wrap a format thunk with a vbox with specified indentation. *)
 
-val hvbox : ?name:string -> int -> t -> t
+val hvbox: ?name:string -> int -> t -> t
 (** Wrap a format thunk with an hvbox with specified indentation. *)
 
-val hovbox : ?name:string -> int -> t -> t
+val hovbox: ?name:string -> int -> t -> t
 (** Wrap a format thunk with an hovbox with specified indentation. *)
 
-val cbox_if : ?name:string -> bool -> int -> t -> t
+val cbox_if: ?name:string -> bool -> int -> t -> t
 (** Conditionally wrap a format thunk with a compacting sbox with specified
     indentation. *)
 
-val vbox_if : ?name:string -> bool -> int -> t -> t
+val vbox_if: ?name:string -> bool -> int -> t -> t
 (** Conditionally wrap a format thunk with a vbox with specified indentation. *)
 
-val hvbox_if : ?name:string -> bool -> int -> t -> t
+val hvbox_if: ?name:string -> bool -> int -> t -> t
 (** Conditionally wrap a format thunk with an hvbox with specified
     indentation. *)
 
-val hovbox_if : ?name:string -> bool -> int -> t -> t
+val hovbox_if: ?name:string -> bool -> int -> t -> t
 (** Conditionally wrap a format thunk with an hovbox with specified
     indentation. *)
 
 (** Text filling --------------------------------------------------------*)
 
-val fill_text : ?epi:string -> string -> t
+val fill_text: ?epi:string -> string -> t
 (** Format a non-empty string as filled text wrapped at the margin. *)

--- a/lib/Fmt_ast.mli
+++ b/lib/Fmt_ast.mli
@@ -11,7 +11,7 @@
 
 (** Format OCaml Ast *)
 
-val fmt_ast :
+val fmt_ast:
      'a Extended_ast.t
   -> debug:bool
   -> Source.t

--- a/lib/Fmt_odoc.mli
+++ b/lib/Fmt_odoc.mli
@@ -9,5 +9,5 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val fmt :
+val fmt:
   fmt_code:(string -> (Fmt.t, unit) Result.t) -> Odoc_parser.Ast.t -> Fmt.t

--- a/lib/Indent.mli
+++ b/lib/Indent.mli
@@ -10,7 +10,7 @@
 (**************************************************************************)
 
 module Valid_ast : sig
-  val indent_range :
+  val indent_range:
        'a Extended_ast.t
     -> unformatted:'a * string
     -> formatted:'a * Source.t
@@ -20,5 +20,5 @@ module Valid_ast : sig
 end
 
 module Partial_ast : sig
-  val indent_range : source:string -> range:int * int -> int list
+  val indent_range: source:string -> range:int * int -> int list
 end

--- a/lib/Literal_lexer.mli
+++ b/lib/Literal_lexer.mli
@@ -9,6 +9,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val string : [`Normalize | `Preserve] -> string -> string option
+val string: [`Normalize | `Preserve] -> string -> string option
 
-val char : string -> string option
+val char: string -> string option

--- a/lib/Loc_tree.mli
+++ b/lib/Loc_tree.mli
@@ -11,5 +11,5 @@
 
 include Non_overlapping_interval_tree.S with type itv = Location.t
 
-val of_ast : 'a Extended_ast.t -> 'a -> t * Location.t list
+val of_ast: 'a Extended_ast.t -> 'a -> t * Location.t list
 (** Use Ast_mapper to collect all locs in ast, and create a tree of them. *)

--- a/lib/Migrate_ast.mli
+++ b/lib/Migrate_ast.mli
@@ -14,11 +14,11 @@ module Position : sig
 
   include Comparator.S with type t := t
 
-  val column : t -> int
+  val column: t -> int
 
-  val distance : t -> t -> int
+  val distance: t -> t -> int
 
-  val compare : t -> t -> int
+  val compare: t -> t -> int
 end
 
 module Location : sig
@@ -26,13 +26,13 @@ module Location : sig
 
   type comparator_witness
 
-  val comparator : (t, comparator_witness) Comparator.t
+  val comparator: (t, comparator_witness) Comparator.t
 
-  val contains : t -> t -> bool
+  val contains: t -> t -> bool
 
-  val sexp_of_t : t -> Sexp.t
+  val sexp_of_t: t -> Sexp.t
 
-  val compare_width_decreasing : t -> t -> int
+  val compare_width_decreasing: t -> t -> int
   (** Compare, in order:
 
       - start
@@ -41,37 +41,37 @@ module Location : sig
 
       Locs (start and end) are compared using [Position.compare]. *)
 
-  val compare : t -> t -> int
+  val compare: t -> t -> int
 
-  val compare_start : t -> t -> int
+  val compare_start: t -> t -> int
 
-  val compare_start_col : t -> t -> int
+  val compare_start_col: t -> t -> int
 
-  val compare_end : t -> t -> int
+  val compare_end: t -> t -> int
 
-  val compare_end_col : t -> t -> int
+  val compare_end_col: t -> t -> int
 
-  val line_difference : t -> t -> int
+  val line_difference: t -> t -> int
   (** [line_difference x y] returns the difference between the line at the
       start of [y] and at the end of [x]. [x] must precede [y], undefined
       behavior otherwise, or if one location includes the other. *)
 
-  val fmt : Format.formatter -> t -> unit
+  val fmt: Format.formatter -> t -> unit
 
-  val smallest : t -> t list -> t
+  val smallest: t -> t list -> t
 
-  val width : t -> int
+  val width: t -> int
 
-  val is_single_line : t -> int -> bool
+  val is_single_line: t -> int -> bool
 
-  val of_lexbuf : Lexing.lexbuf -> t
+  val of_lexbuf: Lexing.lexbuf -> t
 
-  val print : Format.formatter -> t -> unit
+  val print: Format.formatter -> t -> unit
 end
 
 module Longident : sig
   include module type of Longident
 
-  val lident : string -> t
+  val lident: string -> t
   (** Make a Lident from a dotless string *)
 end

--- a/lib/Multimap.mli
+++ b/lib/Multimap.mli
@@ -22,17 +22,17 @@ end) : sig
   type nonrec 'value t = (K.t, 'value, K.comparator_witness) t
 end
 
-val update_multi :
+val update_multi:
      ('key, 'value, 'cmp) t
   -> src:'key
   -> dst:'key
   -> f:('value list -> 'value list -> 'value list)
   -> ('key, 'value, 'cmp) t
 
-val change_multi :
+val change_multi:
   ('key, 'value, 'cmp) t -> 'key -> 'value list -> ('key, 'value, 'cmp) t
 
-val partition_multi :
+val partition_multi:
      ('key, 'value, 'cmp) t
   -> src:'key
   -> dst:'key
@@ -41,7 +41,7 @@ val partition_multi :
 (** Split the values of key [src] with [f], the values satisfying [f] are
     moved to key [dst] while the others remain associated to key [src]. *)
 
-val filter :
+val filter:
   ('key, 'value, 'cmp) t -> f:('value -> bool) -> ('key, 'value, 'cmp) t
 
-val to_list : (_, 'value, _) t -> 'value list
+val to_list: (_, 'value, _) t -> 'value list

--- a/lib/Non_overlapping_interval_tree.ml
+++ b/lib/Non_overlapping_interval_tree.ml
@@ -12,9 +12,9 @@
 module type IN = sig
   include Comparator.S
 
-  val contains : t -> t -> bool
+  val contains: t -> t -> bool
 
-  val compare_width_decreasing : t -> t -> int
+  val compare_width_decreasing: t -> t -> int
 end
 
 module type S = sig
@@ -22,15 +22,15 @@ module type S = sig
 
   type t
 
-  val of_list : itv list -> t
+  val of_list: itv list -> t
   (** If there are duplicates in the input list, earlier elements will be
       ancestors of later elements. *)
 
-  val roots : t -> itv list
+  val roots: t -> itv list
 
-  val children : t -> itv -> itv list
+  val children: t -> itv -> itv list
 
-  val dump : t -> Fmt.t
+  val dump: t -> Fmt.t
   (** Debug: dump debug representation of tree. *)
 end
 

--- a/lib/Non_overlapping_interval_tree.mli
+++ b/lib/Non_overlapping_interval_tree.mli
@@ -16,9 +16,9 @@
 module type IN = sig
   include Comparator.S
 
-  val contains : t -> t -> bool
+  val contains: t -> t -> bool
 
-  val compare_width_decreasing : t -> t -> int
+  val compare_width_decreasing: t -> t -> int
 end
 
 module type S = sig
@@ -26,15 +26,15 @@ module type S = sig
 
   type t
 
-  val of_list : itv list -> t
+  val of_list: itv list -> t
   (** If there are duplicates in the input list, earlier elements will be
       ancestors of later elements. *)
 
-  val roots : t -> itv list
+  val roots: t -> itv list
 
-  val children : t -> itv -> itv list
+  val children: t -> itv -> itv list
 
-  val dump : t -> Fmt.t
+  val dump: t -> Fmt.t
   (** Debug: dump debug representation of tree. *)
 end
 

--- a/lib/Normalize_extended_ast.mli
+++ b/lib/Normalize_extended_ast.mli
@@ -9,5 +9,5 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val dedup_cmts : 'a Extended_ast.t -> 'a -> Cmt.t list -> Cmt.t list
+val dedup_cmts: 'a Extended_ast.t -> 'a -> Cmt.t list -> Cmt.t list
 (** Remove comments that duplicate docstrings (or other comments). *)

--- a/lib/Normalize_std_ast.mli
+++ b/lib/Normalize_std_ast.mli
@@ -9,20 +9,20 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val ast : 'a Std_ast.t -> Conf.t -> 'a -> 'a
+val ast: 'a Std_ast.t -> Conf.t -> 'a -> 'a
 (** Normalize an AST fragment. *)
 
-val equal :
+val equal:
   'a Std_ast.t -> ignore_doc_comments:bool -> Conf.t -> 'a -> 'a -> bool
 (** Compare fragments for equality up to normalization. *)
 
-val moved_docstrings :
+val moved_docstrings:
   'a Std_ast.t -> Conf.t -> 'a -> 'a -> Docstring.error list
 
-val diff_docstrings :
+val diff_docstrings:
   Conf.t -> Cmt.t list -> Cmt.t list -> (string, string) Either.t Sequence.t
 (** Difference between two lists of doc comments. *)
 
-val diff_cmts :
+val diff_cmts:
   Conf.t -> Cmt.t list -> Cmt.t list -> (string, string) Either.t Sequence.t
 (** Difference between two lists of comments. *)

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -12,13 +12,13 @@
 module Format = Format_
 open Extended_ast
 
-val parens_if : bool -> Conf.t -> ?disambiguate:bool -> Fmt.t -> Fmt.t
+val parens_if: bool -> Conf.t -> ?disambiguate:bool -> Fmt.t -> Fmt.t
 
-val parens : Conf.t -> ?disambiguate:bool -> Fmt.t -> Fmt.t
+val parens: Conf.t -> ?disambiguate:bool -> Fmt.t -> Fmt.t
 
 module Exp : sig
   module Infix_op_arg : sig
-    val wrap :
+    val wrap:
          Conf.t
       -> ?parens_nested:bool
       -> ext:Fmt.t
@@ -29,7 +29,7 @@ module Exp : sig
       -> Fmt.t
   end
 
-  val wrap :
+  val wrap:
        Conf.t
     -> ?disambiguate:bool
     -> ?fits_breaks:bool
@@ -44,7 +44,7 @@ module Exp : sig
     -> Fmt.t
 end
 
-val get_or_pattern_sep :
+val get_or_pattern_sep:
   ?cmts_before:bool -> ?space:bool -> Conf.t -> ctx:Ast.t -> Fmt.t
 
 type cases =
@@ -58,7 +58,7 @@ type cases =
   ; break_after_opening_paren: Fmt.t
   ; close_paren_branch: Fmt.t }
 
-val get_cases :
+val get_cases:
      Conf.t
   -> first:bool
   -> indent:int
@@ -67,7 +67,7 @@ val get_cases :
   -> loc:Location.t
   -> cases
 
-val wrap_tuple :
+val wrap_tuple:
   Conf.t -> parens:bool -> no_parens_if_break:bool -> Fmt.t -> Fmt.t
 
 type record_type =
@@ -80,7 +80,7 @@ type record_type =
   ; break_after: Fmt.t
   ; docked_after: Fmt.t }
 
-val get_record_type : Conf.t -> record_type
+val get_record_type: Conf.t -> record_type
 
 type elements_collection =
   { box: Fmt.t -> Fmt.t
@@ -92,19 +92,19 @@ type elements_collection_record_expr = {break_after_with: Fmt.t}
 
 type elements_collection_record_pat = {wildcard: Fmt.t}
 
-val get_record_expr :
+val get_record_expr:
   Conf.t -> elements_collection * elements_collection_record_expr
 
-val get_list_expr : Conf.t -> elements_collection
+val get_list_expr: Conf.t -> elements_collection
 
-val get_array_expr : Conf.t -> elements_collection
+val get_array_expr: Conf.t -> elements_collection
 
-val get_record_pat :
+val get_record_pat:
   Conf.t -> ctx:Ast.t -> elements_collection * elements_collection_record_pat
 
-val get_list_pat : Conf.t -> ctx:Ast.t -> elements_collection
+val get_list_pat: Conf.t -> ctx:Ast.t -> elements_collection
 
-val get_array_pat : Conf.t -> ctx:Ast.t -> elements_collection
+val get_array_pat: Conf.t -> ctx:Ast.t -> elements_collection
 
 type if_then_else =
   { box_branch: Fmt.t -> Fmt.t
@@ -117,7 +117,7 @@ type if_then_else =
   ; break_end_branch: Fmt.t
   ; space_between_branches: Fmt.t }
 
-val get_if_then_else :
+val get_if_then_else:
      Conf.t
   -> first:bool
   -> last:bool
@@ -133,21 +133,21 @@ val get_if_then_else :
   -> Source.t
   -> if_then_else
 
-val match_indent : ?default:int -> Conf.t -> ctx:Ast.t -> int
+val match_indent: ?default:int -> Conf.t -> ctx:Ast.t -> int
 (** [match_indent c ~ctx ~default] returns the indentation used for the
     pattern-matching in context [ctx], depending on the `match-indent-nested`
     option, or using the [default] indentation (0 if not provided) if the
     option does not apply. *)
 
-val function_indent : ?default:int -> Conf.t -> ctx:Ast.t -> int
+val function_indent: ?default:int -> Conf.t -> ctx:Ast.t -> int
 (** [function_indent c ~ctx ~default] returns the indentation used for the
     function in context [ctx], depending on the `function-indent-nested`
     option, or using the [default] indentation (0 if not provided) if the
     option does not apply. *)
 
-val comma_sep : Conf.t -> Fmt.s
+val comma_sep: Conf.t -> Fmt.s
 (** [comma_sep c] returns the format string used to separate two elements
     with a comma, depending on the `break-separators` option. *)
 
-val semi_sep : Conf.t -> Fmt.s
+val semi_sep: Conf.t -> Fmt.s
 (** Like [comma_sep] but use a semicolon as separator. *)

--- a/lib/Parse_with_comments.mli
+++ b/lib/Parse_with_comments.mli
@@ -15,18 +15,18 @@ type 'a with_comments =
 module W : sig
   type t
 
-  val in_lexer : int list
+  val in_lexer: int list
 
-  val disable : int -> t
+  val disable: int -> t
 
-  val enable : int -> t
+  val enable: int -> t
 
-  val to_string : t list -> string
+  val to_string: t list -> string
 end
 
 exception Warning50 of (Location.t * Warnings.t) list
 
-val parse :
+val parse:
      ?disable_w50:bool
   -> ('b -> Lexing.lexbuf -> 'a)
   -> 'b

--- a/lib/Prec.mli
+++ b/lib/Prec.mli
@@ -33,8 +33,8 @@ type t =
   | High
   | Atomic
 
-val compare : t -> t -> int
+val compare: t -> t -> int
 
-val equal : t -> t -> bool
+val equal: t -> t -> bool
 
-val to_string : t -> string
+val to_string: t -> string

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -13,70 +13,70 @@ open Extended_ast
 
 type t
 
-val create : text:string -> tokens:(Parser.token * Location.t) list -> t
+val create: text:string -> tokens:(Parser.token * Location.t) list -> t
 
-val empty_line_between : t -> Lexing.position -> Lexing.position -> bool
+val empty_line_between: t -> Lexing.position -> Lexing.position -> bool
 (** [empty_line_between t p1 p2] is [true] if there is an empty line between
     [p1] and [p2]. The lines containing [p1] and [p2] are not considered
     empty. *)
 
-val empty_line_before : t -> Location.t -> bool
+val empty_line_before: t -> Location.t -> bool
 
-val empty_line_after : t -> Location.t -> bool
+val empty_line_after: t -> Location.t -> bool
 
-val tokens_between :
+val tokens_between:
      t
   -> filter:(Parser.token -> bool)
   -> Lexing.position
   -> Lexing.position
   -> (Parser.token * Location.t) list
 
-val string_at : t -> Location.t -> string
+val string_at: t -> Location.t -> string
 
-val find_token_after :
+val find_token_after:
      t
   -> filter:(Parser.token -> bool)
   -> Lexing.position
   -> (Parser.token * Location.t) option
 
-val find_token_before :
+val find_token_before:
      t
   -> filter:(Parser.token -> bool)
   -> Lexing.position
   -> (Parser.token * Location.t) option
 
-val string_literal : t -> [`Normalize | `Preserve] -> Location.t -> string
+val string_literal: t -> [`Normalize | `Preserve] -> Location.t -> string
 
-val char_literal : t -> Location.t -> string
+val char_literal: t -> Location.t -> string
 
-val is_long_pexp_open : t -> expression -> bool
+val is_long_pexp_open: t -> expression -> bool
 (** [is_long_pexp_open source exp] holds if [exp] is a [Pexp_open] expression
     that is expressed in long ('let open') form in source. *)
 
-val is_long_pmod_functor : t -> module_expr -> bool
+val is_long_pmod_functor: t -> module_expr -> bool
 (** [is_long_pmod_functor source mod_exp] holds if [mod_exp] is a
     [Pmod_functor] expression that is expressed in long ('functor (M) ->')
     form in source. *)
 
-val is_long_pmty_functor : t -> module_type -> bool
+val is_long_pmty_functor: t -> module_type -> bool
 (** [is_long_pmty_functor source mod_type] holds if [mod_type] is a
     [Pmty_functor] type that is expressed in long ('functor (M) ->') form in
     source. *)
 
-val begins_line : ?ignore_spaces:bool -> t -> Location.t -> bool
+val begins_line: ?ignore_spaces:bool -> t -> Location.t -> bool
 
-val ends_line : t -> Location.t -> bool
+val ends_line: t -> Location.t -> bool
 
-val extension_using_sugar :
+val extension_using_sugar:
   name:string Location.loc -> payload:Location.t -> bool
 
-val extend_loc_to_include_attributes : Location.t -> attributes -> Location.t
+val extend_loc_to_include_attributes: Location.t -> attributes -> Location.t
 
-val type_constraint_is_first : core_type -> Location.t -> bool
+val type_constraint_is_first: core_type -> Location.t -> bool
 
-val is_quoted_string : t -> Location.t -> bool
+val is_quoted_string: t -> Location.t -> bool
 
-val loc_of_first_token_at :
+val loc_of_first_token_at:
   t -> Location.t -> Parser.token -> Location.t option
 
-val find_first_token_on_line : t -> int -> (Parser.token * Location.t) option
+val find_first_token_on_line: t -> int -> (Parser.token * Location.t) option

--- a/lib/Std_ast.mli
+++ b/lib/Std_ast.mli
@@ -26,15 +26,15 @@ type 'a t =
   | Expression : expression t
 
 module Parse : sig
-  val ast : 'a t -> Lexing.lexbuf -> 'a
+  val ast: 'a t -> Lexing.lexbuf -> 'a
 end
 
-val equal : 'a t -> 'a -> 'a -> bool
+val equal: 'a t -> 'a -> 'a -> bool
 
-val map : 'a t -> Ast_mapper.mapper -> 'a -> 'a
+val map: 'a t -> Ast_mapper.mapper -> 'a -> 'a
 
 module Pprintast : sig
   include module type of Pprintast
 
-  val ast : 'a t -> Format.formatter -> 'a -> unit
+  val ast: 'a t -> Format.formatter -> 'a -> unit
 end

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -13,14 +13,14 @@ open Migrate_ast
 open Asttypes
 open Extended_ast
 
-val arrow_typ :
+val arrow_typ:
      Cmts.t
   -> core_type Ast.xt
   -> (Location.t * arg_label * core_type Ast.xt) list
 (** [arrow_typ cmts ty] returns the list of labeled sub-arrow types of the
     type [ty]. *)
 
-val class_arrow_typ :
+val class_arrow_typ:
      Cmts.t
   -> class_type Ast.xt
   -> ( arg_label
@@ -29,7 +29,7 @@ val class_arrow_typ :
 (** [class_arrow_typ cmts ty] returns the list of labeled sub_arrow types of
     the class type [ty]. *)
 
-val or_pat :
+val or_pat:
   ?allow_attribute:bool -> Cmts.t -> pattern Ast.xt -> pattern Ast.xt list
 (** [or_pat allow_attribute cmts pat] returns the list of patterns of a
     pattern disjunction. [allow_attribute] is set by default, otherwise
@@ -40,7 +40,7 @@ type arg_kind =
   | Val of arg_label * pattern Ast.xt * expression Ast.xt option
   | Newtypes of string loc list
 
-val fun_ :
+val fun_:
      Cmts.t
   -> ?will_keep_first_ast_node:bool
   -> expression Ast.xt
@@ -49,7 +49,7 @@ val fun_ :
     and the body of the function [exp]. [will_keep_first_ast_node] is set by
     default, otherwise the [exp] is returned without modification. *)
 
-val cl_fun :
+val cl_fun:
      ?will_keep_first_ast_node:bool
   -> Cmts.t
   -> class_expr Ast.xt
@@ -58,7 +58,7 @@ val cl_fun :
     and the body of the function [exp]. [will_keep_first_ast_node] is set by
     default, otherwise the [exp] is returned without modification. *)
 
-val infix :
+val infix:
      Cmts.t
   -> Prec.t option
   -> expression Ast.xt
@@ -67,14 +67,14 @@ val infix :
     applied to this operator from expression [exp]. [prec] is the precedence
     of the infix operator. *)
 
-val infix_cons :
+val infix_cons:
      Cmts.t
   -> expression Ast.xt
   -> (Longident.t loc option * expression Ast.xt) list
 (** [infix_cons exp] returns a list of expressions if [exp] is an expression
     corresponding to a list ((::) application). *)
 
-val ite :
+val ite:
      Cmts.t
   -> expression Ast.xt
   -> (expression Ast.xt option * expression Ast.xt * attributes) list
@@ -86,7 +86,7 @@ val ite :
     will return the following list:
     [(Some c1, e1); (Some c2, e2); (None, e3)]. *)
 
-val sequence :
+val sequence:
   Cmts.t -> expression Ast.xt -> (label loc option * expression Ast.xt) list
 (** [sequence cmts exp] returns the list of expressions (with the optional
     extension) from a sequence of expressions [exp]. *)
@@ -97,7 +97,7 @@ type functor_arg =
       (** Equivalent of the [functor_parameter] type with a contextualized
           module type. *)
 
-val functor_type :
+val functor_type:
      Cmts.t
   -> for_functor_kw:bool
   -> source_is_long:(module_type -> bool)
@@ -107,7 +107,7 @@ val functor_type :
     applied to the functor of module type [m]. [for_functor_kw] indicates if
     the keyword [functor] is used. *)
 
-val functor_ :
+val functor_:
      Cmts.t
   -> for_functor_kw:bool
   -> source_is_long:(module_expr -> bool)
@@ -117,7 +117,7 @@ val functor_ :
     to the functor of module [m]. [for_functor_kw] indicates if the keyword
     [functor] is used. *)
 
-val mod_with :
+val mod_with:
      module_type Ast.xt
   -> (with_constraint list * Warnings.loc * attributes) list
      * module_type Ast.xt
@@ -138,10 +138,10 @@ module Let_binding : sig
     ; lb_attrs: attribute list
     ; lb_loc: Location.t }
 
-  val of_value_binding :
+  val of_value_binding:
     Cmts.t -> ctx:Ast.t -> first:bool -> value_binding -> t
 
-  val of_value_bindings : Cmts.t -> ctx:Ast.t -> value_binding list -> t list
+  val of_value_bindings: Cmts.t -> ctx:Ast.t -> value_binding list -> t list
 
-  val of_binding_ops : Cmts.t -> ctx:Ast.t -> binding_op list -> t list
+  val of_binding_ops: Cmts.t -> ctx:Ast.t -> binding_op list -> t list
 end

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -12,14 +12,14 @@
 module Error : sig
   type t
 
-  val user_error : string -> t
+  val user_error: string -> t
 
-  val equal : t -> t -> bool
+  val equal: t -> t -> bool
 
-  val print : ?debug:bool -> ?quiet:bool -> Format.formatter -> t -> unit
+  val print: ?debug:bool -> ?quiet:bool -> Format.formatter -> t -> unit
 end
 
-val parse_and_format :
+val parse_and_format:
      Syntax.t
   -> ?output_file:string
   -> input_name:string
@@ -30,7 +30,7 @@ val parse_and_format :
 (** [parse_and_format kind ?output_file ~input_name ~source conf opts] parses
     and formats [source] as a list of fragments. *)
 
-val numeric :
+val numeric:
      Syntax.t
   -> input_name:string
   -> source:string

--- a/lib/Version.mli
+++ b/lib/Version.mli
@@ -11,11 +11,11 @@
 
 type t = V0_10_0 | V0_12_0 | V0_14_2 | V0_16_0 | V0_17_0 | V0_20_0 | V1_0_0
 
-val to_string : t -> string
+val to_string: t -> string
 
-val pp : Format.formatter -> t -> unit
+val pp: Format.formatter -> t -> unit
 
-val current : string
+val current: string
 (** A version number, or "unknown". This is provided by [dune-build-info],
     which means that it will be resolved in the following way:
 

--- a/test/cli/stdin.t
+++ b/test/cli/stdin.t
@@ -18,7 +18,7 @@ Nominal cases:
   let x = 1
 
   $ echo 'val x :     int' | ocamlformat --intf -
-  val x : int
+  val x: int
 
 The kind of syntax --impl/--intf is inferred from the name:
 

--- a/test/passing/tests/attributes.ml
+++ b/test/passing/tests/attributes.ml
@@ -4,9 +4,9 @@ let f (x [@warning ""]) = ()
 
 let v = (fun [@inline] x -> x) 1
 
-external f : (float[@unboxed]) -> int = "blah" [@@noalloc]
+external f: (float[@unboxed]) -> int = "blah" [@@noalloc]
 
-val x : ?x:unit (** not dropped *) -> unit
+val x: ?x:unit (** not dropped *) -> unit
 
 type t =
   { a: int
@@ -25,10 +25,10 @@ type t =
         [@drop_if somethingelse]
         (** docstring that is long enough to break *) }
 
-val foo : int
+val foo: int
   [@@deprecated "it is good the salad"] [@@warning "-32"] [@@warning "-99"]
 
-val foo : int
+val foo: int
   [@@deprecated "it is good the salad"]
   [@@warning "-32"]
   [@@warning "-99"]
@@ -143,7 +143,7 @@ let () = ()
 
 and[@warning "-32"] f = ()
 
-external x : a -> b -> (a -> b[@test]) = ""
+external x: a -> b -> (a -> b[@test]) = ""
 
 let f = fun [@test] x y -> ()
 

--- a/test/passing/tests/binders.ml
+++ b/test/passing/tests/binders.ml
@@ -1,6 +1,6 @@
-external f : 'a -> 'a = "asdf"
+external f: 'a -> 'a = "asdf"
 
-external g :
+external g:
   'aaaaaaa 'aaaaaaaaaaaaaaa 'aaaaaaaaaaaaaaaaaaaaaa 'aaaaaaaaaaaaaa 'aaaaaaa
   'fooooo_foooooo. 'a -> 'a -> 'a = "asdf"
 

--- a/test/passing/tests/break_fun_decl-fit_or_vertical.ml.ref
+++ b/test/passing/tests/break_fun_decl-fit_or_vertical.ml.ref
@@ -102,13 +102,13 @@ class type ffffffffffffffffffff =
       -> cccccccccccccccccccccc
       -> dddddddddddddddddddddd
 
-    val ffffffffffffffffffff :
+    val ffffffffffffffffffff:
          aaaaaaaaaaaaaaaaaaaaaa
       -> bbbbbbbbbbbbbbbbbbbbbb
       -> cccccccccccccccccccccc
       -> dddddddddddddddddddddd
 
-    val ffffffffffffffffffff :
+    val ffffffffffffffffffff:
          (   aaaaaaaaaaaaaaaaaaaaaa
           -> bbbbbbbbbbbbbbbbbbbbbb
           -> cccccccccccccccccccccc

--- a/test/passing/tests/break_fun_decl-smart.ml.ref
+++ b/test/passing/tests/break_fun_decl-smart.ml.ref
@@ -96,13 +96,13 @@ class type ffffffffffffffffffff =
       -> cccccccccccccccccccccc
       -> dddddddddddddddddddddd
 
-    val ffffffffffffffffffff :
+    val ffffffffffffffffffff:
          aaaaaaaaaaaaaaaaaaaaaa
       -> bbbbbbbbbbbbbbbbbbbbbb
       -> cccccccccccccccccccccc
       -> dddddddddddddddddddddd
 
-    val ffffffffffffffffffff :
+    val ffffffffffffffffffff:
          (   aaaaaaaaaaaaaaaaaaaaaa
           -> bbbbbbbbbbbbbbbbbbbbbb
           -> cccccccccccccccccccccc

--- a/test/passing/tests/break_fun_decl-wrap.ml.ref
+++ b/test/passing/tests/break_fun_decl-wrap.ml.ref
@@ -78,13 +78,13 @@ class type ffffffffffffffffffff =
       -> cccccccccccccccccccccc
       -> dddddddddddddddddddddd
 
-    val ffffffffffffffffffff :
+    val ffffffffffffffffffff:
          aaaaaaaaaaaaaaaaaaaaaa
       -> bbbbbbbbbbbbbbbbbbbbbb
       -> cccccccccccccccccccccc
       -> dddddddddddddddddddddd
 
-    val ffffffffffffffffffff :
+    val ffffffffffffffffffff:
          (   aaaaaaaaaaaaaaaaaaaaaa
           -> bbbbbbbbbbbbbbbbbbbbbb
           -> cccccccccccccccccccccc

--- a/test/passing/tests/break_fun_decl.ml
+++ b/test/passing/tests/break_fun_decl.ml
@@ -78,13 +78,13 @@ class type ffffffffffffffffffff =
       -> cccccccccccccccccccccc
       -> dddddddddddddddddddddd
 
-    val ffffffffffffffffffff :
+    val ffffffffffffffffffff:
          aaaaaaaaaaaaaaaaaaaaaa
       -> bbbbbbbbbbbbbbbbbbbbbb
       -> cccccccccccccccccccccc
       -> dddddddddddddddddddddd
 
-    val ffffffffffffffffffff :
+    val ffffffffffffffffffff:
          (   aaaaaaaaaaaaaaaaaaaaaa
           -> bbbbbbbbbbbbbbbbbbbbbb
           -> cccccccccccccccccccccc

--- a/test/passing/tests/break_separators-after.ml.ref
+++ b/test/passing/tests/break_separators-after.ml.ref
@@ -101,7 +101,7 @@ module Fooooo = struct
       record type. *)
   type t = {fooooo: fooo; fooooo: fooooooo}
 
-  val select :
+  val select:
     (* The fsevents context *)
     env ->
     (* Additional file descriptor to select for reading *)
@@ -118,7 +118,7 @@ end
 [@@@ocamlformat "type-decl=sparse"]
 
 module X = struct
-  val select :
+  val select:
     (* The fsevents context *)
     env ->
     (* Additional file descriptor to select for reading *)

--- a/test/passing/tests/break_separators-after_docked.ml.ref
+++ b/test/passing/tests/break_separators-after_docked.ml.ref
@@ -114,7 +114,7 @@ module Fooooo = struct
       record type. *)
   type t = {fooooo: fooo; fooooo: fooooooo}
 
-  val select :
+  val select:
     (* The fsevents context *)
     env ->
     (* Additional file descriptor to select for reading *)
@@ -131,7 +131,7 @@ end
 [@@@ocamlformat "type-decl=sparse"]
 
 module X = struct
-  val select :
+  val select:
     (* The fsevents context *)
     env ->
     (* Additional file descriptor to select for reading *)

--- a/test/passing/tests/break_separators-after_docked_wrap.ml.ref
+++ b/test/passing/tests/break_separators-after_docked_wrap.ml.ref
@@ -112,7 +112,7 @@ module Fooooo = struct
       record type. *)
   type t = {fooooo: fooo; fooooo: fooooooo}
 
-  val select :
+  val select:
     (* The fsevents context *)
     env ->
     (* Additional file descriptor to select for reading *)
@@ -129,7 +129,7 @@ end
 [@@@ocamlformat "type-decl=sparse"]
 
 module X = struct
-  val select :
+  val select:
     (* The fsevents context *)
     env ->
     (* Additional file descriptor to select for reading *)

--- a/test/passing/tests/break_separators-after_wrap.ml.ref
+++ b/test/passing/tests/break_separators-after_wrap.ml.ref
@@ -99,7 +99,7 @@ module Fooooo = struct
       record type. *)
   type t = {fooooo: fooo; fooooo: fooooooo}
 
-  val select :
+  val select:
     (* The fsevents context *)
     env ->
     (* Additional file descriptor to select for reading *)
@@ -116,7 +116,7 @@ end
 [@@@ocamlformat "type-decl=sparse"]
 
 module X = struct
-  val select :
+  val select:
     (* The fsevents context *)
     env ->
     (* Additional file descriptor to select for reading *)

--- a/test/passing/tests/break_separators-before_docked.ml.ref
+++ b/test/passing/tests/break_separators-before_docked.ml.ref
@@ -114,7 +114,7 @@ module Fooooo = struct
       record type. *)
   type t = {fooooo: fooo; fooooo: fooooooo}
 
-  val select :
+  val select:
        (* The fsevents context *)
        env
     -> (* Additional file descriptor to select for reading *)
@@ -131,7 +131,7 @@ end
 [@@@ocamlformat "type-decl=sparse"]
 
 module X = struct
-  val select :
+  val select:
        (* The fsevents context *)
        env
     -> (* Additional file descriptor to select for reading *)

--- a/test/passing/tests/break_separators-before_docked_wrap.ml.ref
+++ b/test/passing/tests/break_separators-before_docked_wrap.ml.ref
@@ -112,7 +112,7 @@ module Fooooo = struct
       record type. *)
   type t = {fooooo: fooo; fooooo: fooooooo}
 
-  val select :
+  val select:
        (* The fsevents context *)
        env
     -> (* Additional file descriptor to select for reading *)
@@ -129,7 +129,7 @@ end
 [@@@ocamlformat "type-decl=sparse"]
 
 module X = struct
-  val select :
+  val select:
        (* The fsevents context *)
        env
     -> (* Additional file descriptor to select for reading *)

--- a/test/passing/tests/break_separators-wrap.ml.ref
+++ b/test/passing/tests/break_separators-wrap.ml.ref
@@ -99,7 +99,7 @@ module Fooooo = struct
       record type. *)
   type t = {fooooo: fooo; fooooo: fooooooo}
 
-  val select :
+  val select:
        (* The fsevents context *)
        env
     -> (* Additional file descriptor to select for reading *)
@@ -116,7 +116,7 @@ end
 [@@@ocamlformat "type-decl=sparse"]
 
 module X = struct
-  val select :
+  val select:
        (* The fsevents context *)
        env
     -> (* Additional file descriptor to select for reading *)

--- a/test/passing/tests/break_separators.ml
+++ b/test/passing/tests/break_separators.ml
@@ -101,7 +101,7 @@ module Fooooo = struct
       record type. *)
   type t = {fooooo: fooo; fooooo: fooooooo}
 
-  val select :
+  val select:
        (* The fsevents context *)
        env
     -> (* Additional file descriptor to select for reading *)
@@ -118,7 +118,7 @@ end
 [@@@ocamlformat "type-decl=sparse"]
 
 module X = struct
-  val select :
+  val select:
        (* The fsevents context *)
        env
     -> (* Additional file descriptor to select for reading *)

--- a/test/passing/tests/cinaps.ml
+++ b/test/passing/tests/cinaps.ml
@@ -22,7 +22,7 @@ let y = 2
 
   ;; List.iter all_fields ~f:(fun (name, type_) -> printf "\nexternal get_%s
   : unit -> %s = \"get_%s\"" name type_ name) *)
-external get_name : unit -> string = "get_name"
+external get_name: unit -> string = "get_name"
 
 (*$*)
 

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -81,7 +81,7 @@ let _ =
   | "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" -> ()
 
 module type M = sig
-  val f (* A list of [name], [count] pairs. *) : (string * int) list -> int
+  val f (* A list of [name], [count] pairs. *): (string * int) list -> int
 end
 
 let _ = f ~f:(fun a b -> c) (* comment *) ~f:(fun a b -> c)

--- a/test/passing/tests/comments.mli
+++ b/test/passing/tests/comments.mli
@@ -1,7 +1,7 @@
-val f : unit
+val f: unit
 (** docstring *)
 (* comment *)
 
-val g : unit
+val g: unit
 (** docstring *)
 (* comment *)

--- a/test/passing/tests/doc_comments-after.ml.ref
+++ b/test/passing/tests/doc_comments-after.ml.ref
@@ -51,7 +51,7 @@ module Comment_placement : sig
     type b
   end
 
-  val a : b
+  val a: b
   (** Val *)
 
   exception E
@@ -70,7 +70,7 @@ module Comment_placement : sig
   open M
   (** Open *)
 
-  external a : b = "c"
+  external a: b = "c"
   (** External *)
 
   module rec A : B
@@ -106,7 +106,7 @@ module Comment_placement : sig
   (** Extension *)
 
   (** A *)
-  external a : b = "double_comment"
+  external a: b = "double_comment"
   (** B *)
 
   (** This comment goes before *)
@@ -128,7 +128,7 @@ module Comment_placement : sig
 
   (** Doc comment still goes after *)
   module Make (Config : sig
-    val blah : string
+    val blah: string
 
     (* this could be a really long signature *)
   end) : S
@@ -182,7 +182,7 @@ end = struct
   open M
   (** Open *)
 
-  external a : b = "c"
+  external a: b = "c"
   (** External *)
 
   module rec A : B = C
@@ -242,7 +242,7 @@ end = struct
   (* ;; *)
 
   (** A *)
-  external a : b = "double_comment"
+  external a: b = "double_comment"
   (** B *)
 end
 

--- a/test/passing/tests/doc_comments-before-except-val.ml.ref
+++ b/test/passing/tests/doc_comments-before-except-val.ml.ref
@@ -51,7 +51,7 @@ module Comment_placement : sig
     type b
   end
 
-  val a : b
+  val a: b
   (** Val *)
 
   (** Exception *)
@@ -70,7 +70,7 @@ module Comment_placement : sig
   (** Open *)
   open M
 
-  external a : b = "c"
+  external a: b = "c"
   (** External *)
 
   (** Rec module *)
@@ -106,7 +106,7 @@ module Comment_placement : sig
   [%%some extension]
 
   (** A *)
-  external a : b = "double_comment"
+  external a: b = "double_comment"
   (** B *)
 
   (** This comment goes before *)
@@ -128,7 +128,7 @@ module Comment_placement : sig
 
   (** Doc comment still goes after *)
   module Make (Config : sig
-    val blah : string
+    val blah: string
 
     (* this could be a really long signature *)
   end) : S
@@ -182,7 +182,7 @@ end = struct
   (** Open *)
   open M
 
-  external a : b = "c"
+  external a: b = "c"
   (** External *)
 
   (** Rec module *)
@@ -242,7 +242,7 @@ end = struct
   (* ;; *)
 
   (** A *)
-  external a : b = "double_comment"
+  external a: b = "double_comment"
   (** B *)
 end
 

--- a/test/passing/tests/doc_comments-before.ml.ref
+++ b/test/passing/tests/doc_comments-before.ml.ref
@@ -52,7 +52,7 @@ module Comment_placement : sig
   end
 
   (** Val *)
-  val a : b
+  val a: b
 
   (** Exception *)
   exception E
@@ -71,7 +71,7 @@ module Comment_placement : sig
   open M
 
   (** External *)
-  external a : b = "c"
+  external a: b = "c"
 
   (** Rec module *)
   module rec A : B
@@ -106,7 +106,7 @@ module Comment_placement : sig
   [%%some extension]
 
   (** A *)
-  external a : b = "double_comment"
+  external a: b = "double_comment"
   (** B *)
 
   (** This comment goes before *)
@@ -128,7 +128,7 @@ module Comment_placement : sig
 
   (** Doc comment still goes after *)
   module Make (Config : sig
-    val blah : string
+    val blah: string
 
     (* this could be a really long signature *)
   end) : S
@@ -183,7 +183,7 @@ end = struct
   open M
 
   (** External *)
-  external a : b = "c"
+  external a: b = "c"
 
   (** Rec module *)
   module rec A : B = C
@@ -242,7 +242,7 @@ end = struct
   (* ;; *)
 
   (** A *)
-  external a : b = "double_comment"
+  external a: b = "double_comment"
   (** B *)
 end
 

--- a/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
+++ b/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
@@ -11,14 +11,14 @@ type block =
 (** Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod *)
 include M with type t := t
 
-val escape : string -> string
+val escape: string -> string
 (** [escape s] escapes [s] from the doc language. *)
 
 type title = string * int * string * string * string
 
 (** {1:standard-section-names Standard section names} *)
 
-val s_name : string
+val s_name: string
 
 (** {1:section-maps Section maps}
 
@@ -26,19 +26,19 @@ val s_name : string
 
 type smap
 
-val smap_append_block : smap -> sec:string -> block -> smap
+val smap_append_block: smap -> sec:string -> block -> smap
 (** [smap_append_block smap sec b] appends [b] at the end of section [sec]
     creating it at the right place if needed. *)
 
 (** {1:content-boilerplate Content boilerplate} *)
 
-val s_environment_intro : block
+val s_environment_intro: block
 
 (** {1:output Output} *)
 
 type format = [`Auto | `Pager | `Plain | `Groff]
 
-val print :
+val print:
      ?errs:Format.formatter
   -> ?subst:(string -> string option)
   -> format
@@ -49,7 +49,7 @@ val print :
 (** {1:printers-and-escapes-used-by-cmdliner-module Printers and escapes used
     by Cmdliner module} *)
 
-val subst_vars :
+val subst_vars:
      errs:Format.formatter
   -> subst:(string -> string option)
   -> Buffer.t
@@ -61,7 +61,7 @@ val subst_vars :
 
     @raise Invalid_argument in case of illegal syntax. *)
 
-val doc_to_plain :
+val doc_to_plain:
      errs:Format.formatter
   -> subst:(string -> string option)
   -> Buffer.t
@@ -72,7 +72,7 @@ val doc_to_plain :
 
     @raise Invalid_argument in case of illegal syntax. *)
 
-val k : k
+val k: k
 (** this is a comment
 
     @author foo
@@ -131,7 +131,7 @@ val k : k
     @canonical
     Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar *)
 
-val x : x
+val x: x
 (** a comment @version foo *)
 
 (** Managing Chunks.
@@ -223,24 +223,24 @@ val x : x
 (** generic command: ∀xs.[foot]-[post] *)
 
 (** A *)
-val foo : int -> unit
+val foo: int -> unit
 (** B *)
 
 (** C *)
 
 (** A *)
-val foo : int -> unit
+val foo: int -> unit
 (** B *)
 
 module Foo : sig
   (** A *)
-  val foo : int -> unit
+  val foo: int -> unit
   (** B *)
 
   (** C *)
 
   (** A *)
-  val foo : int -> unit
+  val foo: int -> unit
   (** B *)
 end
 
@@ -363,11 +363,11 @@ end
 (** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooooooo {b
     + eee + eee eee} *)
 
-val f : int
+val f: int
 
 (***)
 
-val k : int
+val k: int
 
 (**)
 
@@ -445,7 +445,7 @@ val k : int
 
 (** {[(* a b *)]} *)
 
-val a :
+val a:
      fooooooooooooooooooooooooooo (** {[(* a b *)]} *)
   -> fooooooooooooooooooooooooo
 

--- a/test/passing/tests/doc_comments-no-wrap.mli.ref
+++ b/test/passing/tests/doc_comments-no-wrap.mli.ref
@@ -11,14 +11,14 @@ type block =
 (** Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod *)
 include M with type t := t
 
-val escape : string -> string
+val escape: string -> string
 (** [escape s] escapes [s] from the doc language. *)
 
 type title = string * int * string * string * string
 
 (** {1:standard-section-names Standard section names} *)
 
-val s_name : string
+val s_name: string
 
 (** {1:section-maps Section maps}
 
@@ -26,19 +26,19 @@ val s_name : string
 
 type smap
 
-val smap_append_block : smap -> sec:string -> block -> smap
+val smap_append_block: smap -> sec:string -> block -> smap
 (** [smap_append_block smap sec b] appends [b] at the end of section [sec]
     creating it at the right place if needed. *)
 
 (** {1:content-boilerplate Content boilerplate} *)
 
-val s_environment_intro : block
+val s_environment_intro: block
 
 (** {1:output Output} *)
 
 type format = [`Auto | `Pager | `Plain | `Groff]
 
-val print :
+val print:
      ?errs:Format.formatter
   -> ?subst:(string -> string option)
   -> format
@@ -49,7 +49,7 @@ val print :
 (** {1:printers-and-escapes-used-by-cmdliner-module Printers and escapes used
     by Cmdliner module} *)
 
-val subst_vars :
+val subst_vars:
      errs:Format.formatter
   -> subst:(string -> string option)
   -> Buffer.t
@@ -61,7 +61,7 @@ val subst_vars :
 
     @raise Invalid_argument in case of illegal syntax. *)
 
-val doc_to_plain :
+val doc_to_plain:
      errs:Format.formatter
   -> subst:(string -> string option)
   -> Buffer.t
@@ -72,7 +72,7 @@ val doc_to_plain :
 
     @raise Invalid_argument in case of illegal syntax. *)
 
-val k : k
+val k: k
 (** this is a comment
 
     @author foo
@@ -104,7 +104,7 @@ val k : k
     @canonical foo
     @canonical Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar *)
 
-val x : x
+val x: x
 (** a comment
 
     @version foo *)
@@ -224,24 +224,24 @@ val x : x
 (** generic command: ∀xs.[foot]-[post] *)
 
 (** A *)
-val foo : int -> unit
+val foo: int -> unit
 (** B *)
 
 (** C *)
 
 (** A *)
-val foo : int -> unit
+val foo: int -> unit
 (** B *)
 
 module Foo : sig
   (** A *)
-  val foo : int -> unit
+  val foo: int -> unit
   (** B *)
 
   (** C *)
 
   (** A *)
-  val foo : int -> unit
+  val foo: int -> unit
   (** B *)
 end
 
@@ -437,11 +437,11 @@ end
 (** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooooooo
     {b + eee + eee eee} *)
 
-val f : int
+val f: int
 
 (***)
 
-val k : int
+val k: int
 
 (**)
 
@@ -530,7 +530,7 @@ val k : int
          b *)
     ]} *)
 
-val a :
+val a:
      fooooooooooooooooooooooooooo
      (** {[
            (* a

--- a/test/passing/tests/doc_comments.ml.ref
+++ b/test/passing/tests/doc_comments.ml.ref
@@ -51,7 +51,7 @@ module Comment_placement : sig
     type b
   end
 
-  val a : b
+  val a: b
   (** Val *)
 
   (** Exception *)
@@ -70,7 +70,7 @@ module Comment_placement : sig
   (** Open *)
   open M
 
-  external a : b = "c"
+  external a: b = "c"
   (** External *)
 
   (** Rec module *)
@@ -106,7 +106,7 @@ module Comment_placement : sig
   [%%some extension]
 
   (** A *)
-  external a : b = "double_comment"
+  external a: b = "double_comment"
   (** B *)
 
   (** This comment goes before *)
@@ -128,7 +128,7 @@ module Comment_placement : sig
 
   (** Doc comment still goes after *)
   module Make (Config : sig
-    val blah : string
+    val blah: string
 
     (* this could be a really long signature *)
   end) : S
@@ -182,7 +182,7 @@ end = struct
   (** Open *)
   open M
 
-  external a : b = "c"
+  external a: b = "c"
   (** External *)
 
   (** Rec module *)
@@ -242,7 +242,7 @@ end = struct
   (* ;; *)
 
   (** A *)
-  external a : b = "double_comment"
+  external a: b = "double_comment"
   (** B *)
 end
 

--- a/test/passing/tests/doc_comments.mli.ref
+++ b/test/passing/tests/doc_comments.mli.ref
@@ -11,14 +11,14 @@ type block =
 (** Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod *)
 include M with type t := t
 
-val escape : string -> string
+val escape: string -> string
 (** [escape s] escapes [s] from the doc language. *)
 
 type title = string * int * string * string * string
 
 (** {1:standard-section-names Standard section names} *)
 
-val s_name : string
+val s_name: string
 
 (** {1:section-maps Section maps}
 
@@ -26,19 +26,19 @@ val s_name : string
 
 type smap
 
-val smap_append_block : smap -> sec:string -> block -> smap
+val smap_append_block: smap -> sec:string -> block -> smap
 (** [smap_append_block smap sec b] appends [b] at the end of section [sec]
     creating it at the right place if needed. *)
 
 (** {1:content-boilerplate Content boilerplate} *)
 
-val s_environment_intro : block
+val s_environment_intro: block
 
 (** {1:output Output} *)
 
 type format = [`Auto | `Pager | `Plain | `Groff]
 
-val print :
+val print:
      ?errs:Format.formatter
   -> ?subst:(string -> string option)
   -> format
@@ -49,7 +49,7 @@ val print :
 (** {1:printers-and-escapes-used-by-cmdliner-module Printers and escapes used
     by Cmdliner module} *)
 
-val subst_vars :
+val subst_vars:
      errs:Format.formatter
   -> subst:(string -> string option)
   -> Buffer.t
@@ -61,7 +61,7 @@ val subst_vars :
 
     @raise Invalid_argument in case of illegal syntax. *)
 
-val doc_to_plain :
+val doc_to_plain:
      errs:Format.formatter
   -> subst:(string -> string option)
   -> Buffer.t
@@ -72,7 +72,7 @@ val doc_to_plain :
 
     @raise Invalid_argument in case of illegal syntax. *)
 
-val k : k
+val k: k
 (** this is a comment
 
     @author foo
@@ -104,7 +104,7 @@ val k : k
     @canonical foo
     @canonical Foooooooooooooooooooooooooooooooooooo.Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar *)
 
-val x : x
+val x: x
 (** a comment
 
     @version foo *)
@@ -224,24 +224,24 @@ val x : x
 (** generic command: ∀xs.[foot]-[post] *)
 
 (** A *)
-val foo : int -> unit
+val foo: int -> unit
 (** B *)
 
 (** C *)
 
 (** A *)
-val foo : int -> unit
+val foo: int -> unit
 (** B *)
 
 module Foo : sig
   (** A *)
-  val foo : int -> unit
+  val foo: int -> unit
   (** B *)
 
   (** C *)
 
   (** A *)
-  val foo : int -> unit
+  val foo: int -> unit
   (** B *)
 end
 
@@ -437,11 +437,11 @@ end
 (** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooooooo
     {b + eee + eee eee} *)
 
-val f : int
+val f: int
 
 (***)
 
-val k : int
+val k: int
 
 (**)
 
@@ -527,7 +527,7 @@ val k : int
 
 (** {[ (* a b *) ]} *)
 
-val a :
+val a:
      fooooooooooooooooooooooooooo (** {[ (* a b *) ]} *)
   -> fooooooooooooooooooooooooo
 

--- a/test/passing/tests/extensions-indent.ml.ref
+++ b/test/passing/tests/extensions-indent.ml.ref
@@ -9,7 +9,7 @@ let _ =
       let%test x = d in
       d
 
-val f : compare:[%compare: 'a] -> sexp_of:[%sexp_of: 'a] -> t
+val f: compare:[%compare: 'a] -> sexp_of:[%sexp_of: 'a] -> t
 
 let invariant t =
   Invariant.invariant [%here] t [%sexp_of: t] (fun () ->

--- a/test/passing/tests/extensions-indent.mli.ref
+++ b/test/passing/tests/extensions-indent.mli.ref
@@ -22,9 +22,9 @@ type t =
      foooooooooooooooooooooooooooo]
 
 [%%ext
-val foooooooooooooooooooooo : fooooooooooo
+val foooooooooooooooooooooo: fooooooooooo
 
-val fooooooooooooooooooooooooooo : fooooo]
+val fooooooooooooooooooooooooooo: fooooo]
 
 exception%ext E
 
@@ -65,13 +65,13 @@ type%foo t += T
 
 [%%foo: type t += T]
 
-val%foo x : t
+val%foo x: t
 
-[%%foo: val x : t]
+[%%foo: val x: t]
 
-external%foo x : t = ""
+external%foo x: t = ""
 
-[%%foo: external x : t = ""]
+[%%foo: external x: t = ""]
 
 class%foo x : t
 

--- a/test/passing/tests/extensions.ml.ref
+++ b/test/passing/tests/extensions.ml.ref
@@ -9,7 +9,7 @@ let _ =
       let%test x = d in
       d
 
-val f : compare:[%compare: 'a] -> sexp_of:[%sexp_of: 'a] -> t
+val f: compare:[%compare: 'a] -> sexp_of:[%sexp_of: 'a] -> t
 
 let invariant t =
   Invariant.invariant [%here] t [%sexp_of: t] (fun () ->

--- a/test/passing/tests/extensions.mli
+++ b/test/passing/tests/extensions.mli
@@ -22,9 +22,9 @@ fooooooooooooooooooooooooooo foooooooooooooooooooooooooooooooooo
   foooooooooooooooooooooooooooo]
 
 [%%ext
-val foooooooooooooooooooooo : fooooooooooo
+val foooooooooooooooooooooo: fooooooooooo
 
-val fooooooooooooooooooooooooooo : fooooo]
+val fooooooooooooooooooooooooooo: fooooo]
 
 exception%ext E
 
@@ -65,13 +65,13 @@ type%foo t += T
 
 [%%foo: type t += T]
 
-val%foo x : t
+val%foo x: t
 
-[%%foo: val x : t]
+[%%foo: val x: t]
 
-external%foo x : t = ""
+external%foo x: t = ""
 
-[%%foo: external x : t = ""]
+[%%foo: external x: t = ""]
 
 class%foo x : t
 

--- a/test/passing/tests/first_class_module.ml
+++ b/test/passing/tests/first_class_module.ml
@@ -3,7 +3,7 @@ module type S = sig end
 type t = (module S)
 
 module type S = sig
-  val x : int
+  val x: int
 end
 
 module M = struct
@@ -18,7 +18,7 @@ let () =
   ()
 
 module type S = sig
-  val x : int
+  val x: int
 end
 
 module M = struct
@@ -38,11 +38,11 @@ let v = f (module M : S with type t = t)
 module type S = sig
   type a
 
-  val va : a
+  val va: a
 
   type b
 
-  val vb : b
+  val vb: b
 end
 
 let f (module M : S with type a = int and type b = int) = M.va + M.vb
@@ -63,7 +63,7 @@ let f (module M : S with type a = int and type b = int)
   M.va + N.vb
 
 module type M = sig
-  val storage : (module S with type t = t)
+  val storage: (module S with type t = t)
 end
 
 let _ =

--- a/test/passing/tests/functor.ml
+++ b/test/passing/tests/functor.ml
@@ -16,9 +16,9 @@ module type M = functor
   (SSSSS : SSSSSSSSSSSSSS)
   (TTTTT : TTTTTTTTTTTTTTTT)
   -> sig
-  val t1 : a
+  val t1: a
 
-  val t2 : b
+  val t2: b
 end
 
 module M : functor () -> sig end = functor () -> struct end

--- a/test/passing/tests/funsig.ml
+++ b/test/passing/tests/funsig.ml
@@ -1,21 +1,20 @@
-val fffffffff : aaaaaa -> bbbbbbbbbb ccccccccc -> dddd
+val fffffffff: aaaaaa -> bbbbbbbbbb ccccccccc -> dddd
 
-val fffffffff :
-  aaaaaa -> bbbbbbbbbb ccccccccc -> dddd -> dddd -> dddd -> dddd
+val fffffffff: aaaaaa -> bbbbbbbbbb ccccccccc -> dddd -> dddd -> dddd -> dddd
 
-val fffffffff :
+val fffffffff:
   aaaaaa -> (bbbbbbbbbb ccccccccc -> int) -> bbbbbbbbbb ccccccccc -> dddd
 
-val fffffffff :
+val fffffffff:
      eeee:('a, 'b) aaaaaa
   -> (bbbbbbbbbb ccccccccc -> int)
   -> bbbbbbbbbb ccccccccc
   -> dddd
   -> dddd
 
-val m : (module S with type t = t)
+val m: (module S with type t = t)
 
-val f :
+val f:
   ( 'aaaaaaaaaaaaaaaaaaaa
   ,    xxxxxxxxxxxxxxxxxxxxxxxxx
     -> yyyyyyyyyyyyyyyyyyyyyyyyy
@@ -41,16 +40,16 @@ type t =
 type ('aaaa, 'bbbb, 'cccc) t =
   llll:('aaaa, 'bbbb, 'cccc) s -> dddddd list -> 'aaaa * 'cccc -> 'bbbb uuuuu
 
-external ident : a -> b -> c -> d = "something"
+external ident: a -> b -> c -> d = "something"
 
-external ident : a -> b -> c -> d = "something" "else"
+external ident: a -> b -> c -> d = "something" "else"
 
-val ident : a -> b -> c -> d
+val ident: a -> b -> c -> d
 
-val ident :
+val ident:
   arg1_is_loooooooooooooooooooooooooooooooong -> arg2 -> arg3 -> arg4
 
-external ident :
+external ident:
   arg1_is_loooooooooooooooooooooooooooooooong -> arg2 -> arg3 -> arg4
   = "something" "else"
 

--- a/test/passing/tests/issue51.ml
+++ b/test/passing/tests/issue51.ml
@@ -1,4 +1,4 @@
-val run :
+val run:
      unit
   -> (unit -> ('a, ([> `Msg of string] as 'b)) result)
   -> ('a, 'b) result

--- a/test/passing/tests/js_to_do.ml.ref
+++ b/test/passing/tests/js_to_do.ml.ref
@@ -38,7 +38,7 @@ let _ =
    first, and then the first argument is aligned accordingly. So, there's no
    manual indentation or spacing below. *)
 
-val instances :
+val instances:
      unit
   -> (    Config.Network.t
        -> (App.t * Config.instance * Config.app) list
@@ -47,7 +47,7 @@ val instances :
      , 'm )
      Command.Spec.t
 
-val instances :
+val instances:
      unit
   -> (    Config.Network.t
        -> (App.t * Config.instance * Config.app) list
@@ -57,7 +57,7 @@ val instances :
      Command.Spec.t
 
 (* presumed analog with stars *)
-val instances :
+val instances:
   unit
   * ( Config.Network.t
       * (App.t * Config.instance * Config.app) list

--- a/test/passing/tests/mod_type_subst.ml
+++ b/test/passing/tests/mod_type_subst.ml
@@ -94,7 +94,7 @@ module type r =
 module type fst = sig
   module type t
 
-  val x : (module t)
+  val x: (module t)
 end
 
 module type ext
@@ -112,7 +112,7 @@ module type S = sig
     module type T
   end
 
-  val x : (module M.T)
+  val x: (module M.T)
 end
 
 module type R = S with module type M.T := sig end
@@ -121,7 +121,7 @@ module type S = sig
   module M : sig
     module type T
 
-    val x : (module T)
+    val x: (module T)
   end
 end
 
@@ -170,7 +170,7 @@ end
 module type fst = sig
   module type t := sig end
 
-  val x : (module t)
+  val x: (module t)
 end
 
 module type hidden = sig
@@ -180,7 +180,7 @@ module type hidden = sig
 
   include t
 
-  val x : (module t)
+  val x: (module t)
 
-  val x : int
+  val x: int
 end

--- a/test/passing/tests/module_anonymous.ml
+++ b/test/passing/tests/module_anonymous.ml
@@ -10,7 +10,7 @@ end =
 and _ : sig
   type t = A.t
 
-  val x : int * int
+  val x: int * int
 end = struct
   type t = B.t
 

--- a/test/passing/tests/module_item_spacing.mli.ref
+++ b/test/passing/tests/module_item_spacing.mli.ref
@@ -1,31 +1,31 @@
 [@@@ocamlformat "module-item-spacing=compact"]
 
-val z : this one is pretty looooooooooooooooooooooooooooooooooong
-val z : so is this oooooooooooooooooooooooooooooooooooooooooooone
+val z: this one is pretty looooooooooooooooooooooooooooooooooong
+val z: so is this oooooooooooooooooooooooooooooooooooooooooooone
 
-val f : k -> k -> k -> k -> k k -> k k -> k k
+val f: k -> k -> k -> k -> k k -> k k -> k k
 (** [f o o o o o o] is a great function. *)
 
-val z : this one is pretty looooooooooooooooooooooooooooooooooong
-val z : so is this oooooooooooooooooooooooooooooooooooooooooooone
-val g : unit
+val z: this one is pretty looooooooooooooooooooooooooooooooooong
+val z: so is this oooooooooooooooooooooooooooooooooooooooooooone
+val g: unit
 
-val f :
+val f:
      aaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   -> bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
   -> cccccccccccccccccccccccc
   -> dddddddddddd
 
-val x : k
+val x: k
 (** [x] is a great value. *)
 
-val z : k
+val z: k
 
-val y : k
+val y: k
 (** [y] is a great value. *)
 
-val z : this one is pretty looooooooooooooooooooooooooooooooooong
-val z : so is this oooooooooooooooooooooooooooooooooooooooooooone
+val z: this one is pretty looooooooooooooooooooooooooooooooooong
+val z: so is this oooooooooooooooooooooooooooooooooooooooooooone
 
 module A = AA
 module B = BB
@@ -33,41 +33,41 @@ open AA
 module C = CC
 
 module type M = sig
-  val a : z
-  val b : zz
-  val c : zzz
+  val a: z
+  val b: zz
+  val c: zzz
 end
 
-val x : k
-val y : k
-val x : k
-val y : k
+val x: k
+val y: k
+val x: k
+val y: k
 
 type c = {a: int; b: toto; c: char * char * char; d: [`Foo | `Bar]}
 
-val z : this one is pretty looooooooooooooooooooooooooooooooooong
-val z : so is this oooooooooooooooooooooooooooooooooooooooooooone
+val z: this one is pretty looooooooooooooooooooooooooooooooooong
+val z: so is this oooooooooooooooooooooooooooooooooooooooooooone
 
 type k = A | B | K of int * char * string | E
 
-val x : k
-val z : this one is short
-val y : k
+val x: k
+val z: this one is short
+val y: k
 
-val w :
+val w:
   this one is toooooooooooooooooooooooooo looooooooooooooooooooooooog but is
   originally
   a
   one_liner
 
-val k : z
+val k: z
 
 module type N = sig
-  val x : k
-  val z : soooooooooo is this oooooooooooooooooooooooooooooooooooooooooooone
-  val y : k
-  val z : soooooooooo iis this oooooooooooooooooooooooooooooooooooooooooooone
-  val y : k
+  val x: k
+  val z: soooooooooo is this oooooooooooooooooooooooooooooooooooooooooooone
+  val y: k
+  val z: soooooooooo iis this oooooooooooooooooooooooooooooooooooooooooooone
+  val y: k
 
   module A = AA
   include A
@@ -77,19 +77,19 @@ end
 
 [@@@ocamlformat "module-item-spacing=preserve"]
 
-val cmos_rtc_seconds : foo
-val cmos_rtc_seconds_alarm : foo
-val cmos_rtc_minutes : foo
+val cmos_rtc_seconds: foo
+val cmos_rtc_seconds_alarm: foo
+val cmos_rtc_minutes: foo
 
-val x : foo
+val x: foo
 
-val log_other : foo
-val log_cpu : foo
-val log_fpu : foo
+val log_other: foo
+val log_cpu: foo
+val log_fpu: foo
 
-val cr0_pe : foo
-val cr0_mp : foo
-val cr0_em : foo
+val cr0_pe: foo
+val cr0_mp: foo
+val cr0_em: foo
 
 module C : sig
   type config = t

--- a/test/passing/tests/module_type.ml
+++ b/test/passing/tests/module_type.ml
@@ -1,5 +1,5 @@
 module type S = sig
-  val x : unit -> unit
+  val x: unit -> unit
 end
 
 let get = failwith "TODO"

--- a/test/passing/tests/object.ml
+++ b/test/passing/tests/object.ml
@@ -106,7 +106,7 @@ module type A = sig
 
       [@@@attr something]
 
-      val virtual mutable a : int
+      val virtual mutable a: int
 
       method virtual private b : int -> int -> int
     end

--- a/test/passing/tests/ocp_indent_compat.ml
+++ b/test/passing/tests/ocp_indent_compat.ml
@@ -1,29 +1,31 @@
 [@@@ocamlformat "ocp-indent-compat=true"]
 
 (* Bad: unboxing the function type *)
-external i : (int -> float[@unboxed]) = "i" "i_nat"
+external i: (int -> float[@unboxed]) = "i" "i_nat"
 
 module type M = sig
-  val action : action
+  val action: action
   (** Formatting action: input type and source, and output destination. *)
 
-  val doc_atrs
-    :  (string Location.loc * payload) list
+  val doc_atrs:  (string Location.loc * payload) list
     -> (string Location.loc * bool) list option
        * (string Location.loc * payload) list
 
   val transl_modtype_longident
-    (* from Typemod *)
-    : (Location.t -> Env.t -> Longident.t -> Path.t) ref
+    (* from Typemod *): (Location.t -> Env.t -> Longident.t -> Path.t) ref
 
   val transl_modtype_longident
     (* foooooooooo fooooooooooooo foooooooooooo foooooooooooooo
-       foooooooooooooo foooooooooooo *)
-    : (Location.t -> Env.t -> Longident.t -> Path.t) ref
+       foooooooooooooo foooooooooooo *): (Location.t
+                                          -> Env.t
+                                          -> Longident.t
+                                          -> Path.t )
+                                         ref
 
-  val imported_sets_of_closures_table
-    : Simple_value_approx.function_declarations option
-      Set_of_closures_id.Tbl.t
+  val imported_sets_of_closures_table: Simple_value_approx
+                                       .function_declarations
+                                       option
+                                       Set_of_closures_id.Tbl.t
 
   type 'a option_decl =
     names:string list
@@ -34,9 +36,8 @@ module type M = sig
     -> (config -> 'a)
     -> 'a t
 
-  val select
-    :  (* The fsevents context *)
-       env
+  val select:  (* The fsevents context *)
+               env
     -> (* Additional file descriptor to select for reading *)
        ?read_fdl:fd_select list
     -> (* Additional file descriptor to select for writing *)
@@ -47,21 +48,19 @@ module type M = sig
        (event list -> unit)
     -> unit
 
-  val f
-    :  x:t
-         (** an extremely long comment about [x] that does not fit on the
-             same line with [x] *)
+  val f:  x:t
+            (** an extremely long comment about [x] that does not fit on the
+                same line with [x] *)
     -> unit
 
-  val f
-    :  fooooooooooooooooo:
-         (fooooooooooooooo
-          -> fooooooooooooooooooo
-          -> foooooooooooooo
-          -> foooooooooooooo * fooooooooooooooooo
-          -> foooooooooooooooo )
-         (** an extremely long comment about [x] that does not fit on the
-             same line with [x] *)
+  val f:  fooooooooooooooooo:
+            (fooooooooooooooo
+             -> fooooooooooooooooooo
+             -> foooooooooooooo
+             -> foooooooooooooo * fooooooooooooooooo
+             -> foooooooooooooooo )
+            (** an extremely long comment about [x] that does not fit on the
+                same line with [x] *)
     -> unit
 end
 
@@ -90,18 +89,18 @@ let long_function_name
 [@@@ocamlformat "ocp-indent-compat=false"]
 
 module type M = sig
-  val transl_modtype_longident (* from Typemod *) :
+  val transl_modtype_longident (* from Typemod *):
     (Location.t -> Env.t -> Longident.t -> Path.t) ref
 
   val transl_modtype_longident
     (* foooooooooo fooooooooooooo foooooooooooo foooooooooooooo
-       foooooooooooooo foooooooooooo *) :
+       foooooooooooooo foooooooooooo *):
     (Location.t -> Env.t -> Longident.t -> Path.t) ref
 
-  val imported_sets_of_closures_table :
+  val imported_sets_of_closures_table:
     Simple_value_approx.function_declarations option Set_of_closures_id.Tbl.t
 
-  val select :
+  val select:
        (* The fsevents context *)
        env
     -> (* Additional file descriptor to select for reading *)
@@ -114,13 +113,13 @@ module type M = sig
        (event list -> unit)
     -> unit
 
-  val f :
+  val f:
        x:t
          (** an extremely long comment about [x] that does not fit on the
              same line with [x] *)
     -> unit
 
-  val f :
+  val f:
        fooooooooooooooooo:
          (   fooooooooooooooo
           -> fooooooooooooooooooo

--- a/test/passing/tests/ocp_indent_compat.ml.err
+++ b/test/passing/tests/ocp_indent_compat.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/ocp_indent_compat.ml:134 exceeds the margin
+Warning: tests/ocp_indent_compat.ml:133 exceeds the margin

--- a/test/passing/tests/protected_object_types.ml
+++ b/test/passing/tests/protected_object_types.ml
@@ -52,16 +52,16 @@ module Inside_payloads = struct
 
   type a = < f: t > ]
 
-  [@@@a: val b : < .. > ]
+  [@@@a: val b: < .. > ]
 
-  let _ = () [@a: val b : < .. > ]
+  let _ = () [@a: val b: < .. > ]
 
-  let _ = () [@@a: val b : < .. > ]
+  let _ = () [@@a: val b: < .. > ]
 
   [@@@a: type x = < .. > ]
 
   [@@@a:
-  val x : t
+  val x: t
 
   type x = < .. > ]
 

--- a/test/passing/tests/shortcut_ext_attr.ml
+++ b/test/passing/tests/shortcut_ext_attr.ml
@@ -61,9 +61,9 @@ class type t =
   object
     inherit t [@@foo]
 
-    val x : t [@@foo]
+    val x: t [@@foo]
 
-    val mutable x : t [@@foo]
+    val mutable x: t [@@foo]
 
     method x : t [@@foo]
 
@@ -100,7 +100,7 @@ class%foo x = x [@@foo]
 
 class type%foo x = x [@@foo]
 
-external%foo x : _ = "" [@@foo]
+external%foo x: _ = "" [@@foo]
 
 exception%foo X [@@foo]
 
@@ -117,9 +117,9 @@ open%foo M [@@foo]
 
 (* Signature items *)
 module type S = sig
-  [%%foo: val x : t [@@foo]]
+  [%%foo: val x: t [@@foo]]
 
-  [%%foo: external x : t = "" [@@foo]]
+  [%%foo: external x: t = "" [@@foo]]
 
   type%foo t = int [@@foo]
 

--- a/test/passing/tests/sig_value.mli.ref
+++ b/test/passing/tests/sig_value.mli.ref
@@ -1,25 +1,25 @@
-val f : f:(string[@att]) (** doc *) -> unit
+val f: f:(string[@att]) (** doc *) -> unit
 
-val f :
+val f:
      f:(string[@att])
        (** doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc
            doc doc doc doc doc doc doc *)
   -> unit
 
-val f : f:(string[@att]) -> unit
+val f: f:(string[@att]) -> unit
 
-val f : f:string (** doc *) -> unit
+val f: f:string (** doc *) -> unit
 
-val f : f:(string * string[@att]) (** doc *) -> unit
+val f: f:(string * string[@att]) (** doc *) -> unit
 
-val f :
+val f:
      f:(string * string[@att])
        (** doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc doc
            doc doc doc doc doc doc doc *)
   -> unit
 
-val f : f:(string * string[@att]) -> unit
+val f: f:(string * string[@att]) -> unit
 
-val f : f:string * string (** doc *) -> unit
+val f: f:string * string (** doc *) -> unit
 
-val f : t/1 -> f:(unit -> unit t/2) -> unit M/2.t
+val f: t/1 -> f:(unit -> unit t/2) -> unit M/2.t

--- a/test/passing/tests/single_line.mli
+++ b/test/passing/tests/single_line.mli
@@ -1,6 +1,6 @@
 [@@@ocamlformat "module-item-spacing=compact"]
 
-val xx_xxxxxxxx : t -> bool
-val xx_xxxxxxxx : t -> bool
-val xxxxxxxx : t -> [> `Xxxxxxx | `Xxxxxxxxxxx | `Xxxxxxxxxx | `Xxxxxxxxxxxxx]
-val xxxxx : t -> t -> t Xxx.t option
+val xx_xxxxxxxx: t -> bool
+val xx_xxxxxxxx: t -> bool
+val xxxxxxxx: t -> [> `Xxxxxxx | `Xxxxxxxxxxx | `Xxxxxxxxxx | `Xxxxxxxxxxxxx]
+val xxxxx: t -> t -> t Xxx.t option

--- a/test/passing/tests/single_line.mli.err
+++ b/test/passing/tests/single_line.mli.err
@@ -1,1 +1,0 @@
-Warning: tests/single_line.mli:4 exceeds the margin

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -59,9 +59,9 @@ let ([%foo? Bar x | Baz x] : [%foo? #bar]) = [%foo? {x}]
 
 let ([%foo: include S with type t = t] :
       [%foo:
-        val x : t
+        val x: t
 
-        val y : t] ) =
+        val y: t] ) =
   [%foo: type t = t]
 
 let int_with_custom_modifier =
@@ -155,9 +155,9 @@ class type t =
   object
     inherit t [@@foo]
 
-    val x : t [@@foo]
+    val x: t [@@foo]
 
-    val mutable x : t [@@foo]
+    val mutable x: t [@@foo]
 
     method x : t [@@foo]
 
@@ -217,7 +217,7 @@ class%foo x = x [@@foo]
 
 class type%foo x = x [@@foo]
 
-external%foo x : _ = "" [@@foo]
+external%foo x: _ = "" [@@foo]
 
 exception%foo X [@foo]
 
@@ -234,9 +234,9 @@ open%foo M [@@foo]
 
 (* Signature items *)
 module type S = sig
-  val%foo x : t [@@foo]
+  val%foo x: t [@@foo]
 
-  external%foo x : t = "" [@@foo]
+  external%foo x: t = "" [@@foo]
 
   type%foo t = int [@@foo]
 
@@ -639,20 +639,20 @@ module Msg : sig
 
   type result = Result : 'a tag * 'a -> result
 
-  val write : 'a tag -> 'a -> unit
+  val write: 'a tag -> 'a -> unit
 
-  val read : unit -> result
+  val read: unit -> result
 
   type 'a tag += Int : int tag
 
   module type Desc = sig
     type t
 
-    val label : string
+    val label: string
 
-    val write : t -> string
+    val write: t -> string
 
-    val read : string -> t
+    val read: string -> t
   end
 
   module Define (D : Desc) : sig
@@ -712,11 +712,11 @@ end = struct
   module type Desc = sig
     type t
 
-    val label : string
+    val label: string
 
-    val write : t -> string
+    val write: t -> string
 
-    val read : string -> t
+    val read: string -> t
   end
 
   module Define (D : Desc) = struct
@@ -786,11 +786,11 @@ let () =
 module type S = sig
   type t
 
-  val to_string : t -> string
+  val to_string: t -> string
 
-  val apply : t -> t
+  val apply: t -> t
 
-  val x : t
+  val x: t
 end
 
 let create (type s) to_string apply x =
@@ -832,11 +832,11 @@ let () =
 module TypEq : sig
   type ('a, 'b) t
 
-  val apply : ('a, 'b) t -> 'a -> 'b
+  val apply: ('a, 'b) t -> 'a -> 'b
 
-  val refl : ('a, 'a) t
+  val refl: ('a, 'a) t
 
-  val sym : ('a, 'b) t -> ('b, 'a) t
+  val sym: ('a, 'b) t -> ('b, 'a) t
 end = struct
   type ('a, 'b) t = unit
 
@@ -855,11 +855,11 @@ module rec Typ : sig
 
     type t2
 
-    val eq : (t, t1 * t2) TypEq.t
+    val eq: (t, t1 * t2) TypEq.t
 
-    val t1 : t1 Typ.typ
+    val t1: t1 Typ.typ
 
-    val t2 : t2 Typ.typ
+    val t2: t2 Typ.typ
   end
 
   type 'a typ =
@@ -874,11 +874,11 @@ end = struct
 
     type t2
 
-    val eq : (t, t1 * t2) TypEq.t
+    val eq: (t, t1 * t2) TypEq.t
 
-    val t1 : t1 Typ.typ
+    val t1: t1 Typ.typ
 
-    val t2 : t2 Typ.typ
+    val t2: t2 Typ.typ
   end
 
   type 'a typ =
@@ -911,7 +911,7 @@ let pair (type s1 s2) t1 t2 =
   Pair pair
 
 module rec Print : sig
-  val to_string : 'a Typ.typ -> 'a -> string
+  val to_string: 'a Typ.typ -> 'a -> string
 end = struct
   let to_string (type s) t x =
     match t with
@@ -948,7 +948,7 @@ let _f (x : (module X.S)) : (module Y.S) = x
 
 (* PR#6194, main example *)
 module type S3 = sig
-  val x : bool
+  val x: bool
 end
 
 let f = function
@@ -2350,7 +2350,7 @@ end
 module B : sig
   type (_, _) t = Eq : ('a, 'a) t
 
-  val f : 'a -> 'b -> ('a, 'b) t
+  val f: 'a -> 'b -> ('a, 'b) t
 end = struct
   type (_, _) t = Eq : ('a, 'a) t
 
@@ -2428,7 +2428,7 @@ type (_, _) t = Any : ('a, 'b) t | Eq : ('a, 'a) t
 module M : sig
   type s = private [> `A]
 
-  val eq : (s, [`A | `B]) t
+  val eq: (s, [`A | `B]) t
 end = struct
   type s = [`A | `B]
 
@@ -2442,7 +2442,7 @@ let () = print_endline (f M.eq)
 module N : sig
   type s = private < a: int ; .. >
 
-  val eq : (s, < a: int ; b: bool >) t
+  val eq: (s, < a: int ; b: bool >) t
 end = struct
   type s = < a: int ; b: bool >
 
@@ -2460,7 +2460,7 @@ end
 module M : sig
   type t = T
 
-  val comp : (U.t, t) comp
+  val comp: (U.t, t) comp
 end = struct
   include U
 
@@ -2477,7 +2477,7 @@ end
 module M : sig
   type t = {x: int}
 
-  val comp : (U.t, t) comp
+  val comp: (U.t, t) comp
 end = struct
   include U
 
@@ -2616,7 +2616,7 @@ end
 and B : sig
   type t
 
-  val eq : (B.t list, t) eqp
+  val eq: (B.t list, t) eqp
 end = struct
   type t = A.t
 
@@ -2668,7 +2668,7 @@ type (_, _) eq = Refl : ('a, 'a) eq
 let bad (type a) =
   let module N = struct
     module rec M : sig
-      val e : (int, a) eq
+      val e: (int, a) eq
     end = struct
       let (Refl : (int, a) eq) = M.e (* must fail for soundness *)
 
@@ -3012,7 +3012,7 @@ module FM_valid : S
 module Foo : sig
   type t
 
-  val x : t ref
+  val x: t ref
 end = struct
   type t = int
 
@@ -3026,7 +3026,7 @@ module Foo : sig type t val x : t ref end
 module Bar : sig
   type t [@@immediate]
 
-  val x : t ref
+  val x: t ref
 end = struct
   type t = int
 
@@ -3187,7 +3187,7 @@ let sort_cmp (type s) cmp =
 module type S = sig
   type t
 
-  val x : t
+  val x: t
 end
 
 let f (module M : S with type t = int) = M.x
@@ -3225,7 +3225,7 @@ let f {s= (module M)} = M.x
 let f {s= (module M)} {s= (module N)} = M.x + N.x
 
 module type S = sig
-  val x : int
+  val x: int
 end
 
 let f (module M : S) y (module N : S) = M.x + y + N.x
@@ -3264,7 +3264,7 @@ class c =
 module M = (val m)
 
 module type S' = sig
-  val f : int -> int
+  val f: int -> int
 end
 ;;
 
@@ -3283,7 +3283,7 @@ module type S = sig
 
   type u
 
-  val x : t * u
+  val x: t * u
 end
 
 let f (l : (module S with type t = int and type u = bool) list) =
@@ -3295,11 +3295,11 @@ let f (l : (module S with type t = int and type u = bool) list) =
 module TypEq : sig
   type ('a, 'b) t
 
-  val apply : ('a, 'b) t -> 'a -> 'b
+  val apply: ('a, 'b) t -> 'a -> 'b
 
-  val refl : ('a, 'a) t
+  val refl: ('a, 'a) t
 
-  val sym : ('a, 'b) t -> ('b, 'a) t
+  val sym: ('a, 'b) t -> ('b, 'a) t
 end = struct
   type ('a, 'b) t = ('a -> 'b) * ('b -> 'a)
 
@@ -3318,11 +3318,11 @@ module rec Typ : sig
 
     and t2
 
-    val eq : (t, t1 * t2) TypEq.t
+    val eq: (t, t1 * t2) TypEq.t
 
-    val t1 : t1 Typ.typ
+    val t1: t1 Typ.typ
 
-    val t2 : t2 Typ.typ
+    val t2: t2 Typ.typ
   end
 
   type 'a typ =
@@ -3371,9 +3371,9 @@ module type MapT = sig
 
   type map
 
-  val of_t : data t -> map
+  val of_t: data t -> map
 
-  val to_t : map -> data t
+  val to_t: map -> data t
 end
 
 type ('k, 'd, 'm) map =
@@ -4078,20 +4078,18 @@ module Permissioned : sig
   type ('a, -'perms) t
 
   include sig
-    val t_of_sexp :
-      (sexp -> 'a) -> (sexp -> 'perms) -> sexp -> ('a, 'perms) t
+    val t_of_sexp: (sexp -> 'a) -> (sexp -> 'perms) -> sexp -> ('a, 'perms) t
 
-    val sexp_of_t :
-      ('a -> sexp) -> ('perms -> sexp) -> ('a, 'perms) t -> sexp
+    val sexp_of_t: ('a -> sexp) -> ('perms -> sexp) -> ('a, 'perms) t -> sexp
   end
 
   module Int : sig
     type nonrec -'perms t = (int, 'perms) t
 
     include sig
-      val t_of_sexp : (sexp -> 'perms) -> sexp -> 'perms t
+      val t_of_sexp: (sexp -> 'perms) -> sexp -> 'perms t
 
-      val sexp_of_t : ('perms -> sexp) -> 'perms t -> sexp
+      val sexp_of_t: ('perms -> sexp) -> 'perms t -> sexp
     end
   end
 end = struct
@@ -4140,7 +4138,7 @@ let r = {{x= 0; y= 0} with x= 0}
 
 let r' : string foo = r
 
-external foo : int = "%ignore"
+external foo: int = "%ignore"
 
 let _ = foo ()
 
@@ -4180,9 +4178,9 @@ module type PR6505 = sig
 
   and 'o abs constraint 'o = 'o is_an_object
 
-  val abs : 'o is_an_object -> 'o abs
+  val abs: 'o is_an_object -> 'o abs
 
-  val unabs : 'o abs -> 'o
+  val unabs: 'o abs -> 'o
 end
 
 (* fails *)
@@ -4403,7 +4401,7 @@ module X = struct
   module type SIG = sig
     type t = int
 
-    val x : t
+    val x: t
   end
 
   module F (Y : SIG) : SIG = struct
@@ -4425,7 +4423,7 @@ module X2 = struct
   module type SIG = sig
     type t = int
 
-    val x : t
+    val x: t
   end
 
   module F (Y : SIG) (Z : SIG) = struct
@@ -4448,7 +4446,7 @@ module F (M : sig
 
   type 'a u = string
 
-  val f : unit -> _ u t
+  val f: unit -> _ u t
 end) =
 struct
   let t = M.f ()
@@ -4467,16 +4465,16 @@ module T = struct
 end
 
 module Good : sig
-  val bar : t
+  val bar: t
 
-  val foo : t -> t -> unit
+  val foo: t -> t -> unit
 end =
   T
 
 module Bad : sig
-  val foo : t -> t -> unit
+  val foo: t -> t -> unit
 
-  val bar : t
+  val bar: t
 end =
   T
 
@@ -4515,7 +4513,7 @@ end
 module type S = sig
   type t
 
-  val x : t
+  val x: t
 end
 
 module Float = struct
@@ -4569,7 +4567,7 @@ module type S = sig
   include Set.S
 
   module E : sig
-    val x : int
+    val x: int
   end
 end
 
@@ -4784,7 +4782,7 @@ module M = struct
   module type S = sig
     type a
 
-    val v : a
+    val v: a
   end
 
   type 'a s = (module S with type a = 'a)
@@ -4853,26 +4851,26 @@ module G (X : F(N).S) : F(M).S = X
 module M : sig
   type make_dec
 
-  val add_dec : make_dec -> unit
+  val add_dec: make_dec -> unit
 end = struct
   type u
 
   module Fast : sig
     type 'd t
 
-    val create : unit -> 'd t
+    val create: unit -> 'd t
 
     module type S = sig
       module Data : sig
         type t
       end
 
-      val key : Data.t t
+      val key: Data.t t
     end
 
     module Register (D : S) : sig end
 
-    val attach : 'd t -> 'd -> unit
+    val attach: 'd t -> 'd -> unit
   end = struct
     type 'd t = unit
 
@@ -4883,7 +4881,7 @@ end = struct
         type t
       end
 
-      val key : Data.t t
+      val key: Data.t t
     end
 
     module Register (D : S) = struct end
@@ -4916,7 +4914,7 @@ module Simple = struct
       type t
     end
 
-    val key : Data.t t
+    val key: Data.t t
   end
 
   module Register (D : S) = struct
@@ -4944,7 +4942,7 @@ module Simple2 = struct
       type t
     end
 
-    val key : Data.t t
+    val key: Data.t t
   end
 
   module M = struct
@@ -4965,9 +4963,9 @@ module Simple2 = struct
 end
 
 module rec M : sig
-  external f : int -> int = "%identity"
+  external f: int -> int = "%identity"
 end = struct
-  external f : int -> int = "%identity"
+  external f: int -> int = "%identity"
 end
 (* with module *)
 
@@ -5006,7 +5004,7 @@ class type c =
   end
 
 module M : sig
-  val v : (#c as 'a) -> 'a
+  val v: (#c as 'a) -> 'a
 end = struct
   let v x =
     ignore (x :> c) ;
@@ -5115,7 +5113,7 @@ M'.N'.x
 
 module M'' : sig
   module N' : sig
-    val x : int
+    val x: int
   end
 end =
   M'
@@ -5129,7 +5127,7 @@ end
 
 module M3 : sig
   module N' : sig
-    val x : int
+    val x: int
   end
 end = struct
   include M'
@@ -5140,7 +5138,7 @@ M3.N'.x
 
 module M3' : sig
   module N' : sig
-    val x : int
+    val x: int
   end
 end =
   M2
@@ -5150,7 +5148,7 @@ M3'.N'.x
 
 module M4 : sig
   module N' : sig
-    val x : int
+    val x: int
   end
 end = struct
   module N = struct
@@ -5173,7 +5171,7 @@ end
 
 module G : functor (X : sig end) -> sig
   module N' : sig
-    val x : int
+    val x: int
   end
 end =
   F
@@ -5196,7 +5194,7 @@ end
 
 module M1 : sig
   module N : sig
-    val x : int
+    val x: int
   end
 
   module N' = N
@@ -5208,13 +5206,13 @@ M1.N'.x
 
 module M2 : sig
   module N' : sig
-    val x : int
+    val x: int
   end
 end = (
   M :
     sig
       module N : sig
-        val x : int
+        val x: int
       end
 
       module N' = N
@@ -5234,7 +5232,7 @@ end
 
 module M1 : sig
   module C : sig
-    val escaped : char -> string
+    val escaped: char -> string
   end
 
   module C' = C
@@ -5247,13 +5245,13 @@ M1.C'.escaped 'A'
 
 module M2 : sig
   module C' : sig
-    val chr : int -> char
+    val chr: int -> char
   end
 end = (
   M :
     sig
       module C : sig
-        val chr : int -> char
+        val chr: int -> char
       end
 
       module C' = C
@@ -5466,7 +5464,7 @@ module type S = sig
   module M : sig
     type t
 
-    val x : t
+    val x: t
   end
 end
 
@@ -5582,7 +5580,7 @@ end
 
 module rec R : sig
   module M : sig
-    val f : 'a -> 'a
+    val f: 'a -> 'a
   end
 end = struct
   module M = M
@@ -5684,7 +5682,7 @@ module type S3 = sig
 
   type t
 
-  val x : int
+  val x: int
 end
 
 let g3 x = (x : (module S3 with type t = 'a and type u = 'b) :> (module S'))
@@ -5694,7 +5692,7 @@ let g3 x = (x : (module S3 with type t = 'a and type u = 'b) :> (module S'))
 
 (* Without type *)
 module type S = sig
-  val x : int
+  val x: int
 end
 
 let v =
@@ -5716,7 +5714,7 @@ module H (X : sig end) = (val v)
 module type S = sig
   type t
 
-  val x : t
+  val x: t
 end
 
 let v =
@@ -5892,7 +5890,7 @@ module M : sig
   class c :
     'a
     -> object
-         val x : 'b
+         val x: 'b
        end
 end = struct
   class c x =
@@ -6225,7 +6223,7 @@ end
 type 'par t = 'par
 
 module M : sig
-  val x : < m: 'a. 'a >
+  val x: < m: 'a. 'a >
 end = struct
   let x : < m: 'a. 'a t > = Obj.magic ()
 end
@@ -6365,9 +6363,9 @@ let f flag =
 module type S = sig
   type +'a t
 
-  val foo : [`A] t -> unit
+  val foo: [`A] t -> unit
 
-  val bar : [< `A | `B] t -> unit
+  val bar: [< `A | `B] t -> unit
 end
 
 module Make (T : S) = struct
@@ -6385,11 +6383,11 @@ type 'a termk = [`Dia of 'a | `Box of 'a | 'a termpc]
 module type T = sig
   type term
 
-  val map : (term -> term) -> term -> term
+  val map: (term -> term) -> term -> term
 
-  val nnf : term -> term
+  val nnf: term -> term
 
-  val nnf_not : term -> term
+  val nnf_not: term -> term
 end
 
 module Fpc (X : T with type term = private [> 'a termpc] as 'a) = struct
@@ -6443,7 +6441,7 @@ and sexp = private untyped wrapped
 
 class type ['a] s3 =
   object
-    val underlying : 'a t
+    val underlying: 'a t
   end
 
 class ['a] s3object r : ['a] s3 =
@@ -6547,7 +6545,7 @@ end =
 module Bar : sig
   type t = private Foobar.t
 
-  val f : int -> t
+  val f: int -> t
 end = struct
   type t = int
 
@@ -6559,7 +6557,7 @@ end
 module M : sig
   type t = private T of int
 
-  val mk : int -> t
+  val mk: int -> t
 end = struct
   type t = T of int
 
@@ -6569,7 +6567,7 @@ end
 module M1 : sig
   type t = M.t
 
-  val mk : int -> t
+  val mk: int -> t
 end = struct
   type t = M.t
 
@@ -6579,7 +6577,7 @@ end
 module M2 : sig
   type t = M.t
 
-  val mk : int -> t
+  val mk: int -> t
 end = struct
   include M
 end
@@ -6587,14 +6585,14 @@ end
 module M3 : sig
   type t = M.t
 
-  val mk : int -> t
+  val mk: int -> t
 end =
   M
 
 module M4 : sig
   type t = M.t = T of int
 
-  val mk : int -> t
+  val mk: int -> t
 end =
   M
 
@@ -6603,14 +6601,14 @@ end =
 module M5 : sig
   type t = M.t = private T of int
 
-  val mk : int -> t
+  val mk: int -> t
 end =
   M
 
 module M6 : sig
   type t = private T of int
 
-  val mk : int -> t
+  val mk: int -> t
 end =
   M
 
@@ -6619,7 +6617,7 @@ module M' : sig
 
   type t = t_priv
 
-  val mk : int -> t
+  val mk: int -> t
 end = struct
   type t_priv = T of int
 
@@ -6631,7 +6629,7 @@ end
 module M3' : sig
   type t = M'.t
 
-  val mk : int -> t
+  val mk: int -> t
 end =
   M'
 
@@ -6879,7 +6877,7 @@ module PR_4450_2 = struct
 
     and 'a t = private < map: 'b. ('a -> 'b) -> 'b wrap ; .. >
 
-    val create : 'a list -> 'a t
+    val create: 'a list -> 'a t
   end
 
   module MyMap (X : MyT) = struct
@@ -6897,7 +6895,7 @@ module PR_4450_2 = struct
 
     and 'a t = < map: 'b. ('a -> 'b) -> 'b wrap >
 
-    val create : 'a list -> 'a t
+    val create: 'a list -> 'a t
   end = struct
     include MyMap (MyList)
 
@@ -6911,7 +6909,7 @@ end
 module type ORD = sig
   type t
 
-  val compare : t -> t -> int
+  val compare: t -> t -> int
 end
 
 module type SET = sig
@@ -6919,7 +6917,7 @@ module type SET = sig
 
   type t
 
-  val iter : (elt -> unit) -> t -> unit
+  val iter: (elt -> unit) -> t -> unit
 end
 
 type 'a tree = E | N of 'a tree * 'a * 'a tree
@@ -6932,9 +6930,9 @@ struct
   module rec Elt : sig
     type t = I of int * int | D of int * Diet.t * int
 
-    val compare : t -> t -> int
+    val compare: t -> t -> int
 
-    val iter : (int -> unit) -> t -> unit
+    val iter: (int -> unit) -> t -> unit
   end = struct
     type t = I of int * int | D of int * Diet.t * int
 
@@ -7020,7 +7018,7 @@ module PR_4557 = struct
 
       type t = XSet.t XMap.t
 
-      val compare : t -> t -> int
+      val compare: t -> t -> int
     end = struct
       module XSet = Set.Make (X)
       module XMap = Map.Make (X)
@@ -7054,7 +7052,7 @@ module F (X : Set.OrderedType) = struct
 
     type t = XSet.t XMap.t
 
-    val compare : t -> t -> int
+    val compare: t -> t -> int
   end = struct
     module XSet = Set.Make (X)
     module XMap = Map.Make (X)
@@ -7080,7 +7078,7 @@ let test number result expected =
 module rec A : sig
   type t = Leaf of int | Node of ASet.t
 
-  val compare : t -> t -> int
+  val compare: t -> t -> int
 end = struct
   type t = Leaf of int | Node of ASet.t
 
@@ -7106,7 +7104,7 @@ let _ =
 (* Simple value recursion *)
 
 module rec Fib : sig
-  val f : int -> int
+  val f: int -> int
 end = struct
   let f x = if x < 2 then 1 else Fib.f (x - 1) + Fib.f (x - 2)
 end
@@ -7116,7 +7114,7 @@ let _ = test 20 (Fib.f 10) 89
 (* Update function by infix *)
 
 module rec Fib2 : sig
-  val f : int -> int
+  val f: int -> int
 end = struct
   let rec g x = Fib2.f (x - 1) + Fib2.f (x - 2)
 
@@ -7132,7 +7130,7 @@ let _ =
     try
       let module A = struct
         module rec Bad : sig
-          val f : int -> int
+          val f: int -> int
         end = struct
           let f =
             let y = Bad.f 5 in
@@ -7152,13 +7150,13 @@ let _ =
 (* Reordering of evaluation based on dependencies *)
 
 module rec After : sig
-  val x : int
+  val x: int
 end = struct
   let x = Before.x + 1
 end
 
 and Before : sig
-  val x : int
+  val x: int
 end = struct
   let x = 3
 end
@@ -7170,7 +7168,7 @@ let _ = test 40 After.x 4
 module rec Strengthen : sig
   type t
 
-  val f : t -> t
+  val f: t -> t
 end = struct
   type t = A | B
 
@@ -7182,7 +7180,7 @@ end
 module rec Strengthen2 : sig
   type t
 
-  val f : t -> t
+  val f: t -> t
 
   module M : sig
     type u
@@ -7220,7 +7218,7 @@ end
 module rec PolyRec : sig
   type 'a t = Leaf of 'a | Node of 'a list t * 'a list t
 
-  val depth : 'a t -> int
+  val depth: 'a t -> int
 end = struct
   type 'a t = Leaf of 'a | Node of 'a list t * 'a list t
 
@@ -7256,11 +7254,11 @@ module rec Expr : sig
     | Add of t * t
     | Binding of Binding.t * t
 
-  val make_let : string -> t -> t -> t
+  val make_let: string -> t -> t -> t
 
-  val fv : t -> StringSet.t
+  val fv: t -> StringSet.t
 
-  val simpl : t -> t
+  val simpl: t -> t
 end = struct
   type t =
     | Var of string
@@ -7290,11 +7288,11 @@ end
 and Binding : sig
   type t = (string * Expr.t) list
 
-  val fv : t -> StringSet.t
+  val fv: t -> StringSet.t
 
-  val bv : t -> StringSet.t
+  val bv: t -> StringSet.t
 
-  val simpl : t -> t
+  val simpl: t -> t
 end = struct
   type t = (string * Expr.t) list
 
@@ -7322,11 +7320,11 @@ let _ =
 module type ORDERED = sig
   type t
 
-  val eq : t -> t -> bool
+  val eq: t -> t -> bool
 
-  val lt : t -> t -> bool
+  val lt: t -> t -> bool
 
-  val leq : t -> t -> bool
+  val leq: t -> t -> bool
 end
 
 module type HEAP = sig
@@ -7334,17 +7332,17 @@ module type HEAP = sig
 
   type heap
 
-  val empty : heap
+  val empty: heap
 
-  val isEmpty : heap -> bool
+  val isEmpty: heap -> bool
 
-  val insert : Elem.t -> heap -> heap
+  val insert: Elem.t -> heap -> heap
 
-  val merge : heap -> heap -> heap
+  val merge: heap -> heap -> heap
 
-  val findMin : heap -> Elem.t
+  val findMin: heap -> Elem.t
 
-  val deleteMin : heap -> heap
+  val deleteMin: heap -> heap
 end
 
 module Bootstrap (MakeH : functor (Element : ORDERED) ->
@@ -7355,11 +7353,11 @@ module Bootstrap (MakeH : functor (Element : ORDERED) ->
   module rec BE : sig
     type t = E | H of Elem.t * PrimH.heap
 
-    val eq : t -> t -> bool
+    val eq: t -> t -> bool
 
-    val lt : t -> t -> bool
+    val lt: t -> t -> bool
 
-    val leq : t -> t -> bool
+    val leq: t -> t -> bool
   end = struct
     type t = E | H of Elem.t * PrimH.heap
 
@@ -7514,7 +7512,7 @@ let _ =
       end
 
       and BadClass2 : sig
-        val x : int
+        val x: int
       end = struct
         let x = (new BadClass1.c)#m
       end
@@ -7525,12 +7523,12 @@ let _ =
 (* Coercions *)
 
 module rec Coerce1 : sig
-  val g : int -> int
+  val g: int -> int
 
-  val f : int -> int
+  val f: int -> int
 end = struct
   module A : sig
-    val f : int -> int
+    val f: int -> int
   end =
     Coerce1
 
@@ -7554,7 +7552,7 @@ module CoerceF (S : sig end) = struct
 end
 
 module rec Coerce2 : sig
-  val f1 : unit -> int
+  val f1: unit -> int
 end =
   CoerceF (Coerce3)
 
@@ -7563,7 +7561,7 @@ and Coerce3 : sig end = struct end
 let _ = test 81 (Coerce2.f1 ()) 1
 
 module Coerce4 (A : sig
-  val f : int -> int
+  val f: int -> int
 end) =
 struct
   let x = 0
@@ -7572,9 +7570,9 @@ struct
 end
 
 module rec Coerce5 : sig
-  val blabla : int -> int
+  val blabla: int -> int
 
-  val f : int -> int
+  val f: int -> int
 end = struct
   let blabla x = 0
 
@@ -7582,7 +7580,7 @@ end = struct
 end
 
 and Coerce6 : sig
-  val at : int -> int
+  val at: int -> int
 end =
   Coerce4 (Coerce5)
 
@@ -7593,7 +7591,7 @@ let _ = test 82 (Coerce6.at 100) 5
 module rec F : sig
   type t = X of int | Y of int
 
-  val f : t -> bool
+  val f: t -> bool
 end = struct
   type t = X of int | Y of int
 
@@ -7606,7 +7604,7 @@ let _ =
 
 (* PR#4316 *)
 module G (S : sig
-  val x : int Lazy.t
+  val x: int Lazy.t
 end) =
 struct
   include S
@@ -7619,7 +7617,7 @@ end
 let _ = Lazy.force M1.x
 
 module rec M2 : sig
-  val x : int Lazy.t
+  val x: int Lazy.t
 end =
   G (M1)
 
@@ -7628,7 +7626,7 @@ let _ = test 102 (Lazy.force M2.x) 3
 let _ = Gc.full_major () (* will shortcut forwarding in M1.x *)
 
 module rec M3 : sig
-  val x : int Lazy.t
+  val x: int Lazy.t
 end =
   G (M1)
 
@@ -7686,7 +7684,7 @@ module type S = sig
 end
 
 module F (X : sig
-  val x : (module S)
+  val x: (module S)
 end) =
 struct
   module A = (val X.x)
@@ -7758,9 +7756,9 @@ module M : sig
 
   and v = v t
 
-  val f : int -> u
+  val f: int -> u
 
-  val g : v -> bool
+  val g: v -> bool
 end = struct
   type 'a t = 'a
 
@@ -7942,14 +7940,14 @@ end
 module type CORE0 = sig
   module V : VALUE
 
-  val setglobal : V.state -> string -> V.value -> unit
+  val setglobal: V.state -> string -> V.value -> unit
   (* five more functions common to core and evaluator *)
 end
 
 module type CORE = sig
   include CORE0
 
-  val apply : V.value -> V.state -> V.value list -> V.value
+  val apply: V.value -> V.state -> V.value list -> V.value
   (* apply function f in state s to list of args *)
 end
 
@@ -7960,7 +7958,7 @@ module type AST = sig
 
   type program
 
-  val get_value : chunk -> Value.value
+  val get_value: chunk -> Value.value
 end
 
 module type EVALUATOR = sig
@@ -7974,7 +7972,7 @@ module type EVALUATOR = sig
 
   exception Error of string
 
-  val compile : Ast.program -> string
+  val compile: Ast.program -> string
 
   include CORE0 with module V := Value
 end
@@ -7982,7 +7980,7 @@ end
 module type PARSER = sig
   type chunk
 
-  val parse : string -> chunk
+  val parse: string -> chunk
 end
 
 module type INTERP = sig
@@ -7990,17 +7988,17 @@ module type INTERP = sig
 
   module Parser : PARSER with type chunk = Ast.chunk
 
-  val dostring : state -> string -> value list
+  val dostring: state -> string -> value list
 
-  val mk : unit -> state
+  val mk: unit -> state
 end
 
 module type USERTYPE = sig
   type t
 
-  val eq : t -> t -> bool
+  val eq: t -> t -> bool
 
-  val to_string : t -> string
+  val to_string: t -> string
 end
 
 module type TYPEVIEW = sig
@@ -8008,7 +8006,7 @@ module type TYPEVIEW = sig
 
   type t
 
-  val map : (combined -> t) * (t -> combined)
+  val map: (combined -> t) * (t -> combined)
 end
 
 module type COMBINED_COMMON = sig
@@ -8030,7 +8028,7 @@ end
 module type BARECODE = sig
   type state
 
-  val init : state -> unit
+  val init: state -> unit
 end
 
 module USERCODE (X : TYPEVIEW) = struct
@@ -8068,13 +8066,13 @@ with module M = M
 module type Printable = sig
   type t
 
-  val print : Format.formatter -> t -> unit
+  val print: Format.formatter -> t -> unit
 end
 
 module type Comparable = sig
   type t
 
-  val compare : t -> t -> int
+  val compare: t -> t -> int
 end
 
 module type PrintableComparable = sig
@@ -8103,7 +8101,7 @@ module type ComparableInt = Comparable with type t := int
 module type S = sig
   type t
 
-  val f : t -> t
+  val f: t -> t
 end
 
 module type S' = S with type t := int
@@ -8111,7 +8109,7 @@ module type S' = S with type t := int
 module type S = sig
   type 'a t
 
-  val map : ('a -> 'b) -> 'a t -> 'b t
+  val map: ('a -> 'b) -> 'a t -> 'b t
 end
 
 module type S1 = S with type 'a t := 'a list
@@ -8129,7 +8127,7 @@ module type S = sig
     type arg
   end
 
-  val f : T.exp -> T.arg
+  val f: T.exp -> T.arg
 end
 
 module M = struct
@@ -8185,156 +8183,156 @@ class ['a] c =
 
 (* Fails *)
 
-external a : (int[@untagged]) -> unit = "a" "a_nat"
+external a: (int[@untagged]) -> unit = "a" "a_nat"
 
-external b : (int32[@unboxed]) -> unit = "b" "b_nat"
+external b: (int32[@unboxed]) -> unit = "b" "b_nat"
 
-external c : (int64[@unboxed]) -> unit = "c" "c_nat"
+external c: (int64[@unboxed]) -> unit = "c" "c_nat"
 
-external d : (nativeint[@unboxed]) -> unit = "d" "d_nat"
+external d: (nativeint[@unboxed]) -> unit = "d" "d_nat"
 
-external e : (float[@unboxed]) -> unit = "e" "e_nat"
+external e: (float[@unboxed]) -> unit = "e" "e_nat"
 
 type t = private int
 
-external f : (t[@untagged]) -> unit = "f" "f_nat"
+external f: (t[@untagged]) -> unit = "f" "f_nat"
 
 module M : sig
-  external a : int -> (int[@untagged]) = "a" "a_nat"
+  external a: int -> (int[@untagged]) = "a" "a_nat"
 
-  external b : (int[@untagged]) -> int = "b" "b_nat"
+  external b: (int[@untagged]) -> int = "b" "b_nat"
 end = struct
-  external a : int -> (int[@untagged]) = "a" "a_nat"
+  external a: int -> (int[@untagged]) = "a" "a_nat"
 
-  external b : (int[@untagged]) -> int = "b" "b_nat"
+  external b: (int[@untagged]) -> int = "b" "b_nat"
 end
 
 module Global_attributes = struct
   [@@@ocaml.warning "-3"]
 
-  external a : float -> float = "a" "noalloc" "a_nat" "float"
+  external a: float -> float = "a" "noalloc" "a_nat" "float"
 
-  external b : float -> float = "b" "noalloc" "b_nat"
+  external b: float -> float = "b" "noalloc" "b_nat"
 
-  external c : float -> float = "c" "c_nat" "float"
+  external c: float -> float = "c" "c_nat" "float"
 
-  external d : float -> float = "d" "noalloc"
+  external d: float -> float = "d" "noalloc"
 
-  external e : float -> float = "e"
+  external e: float -> float = "e"
 
   (* Should output a warning: no native implementation provided *)
-  external f : (int32[@unboxed]) -> (int32[@unboxed]) = "f" "noalloc"
+  external f: (int32[@unboxed]) -> (int32[@unboxed]) = "f" "noalloc"
 
-  external g : int32 -> int32 = "g" "g_nat" [@@unboxed] [@@noalloc]
+  external g: int32 -> int32 = "g" "g_nat" [@@unboxed] [@@noalloc]
 
-  external h : (int[@untagged]) -> (int[@untagged]) = "h" "h_nat" "noalloc"
+  external h: (int[@untagged]) -> (int[@untagged]) = "h" "h_nat" "noalloc"
 
-  external i : int -> int = "i" "i_nat" [@@untagged] [@@noalloc]
+  external i: int -> int = "i" "i_nat" [@@untagged] [@@noalloc]
 end
 
 module Old_style_warning = struct
   [@@@ocaml.warning "+3"]
 
-  external a : float -> float = "a" "noalloc" "a_nat" "float"
+  external a: float -> float = "a" "noalloc" "a_nat" "float"
 
-  external b : float -> float = "b" "noalloc" "b_nat"
+  external b: float -> float = "b" "noalloc" "b_nat"
 
-  external c : float -> float = "c" "c_nat" "float"
+  external c: float -> float = "c" "c_nat" "float"
 
-  external d : float -> float = "d" "noalloc"
+  external d: float -> float = "d" "noalloc"
 
-  external e : float -> float = "c" "float"
+  external e: float -> float = "c" "float"
 end
 
 (* Bad: attributes not reported in the interface *)
 
 module Bad1 : sig
-  external f : int -> int = "f" "f_nat"
+  external f: int -> int = "f" "f_nat"
 end = struct
-  external f : int -> (int[@untagged]) = "f" "f_nat"
+  external f: int -> (int[@untagged]) = "f" "f_nat"
 end
 
 module Bad2 : sig
-  external f : int -> int = "a" "a_nat"
+  external f: int -> int = "a" "a_nat"
 end = struct
-  external f : (int[@untagged]) -> int = "f" "f_nat"
+  external f: (int[@untagged]) -> int = "f" "f_nat"
 end
 
 module Bad3 : sig
-  external f : float -> float = "f" "f_nat"
+  external f: float -> float = "f" "f_nat"
 end = struct
-  external f : float -> (float[@unboxed]) = "f" "f_nat"
+  external f: float -> (float[@unboxed]) = "f" "f_nat"
 end
 
 module Bad4 : sig
-  external f : float -> float = "a" "a_nat"
+  external f: float -> float = "a" "a_nat"
 end = struct
-  external f : (float[@unboxed]) -> float = "f" "f_nat"
+  external f: (float[@unboxed]) -> float = "f" "f_nat"
 end
 
 (* Bad: attributes in the interface but not in the implementation *)
 
 module Bad5 : sig
-  external f : int -> (int[@untagged]) = "f" "f_nat"
+  external f: int -> (int[@untagged]) = "f" "f_nat"
 end = struct
-  external f : int -> int = "f" "f_nat"
+  external f: int -> int = "f" "f_nat"
 end
 
 module Bad6 : sig
-  external f : (int[@untagged]) -> int = "f" "f_nat"
+  external f: (int[@untagged]) -> int = "f" "f_nat"
 end = struct
-  external f : int -> int = "a" "a_nat"
+  external f: int -> int = "a" "a_nat"
 end
 
 module Bad7 : sig
-  external f : float -> (float[@unboxed]) = "f" "f_nat"
+  external f: float -> (float[@unboxed]) = "f" "f_nat"
 end = struct
-  external f : float -> float = "f" "f_nat"
+  external f: float -> float = "f" "f_nat"
 end
 
 module Bad8 : sig
-  external f : (float[@unboxed]) -> float = "f" "f_nat"
+  external f: (float[@unboxed]) -> float = "f" "f_nat"
 end = struct
-  external f : float -> float = "a" "a_nat"
+  external f: float -> float = "a" "a_nat"
 end
 
 (* Bad: unboxed or untagged with the wrong type *)
 
-external g : (float[@untagged]) -> float = "g" "g_nat"
+external g: (float[@untagged]) -> float = "g" "g_nat"
 
-external h : (int[@unboxed]) -> float = "h" "h_nat"
+external h: (int[@unboxed]) -> float = "h" "h_nat"
 
 (* Bad: unboxing the function type *)
-external i : (int -> float[@unboxed]) = "i" "i_nat"
+external i: (int -> float[@unboxed]) = "i" "i_nat"
 
 (* Bad: unboxing a "deep" sub-type. *)
-external j : int -> (float[@unboxed]) * float = "j" "j_nat"
+external j: int -> (float[@unboxed]) * float = "j" "j_nat"
 
 (* This should be rejected, but it is quite complicated to do in the current
    state of things *)
 
-external k : int -> (float[@unboxd]) = "k" "k_nat"
+external k: int -> (float[@unboxd]) = "k" "k_nat"
 
 (* Bad: old style annotations + new style attributes *)
 
-external l : float -> float = "l" "l_nat" "float" [@@unboxed]
+external l: float -> float = "l" "l_nat" "float" [@@unboxed]
 
-external m : (float[@unboxed]) -> float = "m" "m_nat" "float"
+external m: (float[@unboxed]) -> float = "m" "m_nat" "float"
 
-external n : float -> float = "n" "noalloc" [@@noalloc]
+external n: float -> float = "n" "noalloc" [@@noalloc]
 
 (* Warnings: unboxed / untagged without any native implementation *)
-external o : (float[@unboxed]) -> float = "o"
+external o: (float[@unboxed]) -> float = "o"
 
-external p : float -> (float[@unboxed]) = "p"
+external p: float -> (float[@unboxed]) = "p"
 
-external q : (int[@untagged]) -> float = "q"
+external q: (int[@untagged]) -> float = "q"
 
-external r : int -> (int[@untagged]) = "r"
+external r: int -> (int[@untagged]) = "r"
 
-external s : int -> int = "s" [@@untagged]
+external s: int -> int = "s" [@@untagged]
 
-external t : float -> float = "t" [@@unboxed]
+external t: float -> float = "t" [@@unboxed]
 
 let _ = ignore ( + )
 
@@ -8443,7 +8441,7 @@ module A : sig
 
   type b
 
-  val eq : (a, b) cmp
+  val eq: (a, b) cmp
 end = struct
   type a
 
@@ -8535,7 +8533,7 @@ end
 module type T = sig
   type _ is_t = Is : ('a, 'b) TypEq.t -> 'a is_t
 
-  val is_t : unit -> unit is_t option
+  val is_t: unit -> unit is_t option
 end
 
 module Make (M : T) = struct
@@ -8890,7 +8888,7 @@ end = struct
 end
 
 module Unused_exception_outside_patterns : sig
-  val falsity : exn -> bool
+  val falsity: exn -> bool
 end = struct
   exception Nobody_constructs_me
 
@@ -8900,7 +8898,7 @@ end
 module Unused_extension_outside_patterns : sig
   type t = ..
 
-  val falsity : t -> bool
+  val falsity: t -> bool
 end = struct
   type t = ..
 

--- a/test/passing/tests/string.ml.ref
+++ b/test/passing/tests/string.ml.ref
@@ -30,7 +30,7 @@ let f ("test" [@test "test"]) = 2;;
 \ xxxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxxxx \
  xxxxxxxx xxxxxxxxxxx"
 
-external%c print : str:string -> d:int -> void
+external%c print: str:string -> d:int -> void
   = {|
   printf("%s (%d)\n",$str,$d);
   fflush(stdout);

--- a/test/passing/tests/tag_only.mli
+++ b/test/passing/tests/tag_only.mli
@@ -48,7 +48,7 @@ type t
 (** @deprecated *)
 type t = t
 
-val a : b
+val a: b
 (** @deprecated *)
 
 [@@@ocamlformat "doc-comments-tag-only=fit"]
@@ -95,5 +95,5 @@ type t  (** @deprecated *)
 
 type t = t  (** @deprecated *)
 
-val a : b
+val a: b
 (** @deprecated *)

--- a/test/passing/tests/types-compact-space_around-docked.ml.ref
+++ b/test/passing/tests/types-compact-space_around-docked.ml.ref
@@ -77,12 +77,12 @@ type t =
         [ `Moved of Location.t * Location.t * string
         | `Unstable of Location.t * string ] ]
 
-val x :
+val x:
   [ `X of int
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo
@@ -92,12 +92,12 @@ val x :
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of int (* booooom *)
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo

--- a/test/passing/tests/types-compact-space_around.ml.ref
+++ b/test/passing/tests/types-compact-space_around.ml.ref
@@ -75,12 +75,12 @@ type t =
         [ `Moved of Location.t * Location.t * string
         | `Unstable of Location.t * string ] ]
 
-val x :
+val x:
   [ `X of int
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo
@@ -90,12 +90,12 @@ val x :
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of int (* booooom *)
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo

--- a/test/passing/tests/types-compact.ml.ref
+++ b/test/passing/tests/types-compact.ml.ref
@@ -75,12 +75,12 @@ type t =
         [ `Moved of Location.t * Location.t * string
         | `Unstable of Location.t * string ] ]
 
-val x :
+val x:
   [ `X of int
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo
@@ -90,12 +90,12 @@ val x :
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of int (* booooom *)
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo

--- a/test/passing/tests/types-indent.ml.ref
+++ b/test/passing/tests/types-indent.ml.ref
@@ -75,12 +75,12 @@ type t =
             [ `Moved of Location.t * Location.t * string
             | `Unstable of Location.t * string ] ]
 
-val x :
+val x:
   [ `X of int
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo
@@ -90,12 +90,12 @@ val x :
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of int (* booooom *)
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo

--- a/test/passing/tests/types-sparse-space_around.ml.ref
+++ b/test/passing/tests/types-sparse-space_around.ml.ref
@@ -103,13 +103,13 @@ type t =
         ]
       ]
 
-val x :
+val x:
   [ `X of int
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *)
   ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo
@@ -120,13 +120,13 @@ val x :
         fooooooooooooooooooo fooooooooooooooo *)
   ]
 
-val x :
+val x:
   [ `X of int (* booooom *)
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *)
   ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo

--- a/test/passing/tests/types-sparse.ml.ref
+++ b/test/passing/tests/types-sparse.ml.ref
@@ -93,12 +93,12 @@ type t =
         [ `Moved of Location.t * Location.t * string
         | `Unstable of Location.t * string ] ]
 
-val x :
+val x:
   [ `X of int
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo
@@ -108,12 +108,12 @@ val x :
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of int (* booooom *)
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo

--- a/test/passing/tests/types.ml
+++ b/test/passing/tests/types.ml
@@ -75,12 +75,12 @@ type t =
         [ `Moved of Location.t * Location.t * string
         | `Unstable of Location.t * string ] ]
 
-val x :
+val x:
   [ `X of int
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo
@@ -90,12 +90,12 @@ val x :
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of int (* booooom *)
     (** foooooooooooooooo foooooooooooooooooooooooo fooooooooooooooooooooooo
         fooooooooooooooooooo fooooooooooooooo *) ]
 
-val x :
+val x:
   [ `X of
     int
     * foooooooooooooo

--- a/test/unit/test_ast.mli
+++ b/test/unit/test_ast.mli
@@ -1,1 +1,1 @@
-val tests : unit Alcotest.test_case list
+val tests: unit Alcotest.test_case list

--- a/test/unit/test_fmt.mli
+++ b/test/unit/test_fmt.mli
@@ -1,1 +1,1 @@
-val tests : unit Alcotest.test_case list
+val tests: unit Alcotest.test_case list

--- a/test/unit/test_indent.mli
+++ b/test/unit/test_indent.mli
@@ -1,1 +1,1 @@
-val tests : unit Alcotest.test_case list
+val tests: unit Alcotest.test_case list

--- a/test/unit/test_literal_lexer.mli
+++ b/test/unit/test_literal_lexer.mli
@@ -1,1 +1,1 @@
-val tests : unit Alcotest.test_case list
+val tests: unit Alcotest.test_case list

--- a/test/unit/test_translation_unit.mli
+++ b/test/unit/test_translation_unit.mli
@@ -1,3 +1,3 @@
-val tests : unit Alcotest.test_case list
+val tests: unit Alcotest.test_case list
 
-val reindent : source:string -> range:int * int -> int list -> string
+val reindent: source:string -> range:int * int -> int list -> string


### PR DESCRIPTION
Fix #1802

It makes sense to apply this option to values in signatures since it's similar to types of record fields. There is no diff for `conventional` and `janestreet` profiles, but the diff for the `ocamlformat` profile can be seen on the files of ocamlformat itself (@jberdine what do you think?).
This PR adds consistency.

About the future of this option, I was already thinking of making `field-space=tight-decl` the new default, deprecating the 2 other values (loose and tight) in the meantime, that would be done in another PR if we choose to go with it. If it sounds like a good idea I can open another issue for that.