### PR TITLE
Simplify sugaring of infix op applications

### DIFF
--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -62,7 +62,7 @@ val infix :
      Cmts.t
   -> Prec.t option
   -> expression Ast.xt
-  -> (expression Ast.xt option * (arg_label * expression Ast.xt) list) list
+  -> (expression Ast.xt option * arg_label * expression Ast.xt) list
 (** [infix cmts prec exp] returns the infix operator and the list of operands
     applied to this operator from expression [exp]. [prec] is the precedence
     of the infix operator. *)


### PR DESCRIPTION
No behavioral change. (still asking for a review in case I made a mistake while rewriting)

The main change is eliminating the list list:
```diff
-  -> (expression Ast.xt option * (arg_label * expression Ast.xt) list) list
+  -> (expression Ast.xt option * arg_label * expression Ast.xt) list
```
The inside list always contained 1 element, I don't remember why we chose this type to begin with.
