### PR TITLE
Add AST mapping functions over toplevel phrases

### DIFF
--- a/lib/Extended_ast.ml
+++ b/lib/Extended_ast.ml
@@ -24,30 +24,11 @@ type 'a t =
   | Module_type : module_type t
   | Expression : expression t
 
-(* Missing from ocaml_migrate_parsetree *)
-let use_file (mapper : Ast_mapper.mapper) use_file =
-  let open Parsetree in
-  List.map use_file ~f:(fun toplevel_phrase ->
-      match (toplevel_phrase : toplevel_phrase) with
-      | Ptop_def structure -> Ptop_def (mapper.structure mapper structure)
-      | Ptop_dir {pdir_name; pdir_arg; pdir_loc} ->
-          let pdir_arg =
-            match pdir_arg with
-            | None -> None
-            | Some a ->
-                Some {a with pdira_loc= mapper.location mapper a.pdira_loc}
-          in
-          Ptop_dir
-            { pdir_name=
-                {pdir_name with loc= mapper.location mapper pdir_name.loc}
-            ; pdir_arg
-            ; pdir_loc= mapper.location mapper pdir_loc } )
-
 let map (type a) (x : a t) (m : Ast_mapper.mapper) : a -> a =
   match x with
   | Structure -> m.structure m
   | Signature -> m.signature m
-  | Use_file -> use_file m
+  | Use_file -> List.map ~f:(m.toplevel_phrase m)
   | Core_type -> m.typ m
   | Module_type -> m.module_type m
   | Expression -> m.expr m

--- a/lib/Std_ast.ml
+++ b/lib/Std_ast.ml
@@ -24,30 +24,11 @@ type 'a t =
 
 let equal (type a) (_ : a t) : a -> a -> bool = Poly.equal
 
-(* Missing from ocaml_migrate_parsetree *)
-let use_file (mapper : Ast_mapper.mapper) use_file =
-  let open Parsetree in
-  List.map use_file ~f:(fun toplevel_phrase ->
-      match (toplevel_phrase : toplevel_phrase) with
-      | Ptop_def structure -> Ptop_def (mapper.structure mapper structure)
-      | Ptop_dir {pdir_name; pdir_arg; pdir_loc} ->
-          let pdir_arg =
-            match pdir_arg with
-            | None -> None
-            | Some a ->
-                Some {a with pdira_loc= mapper.location mapper a.pdira_loc}
-          in
-          Ptop_dir
-            { pdir_name=
-                {pdir_name with loc= mapper.location mapper pdir_name.loc}
-            ; pdir_arg
-            ; pdir_loc= mapper.location mapper pdir_loc } )
-
 let map (type a) (x : a t) (m : Ast_mapper.mapper) : a -> a =
   match x with
   | Structure -> m.structure m
   | Signature -> m.signature m
-  | Use_file -> use_file m
+  | Use_file -> List.map ~f:(m.toplevel_phrase m)
   | Core_type -> m.typ m
   | Module_type -> m.module_type m
   | Expression -> m.expr m

--- a/vendor/diff-parsers-upstream-std.patch
+++ b/vendor/diff-parsers-upstream-std.patch
@@ -53,6 +53,20 @@
 --- ocaml-4.13-upstream/ast_mapper.ml
 +++ ocaml-4.13/ast_mapper.ml
 @@@@
+   type_exception: mapper -> type_exception -> type_exception;
+   type_kind: mapper -> type_kind -> type_kind;
+   value_binding: mapper -> value_binding -> value_binding;
+   value_description: mapper -> value_description -> value_description;
+   with_constraint: mapper -> with_constraint -> with_constraint;
++  directive_argument: mapper -> directive_argument -> directive_argument;
++  toplevel_directive: mapper -> toplevel_directive -> toplevel_directive;
++  toplevel_phrase: mapper -> toplevel_phrase -> toplevel_phrase;
+ }
+ 
+ let map_fst f (x, y) = (f x, y)
+ let map_snd f (x, y) = (x, f y)
+ let map_tuple f1 f2 (x, y) = (f1 x, f2 y)
+@@@@
      | Pmod_constraint (m, mty) ->
          constraint_ ~loc ~attrs (sub.module_expr sub m)
                      (sub.module_type sub mty)
@@ -76,6 +90,49 @@
      let open Exp in
      let op = map_loc sub pbop_op in
      let pat = sub.pat sub pbop_pat in
+@@@@
+          | PStr x -> PStr (this.structure this x)
+          | PSig x -> PSig (this.signature this x)
+          | PTyp x -> PTyp (this.typ this x)
+          | PPat (x, g) -> PPat (this.pat this x, map_opt (this.expr this) g)
+       );
++
++    directive_argument =
++      (fun this a ->
++         { pdira_desc= a.pdira_desc
++         ; pdira_loc= this.location this a.pdira_loc} );
++
++    toplevel_directive =
++      (fun this d ->
++         { pdir_name= map_loc this d.pdir_name
++         ; pdir_arg= map_opt (this.directive_argument this) d.pdir_arg
++         ; pdir_loc= this.location this d.pdir_loc } );
++
++    toplevel_phrase =
++      (fun this -> function
++         | Ptop_def s -> Ptop_def (this.structure this s)
++         | Ptop_dir d -> Ptop_dir (this.toplevel_directive this d) );
+   }
+ 
+ let extension_of_error {kind; main; sub} =
+   if kind <> Location.Report_error then
+     raise (Invalid_argument "extension_of_error: expected kind Report_error");
+--- ocaml-4.13-upstream/ast_mapper.mli
++++ ocaml-4.13/ast_mapper.mli
+@@@@
+   type_exception: mapper -> type_exception -> type_exception;
+   type_kind: mapper -> type_kind -> type_kind;
+   value_binding: mapper -> value_binding -> value_binding;
+   value_description: mapper -> value_description -> value_description;
+   with_constraint: mapper -> with_constraint -> with_constraint;
++  directive_argument: mapper -> directive_argument -> directive_argument;
++  toplevel_directive: mapper -> toplevel_directive -> toplevel_directive;
++  toplevel_phrase: mapper -> toplevel_phrase -> toplevel_phrase;
+ }
+ (** A mapper record implements one "method" per syntactic category,
+     using an open recursion style: each method takes as its first
+     argument the mapper to be applied to children in the syntax
+     tree. *)
 --- ocaml-4.13-upstream/lexer.mll
 +++ ocaml-4.13/lexer.mll
 @@@@

--- a/vendor/ocaml-4.13-extended/ast_mapper.ml
+++ b/vendor/ocaml-4.13-extended/ast_mapper.ml
@@ -76,6 +76,9 @@ type mapper = {
   value_binding: mapper -> value_binding -> value_binding;
   value_description: mapper -> value_description -> value_description;
   with_constraint: mapper -> with_constraint -> with_constraint;
+  directive_argument: mapper -> directive_argument -> directive_argument;
+  toplevel_directive: mapper -> toplevel_directive -> toplevel_directive;
+  toplevel_phrase: mapper -> toplevel_phrase -> toplevel_phrase;
 }
 
 let map_fst f (x, y) = (f x, y)
@@ -763,6 +766,22 @@ let default_mapper =
          | PTyp x -> PTyp (this.typ this x)
          | PPat (x, g) -> PPat (this.pat this x, map_opt (this.expr this) g)
       );
+
+    directive_argument =
+      (fun this a ->
+         { pdira_desc= a.pdira_desc
+         ; pdira_loc= this.location this a.pdira_loc} );
+
+    toplevel_directive =
+      (fun this d ->
+         { pdir_name= map_loc this d.pdir_name
+         ; pdir_arg= map_opt (this.directive_argument this) d.pdir_arg
+         ; pdir_loc= this.location this d.pdir_loc } );
+
+    toplevel_phrase =
+      (fun this -> function
+         | Ptop_def s -> Ptop_def (this.structure this s)
+         | Ptop_dir d -> Ptop_dir (this.toplevel_directive this d) );
   }
 
 let extension_of_error {kind; main; sub} =

--- a/vendor/ocaml-4.13-extended/ast_mapper.mli
+++ b/vendor/ocaml-4.13-extended/ast_mapper.mli
@@ -105,6 +105,9 @@ type mapper = {
   value_binding: mapper -> value_binding -> value_binding;
   value_description: mapper -> value_description -> value_description;
   with_constraint: mapper -> with_constraint -> with_constraint;
+  directive_argument: mapper -> directive_argument -> directive_argument;
+  toplevel_directive: mapper -> toplevel_directive -> toplevel_directive;
+  toplevel_phrase: mapper -> toplevel_phrase -> toplevel_phrase;
 }
 (** A mapper record implements one "method" per syntactic category,
     using an open recursion style: each method takes as its first

--- a/vendor/ocaml-4.13/ast_mapper.ml
+++ b/vendor/ocaml-4.13/ast_mapper.ml
@@ -76,6 +76,9 @@ type mapper = {
   value_binding: mapper -> value_binding -> value_binding;
   value_description: mapper -> value_description -> value_description;
   with_constraint: mapper -> with_constraint -> with_constraint;
+  directive_argument: mapper -> directive_argument -> directive_argument;
+  toplevel_directive: mapper -> toplevel_directive -> toplevel_directive;
+  toplevel_phrase: mapper -> toplevel_phrase -> toplevel_phrase;
 }
 
 let map_fst f (x, y) = (f x, y)
@@ -754,6 +757,22 @@ let default_mapper =
          | PTyp x -> PTyp (this.typ this x)
          | PPat (x, g) -> PPat (this.pat this x, map_opt (this.expr this) g)
       );
+
+    directive_argument =
+      (fun this a ->
+         { pdira_desc= a.pdira_desc
+         ; pdira_loc= this.location this a.pdira_loc} );
+
+    toplevel_directive =
+      (fun this d ->
+         { pdir_name= map_loc this d.pdir_name
+         ; pdir_arg= map_opt (this.directive_argument this) d.pdir_arg
+         ; pdir_loc= this.location this d.pdir_loc } );
+
+    toplevel_phrase =
+      (fun this -> function
+         | Ptop_def s -> Ptop_def (this.structure this s)
+         | Ptop_dir d -> Ptop_dir (this.toplevel_directive this d) );
   }
 
 let extension_of_error {kind; main; sub} =

--- a/vendor/ocaml-4.13/ast_mapper.mli
+++ b/vendor/ocaml-4.13/ast_mapper.mli
@@ -105,6 +105,9 @@ type mapper = {
   value_binding: mapper -> value_binding -> value_binding;
   value_description: mapper -> value_description -> value_description;
   with_constraint: mapper -> with_constraint -> with_constraint;
+  directive_argument: mapper -> directive_argument -> directive_argument;
+  toplevel_directive: mapper -> toplevel_directive -> toplevel_directive;
+  toplevel_phrase: mapper -> toplevel_phrase -> toplevel_phrase;
 }
 (** A mapper record implements one "method" per syntactic category,
     using an open recursion style: each method takes as its first


### PR DESCRIPTION
Decluttering ocamformat's lib, this should be upstreamed to ocaml (don't merge this one before we get a feedback)