### PR TITLE
Move documentation from the README to odoc pages

### DIFF
--- a/HACKING.org
+++ b/HACKING.org
@@ -237,3 +237,7 @@ remove the =_build-mingw64= directory.
 This script can also be triggered as a GitHub Action named =build-mingw64= which
 will build the binary in a GitHub worker and upload it back to GitHub. To
 retrieve it, select the Action run in question and scroll down to "Artifacts".
+
+* Building the documentation
+
+=dune build @doc && xdg-open _build/default/_doc/_html/ocamlformat/index.html=

--- a/HACKING.org
+++ b/HACKING.org
@@ -23,7 +23,7 @@ Git is used to manage the script's state:
 - If a supported OCaml version does not have CI support, run test suite locally.
 
 - In =CHANGES.md=, change =(unreleased)= with the current version (=a.b.c=)
-  and date. In =README.md=, update the recommended version to use in
+  and date. In =README.md=, =doc/faq.mld= and =doc/getting_started.mld= update the recommended version to use in
   =.ocamlformat= files. Commit the changes.
 
 - Tag

--- a/README.md
+++ b/README.md
@@ -2,28 +2,6 @@
 
 # OCamlFormat
 
-OCamlFormat is a tool to format OCaml code.
-
-OCamlFormat works by parsing source code using the OCaml compiler's standard parser, deciding where to place comments in the parse tree, and writing the parse tree and comments in a consistent style.
-
-See the source code of OCamlFormat itself and [Infer](https://github.com/facebook/infer) for examples of the styles of code it produces.
-
-## Table of Contents
-- [FAQ for new users](#faq-for-new-users)
-- [Features](#features)
-  - [Overview](#overview)
-  - [Code style](#code-style)
-  - [Options](#options)
-- [Installation](#installation)
-- [Editor setup](#editor-setup)
-  - [Emacs setup](#emacs-setup)
-  - [Vim setup](#vim-setup)
-- [Documentation](#documentation)
-- [Community](#community)
-- [License](#license)
-
-## FAQ for new users
-
 Hello, new user! Welcome! :wave:
 
 If you are here, you are probably interested in using a formatting tool for your
@@ -31,150 +9,13 @@ code base, so that you do not have to worry about formatting it by hand, and to
 speed up code review by focusing on the important parts.
 
 OCamlFormat is probably what you are after!
-But there are some things that you should know before formatting all the things.
+OCamlFormat is a tool to format OCaml code.
 
-### Should I use OCamlFormat?
+OCamlFormat works by parsing source code using the OCaml compiler's standard parser, deciding where to place comments in the parse tree, and writing the parse tree and comments in a consistent style.
 
-OCamlFormat is already being used by several projects, but it comes with some
-important caveats. This FAQ should help you decide if it can work for you.
+## Getting started
 
-OCamlFormat is beta software.
-While we do not follow [SemVer](https://semver.org/), we expect the program to change considerably before we reach version 1.0.0.
-In particular, upgrading the `ocamlformat` package will cause your program to get reformatted.
-Sometimes it is relatively pain-free, but sometimes it will make a diff in almost every file.
-This can be a hard price to pay, since this means losing the corresponding git history.
-
-If you use a custom configuration, options you rely on might also get removed in
-a later release.
-
-Moreover if you adopt OCamlFormat in one project it will not break your workflow in your other projects. Indeed OCamlFormat modifies a file only if it can find an `.ocamlformat` file, so adding a save hook in your editor will only simplify your workflow in projects using OCamlFormat.
-
-### Using OCamlFormat without breaking `git blame`
-
-* Create `.git-blame-ignore-revs` in your project
-* Add revision(s) where the code was re-formatted
-```
-# Apply new formatting with OCamlFormat
-2ceaf76b9f84cb632327c1479d0f30acfa3eeba2
-```
-* Run `git config --local blame.ignoreRevsFile .git-blame-ignore-revs`
-* All future use of `git blame` will now provide blame information omitting the reformatting commits: lines that were changed or added by an ignored commit will be blamed on the previous commit that changed that line or nearby lines.
-
-### What configuration should I use?
-
-The recommended way is to use a versioned default profile, such as:
-
-```
-version=0.20.1
-```
-
-(or replace with the output of `ocamlformat --version`)
-
-This ensures two things:
-- you are using the default formatting configuration.
-- the version that you use to format is recorded somewhere.
-  If somebody else working on the project tries to use a different version,
-  they will see an error message instead of reformatting the whole project in a
-  different way.
-
-### Can OCamlFormat support my style?
-
-No.
-It is better to see OCamlFormat as a tool to apply *a* style, rather than a tweakable tool to enforce your existing style.
-There are some knobs that you can turn, such as overriding `margin` to determine the maximum line width.
-But it is better not to set individual options to override what the default profile is doing.
-
-To quote (and sed) [prettier's page on option philosophy](https://prettier.io/docs/en/option-philosophy.html):
-
-> OCamlFormat has a few options because of history. **But we don’t want more of them.**
->
-> By far the biggest reason for adopting OCamlFormat is to stop all the on-going debates over styles.
->
-> The more options OCamlFormat has, the further from the above goal it gets. The debates over styles just turn into debates over which OCamlFormat options to use.
-
-### How to locally disable OCamlFormat?
-
-To disable the formatting of a specific toplevel item you must attach an `[@@ocamlformat "option=VAL"]` attribute to this item in the processed file, such as:
-
-```ocaml
-let do_not_touch
-    (x : t)
-      (y : t)
-        (z : t) = [
-  x; y; z
-] [@@ocamlformat "disable"]
-```
-
-To disable the formatting of a specific expression you must attach an `[@ocamlformat "option=VAL"]` attribute to this expression in the processed file, such as:
-
-```ocaml
-let do_not_touch (x : t) (y : t) (z : t) = [
-  x; y; z
-] [@ocamlformat "disable"]
-```
-
-To disable a whole file, the preferred way is to add the name of the file to a local `.ocamlformat-ignore` file. An `.ocamlformat-ignore` file specifies files that OCamlFormat should ignore. Each line in an `.ocamlformat-ignore` file specifies a filename relative to the directory containing the `.ocamlformat-ignore` file.
-Shell-style regular expressions are supported. Lines starting with `#` are ignored and can be used as comments.
-
-## Features
-
-### Overview
-
-OCamlFormat requires source code that meets the following conditions:
-
-- Does not trigger warning 50 (“Unexpected documentation comment.”). For code that triggers warning 50, it is unlikely that OCamlFormat will happen to preserve the documentation string attachment.
-
-- Parses without any preprocessing, using the version of the standard OCaml (not camlp4) parser used to build OCamlFormat. Attributes and extension points should be correctly preserved, but other mechanisms such as camlp4, cppo, etc. will not work.
-
-- Is either a module implementation (`.ml`), an interface (`.mli`) or a sequence of toplevel phrases (`.mlt`). dune files in OCaml syntax also work.
-
-Under those conditions, OCamlFormat is expected to produce output equivalent to the input. As a safety check in case of bugs, prior to terminating or modifying any input file, OCamlFormat enforces the following checks:
-
-- The parse trees obtained by parsing the original and formatted files are equal up to some minor normalization (see [`Normalize`](./lib/Normalize.ml)`.equal`).
-
-- The documentation strings, and their attachment, has been preserved (implicit in the parse tree check).
-
-- The set of comments in the original and formatted files is the same up to their location.
-
-### Code style
-
-There are a number of preset code style profiles, selected using the `--profile` option by passing `--profile=<name>` on the command line or adding `profile = <name>` to an .ocamlformat configuration file. Each profile is a collection of settings for all options, overriding lower priority configuration of individual options. So a profile can be selected and then individual options can be overridden if desired.
-
-The `conventional` or `default` profile aims to be as familiar and "conventional" appearing as the available options allow.
-
-The `ocamlformat` profile aims to take advantage of the strengths of a parsetree-based auto-formatter, and to limit the consequences of the weaknesses imposed by the current implementation. This is a style which optimizes for what the formatter can do best, rather than to match the style of any existing code. Instead of familiarity, the focus is on legibility, keeping the common cases reasonably compact while attempting to avoid confusing formatting in corner cases. General guidelines that have directed the design include:
-
-- Legibility, in the sense of making it as hard as possible for quick visual parsing to give the wrong interpretation, is of highest priority;
-
-- Whenever possible the high-level structure of the code should be obvious by looking only at the left margin, in particular, it should not be necessary to visually jump from left to right hunting for critical keywords, tokens, etc;
-
-- All else equal compact code is preferred as reading without scrolling is easier, so indentation or white space is avoided unless it helps legibility;
-
-- Attention has been given to making some syntactic gotchas visually obvious.
-
-The `compact` profile is similar to `ocamlformat` but opts for a generally more compact code style.
-
-The `sparse` profile is similar to `ocamlformat` but opts for a generally more sparse code style.
-
-If no profile is selected, the `conventional` one is used.
-
-### Options
-
-The full options' documentation is available in [ocamlformat-help.txt] and through `ocamlformat --help`.
-Options can be modified by the means of:
-- an .ocamlformat configuration file with an `option = VAL` line
-- using the `OCAMLFORMAT` environment variable: `OCAMLFORMAT=option=VAL,...,option=VAL`
-- an optional parameter on the command line
-- a global `[@@@ocamlformat "option=VAL"]` attribute in the processed file
-- an `[@@ocamlformat "option=VAL"]` attribute on an expression in the processed file
-
-.ocamlformat files in the containing and all ancestor directories for each input file are used, as well as the global .ocamlformat file defined in `$XDG_CONFIG_HOME/ocamlformat`. The global .ocamlformat file has the lowest priority, then the closer the directory is to the processed file, the higher the priority.
-
-When the option `--enable-outside-detected-project` is not set, .ocamlformat files outside of the project (including the one in `XDG_CONFIG_HOME`) are not read. The project root of an input file is taken to be the nearest ancestor directory that contains a .git or .hg or dune-project file. If no config file is found, formatting is disabled.
-
-An `.ocamlformat-ignore` file specifies files that OCamlFormat should ignore.  Each line in an `.ocamlformat-ignore` file specifies a filename relative to the directory containing the `.ocamlformat-ignore` file. Lines starting with `#` are ignored and can be used as comments.
-
-## Installation
+### Installation
 
 OCamlFormat can be installed with `opam`:
 
@@ -182,114 +23,41 @@ OCamlFormat can be installed with `opam`:
 opam install ocamlformat
 ```
 
-Alternately, see [`ocamlformat.opam`](./ocamlformat.opam) for manual build instructions.
+Alternatively, see [`ocamlformat.opam`](./ocamlformat.opam) for manual build instructions.
 
-## Editor setup
+### Formatting code!
 
-### Disable outside project
-
-As mentioned in the Options section, when the option `--disable-outside-detected-project` is set, .ocamlformat files outside of the project (including the one in `XDG_CONFIG_HOME`) are not read. The project root of an input file is taken to be the nearest ancestor directory that contains a .git or .hg or dune-project file. If no config file is found, then the formatting is disabled.
-
-This feature is often the behavior you can expect from OCamlFormat when it is directly run from your text editor, so it is advised to use this option.
-
-### Emacs setup
-
-- add `$(opam config var share)/emacs/site-lisp` to `load-path` (as done by `opam user-setup install`)
-
-- add `(require 'ocamlformat)` to `.emacs`
-
-- optionally add the following to `.emacs` to bind `C-M-<tab>` to the ocamlformat command and install a hook to run ocamlformat when saving:
-```elisp
-(add-hook 'tuareg-mode-hook (lambda ()
-  (define-key tuareg-mode-map (kbd "C-M-<tab>") #'ocamlformat)
-  (add-hook 'before-save-hook #'ocamlformat-before-save)))
+First of all, make sure you have an `.ocamlformat` file at the root of your project. Setting up your project to use the default profile and the OCamlFormat version you installed (hopefully the last one) in this `.ocamlformat` file is considered good practice:
+```
+profile = default
+version = 0.20.0
 ```
 
-To pass the option `--disable-outside-detected-project` (or `--disable`) to OCamlFormat:
-- run `emacs`
-- run `M-x customize-group⏎` then enter `ocamlformat⏎`
-- select the Ocamlformat Enable item
-- select the OCamlformat mode in the Value Menu: `Enable` (by default), `Disable` or `Disable outside detected project`
-- save the buffer (`C-x C-s`) then enter `yes⏎` and exit
+To manually invoke OCamlformat the general command is:
 
-Other OCamlFormat options can be set in .ocamlformat configuration files.
-
-#### With use-package
-
-A basic configuration with [use-package](https://github.com/jwiegley/use-package):
-
-```elisp
-(use-package ocamlformat
-  :custom (ocamlformat-enable 'enable-outside-detected-project)
-  :hook (before-save . ocamlformat-before-save)
-  )
 ```
-
-Sometimes you need to have a switch for OCamlFormat (because of version conflicts or because you don't want to install it in every switch, for example). Considering your OCamlFormat switch is named `ocamlformat`:
-
-```elisp
-(use-package ocamlformat
-  :load-path
-  (lambda ()
-    (concat
-         ;; Never use "/" or "\" since this is not portable (opam-user-setup does this though)
-         ;; Always use file-name-as-directory since this will append the correct separator if needed
-         ;; (or use a package that does it well like https://github.com/rejeep/f.el)
-         ;; This is the verbose and not package depending version:
-         (file-name-as-directory
-          ;; Couldn't find an option to remove the newline so a substring is needed
-          (substring (shell-command-to-string "opam config var share --switch=ocamlformat --safe") 0 -1))
-         (file-name-as-directory "emacs")
-         (file-name-as-directory "site-lisp")))
-  :custom
-  (ocamlformat-enable 'enable-outside-detected-project)
-  (ocamlformat-command
-   (concat
-    (file-name-as-directory
-     (substring (shell-command-to-string "opam config var bin --switch=ocamlformat --safe") 0 -1))
-    "ocamlformat"))
-  :hook (before-save . ocamlformat-before-save)
-  )
+ocamlformat [OPTION]... [SRC]...
 ```
-(Notice the `:custom` to customize the OCamlFormat binary)
+See `ocamlformat --help` or `man ocamlformat` for the detail about options.
 
-This could be made simpler (by defining an elisp variable corresponding to the switch prefix when loading tuareg, for example) but it allows to have a full configuration in one place only which is often less error prone.
+You can also view it [online](ocamlformat-help.txt).
 
-### Vim setup
+The most common usecase involves using the `dune` build system, once your project is correctly setup (see [Dune's manual](https://dune.readthedocs.io/en/stable/formatting.html#formatting-a-project)) you can reformat your project using:
 
-- be sure the `ocamlformat` binary can be found in PATH
-
-- install the [Neoformat](https://github.com/sbdchd/neoformat#install) plugin
-
-Optional: You can change the options passed to OCamlFormat (to use the option `--disable-outside-detected-project` for example), you can [customize NeoFormat](https://github.com/sbdchd/neoformat#config-optional) with:
 ```
-let g:opambin = substitute(system('opam config var bin'),'\n$','','''')
-let g:neoformat_ocaml_ocamlformat = {
-            \ 'exe': g:opambin . '/ocamlformat',
-            \ 'no_append': 1,
-            \ 'stdin': 1,
-            \ 'args': ['--disable-outside-detected-project', '--name', '"%:p"', '-']
-            \ }
-
-let g:neoformat_enabled_ocaml = ['ocamlformat']
+dune build @fmt
 ```
 
 ## Documentation
 
-OCamlFormat is documented in its man page and through its internal help:
+If you have further questions, please read OCamlFormat's user manual: <...>
 
-* `ocamlformat --help`
-* `man ocamlformat`
+You can also build the documentation and browse it locally:
 
-You can also view it [online](ocamlformat-help.txt).
-
-## Reason
-
-OCamlFormat is influenced by and follows the same basic design as `refmt` for [Reason](https://github.com/facebook/reason), but outputs OCaml instead of Reason.
-
-This tool is not able to deal directly with Reason code (`*.re`/`*.rei` files),
-but it is possible to first convert these files to OCaml syntax using `refmt -p
-ml` and then running `ocamlformat` on this output.
+```
+dune build @doc
+xdg-open _build/default/_doc/_html/ocamlformat/index.html
+```
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 Hello, new user! Welcome! :wave:
 
-If you are here, you are probably interested in using a formatting tool for your
-code base, so that you do not have to worry about formatting it by hand, and to
-speed up code review by focusing on the important parts.
+If you are here, you are probably interested in using a formatting tool for your code base, so that you do not have to worry about formatting it by hand, and to speed up code review by focusing on the important parts.
 
 OCamlFormat is probably what you are after!
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ code base, so that you do not have to worry about formatting it by hand, and to
 speed up code review by focusing on the important parts.
 
 OCamlFormat is probably what you are after!
-OCamlFormat is a tool to format OCaml code.
 
 OCamlFormat works by parsing then outputting again the same OCaml source file in a consistent style.
 
@@ -46,17 +45,6 @@ The most common usecase involves using the `dune` build system, once your projec
 
 ```
 dune build @fmt
-```
-
-## Documentation
-
-If you have further questions, please read OCamlFormat's user manual: <...>
-
-You can also build the documentation and browse it locally:
-
-```
-dune build @doc
-xdg-open _build/default/_doc/_html/ocamlformat/index.html
 ```
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ speed up code review by focusing on the important parts.
 OCamlFormat is probably what you are after!
 OCamlFormat is a tool to format OCaml code.
 
-OCamlFormat works by parsing source code using the OCaml compiler's standard parser, deciding where to place comments in the parse tree, and writing the parse tree and comments in a consistent style.
+OCamlFormat works by parsing then outputting again the same OCaml source file in a consistent style.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Alternatively, see [`ocamlformat.opam`](./ocamlformat.opam) for manual build ins
 
 ### Formatting code!
 
-First of all, make sure you have an `.ocamlformat` file at the root of your project. Setting up your project to use the default profile and the OCamlFormat version you installed (hopefully the last one) in this `.ocamlformat` file is considered good practice:
+Setting up your project to use the default profile and the OCamlFormat version you installed (hopefully the last one) in this `.ocamlformat` file is considered good practice:
 ```
 profile = default
 version = 0.20.0

--- a/doc/doc_comments.mld
+++ b/doc/doc_comments.mld
@@ -1,12 +1,10 @@
-{0 OCamlFormat Manual}
-
-{1 Doc-comments language reference}
+{0 Doc-comments language reference}
 
 OCamlFormat uses {{:https://github.com/ocaml/odoc}odoc} to parse doc-comments (also referred to as doc-strings), and hence it inherits the accepted language from [odoc].
 
 Here is the accepted language:
 
-{2 Headings}
+{1 Headings}
 
 {[
 (** {0 Main title}
@@ -15,7 +13,7 @@ Here is the accepted language:
 *)
 ]}
 
-{2 Tags}
+{1 Tags}
 
 {[
 (** @raise Exception explanation.
@@ -38,9 +36,9 @@ Here is the accepted language:
 *)
 ]}
 
-{2 Block elements}
+{1 Block elements}
 
-{3 Code blocks}
+{2 Code blocks}
 
 {%html:
 <pre>
@@ -56,7 +54,7 @@ Here is the accepted language:
 *)</code></pre>
 %}
 
-{3 Verbatim blocks}
+{2 Verbatim blocks}
 
 {[
 (** Verbatim blocks:
@@ -75,9 +73,9 @@ Here is the accepted language:
 *)
 ]}
 
-{3 Lists}
+{2 Lists}
 
-{4 Unordered lists}
+{3 Unordered lists}
 
 {[
 (** Short syntax:
@@ -92,7 +90,7 @@ Here is the accepted language:
 *)
 ]}
 
-{4 Ordered lists}
+{3 Ordered lists}
 
 {[
 (** Short syntax:
@@ -107,9 +105,9 @@ Here is the accepted language:
 *)
 ]}
 
-{2 Inline elements}
+{1 Inline elements}
 
-{3 Basic elements}
+{2 Basic elements}
 
 {[
 (** regular words
@@ -122,7 +120,7 @@ Here is the accepted language:
 *)
 ]}
 
-{3 Markup}
+{2 Markup}
 
 {[
 (** {%html:<p>Raw markup</p>%}
@@ -131,7 +129,7 @@ Here is the accepted language:
 *)
 ]}
 
-{3 Links}
+{2 Links}
 
 {[
 (** {:https://github.com/}
@@ -139,7 +137,7 @@ Here is the accepted language:
 *)
 ]}
 
-{3 References}
+{2 References}
 
 {[
 (** {!module:A} {!module:A.B}

--- a/doc/doc_comments.mld
+++ b/doc/doc_comments.mld
@@ -6,7 +6,7 @@ Here is an example showing a few useful elements:
 
 {%html:
 <pre>
-<code class="ml hljs ocaml">(** {0 Adding integers} *)
+<code class="ml hljs ocaml">(** Adding integers. *)
 
 (** {1 Exception} *)
 

--- a/doc/doc_comments.mld
+++ b/doc/doc_comments.mld
@@ -1,0 +1,156 @@
+{0 OCamlFormat Manual}
+
+{1 Doc-comments language reference}
+
+OCamlFormat uses {{:https://github.com/ocaml/odoc}odoc} to parse doc-comments (also referred to as doc-strings), and hence it inherits the accepted language from [odoc].
+
+Here is the accepted language:
+
+{2 Headings}
+
+{[
+(** {0 Main title}
+    {1 Sub title}
+    {2:label Sub-sub title with a label}
+*)
+]}
+
+{2 Tags}
+
+{[
+(** @raise [Abc] def.
+    @author Abc def
+    @param [id] [def]
+    @raise [exn] [def]
+    @since [Abc] [def]
+    @before [Abc] [def]
+    @version [Abc] [def]
+    @see <[Abc]> this is an URL
+    @see '[Abc]' this is a file
+    @see "[Abc]" this is a document
+    @deprecated [foo]
+    @param foo [foo]
+    @return [foo]
+    @inline
+    @open
+    @closed
+    @canonical Foo.Bar
+*)
+]}
+
+{2 Block elements}
+
+{3 Code blocks}
+
+{%html:
+<pre>
+<code class="ml hljs ocaml">(** Without metadata:
+    {[
+        ...
+    ]}
+
+    With metadata:
+    {@some_metadata[
+        ...
+    ]}
+*)</code></pre>
+%}
+
+{3 Verbatim blocks}
+
+{[
+(** Verbatim blocks:
+    {v
+        ...
+    v}
+*)
+]}
+
+{3 Module references}
+
+{[
+(** Module references:
+    {!modules:Foo}
+    {!modules:Foo Bar.Baz}
+*)
+]}
+
+{3 Lists}
+
+{4 Unordered lists}
+
+{[
+(** Short syntax:
+    - x
+    - y
+    - z
+
+    Long syntax:
+    {ul
+     {- x}
+     {- y}}
+*)
+]}
+
+{4 Ordered lists}
+
+{[
+(** Short syntax:
+    + x
+    + y
+    + z
+
+    Long syntax:
+    {ol
+     {- x}
+     { -y}}
+*)
+]}
+
+{2 Inline elements}
+
+{3 Basic elements}
+
+{[
+(** regular words
+    [code span]
+    {b this is bold}
+    {i this is italic}
+    {e this is an emphasis}
+    {^ this is superscript}
+    {_ this is subscript}
+*)
+]}
+
+{3 Markup}
+
+{[
+(** {%html:<p>Raw markup</p>%}
+    {%Without language%}
+    {%other:Other language%}
+*)
+]}
+
+{3 Links}
+
+{[
+(** {:https://github.com/}
+    {{:https://github.com/} Github}
+*)
+]}
+
+{3 References}
+
+{[
+(** {!module:A} {!module:A.B}
+    {!module-type:A} {!module-type:A.b}
+    {!class:c} {!class:M.c}
+    {!class-type:c} {!class-type:M.c}
+    {!val:x} {!val:M.x}
+    {!type:t} {!type:M.t}
+    {!exception:E} {!exception:M.E}
+    {!method:m} {!method:c.m}
+    {!constructor:C} {!constructor:M.C}
+    {!field:f} {!field:M.t.f}
+*)
+]}

--- a/doc/doc_comments.mld
+++ b/doc/doc_comments.mld
@@ -1,154 +1,42 @@
 {0 Doc-comments language reference}
 
-OCamlFormat uses {{:https://github.com/ocaml/odoc}odoc} to parse doc-comments (also referred to as doc-strings), and hence it inherits the accepted language from [odoc].
+OCamlFormat uses {{:https://github.com/ocaml/odoc}odoc} to parse doc-comments (also referred to as doc-strings), and hence it inherits the accepted language from [odoc] (detailed in {{:https://ocaml.github.io/odoc/odoc_for_authors.html}odoc's documentation}).
 
-Here is the accepted language:
-
-{1 Headings}
-
-{[
-(** {0 Main title}
-    {1 Sub title}
-    {2:label Sub-sub title with a label}
-*)
-]}
-
-{1 Tags}
-
-{[
-(** @raise Exception explanation.
-    @author Abc def
-    @param [id] [def]
-    @raise [exn] [def]
-    @since [Abc] [def]
-    @before [Abc] [def]
-    @version [Abc] [def]
-    @see <[Abc]> this is an URL
-    @see '[Abc]' this is a file
-    @see "[Abc]" this is a document
-    @deprecated [foo]
-    @param foo [foo]
-    @return [foo]
-    @inline
-    @open
-    @closed
-    @canonical Foo.Bar
-*)
-]}
-
-{1 Block elements}
-
-{2 Code blocks}
+Here is an example showing a few useful elements:
 
 {%html:
 <pre>
-<code class="ml hljs ocaml">(** Without metadata:
-    {[
-        ...
-    ]}
+<code class="ml hljs ocaml">(** {0 Adding integers} *)
 
-    With metadata:
+(** {1 Exception} *)
+
+(** Raised in case of integer overflow *)
+exception Int_overflow
+
+(** {1 Function definition} *)
+
+(** [add ~x ~y] returns [x + y] or raises an exception in case of integer overflow.
+    Usage:
     {@ocaml some_metadata[
-        ...
+    # add ~x:1 ~y:2 ;;
+    - : int = 3
     ]}
-*)</code></pre>
-%}
 
-{2 Verbatim blocks}
-
-{[
-(** Verbatim blocks:
+    Here is a basic diagram:
     {v
-        ...
+          add  ~x:1   ~y:2
+                  \   /
+                   (+)
+                    |
+                    3
     v}
-*)
-]}
 
-{3 Module references}
+    Notes:
+    - {_ check} that exception {!exception:Int_overflow} is {b not raised};
+    - have a look at {!module:Int} ({{:https://ocaml.org/api/Int.html}Documentation}).
 
-{[
-(** Module references:
-    {!modules:Foo}
-    {!modules:Foo Bar.Baz}
-*)
-]}
-
-{2 Lists}
-
-{3 Unordered lists}
-
-{[
-(** Short syntax:
-    - x
-    - y
-    - z
-
-    Long syntax:
-    {ul
-     {- x}
-     {- y}}
-*)
-]}
-
-{3 Ordered lists}
-
-{[
-(** Short syntax:
-    + x
-    + y
-    + z
-
-    Long syntax:
-    {ol
-     {- x}
-     { -y}}
-*)
-]}
-
-{1 Inline elements}
-
-{2 Basic elements}
-
-{[
-(** regular words
-    [code span]
-    {b this is bold}
-    {i this is italic}
-    {e this is an emphasis}
-    {^ this is superscript}
-    {_ this is subscript}
-*)
-]}
-
-{2 Markup}
-
-{[
-(** {%html:<p>Raw markup</p>%}
-    {%Without language%}
-    {%other:Other language%}
-*)
-]}
-
-{2 Links}
-
-{[
-(** {:https://github.com/}
-    {{:https://github.com/} Github}
-*)
-]}
-
-{2 References}
-
-{[
-(** {!module:A} {!module:A.B}
-    {!module-type:A} {!module-type:A.b}
-    {!class:c} {!class:M.c}
-    {!class-type:c} {!class-type:M.c}
-    {!val:x} {!val:M.x}
-    {!type:t} {!type:M.t}
-    {!exception:E} {!exception:M.E}
-    {!method:m} {!method:c.m}
-    {!constructor:C} {!constructor:M.C}
-    {!field:f} {!field:M.t.f}
-*)
-]}
+    @return [x + y]
+    @raise Exception [Int_overflow] *)
+val add: x:int (** one operand *) -> y:int (** another operand *) -> int (** result *)
+</code></pre>
+%}

--- a/doc/doc_comments.mld
+++ b/doc/doc_comments.mld
@@ -18,7 +18,7 @@ Here is the accepted language:
 {2 Tags}
 
 {[
-(** @raise [Abc] def.
+(** @raise Exception explanation.
     @author Abc def
     @param [id] [def]
     @raise [exn] [def]

--- a/doc/doc_comments.mld
+++ b/doc/doc_comments.mld
@@ -33,7 +33,7 @@ exception Int_overflow
 
     Notes:
     - {_ check} that exception {!exception:Int_overflow} is {b not raised};
-    - have a look at {!module:Int} ({{:https://ocaml.org/api/Int.html}Documentation}).
+    - have a look at {!module:Int}.
 
     @return [x + y]
     @raise Exception [Int_overflow] *)

--- a/doc/doc_comments.mld
+++ b/doc/doc_comments.mld
@@ -1,6 +1,6 @@
 {0 Doc-comments language reference}
 
-OCamlFormat uses {{:https://github.com/ocaml/odoc}odoc} to parse doc-comments (also referred to as doc-strings), and hence it inherits the accepted language from [odoc] (detailed in {{:https://ocaml.github.io/odoc/odoc_for_authors.html}odoc's documentation}).
+OCamlFormat uses {{:https://github.com/ocaml-doc/odoc-parser}odoc-parser} to parse doc-comments (also referred to as doc-strings), and hence it inherits the accepted language from {{:https://github.com/ocaml/odoc}odoc} (detailed in {{:https://ocaml.github.io/odoc/odoc_for_authors.html}odoc's documentation}).
 
 Here is an example showing a few useful elements:
 

--- a/doc/doc_comments.mld
+++ b/doc/doc_comments.mld
@@ -50,7 +50,7 @@ Here is the accepted language:
     ]}
 
     With metadata:
-    {@some_metadata[
+    {@ocaml some_metadata[
         ...
     ]}
 *)</code></pre>

--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,2 @@
+(documentation
+ (package ocamlformat))

--- a/doc/editor_setup.mld
+++ b/doc/editor_setup.mld
@@ -2,13 +2,13 @@
 
 First of all, make sure you have an [.ocamlformat] file at the root of your project.
 
-{2 Disable outside project}
+{1 Disable outside project}
 
 As mentioned in {!getting_started.options}, when the option [--disable-outside-detected-project] is set, [.ocamlformat] files outside of the project (including the one in [XDG_CONFIG_HOME]) are not read. The project root of an input file is taken to be the nearest ancestor directory that contains a [.git] or [.hg] or [dune-project] file. If no configuration file is found, then the formatting is disabled.
 
 This feature is often the behavior you can expect from OCamlFormat when it is directly run from your text editor, so it is advised to use this option.
 
-{2 Emacs setup}
+{1 Emacs setup}
 
 - add [$(opam config var share)/emacs/site-lisp] to [load-path] (as done by [opam user-setup install])
 
@@ -30,7 +30,7 @@ To pass the option [--disable-outside-detected-project] (or [--disable]) to OCam
 
 Other OCamlFormat options can be set in .ocamlformat configuration files.
 
-{3 With use-package}
+{2 With use-package}
 
 A basic configuration with {{:https://github.com/jwiegley/use-package}use-package}:
 
@@ -71,7 +71,7 @@ Sometimes you need to have a switch for OCamlFormat (because of version conflict
 
 This could be made simpler (by defining an elisp variable corresponding to the switch prefix when loading tuareg, for example) but it allows to have a full configuration in one place only which is often less error prone.
 
-{2 Vim setup}
+{1 Vim setup}
 
 - be sure the [ocamlformat] binary can be found in [PATH]
 

--- a/doc/editor_setup.mld
+++ b/doc/editor_setup.mld
@@ -1,0 +1,94 @@
+{0 OCamlFormat Manual}
+
+{1 Editor setup}
+
+First of all, make sure you have an [.ocamlformat] file at the root of your project.
+
+{2 Disable outside project}
+
+As mentioned in the Options section, when the option [--disable-outside-detected-project] is set, [.ocamlformat] files outside of the project (including the one in [XDG_CONFIG_HOME]) are not read. The project root of an input file is taken to be the nearest ancestor directory that contains a [.git] or [.hg] or [dune-project] file. If no configuration file is found, then the formatting is disabled.
+
+This feature is often the behavior you can expect from OCamlFormat when it is directly run from your text editor, so it is advised to use this option.
+
+{2 Emacs setup}
+
+- add [$(opam config var share)/emacs/site-lisp] to [load-path] (as done by [opam user-setup install])
+
+- add [(require 'ocamlformat)] to [.emacs]
+
+- optionally add the following to [.emacs] to bind [C-M-<tab>] to the [ocamlformat] command and install a hook to run OCamlFormat when saving:
+{[
+(add-hook 'tuareg-mode-hook (lambda ()
+  (define-key tuareg-mode-map (kbd "C-M-<tab>") #'ocamlformat)
+  (add-hook 'before-save-hook #'ocamlformat-before-save)))
+]}
+
+To pass the option [--disable-outside-detected-project] (or [--disable]) to OCamlFormat:
+- run [emacs]
+- run [M-x customize-group⏎] then enter [ocamlformat⏎]
+- select the Ocamlformat Enable item
+- select the OCamlformat mode in the Value Menu: [Enable] (by default), [Disable] or [Disable outside detected project]
+- save the buffer ([C-x C-s]) then enter [yes⏎] and exit
+
+Other OCamlFormat options can be set in .ocamlformat configuration files.
+
+{3 With use-package}
+
+A basic configuration with {{:https://github.com/jwiegley/use-package}use-package}:
+
+{[
+(use-package ocamlformat
+  :custom (ocamlformat-enable 'enable-outside-detected-project)
+  :hook (before-save . ocamlformat-before-save)
+  )
+]}
+
+Sometimes you need to have a switch for OCamlFormat (because of version conflicts or because you don't want to install it in every switch, for example). Considering your OCamlFormat switch is named [ocamlformat]:
+
+{[
+(use-package ocamlformat
+  :load-path
+  (lambda ()
+    (concat
+         ;; Never use "/" or "\" since this is not portable (opam-user-setup does this though)
+         ;; Always use file-name-as-directory since this will append the correct separator if needed
+         ;; (or use a package that does it well like https://github.com/rejeep/f.el)
+         ;; This is the verbose and not package depending version:
+         (file-name-as-directory
+          ;; Couldn't find an option to remove the newline so a substring is needed
+          (substring (shell-command-to-string "opam config var share --switch=ocamlformat --safe") 0 -1))
+         (file-name-as-directory "emacs")
+         (file-name-as-directory "site-lisp")))
+  :custom
+  (ocamlformat-enable 'enable-outside-detected-project)
+  (ocamlformat-command
+   (concat
+    (file-name-as-directory
+     (substring (shell-command-to-string "opam config var bin --switch=ocamlformat --safe") 0 -1))
+    "ocamlformat"))
+  :hook (before-save . ocamlformat-before-save)
+  )
+]}
+(Notice the [:custom] to customize the OCamlFormat binary)
+
+This could be made simpler (by defining an elisp variable corresponding to the switch prefix when loading tuareg, for example) but it allows to have a full configuration in one place only which is often less error prone.
+
+{2 Vim setup}
+
+- be sure the [ocamlformat] binary can be found in [PATH]
+
+- install the {{:https://github.com/sbdchd/neoformat#install}Neoformat} plugin
+
+Optional: You can change the options passed to OCamlFormat (to use the option [--disable-outside-detected-project] for example), you can {{:https://github.com/sbdchd/neoformat#config-optional}customize NeoFormat} with:
+
+{[
+let g:opambin = substitute(system('opam config var bin'),'\n$','','''')
+let g:neoformat_ocaml_ocamlformat = {
+            \ 'exe': g:opambin . '/ocamlformat',
+            \ 'no_append': 1,
+            \ 'stdin': 1,
+            \ 'args': ['--disable-outside-detected-project', '--name', '"%:p"', '-']
+            \ }
+
+let g:neoformat_enabled_ocaml = ['ocamlformat']
+]}

--- a/doc/editor_setup.mld
+++ b/doc/editor_setup.mld
@@ -1,6 +1,4 @@
-{0 OCamlFormat Manual}
-
-{1 Editor setup}
+{0 Editor setup}
 
 First of all, make sure you have an [.ocamlformat] file at the root of your project.
 

--- a/doc/editor_setup.mld
+++ b/doc/editor_setup.mld
@@ -1,7 +1,5 @@
 {0 Editor setup}
 
-First of all, make sure you have an [.ocamlformat] file at the root of your project.
-
 {1 Disable outside project}
 
 As mentioned in {!getting_started.options}, when the option [--disable-outside-detected-project] is set, [.ocamlformat] files outside of the project (including the one in [XDG_CONFIG_HOME]) are not read. The project root of an input file is taken to be the nearest ancestor directory that contains a [.git] or [.hg] or [dune-project] file. If no configuration file is found, then the formatting is disabled.

--- a/doc/editor_setup.mld
+++ b/doc/editor_setup.mld
@@ -4,7 +4,7 @@ First of all, make sure you have an [.ocamlformat] file at the root of your proj
 
 {2 Disable outside project}
 
-As mentioned in the Options section, when the option [--disable-outside-detected-project] is set, [.ocamlformat] files outside of the project (including the one in [XDG_CONFIG_HOME]) are not read. The project root of an input file is taken to be the nearest ancestor directory that contains a [.git] or [.hg] or [dune-project] file. If no configuration file is found, then the formatting is disabled.
+As mentioned in {!getting_started.options}, when the option [--disable-outside-detected-project] is set, [.ocamlformat] files outside of the project (including the one in [XDG_CONFIG_HOME]) are not read. The project root of an input file is taken to be the nearest ancestor directory that contains a [.git] or [.hg] or [dune-project] file. If no configuration file is found, then the formatting is disabled.
 
 This feature is often the behavior you can expect from OCamlFormat when it is directly run from your text editor, so it is advised to use this option.
 

--- a/doc/faq.mld
+++ b/doc/faq.mld
@@ -76,7 +76,7 @@ dir/*/*/*
 
 {2 How to locally disable OCamlFormat?}
 
-To disable the formatting of a specific toplevel item you must attach an [[@@ocamlformat "option=VAL"]] attribute to this item in the processed file, such as:
+To disable the formatting of a specific toplevel item you must attach an [[@@ocamlformat "disable"]] attribute to this item in the processed file, such as:
 
 {[
 let do_not_touch

--- a/doc/faq.mld
+++ b/doc/faq.mld
@@ -72,6 +72,8 @@ dir/*/*
 dir/*/*/*
 ]}
 
+It is also possible to add an [.ocamlformat-ignore] file containing [*] in every directory that needs to be ignored.
+
 {1 How to locally disable OCamlFormat?}
 
 To disable the formatting of a specific toplevel item you must attach an [[@@ocamlformat "disable"]] attribute to this item in the processed file, such as:

--- a/doc/faq.mld
+++ b/doc/faq.mld
@@ -10,7 +10,7 @@ important caveats. This FAQ should help you decide if it can work for you.
 OCamlFormat is beta software.
 While we do not follow {{:https://semver.org/}SemVer}, we expect the program to change considerably before we reach version 1.0.0.
 In particular, upgrading the [ocamlformat] package will cause your program to get reformatted.
-Sometimes it is relatively pain-free, but sometimes it will make a diff in almost every file.
+Sometimes the changes are relatively small, but sometimes upgrading can cause many changes all over the code base.
 This can be a hard price to pay, since this means losing the corresponding git history.
 
 If you use a custom configuration, options you rely on might also get removed in

--- a/doc/faq.mld
+++ b/doc/faq.mld
@@ -30,7 +30,7 @@ version = 0.20.0
 (or replace with the output of [ocamlformat --version])
 
 This ensures two things:
-- you are using the default formatting configuration.
+- you are using the recommended formatting configuration.
 - the version that you use to format is recorded somewhere.
   If somebody else working on the project tries to use a different version,
   they will see an error message instead of reformatting the whole project in a

--- a/doc/faq.mld
+++ b/doc/faq.mld
@@ -1,8 +1,6 @@
-{0 OCamlFormat Manual}
+{0 Frequently asked questions}
 
-{1 Frequently asked questions}
-
-{2 Should I use OCamlFormat?}
+{1 Should I use OCamlFormat?}
 
 OCamlFormat is already being used by several projects, but it comes with some
 important caveats. This FAQ should help you decide if it can work for you.
@@ -18,7 +16,7 @@ a later release.
 
 Moreover if you adopt OCamlFormat in one project it will not break your workflow in your other projects. Indeed OCamlFormat modifies a file only if it can find an [.ocamlformat] file, so adding a save hook in your editor will only simplify your workflow in projects using OCamlFormat.
 
-{2 What configuration should I use?}
+{1 What configuration should I use?}
 
 The recommended way is to use a versioned default profile, such as:
 
@@ -36,7 +34,7 @@ This ensures two things:
   they will see an error message instead of reformatting the whole project in a
   different way.
 
-{2 Can OCamlFormat support my style?}
+{1 Can OCamlFormat support my style?}
 
 No.
 It is better to see OCamlFormat as a tool to apply a style, rather than a tweakable tool to enforce your existing style.
@@ -55,7 +53,7 @@ The more options OCamlFormat has, the further from the above goal it gets. The d
 </q>
 %}
 
-{2 Can OCamlFormat handle Reason files?}
+{1 Can OCamlFormat handle Reason files?}
 
 OCamlFormat is influenced by and follows the same basic design as [refmt] for {{:https://github.com/facebook/reason}Reason}, but outputs OCaml instead of Reason.
 
@@ -63,7 +61,7 @@ This tool is not able to deal directly with Reason code ([*.re]/[*.rei] files),
 but it is possible to first convert these files to OCaml syntax using [refmt -p
 ml] and then running [ocamlformat] on this output.
 
-{2 How to ignore directories?}
+{1 How to ignore directories?}
 
 It is possible to disable OCamlFormat for the files of a directory by having an [.ocamlformat] file containing disable in this directory, or listing the files to ignore in an [.ocamlformat-ignore] file.
 
@@ -74,7 +72,7 @@ dir/*/*
 dir/*/*/*
 ]}
 
-{2 How to locally disable OCamlFormat?}
+{1 How to locally disable OCamlFormat?}
 
 To disable the formatting of a specific toplevel item you must attach an [[@@ocamlformat "disable"]] attribute to this item in the processed file, such as:
 
@@ -98,6 +96,6 @@ let do_not_touch (x : t) (y : t) (z : t) = [
 To disable a whole file, the preferred way is to add the name of the file to a local [.ocamlformat-ignore] file. An [.ocamlformat-ignore] file specifies files that OCamlFormat should ignore. Each line in an [.ocamlformat-ignore] file specifies a filename relative to the directory containing the [.ocamlformat-ignore] file.
 Shell-style regular expressions are supported. Lines starting with [#] are ignored and can be used as comments.
 
-{2 Why is there an inconsistent spacing on the | character in match blocks?}
+{1 Why is there an inconsistent spacing on the | character in match blocks?}
 
 The change in the indentation of [| ] vs [|] would indicate that there is a short body of a nested or-pattern that could be easily missed if formatted as: [| ]. This can be disabled using [indicate-nested-or-patterns = unsafe-no] if you are happy with the risk. Alternatively, [break-cases = nested] can be used to break after the [->] to avoid the risk at the cost of significantly less compact code.

--- a/doc/faq.mld
+++ b/doc/faq.mld
@@ -53,11 +53,12 @@ The more options OCamlFormat has, the further from the above goal it gets. The d
 </q>
 %}
 
-{1 Can OCamlFormat handle Reason files?}
+{1 Can OCamlFormat format Reason files?}
 
-OCamlFormat is influenced by and follows the same basic design as [refmt] for {{:https://github.com/facebook/reason}Reason}, but outputs OCaml instead of Reason.
+No.
+Although OCamlFormat is influenced by and follows the same basic design as [refmt] for {{:https://github.com/facebook/reason}Reason}, OCamlFormat outputs OCaml instead of Reason.
 
-This tool is not able to deal directly with Reason code ([*.re]/[*.rei] files),
+OCamlFormat is not able to deal directly with Reason code ([*.re]/[*.rei] files),
 but it is possible to first convert these files to OCaml syntax using [refmt -p
 ml] and then running [ocamlformat] on this output.
 

--- a/doc/faq.mld
+++ b/doc/faq.mld
@@ -1,0 +1,103 @@
+{0 OCamlFormat Manual}
+
+{1 Frequently asked questions}
+
+{2 Should I use OCamlFormat?}
+
+OCamlFormat is already being used by several projects, but it comes with some
+important caveats. This FAQ should help you decide if it can work for you.
+
+OCamlFormat is beta software.
+While we do not follow {{:https://semver.org/}SemVer}, we expect the program to change considerably before we reach version 1.0.0.
+In particular, upgrading the [ocamlformat] package will cause your program to get reformatted.
+Sometimes it is relatively pain-free, but sometimes it will make a diff in almost every file.
+This can be a hard price to pay, since this means losing the corresponding git history.
+
+If you use a custom configuration, options you rely on might also get removed in
+a later release.
+
+Moreover if you adopt OCamlFormat in one project it will not break your workflow in your other projects. Indeed OCamlFormat modifies a file only if it can find an [.ocamlformat] file, so adding a save hook in your editor will only simplify your workflow in projects using OCamlFormat.
+
+{2 What configuration should I use?}
+
+The recommended way is to use a versioned default profile, such as:
+
+{[
+profile = default
+version = 0.20.0
+]}
+
+(or replace with the output of [ocamlformat --version])
+
+This ensures two things:
+- you are using the default formatting configuration.
+- the version that you use to format is recorded somewhere.
+  If somebody else working on the project tries to use a different version,
+  they will see an error message instead of reformatting the whole project in a
+  different way.
+
+{2 Can OCamlFormat support my style?}
+
+No.
+It is better to see OCamlFormat as a tool to apply a style, rather than a tweakable tool to enforce your existing style.
+There are some knobs that you can turn, such as overriding [margin] to determine the maximum line width.
+But it is better not to set individual options to override what the default profile is doing.
+
+To quote (and sed) {{:https://prettier.io/docs/en/option-philosophy.html}prettier's page on option philosophy}:
+
+{%html:
+<q>
+OCamlFormat has a few options because of history. <i>But we don’t want more of them.</i>
+
+By far the biggest reason for adopting OCamlFormat is to stop all the on-going debates over styles.
+
+The more options OCamlFormat has, the further from the above goal it gets. The debates over styles just turn into debates over which OCamlFormat options to use.
+</q>
+%}
+
+{2 Can OCamlFormat handle Reason files?}
+
+OCamlFormat is influenced by and follows the same basic design as [refmt] for {{:https://github.com/facebook/reason}Reason}, but outputs OCaml instead of Reason.
+
+This tool is not able to deal directly with Reason code ([*.re]/[*.rei] files),
+but it is possible to first convert these files to OCaml syntax using [refmt -p
+ml] and then running [ocamlformat] on this output.
+
+{2 How to ignore directories?}
+
+It is possible to disable OCamlFormat for the files of a directory by having an [.ocamlformat] file containing disable in this directory, or listing the files to ignore in an [.ocamlformat-ignore] file.
+
+For now it is not possible to recursively ignore all subdirectories and files from a parent directory, you need to list all the descendants of the directory to ignore them, e.g.:
+{[
+dir/*
+dir/*/*
+dir/*/*/*
+]}
+
+{2 How to locally disable OCamlFormat?}
+
+To disable the formatting of a specific toplevel item you must attach an [[@@ocamlformat "option=VAL"]] attribute to this item in the processed file, such as:
+
+{[
+let do_not_touch
+    (x : t)
+      (y : t)
+        (z : t) = [
+  x; y; z
+] [@@ocamlformat "disable"]
+]}
+
+To disable the formatting of a specific expression you must attach an [[@ocamlformat "option=VAL"]] attribute to this expression in the processed file, such as:
+
+{[
+let do_not_touch (x : t) (y : t) (z : t) = [
+  x; y; z
+] [@ocamlformat "disable"]
+]}
+
+To disable a whole file, the preferred way is to add the name of the file to a local [.ocamlformat-ignore] file. An [.ocamlformat-ignore] file specifies files that OCamlFormat should ignore. Each line in an [.ocamlformat-ignore] file specifies a filename relative to the directory containing the [.ocamlformat-ignore] file.
+Shell-style regular expressions are supported. Lines starting with [#] are ignored and can be used as comments.
+
+{2 Why is there an inconsistent spacing on the | character in match blocks?}
+
+The change in the indentation of [| ] vs [|] would indicate that there is a short body of a nested or-pattern that could be easily missed if formatted as: [| ]. This can be disabled using [indicate-nested-or-patterns = false] if you are happy with the risk. Alternatively, [break-cases = nested] can be used to break after the [->] to avoid the risk at the cost of significantly less compact code.

--- a/doc/faq.mld
+++ b/doc/faq.mld
@@ -100,4 +100,4 @@ Shell-style regular expressions are supported. Lines starting with [#] are ignor
 
 {2 Why is there an inconsistent spacing on the | character in match blocks?}
 
-The change in the indentation of [| ] vs [|] would indicate that there is a short body of a nested or-pattern that could be easily missed if formatted as: [| ]. This can be disabled using [indicate-nested-or-patterns = false] if you are happy with the risk. Alternatively, [break-cases = nested] can be used to break after the [->] to avoid the risk at the cost of significantly less compact code.
+The change in the indentation of [| ] vs [|] would indicate that there is a short body of a nested or-pattern that could be easily missed if formatted as: [| ]. This can be disabled using [indicate-nested-or-patterns = unsafe-no] if you are happy with the risk. Alternatively, [break-cases = nested] can be used to break after the [->] to avoid the risk at the cost of significantly less compact code.

--- a/doc/faq.mld
+++ b/doc/faq.mld
@@ -5,8 +5,7 @@
 OCamlFormat is already being used by several projects, but it comes with some
 important caveats. This FAQ should help you decide if it can work for you.
 
-OCamlFormat is beta software.
-While we do not follow {{:https://semver.org/}SemVer}, we expect the program to change considerably before we reach version 1.0.0.
+OCamlFormat is beta software, and we expect the program to change considerably before we reach version 1.0.0.
 In particular, upgrading the [ocamlformat] package will cause your program to get reformatted.
 Sometimes the changes are relatively small, but sometimes upgrading can cause many changes all over the code base.
 This can be a hard price to pay, since this means losing the corresponding git history.
@@ -41,7 +40,7 @@ It is better to see OCamlFormat as a tool to apply a style, rather than a tweaka
 There are some knobs that you can turn, such as overriding [margin] to determine the maximum line width.
 But it is better not to set individual options to override what the default profile is doing.
 
-To quote (and sed) {{:https://prettier.io/docs/en/option-philosophy.html}prettier's page on option philosophy}:
+To paraphrase {{:https://prettier.io/docs/en/option-philosophy.html}prettier's page on option philosophy}:
 
 {%html:
 <q>

--- a/doc/faq.mld
+++ b/doc/faq.mld
@@ -87,7 +87,7 @@ let do_not_touch
 ] [@@ocamlformat "disable"]
 ]}
 
-To disable the formatting of a specific expression you must attach an [[@ocamlformat "option=VAL"]] attribute to this expression in the processed file, such as:
+To disable the formatting of a specific expression you must attach an [[@ocamlformat "disable"]] attribute to this expression in the processed file, such as:
 
 {[
 let do_not_touch (x : t) (y : t) (z : t) = [

--- a/doc/getting_started.mld
+++ b/doc/getting_started.mld
@@ -1,8 +1,6 @@
-{0 OCamlFormat Manual}
+{0 Getting started}
 
-{1 Getting started}
-
-{2 Installation}
+{1 Installation}
 
 OCamlFormat can be installed with [opam]:
 
@@ -18,7 +16,7 @@ dune subst
 dune build @install
 ]}
 
-{2 Formatting code!}
+{1 Formatting code!}
 
 First of all, make sure you have an [.ocamlformat] file at the root of your project. Setting up your project to use the default profile and the OCamlFormat version you installed (hopefully the last one) in this [.ocamlformat] file is considered good practice:
 {[
@@ -41,7 +39,7 @@ dune build @fmt
 With this command, Dune will apply the appropriate autoformatter on each kind of file (where OCamlFormat is the one called on .ml, .mli, .mlt, .eliom and .eliomi files).
 All files are formatted, unless explicitly excluded (see below).
 
-{2 Code style}
+{1 Code style}
 
 There are a number of preset code style profiles, selected using the [--profile] option by passing [--profile=<name>] on the command line or adding [profile = <name>] to an [.ocamlformat] configuration file.
 The available profiles are:
@@ -64,7 +62,7 @@ The [ocamlformat] profile aims to take advantage of the strengths of a parsetree
 
 If no profile is selected, the [default] one is used.
 
-{2 Options}
+{1 Options}
 
 The full options' documentation is available through [ocamlformat --help].
 Options can be modified by the means of:
@@ -81,7 +79,7 @@ When this option is not set, [.ocamlformat] files outside of the project are ign
 
 An [.ocamlformat-ignore] file specifies files that OCamlFormat should ignore. Each line in an [.ocamlformat-ignore] file specifies a filename relative to the directory containing the [.ocamlformat-ignore] file. Lines starting with [#] are ignored and can be used as comments.
 
-{2 Version}
+{1 Version}
 
 On existing projects, it is likely an [.ocamlformat] file is already present, specifying a field [version = A.B.C] (e.g. [0.20.0]).
 
@@ -93,7 +91,7 @@ opam install ocamlformat.0.20.0
 
 Setting an OCamlFormat version in the configuration file is a good practice to ensure every contributor of a project gets the same formatting.
 
-{2 Requirements}
+{1 Requirements}
 
 OCamlFormat requires source code that meets the following conditions:
 
@@ -101,7 +99,7 @@ OCamlFormat requires source code that meets the following conditions:
 - Parses without any preprocessing, using the version of the standard OCaml (not camlp4) parser used to build OCamlFormat. Attributes and extension points should be correctly preserved, but other mechanisms such as camlp4, cppo, etc. will not work.
 - Is either a module implementation ([.ml]), an interface ([.mli]) or a sequence of toplevel phrases ([.mlt]). dune files in OCaml syntax also work.
 
-{2 Warranty}
+{1 Warranty}
 
 Under those conditions, OCamlFormat is expected to produce output equivalent to the input. As a safety check in case of bugs, prior to terminating or modifying any input file, OCamlFormat enforces the following checks:
 - The parse trees obtained by parsing the original and formatted files are equal up to some minor normalization (see {{:https://github.com/ocaml-ppx/ocamlformat/blob/main/lib/Normalize.ml}Normalize}[.equal]).

--- a/doc/getting_started.mld
+++ b/doc/getting_started.mld
@@ -1,0 +1,109 @@
+{0 OCamlFormat Manual}
+
+{1 Getting started}
+
+{2 Installation}
+
+OCamlFormat can be installed with [opam]:
+
+{[
+opam install ocamlformat
+]}
+
+Alternatively, it can be built manually with:
+
+{[
+# To properly set `ocamlformat --version`
+dune subst
+dune build @install
+]}
+
+{2 Formatting code!}
+
+First of all, make sure you have an [.ocamlformat] file at the root of your project. Setting up your project to use the default profile and the OCamlFormat version you installed (hopefully the last one) in this [.ocamlformat] file is considered good practice:
+{[
+profile = default
+version = 0.20.0
+]}
+
+To manually invoke OCamlformat the general command is:
+
+{[
+ocamlformat [OPTION]... [SRC]...
+]}
+
+The most common usecase involves using the Dune build system, once your project is correctly setup (see {{:https://dune.readthedocs.io/en/stable/formatting.html#formatting-a-project}Dune's manual}) you can reformat your project using:
+
+{[
+dune build @fmt
+]}
+
+With this command, Dune will apply the appropriate autoformatter on each kind of file (where OCamlFormat is the one called on .ml, .mli, .mlt, .eliom and .eliomi files).
+All files are formatted, unless explicitly excluded (see below).
+
+{2 Code style}
+
+There are a number of preset code style profiles, selected using the [--profile] option by passing [--profile=<name>] on the command line or adding [profile = <name>] to an [.ocamlformat] configuration file.
+The available profiles are:
+- [conventional] (also known as [default]);
+- [ocamlformat];
+- [janestreet].
+
+It is considered a good practice to set a profile in the [.ocamlformat] configuration file of a project, even if you plan on using the [default] profile, explicitly setting [project = default] is recommended.
+
+Each profile is a collection of settings for all options, overriding lower priority configuration of individual options. So a profile can be selected and then individual options can be overridden if desired.
+
+The [conventional] (or [default]) profile aims to be as familiar and "conventional" appearing as the available options allow.
+
+The [ocamlformat] profile aims to take advantage of the strengths of a parsetree-based auto-formatter, and to limit the consequences of the weaknesses imposed by the current implementation. This is a style which optimizes for what the formatter can do best, rather than to match the style of any existing code. Instead of familiarity, the focus is on legibility, keeping the common cases reasonably compact while attempting to avoid confusing formatting in corner cases. General guidelines that have directed the design include:
+
+- Legibility, in the sense of making it as hard as possible for quick visual parsing to give the wrong interpretation, is of highest priority;
+- Whenever possible the high-level structure of the code should be obvious by looking only at the left margin, in particular, it should not be necessary to visually jump from left to right hunting for critical keywords, tokens, etc;
+- All else equal compact code is preferred as reading without scrolling is easier, so indentation or white space is avoided unless it helps legibility;
+- Attention has been given to making some syntactic gotchas visually obvious.
+
+If no profile is selected, the [default] one is used.
+
+{2 Options}
+
+The full options' documentation is available through [ocamlformat --help].
+Options can be modified by the means of:
+- an [.ocamlformat] configuration file with an [option = VAL] line
+- using the [OCAMLFORMAT] environment variable: [OCAMLFORMAT=option=VAL,...,option=VAL]
+- an optional parameter on the command line
+- a global [[@@@ocamlformat "option=VAL"]] attribute in the processed file
+- an [[@@ocamlformat "option=VAL"]] attribute on an expression in the processed file
+
+[.ocamlformat] files in the containing and all ancestor directories for each input file are used, as well as the global [.ocamlformat] file defined in [$XDG_CONFIG_HOME/ocamlformat]. The global [.ocamlformat] file has the lowest priority, then the closer the directory is to the processed file, the higher the priority.
+
+When the option [--enable-outside-detected-project] is set, [.ocamlformat] files outside of the project (including the one in [XDG_CONFIG_HOME]) are read. The project root of an input file is taken to be the nearest ancestor directory that contains a [.git] or [.hg] or [dune-project] file.
+When this option is not set, [.ocamlformat] files outside of the project are ignored. If no configuration file is found, formatting is disabled.
+
+An [.ocamlformat-ignore] file specifies files that OCamlFormat should ignore. Each line in an [.ocamlformat-ignore] file specifies a filename relative to the directory containing the [.ocamlformat-ignore] file. Lines starting with [#] are ignored and can be used as comments.
+
+{2 Version}
+
+On existing projects, it is likely an [.ocamlformat] file is already present, specifying a field [version = A.B.C] (e.g. [0.20.0]).
+
+It is the user's responsability to install the appropriate OCamlFormat binary, requesting an older version if one's project requires it:
+
+{[
+opam install ocamlformat.0.20.0
+]}
+
+Setting an OCamlFormat version in the configuration file is a good practice to ensure every contributor of a project gets the same formatting.
+
+{2 Requirements}
+
+OCamlFormat requires source code that meets the following conditions:
+
+- Does not trigger warning 50 (“Unexpected documentation comment.”). For code that triggers warning 50, it is unlikely that OCamlFormat will happen to preserve the documentation string attachment.
+- Parses without any preprocessing, using the version of the standard OCaml (not camlp4) parser used to build OCamlFormat. Attributes and extension points should be correctly preserved, but other mechanisms such as camlp4, cppo, etc. will not work.
+- Is either a module implementation ([.ml]), an interface ([.mli]) or a sequence of toplevel phrases ([.mlt]). dune files in OCaml syntax also work.
+
+{2 Warranty}
+
+Under those conditions, OCamlFormat is expected to produce output equivalent to the input. As a safety check in case of bugs, prior to terminating or modifying any input file, OCamlFormat enforces the following checks:
+- The parse trees obtained by parsing the original and formatted files are equal up to some minor normalization (see {{:https://github.com/ocaml-ppx/ocamlformat/blob/main/lib/Normalize.ml}Normalize}[.equal]).
+- The documentation strings, and their attachment, has been preserved (implicit in the parse tree check).
+- The set of comments in the original and formatted files is the same up to their location.

--- a/doc/howtos.mld
+++ b/doc/howtos.mld
@@ -1,0 +1,51 @@
+{0 OCamlFormat Manual}
+
+{1 How-To's}
+
+Using an autoformatter will make your process easier but it can also introduce a few pain points. Here are how to solve the most commonly encountered pain points.
+
+{2 Using OCamlFormat without breaking [git blame]}
+
+- Create [.git-blame-ignore-revs] in your project
+- Add revision(s) where the code was re-formatted
+
+{[
+# Apply new formatting with OCamlFormat
+2ceaf76b9f84cb632327c1479d0f30acfa3eeba2
+]}
+
+- Run [git config --local blame.ignoreRevsFile .git-blame-ignore-revs]
+- All future use of [git blame] will now provide blame information omitting the reformatting commits: lines that were changed or added by an ignored commit will be blamed on the previous commit that changed that line or nearby lines.
+
+{2 Resolve merge conflicts using Merge-fmt and OCamlFormat}
+
+{{:https://github.com/hhugo/merge-fmt}Merge-fmt} is a small wrapper on top of [git] commands to help resolve conflicts caused by code formatters.
+
+There are three ways to use [merge-fmt].
+
+{3 Standalone}
+Just call [merge-fmt] while there are unresolved conflicts. [merge-fmt] will try to
+resolve conflicts automatically.
+
+{3 As a Git mergetool}
+[merge-fmt] can act as a git {{:https://git-scm.com/docs/git-mergetool}mergetool}.
+First configure the current git repository with
+
+{[
+merge-fmt setup-mergetool
+git config --local mergetool.mergefmt.cmd 'merge-fmt mergetool --base=$BASE --current=$LOCAL --other=$REMOTE -o $MERGED'
+git config --local mergetool.mergefmt.trustExitCode true
+]}
+
+Then, use [git mergetool] to resolve conflicts with [git mergetool -t mergefmt].
+
+{3 As a git merge driver}
+[merge-fmt] can act as a git {{:https://git-scm.com/docs/gitattributes}merge driver}.
+Configure the current git repository to use [merge-fmt] as the default merge driver.
+{[
+$ merge-fmt setup-merge
+git config --local merge.mergefmt.name 'merge-fmt driver'
+git config --local merge.mergefmt.driver 'merge-fmt mergetool --base=%O --current=%A --other=%B -o %A --name=%P'
+git config --local merge.tool 'mergefmt'
+git config --local merge.default 'mergefmt'
+]}

--- a/doc/howtos.mld
+++ b/doc/howtos.mld
@@ -1,10 +1,8 @@
-{0 OCamlFormat Manual}
-
-{1 How-To's}
+{0 How-To's}
 
 Using an autoformatter will make your process easier but it can also introduce a few pain points. Here are how to solve the most commonly encountered pain points.
 
-{2 Using OCamlFormat without breaking [git blame]}
+{1 Using OCamlFormat without breaking [git blame]}
 
 - Create [.git-blame-ignore-revs] in your project
 - Add revision(s) where the code was re-formatted
@@ -17,17 +15,17 @@ Using an autoformatter will make your process easier but it can also introduce a
 - Run [git config --local blame.ignoreRevsFile .git-blame-ignore-revs]
 - All future use of [git blame] will now provide blame information omitting the reformatting commits: lines that were changed or added by an ignored commit will be blamed on the previous commit that changed that line or nearby lines.
 
-{2 Resolve merge conflicts using Merge-fmt and OCamlFormat}
+{1 Resolve merge conflicts using Merge-fmt and OCamlFormat}
 
 {{:https://github.com/hhugo/merge-fmt}Merge-fmt} is a small wrapper on top of [git] commands to help resolve conflicts caused by code formatters.
 
 There are three ways to use [merge-fmt].
 
-{3 Standalone}
+{2 Standalone}
 Just call [merge-fmt] while there are unresolved conflicts. [merge-fmt] will try to
 resolve conflicts automatically.
 
-{3 As a Git mergetool}
+{2 As a Git mergetool}
 [merge-fmt] can act as a git {{:https://git-scm.com/docs/git-mergetool}mergetool}.
 First configure the current git repository with
 
@@ -39,7 +37,7 @@ git config --local mergetool.mergefmt.trustExitCode true
 
 Then, use [git mergetool] to resolve conflicts with [git mergetool -t mergefmt].
 
-{3 As a git merge driver}
+{2 As a git merge driver}
 [merge-fmt] can act as a git {{:https://git-scm.com/docs/gitattributes}merge driver}.
 Configure the current git repository to use [merge-fmt] as the default merge driver.
 {[

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,15 @@
+{0 OCamlFormat Manual}
+
+If you are here, you are probably interested in using a formatting tool for your
+code base, so that you do not have to worry about formatting it by hand, and to
+speed up code review by focusing on the important parts.
+
+OCamlFormat is probably what you are after!
+OCamlFormat is a tool to format OCaml code.
+
+{1 Table of Content}
+- {{!page-getting_started}Getting started}
+- {{!page-editor_setup}Editor setup}
+- {{!page-howtos}How-To's}
+- {{!page-faq}Frequently asked questions}
+- {{!page-doc_comments}Doc-comments language reference}


### PR DESCRIPTION
Even if this PR is not finished, any feedback and help is of course welcomed!

- [x] Trimming the README to only keep a "getting started" section and link to the full manual
- [x] Gather the questions in a FAQ page (currently in the wiki)
- [x] Mention `dune` integration (I can't believe we didn't)
- [x] Mention `merge-fmt` in the Workflows page (fix #1155)
- [x] Document the doc-comment language accepted (fix #1347)

cc @tmattio