### PR TITLE
Remove unnecessary surrounding parentheses for immediate objects (OCaml 4.14 feature)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,9 @@
   + Handle let operator punning uniformly with other punning forms.
     Normalizes let operator to the punned form where possible, if output syntax version is at least OCaml 4.13.0. (#1834, #1846, @jberdine)
 
+  + Remove unnecessary surrounding parentheses for immediate objects.
+    This syntax is only produced when the output syntax is at least OCaml 4.14. (#<PR_NUMBER>, @gpetiot)
+
 ### 0.19.0 (2021-07-16)
 
 #### Bug fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -109,7 +109,7 @@
     Normalizes let operator to the punned form where possible, if output syntax version is at least OCaml 4.13.0. (#1834, #1846, @jberdine)
 
   + Remove unnecessary surrounding parentheses for immediate objects.
-    This syntax is only produced when the output syntax is at least OCaml 4.14. (#<PR_NUMBER>, @gpetiot)
+    This syntax is only produced when the output syntax is at least OCaml 4.14. (#1934, @gpetiot)
 
 ### 0.19.0 (2021-07-16)
 

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -3764,6 +3764,42 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to object_expr-414.ml.stdout
+   (with-stderr-to object_expr-414.ml.stderr
+     (run %{bin:ocamlformat} --margin-check --ocaml-version=4.14.0 %{dep:tests/object_expr.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/object_expr-414.ml.ref object_expr-414.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/object_expr-414.ml.err object_expr-414.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to object_expr.ml.stdout
+   (with-stderr-to object_expr.ml.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/object_expr.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/object_expr.ml.ref object_expr.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/object_expr.ml.err object_expr.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to object_type.ml.stdout
    (with-stderr-to object_type.ml.stderr
      (run %{bin:ocamlformat} --margin-check %{dep:tests/object_type.ml})))))

--- a/test/passing/tests/object_expr-414.ml.opts
+++ b/test/passing/tests/object_expr-414.ml.opts
@@ -1,0 +1,1 @@
+--ocaml-version=4.14.0

--- a/test/passing/tests/object_expr-414.ml.ref
+++ b/test/passing/tests/object_expr-414.ml.ref
@@ -1,0 +1,16 @@
+object
+  method one = 1
+end
+  #one
+;;
+
+Some
+  object
+    method one = 1
+  end
+;;
+
+ignore
+  object
+    method one = 1
+  end

--- a/test/passing/tests/object_expr.ml
+++ b/test/passing/tests/object_expr.ml
@@ -1,0 +1,3 @@
+object method one = 1 end # one;;
+Some object method one = 1 end;;
+ignore object method one = 1 end;;

--- a/test/passing/tests/object_expr.ml.ref
+++ b/test/passing/tests/object_expr.ml.ref
@@ -1,0 +1,16 @@
+(object
+   method one = 1
+end )
+  #one
+;;
+
+Some
+  (object
+     method one = 1
+  end )
+;;
+
+ignore
+  (object
+     method one = 1
+  end )


### PR DESCRIPTION
Handle https://github.com/ocaml/ocaml/pull/10441