### PR TITLE
Make the formatting of attributes and docstrings more consistent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,6 +81,8 @@
 
   + Fix position of comments preceding Pmod_ident (#1939, @gpetiot)
 
+  + Make the formatting of attributes and docstrings more consistent (#1929, @gpetiot)
+
 #### Changes
 
   + Set 'module-item-spacing=compact' in the default/conventional profile (#1848, @gpetiot)

--- a/test/passing/tests/module_attributes.ml.err
+++ b/test/passing/tests/module_attributes.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/module_attributes.ml:23 exceeds the margin
+Warning: tests/module_attributes.ml:22 exceeds the margin

--- a/test/passing/tests/module_attributes.ml.ref
+++ b/test/passing/tests/module_attributes.ml.ref
@@ -2,8 +2,7 @@ include (functor [@warning "item"] (M : S) -> N) [@@warning "structure"]
 
 include struct
   type t
-end
-[@warning "item"] [@@warning "structure"]
+end [@warning "item"] [@@warning "structure"]
 
 include M [@warning "item"] [@@warning "structure"]
 

--- a/test/passing/tests/source.ml.err
+++ b/test/passing/tests/source.ml.err
@@ -1,2 +1,2 @@
-Warning: tests/source.ml:700 exceeds the margin
-Warning: tests/source.ml:2317 exceeds the margin
+Warning: tests/source.ml:699 exceeds the margin
+Warning: tests/source.ml:2316 exceeds the margin

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -10,8 +10,7 @@ module M = struct
   type t = {l: (t[@foo]) [@foo]} [@@foo] [@@foo]
 
   [@@@foo]
-end
-[@foo]
+end [@foo]
 [@@foo]
 
 module type S = sig


### PR DESCRIPTION
This PR removes a lot of local tweaks, remove some boilerplate code and improves consistency. I would like to go even further and remove every call of the function `doc_atrs` , and instead have something like `wrap_attributes_and_docstrings` that would correctly place attributes and docstrings (duh!), and automatically takes care of the docstrings that only go before and the ones that can go both depending of the `doc-comments` option. But this PR looks good enough to be merged in my opinion.

The tests look good, the small diff shows the improved consistency (you can see in each file that it becomes more consistent with the rest).