### PR TITLE
Define module Key for attributes and extensions

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -242,9 +242,26 @@ module Longident = struct
 end
 
 module Attr = struct
+  module Key = struct
+    type t = Regular | Item | Floating
+
+    let to_string = function
+      | Regular -> "@"
+      | Item -> "@@"
+      | Floating -> "@@@"
+  end
+
   let is_doc = function
     | {attr_name= {Location.txt= "ocaml.doc" | "ocaml.text"; _}; _} -> true
     | _ -> false
+end
+
+module Ext = struct
+  module Key = struct
+    type t = Regular | Item
+
+    let to_string = function Regular -> "%" | Item -> "%%"
+  end
 end
 
 module Exp = struct

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -18,8 +18,25 @@ val init : Conf.t -> unit
 (** Initialize internal state *)
 
 module Attr : sig
+  module Key : sig
+    type t =
+      | Regular  (** [@attr] *)
+      | Item  (** [@@attr] *)
+      | Floating  (** [@@@attr] *)
+
+    val to_string : t -> string
+  end
+
   val is_doc : attribute -> bool
   (** Holds for docstrings, that are attributes of the form [(** ... *)]. *)
+end
+
+module Ext : sig
+  module Key : sig
+    type t = Regular  (** [%ext] *) | Item  (** [%%ext] *)
+
+    val to_string : t -> string
+  end
 end
 
 module Token : sig


### PR DESCRIPTION
Do not pass the key as a literal string anymore, it was a bit error prone.