### PR TITLE
Extract file system functions from Conf

### DIFF
--- a/lib/File_system.ml
+++ b/lib/File_system.ml
@@ -1,0 +1,108 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlFormat                               *)
+(*                                                                        *)
+(*            Copyright (c) Facebook, Inc. and its affiliates.            *)
+(*                                                                        *)
+(*      This source code is licensed under the MIT license found in       *)
+(*      the LICENSE file in the root directory of this source tree.       *)
+(*                                                                        *)
+(**************************************************************************)
+
+let project_root_witness = [".git"; ".hg"; "dune-project"]
+
+let is_project_root ~root dir =
+  match root with
+  | Some root -> Fpath.equal dir root
+  | None ->
+      List.exists project_root_witness ~f:(fun name ->
+          Fpath.(exists (dir / name)) )
+
+let dot_ocp_indent = ".ocp-indent"
+
+let dot_ocamlformat = ".ocamlformat"
+
+let dot_ocamlformat_ignore = ".ocamlformat-ignore"
+
+let dot_ocamlformat_enable = ".ocamlformat-enable"
+
+type configuration_file = Ocamlformat of Fpath.t | Ocp_indent of Fpath.t
+
+let is_ocp_indent_file = function
+  | Ocamlformat _ -> false
+  | Ocp_indent _ -> true
+
+let root_ocamlformat_file ~root =
+  let root = Option.value root ~default:(Fpath.cwd ()) in
+  Fpath.(root / dot_ocamlformat)
+
+let xdg_config () =
+  let xdg_config_home =
+    match Caml.Sys.getenv_opt "XDG_CONFIG_HOME" with
+    | None | Some "" -> (
+      match Caml.Sys.getenv_opt "HOME" with
+      | None | Some "" -> None
+      | Some home -> Some Fpath.(v home / ".config") )
+    | Some xdg_config_home -> Some (Fpath.v xdg_config_home)
+  in
+  match xdg_config_home with
+  | Some xdg_config_home ->
+      let filename = Fpath.(xdg_config_home / "ocamlformat") in
+      if Fpath.exists filename then Some filename else None
+  | None -> None
+
+type t =
+  { ignore_files: Fpath.t list
+  ; enable_files: Fpath.t list
+  ; configuration_files: configuration_file list
+  ; project_root: Fpath.t option }
+
+let make ~enable_outside_detected_project ~disable_conf_files ~root ~file =
+  let dir = Fpath.(file |> split_base |> fst) in
+  let volume, dir = Fpath.split_volume dir in
+  let segs = Fpath.segs dir |> List.rev in
+  let rec aux fs segs =
+    match segs with
+    | [] | [""] -> fs
+    | "" :: upper_segs -> aux fs upper_segs
+    | _ :: upper_segs ->
+        let sep = Fpath.dir_sep in
+        let dir = Fpath.v (volume ^ String.concat ~sep (List.rev segs)) in
+        let fs =
+          { fs with
+            ignore_files=
+              (let filename = Fpath.(dir / dot_ocamlformat_ignore) in
+               if Fpath.exists filename then filename :: fs.ignore_files
+               else fs.ignore_files )
+          ; enable_files=
+              (let filename = Fpath.(dir / dot_ocamlformat_enable) in
+               if Fpath.exists filename then filename :: fs.enable_files
+               else fs.enable_files )
+          ; configuration_files=
+              ( if disable_conf_files then []
+              else
+                let f_1 = Fpath.(dir / dot_ocamlformat) in
+                let files =
+                  if Fpath.exists f_1 then
+                    Ocamlformat f_1 :: fs.configuration_files
+                  else fs.configuration_files
+                in
+                let f_2 = Fpath.(dir / dot_ocp_indent) in
+                if Fpath.exists f_2 then Ocp_indent f_2 :: files else files
+              ) }
+        in
+        if is_project_root ~root dir && not enable_outside_detected_project
+        then {fs with project_root= Some dir}
+        else aux fs upper_segs
+  in
+  let init =
+    { ignore_files= []
+    ; enable_files= []
+    ; configuration_files= []
+    ; project_root= None }
+  in
+  let fs = aux init segs in
+  match (xdg_config (), enable_outside_detected_project) with
+  | None, _ | Some _, false -> fs
+  | Some xdg, true ->
+      {fs with configuration_files= Ocamlformat xdg :: fs.configuration_files}

--- a/lib/File_system.mli
+++ b/lib/File_system.mli
@@ -1,0 +1,31 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlFormat                               *)
+(*                                                                        *)
+(*            Copyright (c) Facebook, Inc. and its affiliates.            *)
+(*                                                                        *)
+(*      This source code is licensed under the MIT license found in       *)
+(*      the LICENSE file in the root directory of this source tree.       *)
+(*                                                                        *)
+(**************************************************************************)
+
+val project_root_witness : string list
+
+type configuration_file = Ocamlformat of Fpath.t | Ocp_indent of Fpath.t
+
+val is_ocp_indent_file : configuration_file -> bool
+
+val root_ocamlformat_file : root:Fpath.t option -> Fpath.t
+
+type t =
+  { ignore_files: Fpath.t list
+  ; enable_files: Fpath.t list
+  ; configuration_files: configuration_file list
+  ; project_root: Fpath.t option }
+
+val make :
+     enable_outside_detected_project:bool
+  -> disable_conf_files:bool
+  -> root:Fpath.t option
+  -> file:Fpath.t (** Absolute path of the file to format. *)
+  -> t

--- a/test/cli/conf.t
+++ b/test/cli/conf.t
@@ -6,7 +6,7 @@ Invalid version:
 Exit code is printed by hand because sed succeeding would hide the error.
 
   $ (<a.ml ocamlformat --impl -; echo [$?]) 2>&1 | sed 's/expecting "[^"]*"/expecting "..."/g'
-  ocamlformat: Error while parsing .ocamlformat:
+  ocamlformat: Error while parsing $TESTCASE_ROOT/.ocamlformat:
                For option "version": expecting "..." but got "bad"
   [1]
 
@@ -14,7 +14,7 @@ Invalid syntax in .ocamlformat file:
 
   $ echo 'a = b = c' > .ocamlformat
   $ echo 'let x = 1"' | ocamlformat --impl -
-  ocamlformat: Error while parsing .ocamlformat:
+  ocamlformat: Error while parsing $TESTCASE_ROOT/.ocamlformat:
                Invalid format "a = b = c"
   [1]
 
@@ -22,7 +22,7 @@ Invalid option:
 
   $ echo 'unknown_option = true' > .ocamlformat
   $ echo 'let x = 1' | ocamlformat --impl -
-  ocamlformat: Error while parsing .ocamlformat:
+  ocamlformat: Error while parsing $TESTCASE_ROOT/.ocamlformat:
                Unknown option "unknown_option"
   [1]
 
@@ -30,7 +30,7 @@ Invalid option (short negated form):
 
   $ echo 'no-wrap-comments' > .ocamlformat
   $ echo 'let x = 1' | ocamlformat --impl -
-  ocamlformat: Error while parsing .ocamlformat:
+  ocamlformat: Error while parsing $TESTCASE_ROOT/.ocamlformat:
                Unknown option "no-wrap-comments": "no-wrap-comments" is the short form for "wrap-comments=false". It is only accepted on command line, please use "wrap-comments=false" or "wrap-comments=true" instead.
   [1]
 
@@ -38,6 +38,6 @@ Invalid value:
 
   $ echo 'field-space = unknown_value' > .ocamlformat
   $ echo 'let x = 1' | ocamlformat --impl -
-  ocamlformat: Error while parsing .ocamlformat:
+  ocamlformat: Error while parsing $TESTCASE_ROOT/.ocamlformat:
                For option "field-space": invalid value `unknown_value', expected one of `loose', `tight' or `tight-decl'
   [1]

--- a/test/cli/removed_option.t
+++ b/test/cli/removed_option.t
@@ -54,7 +54,7 @@ An error is also reported if a removed option is set in an .ocamlformat file:
 
   $ echo 'escape-chars = preserve' > .ocamlformat
   $ ocamlformat a.ml
-  ocamlformat: Error while parsing .ocamlformat:
+  ocamlformat: Error while parsing $TESTCASE_ROOT/.ocamlformat:
                For option "escape-chars": This option has been removed in version 0.16.0. Concrete syntax will now always be preserved.
   [1]
 


### PR DESCRIPTION
Just some cleaning of the Conf.ml file, the error message when parsing a configuration file now displays the path instead of just ".ocamlformat"