### PR TITLE
Fix indentation of with-type constraints

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3497,8 +3497,8 @@ and fmt_module_type c ({ast= mty; _} as xmty) =
   | Pmty_with _ ->
       let wcs, mt = Sugar.mod_with (sub_mty ~ctx mty) in
       let fmt_cstr ~first ~last:_ wc =
-        let pre = if first then "with" else "and" in
-        fmt "@ " $ fmt_with_constraint c ctx ~pre wc
+        let pre = if first then "with" else " and" in
+        fmt_or first "@ " "@," $ fmt_with_constraint c ctx ~pre wc
       in
       let fmt_cstrs ~first:_ ~last:_ (wcs_and, loc, attr) =
         Cmts.fmt c loc

--- a/test/passing/tests/attributes.ml
+++ b/test/passing/tests/attributes.ml
@@ -54,9 +54,9 @@ module type M = sig
   module T :
     (S
       with type t = t
-      and type u := u
-      and module R = R
-      and module S := S
+       and type u := u
+       and module R = R
+       and module S := S
      [@test])
 
   module T : module type of X [@test5]

--- a/test/passing/tests/functor.ml
+++ b/test/passing/tests/functor.ml
@@ -63,18 +63,18 @@ end
 module type KV_MAKER = functor (G : Irmin_git.G) (C : Irmin.Contents.S) ->
   S
     with type key = string list
-    and type step = string
-    and type contents = C.t
-    and type branch = string
-    and module Git = G
+     and type step = string
+     and type contents = C.t
+     and type branch = string
+     and module Git = G
 
 module Make
     (TT : TableFormat.TABLES)
     (IT : InspectionTableFormat.TABLES with type 'a lr1state = int)
     (ET : EngineTypes.TABLE
             with type terminal = int
-            and type nonterminal = int
-            and type semantic_value = Obj.t)
+             and type nonterminal = int
+             and type semantic_value = Obj.t)
     (E : sig
       type 'a env = (ET.state, ET.semantic_value, ET.token) EngineTypes.env
     end) =

--- a/test/passing/tests/module.ml
+++ b/test/passing/tests/module.ml
@@ -40,7 +40,7 @@ module O : sig
   type t
 end
 with type t := t
-and type s := s = struct
+ and type s := s = struct
   let () = ()
 end
 

--- a/test/passing/tests/module_type.ml
+++ b/test/passing/tests/module_type.ml
@@ -27,9 +27,9 @@ module type M =
   module type of M
     with module A := A
     (*test*)
-    and module A = A
+     and module A = A
     (*test*)
-    and module A = A
+     and module A = A
     with module A = A
     (*test*)
     with module A = A
@@ -37,13 +37,13 @@ module type M =
 module U :
   S
     with type ttttttttt = int
-    and type uuuuuuuu = int
-    and type vvvvvvvvvvv = int = struct end
+     and type uuuuuuuu = int
+     and type vvvvvvvvvvv = int = struct end
 
 module U :
   S
     with type ttttttttt = int
-    and type uuuuuuu = int
+     and type uuuuuuu = int
     with type vvvvvvvvv = int = struct end
 
 module U :
@@ -54,7 +54,7 @@ module U :
       | `Error of string
       | `Config of (string * string) list
       | `Format of string ]
-    and type Command.t =
+     and type Command.t =
       [ `Halt
       | `Unknown
       | `Error of string


### PR DESCRIPTION
Diff of test_branch.sh:
```diff
diff --git a/lib-rpc/ocamlformat_rpc_lib.ml b/lib-rpc/ocamlformat_rpc_lib.ml
index 159908c2..d9853d7f 100644
--- a/lib-rpc/ocamlformat_rpc_lib.ml
+++ b/lib-rpc/ocamlformat_rpc_lib.ml
@@ -41,10 +41,10 @@ module Csexp = Csexp.Make (Sexp)
 module Init :
   Command_S
     with type t =
-          [ `Halt
-          | `Unknown
-          | `Version of string
-          ] = struct
+      [ `Halt
+      | `Unknown
+      | `Version of string
+      ] = struct
   type t =
     [ `Halt
     | `Unknown
@@ -76,12 +76,12 @@ end
 module V1 :
   V
     with type Command.t =
-          [ `Halt
-          | `Unknown
-          | `Error of string
-          | `Config of (string * string) list
-          | `Format of string
-          ] = struct
+      [ `Halt
+      | `Unknown
+      | `Error of string
+      | `Config of (string * string) list
+      | `Format of string
+      ] = struct
   module Command = struct
     type t =
       [ `Halt
diff --git a/lib-rpc/ocamlformat_rpc_lib.mli b/lib-rpc/ocamlformat_rpc_lib.mli
index 269c1ef4..16cdea37 100644
--- a/lib-rpc/ocamlformat_rpc_lib.mli
+++ b/lib-rpc/ocamlformat_rpc_lib.mli
@@ -38,20 +38,20 @@ end
 module Init :
   Command_S
     with type t =
-          [ `Halt
-          | `Unknown
-          | `Version of string
-          ]
+      [ `Halt
+      | `Unknown
+      | `Version of string
+      ]
 
 module V1 :
   V
     with type Command.t =
-          [ `Halt
-          | `Unknown
-          | `Error of string
-          | `Config of (string * string) list
-          | `Format of string
-          ]
+      [ `Halt
+      | `Unknown
+      | `Error of string
+      | `Config of (string * string) list
+      | `Format of string
+      ]
 
 type client = [ `V1 of V1.Client.t ]
 
diff --git a/infer/src/absint/ProcnameDispatcher.mli b/infer/src/absint/ProcnameDispatcher.mli
index 39faa94e8..d80caafee 100644
--- a/infer/src/absint/ProcnameDispatcher.mli
+++ b/infer/src/absint/ProcnameDispatcher.mli
@@ -145,7 +145,7 @@ end
 module ProcName :
   NameCommon
     with type ('context, 'f, 'arg_payload) dispatcher =
-          'context -> Procname.t -> 'f option
+      'context -> Procname.t -> 'f option
 
 module TypName :
   NameCommon
@@ -164,7 +164,7 @@ module Call : sig
   include
     Common
       with type ('context, 'f, 'arg_payload) dispatcher =
-            'context -> Procname.t -> 'arg_payload FuncArg.t list -> 'f option
+        'context -> Procname.t -> 'arg_payload FuncArg.t list -> 'f option
```