### PR TITLE
Improve the error message issued when using a 'no-x' option form in .ocamlformat files and in attributes

### DIFF
--- a/bin/ocamlformat-rpc/main.ml
+++ b/bin/ocamlformat-rpc/main.ml
@@ -109,8 +109,8 @@ let rec rpc_main = function
                 | `Misplaced (x, y) ->
                     Format.sprintf "Misplaced configuration value (%s, %s)" x
                       y
-                | `Unknown (x, y) ->
-                    Format.sprintf "Unknown configuration value (%s, %s)" x y
+                | `Unknown (x, _) ->
+                    Format.sprintf "Unknown configuration option %s" x
               in
               V1.Command.output stdout (`Error msg) ;
               Out_channel.flush stdout ;

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1731,7 +1731,9 @@ let ocp_indent_janestreet_profile =
 let string_of_user_error = function
   | `Malformed line -> Format.sprintf "Invalid format %S" line
   | `Misplaced (name, _) -> Format.sprintf "%s not allowed here" name
-  | `Unknown (name, _) -> Format.sprintf "Unknown option %S" name
+  | `Unknown (name, None) -> Format.sprintf "Unknown option %S" name
+  | `Unknown (name, Some (`Msg msg)) ->
+      Format.sprintf "Unknown option %S: %s" name msg
   | `Bad_value (name, msg) -> Format.sprintf "For option %S: %s" name msg
 
 let parse_line config ~from s =

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -120,7 +120,7 @@ val update_value :
      , [ `Bad_value of string * string
        | `Malformed of string
        | `Misplaced of string * string
-       | `Unknown of string * string ] )
+       | `Unknown of string * [`Msg of string] option ] )
      Result.t
 
 val print_config : t -> unit

--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -345,8 +345,21 @@ module Make (C : CONFIG) = struct
                 update_from config name from ;
                 Some (Ok config)
             | Error (`Msg error) -> Some (Error (`Bad_value (name, error)))
-        else None )
-    |> Option.value ~default:(Error (`Unknown (name, value)))
+        else
+          match
+            List.find names ~f:(fun x -> String.equal ("no-" ^ x) name)
+          with
+          | Some valid_name ->
+              let error =
+                Format.sprintf
+                  "%S is the short form for \"%s=false\". It is only \
+                   accepted on command line, please use \"%s=false\" or \
+                   \"%s=true\" instead."
+                  name valid_name valid_name valid_name
+              in
+              Some (Error (`Unknown (name, Some (`Msg error))))
+          | None -> None )
+    |> Option.value ~default:(Error (`Unknown (name, None)))
 
   let default {default; _} = default
 

--- a/lib/Config_option.mli
+++ b/lib/Config_option.mli
@@ -102,7 +102,7 @@ module Make (C : CONFIG) : sig
     -> value:string
     -> inline:bool
     -> ( config
-       , [ `Unknown of string * string
+       , [ `Unknown of string * [`Msg of string] option
          | `Bad_value of string * string
          | `Malformed of string
          | `Misplaced of string * string ] )

--- a/test/cli/conf.t
+++ b/test/cli/conf.t
@@ -26,6 +26,14 @@ Invalid option:
                Unknown option "unknown_option"
   [1]
 
+Invalid option (short negated form):
+
+  $ echo 'no-wrap-comments' > .ocamlformat
+  $ echo 'let x = 1' | ocamlformat --impl -
+  ocamlformat: Error while parsing .ocamlformat:
+               Unknown option "no-wrap-comments": "no-wrap-comments" is the short form for "wrap-comments=false". It is only accepted on command line, please use "wrap-comments=false" or "wrap-comments=true" instead.
+  [1]
+
 Invalid value:
 
   $ echo 'field-space = unknown_value' > .ocamlformat

--- a/test/rpc/rpc_test.expected
+++ b/test/rpc/rpc_test.expected
@@ -15,7 +15,7 @@ Output: int -> int
 Output: int (* foo *) -> int (* bar *)
 
 [ocf] Config
-Error: Unknown configuration value (foo, bar)
+Error: Unknown configuration option foo
 [ocf] Config
 [ocf] Format 'aaa -> bbb -> ccc -> ddd -> eee -> fff -> ggg'
 Output: aaa ->


### PR DESCRIPTION
First half of #1131 (the second half is deprecating the short option form in .ocamlformat files and in attributes)