### PR TITLE
Mention that operational options cannot be set in attributes or .ocamlformat files

### DIFF
--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -169,7 +169,11 @@ let info =
          $(b,.ocamlformat-enable) file specifies a filename relative to the \
          directory containing the $(b,.ocamlformat-enable) file. \
          Shell-style regular expressions are supported. Lines starting with \
-         $(b,#) are ignored and can be used as comments." ]
+         $(b,#) are ignored and can be used as comments."
+    ; `S (C.section_name C.Operational `Valid)
+    ; `P
+        "Unless mentioned otherwise non-formatting options cannot be set \
+         neither in attributes nor in $(b,ocamlformat) files." ]
   in
   Term.info "ocamlformat" ~version:Version.current ~doc ~man
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -172,8 +172,8 @@ let info =
          $(b,#) are ignored and can be used as comments."
     ; `S (C.section_name C.Operational `Valid)
     ; `P
-        "Unless mentioned otherwise non-formatting options cannot be set \
-         in attributes or $(b,ocamlformat) files." ]
+        "Unless mentioned otherwise non-formatting options cannot be set in \
+         attributes or $(b,.ocamlformat) files." ]
   in
   Term.info "ocamlformat" ~version:Version.current ~doc ~man
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -173,7 +173,7 @@ let info =
     ; `S (C.section_name C.Operational `Valid)
     ; `P
         "Unless mentioned otherwise non-formatting options cannot be set \
-         neither in attributes nor in $(b,ocamlformat) files." ]
+         in attributes or $(b,ocamlformat) files." ]
   in
   Term.info "ocamlformat" ~version:Version.current ~doc ~man
 

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -562,8 +562,8 @@ OPTIONS (DEPRECATED)
            0.20.0. It will be removed by version 1.0.0.
 
 OPTIONS
-       Unless mentioned otherwise non-formatting options cannot be set
-       neither in attributes nor in ocamlformat files.
+       Unless mentioned otherwise non-formatting options cannot be set in
+       attributes or .ocamlformat files.
 
        -c VAL, --config=VAL (absent OCAMLFORMAT env)
            Aggregate options. Options are specified as a comma-separated list

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -562,6 +562,9 @@ OPTIONS (DEPRECATED)
            0.20.0. It will be removed by version 1.0.0.
 
 OPTIONS
+       Unless mentioned otherwise non-formatting options cannot be set
+       neither in attributes nor in ocamlformat files.
+
        -c VAL, --config=VAL (absent OCAMLFORMAT env)
            Aggregate options. Options are specified as a comma-separated list
            of pairs: option=VAL,...,option=VAL.


### PR DESCRIPTION
Fix #1917