### PR TITLE
Expose Parse.module_type and fix locations in error messages

### DIFF
--- a/lib/Extended_ast.ml
+++ b/lib/Extended_ast.ml
@@ -53,28 +53,6 @@ let map (type a) (x : a t) (m : Ast_mapper.mapper) : a -> a =
   | Expression -> m.expr m
 
 module Parse = struct
-  let implementation = Parse.implementation
-
-  let interface = Parse.interface
-
-  let use_file = Parse.use_file
-
-  let core_type = Parse.core_type
-
-  let module_type (lx : Lexing.lexbuf) =
-    let pre = "module X : " in
-    let lex_buffer_len = lx.lex_buffer_len + String.length pre in
-    let input = Bytes.to_string lx.lex_buffer in
-    let lex_buffer = Bytes.of_string (pre ^ input) in
-    let lx = {lx with lex_buffer; lex_buffer_len} in
-    match interface lx with
-    | [{psig_desc= Psig_module {pmd_type; _}; _}] -> pmd_type
-    | _ ->
-        failwith
-          (Format.sprintf "Syntax error: %s is not a module type" input)
-
-  let expression = Parse.expression
-
   let fix_letop_locs =
     let binding_op (m : Ast_mapper.mapper) b =
       let b' =
@@ -92,12 +70,12 @@ module Parse = struct
     normalize fg
     @@
     match fg with
-    | Structure -> implementation lexbuf
-    | Signature -> interface lexbuf
-    | Use_file -> use_file lexbuf
-    | Core_type -> core_type lexbuf
-    | Module_type -> module_type lexbuf
-    | Expression -> expression lexbuf
+    | Structure -> Parse.implementation lexbuf
+    | Signature -> Parse.interface lexbuf
+    | Use_file -> Parse.use_file lexbuf
+    | Core_type -> Parse.core_type lexbuf
+    | Module_type -> Parse.module_type lexbuf
+    | Expression -> Parse.expression lexbuf
 end
 
 module Pprintast = struct

--- a/lib/Std_ast.ml
+++ b/lib/Std_ast.ml
@@ -53,36 +53,14 @@ let map (type a) (x : a t) (m : Ast_mapper.mapper) : a -> a =
   | Expression -> m.expr m
 
 module Parse = struct
-  let implementation = Parse.implementation
-
-  let interface = Parse.interface
-
-  let use_file = Parse.use_file
-
-  let core_type = Parse.core_type
-
-  let module_type (lx : Lexing.lexbuf) =
-    let pre = "module X : " in
-    let lex_buffer_len = lx.lex_buffer_len + String.length pre in
-    let input = Bytes.to_string lx.lex_buffer in
-    let lex_buffer = Bytes.of_string (pre ^ input) in
-    let lx = {lx with lex_buffer; lex_buffer_len} in
-    match interface lx with
-    | [{psig_desc= Psig_module {pmd_type; _}; _}] -> pmd_type
-    | _ ->
-        failwith
-          (Format.sprintf "Syntax error: %s is not a module type" input)
-
-  let expression = Parse.expression
-
   let ast (type a) (fg : a t) lexbuf : a =
     match fg with
-    | Structure -> implementation lexbuf
-    | Signature -> interface lexbuf
-    | Use_file -> use_file lexbuf
-    | Core_type -> core_type lexbuf
-    | Module_type -> module_type lexbuf
-    | Expression -> expression lexbuf
+    | Structure -> Parse.implementation lexbuf
+    | Signature -> Parse.interface lexbuf
+    | Use_file -> Parse.use_file lexbuf
+    | Core_type -> Parse.core_type lexbuf
+    | Module_type -> Parse.module_type lexbuf
+    | Expression -> Parse.expression lexbuf
 end
 
 module Pprintast = struct

--- a/test/unit/test_translation_unit.ml
+++ b/test/unit/test_translation_unit.ml
@@ -66,9 +66,9 @@ let test_parse_and_format_module_type =
       ~expected:
         (Error
            {|test_unit: ignoring "<test>" (syntax error)
-File "<test>", line 1, characters 14-14:
+File "<test>", line 1, characters 3-3:
 Error: Syntax error: 'end' expected
-File "<test>", line 1, characters 11-14:
+File "<test>", line 1, characters 0-3:
   This 'sig' might be unmatched
 |}
         )

--- a/vendor/diff-parsers-upstream-std.patch
+++ b/vendor/diff-parsers-upstream-std.patch
@@ -230,6 +230,8 @@
 -and core_type = wrap Parser.parse_core_type
 -and expression = wrap Parser.parse_expression
 -and pattern = wrap Parser.parse_pattern
+-let module_type = wrap Parser.parse_module_type
+-let module_expr = wrap Parser.parse_module_expr
 -
 -let longident = wrap Parser.parse_any_longident
 -let val_ident = wrap Parser.parse_val_longident
@@ -244,6 +246,8 @@
 +and core_type = wrap Parser.Incremental.parse_core_type
 +and expression = wrap Parser.Incremental.parse_expression
 +and pattern = wrap Parser.Incremental.parse_pattern
++let module_type = wrap Parser.Incremental.parse_module_type
++let module_expr = wrap Parser.Incremental.parse_module_expr
 +
 +let longident = wrap Parser.Incremental.parse_any_longident
 +let val_ident = wrap Parser.Incremental.parse_val_longident

--- a/vendor/import-ocaml-upstream.sh
+++ b/vendor/import-ocaml-upstream.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-dune exec ../tools/diff-ocaml/diff_ocaml.exe -- import 45612f1 ocaml-4.13-upstream
+dune exec ../tools/diff-ocaml/diff_ocaml.exe -- import 0be3ae6 ocaml-4.13-upstream

--- a/vendor/ocaml-4.13-extended/parse.ml
+++ b/vendor/ocaml-4.13-extended/parse.ml
@@ -125,6 +125,8 @@ and use_file = wrap Parser.Incremental.use_file
 and core_type = wrap Parser.Incremental.parse_core_type
 and expression = wrap Parser.Incremental.parse_expression
 and pattern = wrap Parser.Incremental.parse_pattern
+let module_type = wrap Parser.Incremental.parse_module_type
+let module_expr = wrap Parser.Incremental.parse_module_expr
 
 let longident = wrap Parser.Incremental.parse_any_longident
 let val_ident = wrap Parser.Incremental.parse_val_longident

--- a/vendor/ocaml-4.13-extended/parse.mli
+++ b/vendor/ocaml-4.13-extended/parse.mli
@@ -27,6 +27,8 @@ val use_file : Lexing.lexbuf -> Parsetree.toplevel_phrase list
 val core_type : Lexing.lexbuf -> Parsetree.core_type
 val expression : Lexing.lexbuf -> Parsetree.expression
 val pattern : Lexing.lexbuf -> Parsetree.pattern
+val module_type : Lexing.lexbuf -> Parsetree.module_type
+val module_expr : Lexing.lexbuf -> Parsetree.module_expr
 
 (** The functions below can be used to parse Longident safely. *)
 

--- a/vendor/ocaml-4.13-extended/parser.mly
+++ b/vendor/ocaml-4.13-extended/parser.mly
@@ -828,6 +828,10 @@ The precedences must be listed from low to high.
 %start use_file                         /* for the #use directive */
 %type <Parsetree.toplevel_phrase list> use_file
 /* BEGIN AVOID */
+%start parse_module_type
+%type <Parsetree.module_type> parse_module_type
+%start parse_module_expr
+%type <Parsetree.module_expr> parse_module_expr
 %start parse_core_type
 %type <Parsetree.core_type> parse_core_type
 %start parse_expression
@@ -1177,6 +1181,16 @@ use_file:
 ;
 
 /* BEGIN AVOID */
+parse_module_type:
+  module_type EOF
+    { $1 }
+;
+
+parse_module_expr:
+  module_expr EOF
+    { $1 }
+;
+
 parse_core_type:
   core_type EOF
     { $1 }

--- a/vendor/ocaml-4.13-upstream/parse.ml
+++ b/vendor/ocaml-4.13-upstream/parse.ml
@@ -95,6 +95,8 @@ and use_file = wrap Parser.use_file
 and core_type = wrap Parser.parse_core_type
 and expression = wrap Parser.parse_expression
 and pattern = wrap Parser.parse_pattern
+let module_type = wrap Parser.parse_module_type
+let module_expr = wrap Parser.parse_module_expr
 
 let longident = wrap Parser.parse_any_longident
 let val_ident = wrap Parser.parse_val_longident

--- a/vendor/ocaml-4.13-upstream/parse.mli
+++ b/vendor/ocaml-4.13-upstream/parse.mli
@@ -27,6 +27,8 @@ val use_file : Lexing.lexbuf -> Parsetree.toplevel_phrase list
 val core_type : Lexing.lexbuf -> Parsetree.core_type
 val expression : Lexing.lexbuf -> Parsetree.expression
 val pattern : Lexing.lexbuf -> Parsetree.pattern
+val module_type : Lexing.lexbuf -> Parsetree.module_type
+val module_expr : Lexing.lexbuf -> Parsetree.module_expr
 
 (** The functions below can be used to parse Longident safely. *)
 

--- a/vendor/ocaml-4.13-upstream/parser.mly
+++ b/vendor/ocaml-4.13-upstream/parser.mly
@@ -849,6 +849,10 @@ The precedences must be listed from low to high.
 %start use_file                         /* for the #use directive */
 %type <Parsetree.toplevel_phrase list> use_file
 /* BEGIN AVOID */
+%start parse_module_type
+%type <Parsetree.module_type> parse_module_type
+%start parse_module_expr
+%type <Parsetree.module_expr> parse_module_expr
 %start parse_core_type
 %type <Parsetree.core_type> parse_core_type
 %start parse_expression
@@ -1198,6 +1202,16 @@ use_file:
 ;
 
 /* BEGIN AVOID */
+parse_module_type:
+  module_type EOF
+    { $1 }
+;
+
+parse_module_expr:
+  module_expr EOF
+    { $1 }
+;
+
 parse_core_type:
   core_type EOF
     { $1 }

--- a/vendor/ocaml-4.13/parse.ml
+++ b/vendor/ocaml-4.13/parse.ml
@@ -125,6 +125,8 @@ and use_file = wrap Parser.Incremental.use_file
 and core_type = wrap Parser.Incremental.parse_core_type
 and expression = wrap Parser.Incremental.parse_expression
 and pattern = wrap Parser.Incremental.parse_pattern
+let module_type = wrap Parser.Incremental.parse_module_type
+let module_expr = wrap Parser.Incremental.parse_module_expr
 
 let longident = wrap Parser.Incremental.parse_any_longident
 let val_ident = wrap Parser.Incremental.parse_val_longident

--- a/vendor/ocaml-4.13/parse.mli
+++ b/vendor/ocaml-4.13/parse.mli
@@ -27,6 +27,8 @@ val use_file : Lexing.lexbuf -> Parsetree.toplevel_phrase list
 val core_type : Lexing.lexbuf -> Parsetree.core_type
 val expression : Lexing.lexbuf -> Parsetree.expression
 val pattern : Lexing.lexbuf -> Parsetree.pattern
+val module_type : Lexing.lexbuf -> Parsetree.module_type
+val module_expr : Lexing.lexbuf -> Parsetree.module_expr
 
 (** The functions below can be used to parse Longident safely. *)
 

--- a/vendor/ocaml-4.13/parser.mly
+++ b/vendor/ocaml-4.13/parser.mly
@@ -852,6 +852,10 @@ The precedences must be listed from low to high.
 %start use_file                         /* for the #use directive */
 %type <Parsetree.toplevel_phrase list> use_file
 /* BEGIN AVOID */
+%start parse_module_type
+%type <Parsetree.module_type> parse_module_type
+%start parse_module_expr
+%type <Parsetree.module_expr> parse_module_expr
 %start parse_core_type
 %type <Parsetree.core_type> parse_core_type
 %start parse_expression
@@ -1201,6 +1205,16 @@ use_file:
 ;
 
 /* BEGIN AVOID */
+parse_module_type:
+  module_type EOF
+    { $1 }
+;
+
+parse_module_expr:
+  module_expr EOF
+    { $1 }
+;
+
 parse_core_type:
   core_type EOF
     { $1 }

--- a/vendor/parse-wyc/lib/parser.mly
+++ b/vendor/parse-wyc/lib/parser.mly
@@ -829,6 +829,10 @@ The precedences must be listed from low to high.
 %start use_file                         /* for the #use directive */
 %type <Parsetree.toplevel_phrase list> use_file
 /* BEGIN AVOID */
+%start parse_module_type
+%type <Parsetree.module_type> parse_module_type
+%start parse_module_expr
+%type <Parsetree.module_expr> parse_module_expr
 %start parse_core_type
 %type <Parsetree.core_type> parse_core_type
 %start parse_expression
@@ -1178,6 +1182,16 @@ use_file:
 ;
 
 /* BEGIN AVOID */
+parse_module_type:
+  module_type EOF
+    { $1 }
+;
+
+parse_module_expr:
+  module_expr EOF
+    { $1 }
+;
+
 parse_core_type:
   core_type EOF
     { $1 }


### PR DESCRIPTION
Decluttering ocamformat's lib, this should be upstreamed to ocaml (don't merge this one before we get a feedback)