### PR TITLE
Improve comment attachment when followed but not preceded by a linebreak

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,8 @@
 
   + Preserve sugared syntax of extension points with attributes (#1913, @gpetiot)
 
+  + Improve comment attachment when followed but not preceded by a linebreak (#1926, @gpetiot)
+
 #### Changes
 
   + Set 'module-item-spacing=compact' in the default/conventional profile (#1848, @gpetiot)

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1011,6 +1011,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to comments.mli.stdout
+   (with-stderr-to comments.mli.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/comments.mli})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/comments.mli comments.mli.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/comments.mli.err comments.mli.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to comments_args.ml.stdout
    (with-stderr-to comments_args.ml.stderr
      (run %{bin:ocamlformat} --margin-check --max-iter=4 %{dep:tests/comments_args.ml})))))

--- a/test/passing/tests/comments.mli
+++ b/test/passing/tests/comments.mli
@@ -1,0 +1,7 @@
+val f : unit
+(** docstring *)
+(* comment *)
+
+val g : unit
+(** docstring *)
+(* comment *)

--- a/test/passing/tests/holes.ml.ref
+++ b/test/passing/tests/holes.ml.ref
@@ -1,15 +1,11 @@
 let () = _
 
 (** doc *)
-let () = (* A *) _ (* B *) [@attr]
-
-(* C *)
+let () = (* A *) _ (* B *) [@attr] (* C *)
 
 module M = _
 
 (** doc *)
-module M = (* A *) _ (* B *) [@attr]
-
-(* C *)
+module M = (* A *) _ (* B *) [@attr] (* C *)
 
 module M = _ (_) (_)

--- a/test/passing/tests/source.ml.err
+++ b/test/passing/tests/source.ml.err
@@ -1,2 +1,2 @@
 Warning: tests/source.ml:700 exceeds the margin
-Warning: tests/source.ml:2318 exceeds the margin
+Warning: tests/source.ml:2317 exceeds the margin

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -1007,7 +1007,6 @@ let g (type t) (x : t) (tag : t ty) =
 
 let g (type t) (x : t) (tag : t ty) =
   match tag with Bool -> idb2 x | Int -> x > 0
-
 (* Encoding generics using GADTs *)
 (* (c) Alain Frisch / Lexifi *)
 (* cf. http://www.lexifi.com/blog/dynamic-types *)


### PR DESCRIPTION
Fix #1925, this is a cheap fix that only makes Cmts.ml dirtier, but it allows to fix this for 0.20.0, as a bigger rework looks out of scope.
No diff with test_branch.sh