### PR TITLE
Break arg group when there is a comment after

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,7 +63,7 @@
 
   + Emacs: only hook ocamlformat mode on tuareg/caml modes when ocamlformat is not disabled (#1814, @gpetiot)
 
-  + Fix boxing of labelled arguments, avoid having a linebreak after a label when the argument has a comment attached (#1830, #<PR_NUMBER>, @gpetiot)
+  + Fix boxing of labelled arguments, avoid having a linebreak after a label when the argument has a comment attached (#1830, #1885, @gpetiot)
 
   + Add missing parentheses around application of prefix op when applied to other operands (#1825, @gpetiot)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,7 +63,7 @@
 
   + Emacs: only hook ocamlformat mode on tuareg/caml modes when ocamlformat is not disabled (#1814, @gpetiot)
 
-  + Fix boxing of labelled arguments, avoid having a linebreak after a label when the argument has a comment attached (#1830, @gpetiot)
+  + Fix boxing of labelled arguments, avoid having a linebreak after a label when the argument has a comment attached (#1830, #<PR_NUMBER>, @gpetiot)
 
   + Add missing parentheses around application of prefix op when applied to other operands (#1825, @gpetiot)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1450,7 +1450,9 @@ and fmt_args_grouped ?epi:(global_epi = noop) c ctx args =
     let breaks = String.(rstrip output |> is_substring ~substring:"\n   ") in
     is_simple c.conf (expression_width c) xexp && not breaks
   in
-  let break x y = not (is_simple x && is_simple y) in
+  let break x y =
+    Cmts.has_after c.cmts (snd x).pexp_loc || not (is_simple x && is_simple y)
+  in
   let groups =
     if c.conf.wrap_fun_args then List.group args ~break
     else List.map args ~f:(fun x -> [x])

--- a/test/passing/tests/args_grouped-conventional.ml.err
+++ b/test/passing/tests/args_grouped-conventional.ml.err
@@ -20,4 +20,8 @@ Warning: tests/args_grouped.ml:124 exceeds the margin
 Warning: tests/args_grouped.ml:137 exceeds the margin
 Warning: tests/args_grouped.ml:141 exceeds the margin
 Warning: tests/args_grouped.ml:145 exceeds the margin
-Warning: tests/args_grouped.ml:151 exceeds the margin
+Warning: tests/args_grouped.ml:150 exceeds the margin
+Warning: tests/args_grouped.ml:155 exceeds the margin
+Warning: tests/args_grouped.ml:159 exceeds the margin
+Warning: tests/args_grouped.ml:160 exceeds the margin
+Warning: tests/args_grouped.ml:165 exceeds the margin

--- a/test/passing/tests/args_grouped-conventional.ml.err
+++ b/test/passing/tests/args_grouped-conventional.ml.err
@@ -18,3 +18,6 @@ Warning: tests/args_grouped.ml:105 exceeds the margin
 Warning: tests/args_grouped.ml:123 exceeds the margin
 Warning: tests/args_grouped.ml:124 exceeds the margin
 Warning: tests/args_grouped.ml:137 exceeds the margin
+Warning: tests/args_grouped.ml:141 exceeds the margin
+Warning: tests/args_grouped.ml:145 exceeds the margin
+Warning: tests/args_grouped.ml:151 exceeds the margin

--- a/test/passing/tests/args_grouped-conventional.ml.ref
+++ b/test/passing/tests/args_grouped-conventional.ml.ref
@@ -138,3 +138,18 @@ let f =
          multiple-line-spanning
          comment *)
     ~y
+
+let eradicate_meta_class_is_nullsafe
+    =
+  register
+    ~id:
+      "ERADICATE_META_CLASS_IS_NULLSAFE"
+    ~hum:
+      "Class is marked \
+       @Nullsafe and has 0 \
+       issues"
+    
+      (* Should be enabled for special integrations *)
+    ~enabled:false Info
+    Eradicate (* TODO *)
+    ~user_documentation:""

--- a/test/passing/tests/args_grouped-conventional.ml.ref
+++ b/test/passing/tests/args_grouped-conventional.ml.ref
@@ -148,8 +148,20 @@ let eradicate_meta_class_is_nullsafe
       "Class is marked \
        @Nullsafe and has 0 \
        issues"
-    
       (* Should be enabled for special integrations *)
     ~enabled:false Info
     Eradicate (* TODO *)
     ~user_documentation:""
+
+let eradicate_meta_class_is_nullsafe
+    =
+  register
+    ~id:
+      "ERADICATE_META_CLASS_IS_NULLSAFE"
+      (* Should be enabled for special integrations *)
+    ~hum:
+      "Class is marked \
+       @Nullsafe and has 0 \
+       issues"
+      (* Should be enabled for special integrations *)
+    ~enabled:false Info

--- a/test/passing/tests/args_grouped.ml
+++ b/test/passing/tests/args_grouped.ml
@@ -78,3 +78,9 @@ let f =
          multiple-line-spanning
          comment *)
     ~y
+
+let eradicate_meta_class_is_nullsafe =
+  register ~id:"ERADICATE_META_CLASS_IS_NULLSAFE"
+    ~hum:"Class is marked @Nullsafe and has 0 issues"
+      (* Should be enabled for special integrations *) ~enabled:false Info Eradicate (* TODO *)
+    ~user_documentation:""

--- a/test/passing/tests/args_grouped.ml
+++ b/test/passing/tests/args_grouped.ml
@@ -82,5 +82,12 @@ let f =
 let eradicate_meta_class_is_nullsafe =
   register ~id:"ERADICATE_META_CLASS_IS_NULLSAFE"
     ~hum:"Class is marked @Nullsafe and has 0 issues"
-      (* Should be enabled for special integrations *) ~enabled:false Info Eradicate (* TODO *)
+      (* Should be enabled for special integrations *)
+    ~enabled:false Info Eradicate (* TODO *)
     ~user_documentation:""
+
+let eradicate_meta_class_is_nullsafe =
+  register ~id:"ERADICATE_META_CLASS_IS_NULLSAFE" (* Should be enabled for special integrations *)
+    ~hum:"Class is marked @Nullsafe and has 0 issues"
+      (* Should be enabled for special integrations *)
+    ~enabled:false Info

--- a/test/passing/tests/comments_args.ml.ref
+++ b/test/passing/tests/comments_args.ml.ref
@@ -3,10 +3,13 @@
 let emit_wrapper_function =
   Hhas_function.make function_attributes name body
     (Hhas_pos.pos_to_span ast_fun.Ast.f_span)
-    false (* is_async *) false (* is_generator *) false
-    (* is_pair_generator *) hoisted true (* no_injection *) true
-    (* inout_wrapper *) is_interceptable false (* is_memoize_impl *) Rx.NonRx
-    false
+    false (* is_async *)
+    false (* is_generator *)
+    false (* is_pair_generator *)
+    hoisted true (* no_injection *)
+    true (* inout_wrapper *)
+    is_interceptable false (* is_memoize_impl *)
+    Rx.NonRx false
 
 [@@@ocamlformat "wrap-fun-args=false"]
 

--- a/test/passing/tests/source.ml
+++ b/test/passing/tests/source.ml
@@ -7405,3 +7405,10 @@ let eradicate_meta_class_is_nullsafe =
     ~hum:"Class is marked @Nullsafe and has 0 issues"
       (* Should be enabled for special integrations *) ~enabled:false Info Eradicate (* TODO *)
     ~user_documentation:""
+
+let eradicate_meta_class_is_nullsafe =
+  register ~id:"ERADICATE_META_CLASS_IS_NULLSAFE"
+    ~hum:(* Should be enabled for special integrations *)
+      "Class is marked @Nullsafe and has 0 issues"
+      (* Should be enabled for special integrations *)
+    ~enabled:false Info

--- a/test/passing/tests/source.ml
+++ b/test/passing/tests/source.ml
@@ -7399,3 +7399,9 @@ let xxxxxx =
   { zzzzzzzzzzzzz }
 
 let _ = fun (x : int as 'a) -> (x : int as 'a)
+
+let eradicate_meta_class_is_nullsafe =
+  register ~id:"ERADICATE_META_CLASS_IS_NULLSAFE"
+    ~hum:"Class is marked @Nullsafe and has 0 issues"
+      (* Should be enabled for special integrations *) ~enabled:false Info Eradicate (* TODO *)
+    ~user_documentation:""

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -9186,5 +9186,14 @@ let _ = fun (x : int as 'a) : (int as 'a) -> x
 let eradicate_meta_class_is_nullsafe =
   register ~id:"ERADICATE_META_CLASS_IS_NULLSAFE"
     ~hum:"Class is marked @Nullsafe and has 0 issues"
-      (* Should be enabled for special integrations *) ~enabled:false Info
-    Eradicate (* TODO *) ~user_documentation:""
+      (* Should be enabled for special integrations *)
+    ~enabled:false Info Eradicate (* TODO *)
+    ~user_documentation:""
+
+let eradicate_meta_class_is_nullsafe =
+  register
+    ~id:"ERADICATE_META_CLASS_IS_NULLSAFE"
+      (* Should be enabled for special integrations *)
+    ~hum:"Class is marked @Nullsafe and has 0 issues"
+      (* Should be enabled for special integrations *)
+    ~enabled:false Info

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -9182,3 +9182,9 @@ let xxxxxx =
   {zzzzzzzzzzzzz}
 
 let _ = fun (x : int as 'a) : (int as 'a) -> x
+
+let eradicate_meta_class_is_nullsafe =
+  register ~id:"ERADICATE_META_CLASS_IS_NULLSAFE"
+    ~hum:"Class is marked @Nullsafe and has 0 issues"
+      (* Should be enabled for special integrations *) ~enabled:false Info
+    Eradicate (* TODO *) ~user_documentation:""


### PR DESCRIPTION
Fix a regression spotted in https://github.com/facebook/infer/pull/1546

ping @jberdine since it's originally found on `infer`, btw the comments are located before the arguments on `infer`, it would be better to put them after