### PR TITLE
Fix position of comments preceding Pmod_ident

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,7 +79,7 @@
 
   + Improve comment attachment when followed but not preceded by a linebreak (#1926, @gpetiot)
 
-  + Fix position of comments preceding Pmod_ident (#<PR_NUMBER>, @gpetiot)
+  + Fix position of comments preceding Pmod_ident (#1939, @gpetiot)
 
 #### Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,8 @@
 
   + Improve comment attachment when followed but not preceded by a linebreak (#1926, @gpetiot)
 
+  + Fix position of comments preceding Pmod_ident (#<PR_NUMBER>, @gpetiot)
+
 #### Changes
 
   + Set 'module-item-spacing=compact' in the default/conventional profile (#1848, @gpetiot)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4039,20 +4039,14 @@ and fmt_module_expr ?(can_break_before_struct = false) c ({ast= m; _} as xmod)
             ) }
   | Pmod_ident lid ->
       let doc, atrs = doc_atrs pmod_attributes in
-      let has_pro = Cmts.has_before c.cmts pmod_loc || Option.is_some doc in
-      let has_epi =
-        Cmts.has_after c.cmts pmod_loc || not (List.is_empty atrs)
-      in
       { empty with
         opn= open_hvbox 2
-      ; pro=
-          Option.some_if has_pro
-            (Cmts.fmt_before c pmod_loc $ fmt_docstring c ~epi:(fmt "@,") doc)
-      ; bdy= fmt_longident_loc c lid
-      ; cls= close_box
-      ; epi=
-          Option.some_if has_epi
-            (Cmts.fmt_after c pmod_loc $ fmt_attributes c ~pre:Space atrs) }
+      ; bdy=
+          Cmts.fmt c pmod_loc
+            ( fmt_docstring c ~epi:(fmt "@,") doc
+            $ fmt_longident_loc c lid
+            $ fmt_attributes c ~pre:Space atrs )
+      ; cls= close_box }
   | Pmod_structure sis ->
       let empty =
         List.is_empty sis && not (Cmts.has_within c.cmts pmod_loc)

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -333,8 +333,9 @@ let y =
     (* b *)
     x
 
-module A (* A *) () = (* B *)
-                      (* C *)
+module A (* A *) () =
+  (* B *)
+  (* C *)
   B
 
 let kk = (* foo *) (module A : T)


### PR DESCRIPTION
The diff is arguable but I think it's more consistent to align it with the Pmod_ident it refers to.

test_branch's diff:
```diff
diff --git a/compiler/tests-jsoo/test_rec_mod.ml b/compiler/tests-jsoo/test_rec_mod.ml
index c5efda5b91..427c1d039c 100644
--- a/compiler/tests-jsoo/test_rec_mod.ml
+++ b/compiler/tests-jsoo/test_rec_mod.ml
@@ -24,7 +24,8 @@ module rec Id : sig
   type t = { id : int }
 
   val compare : t -> t -> int
-end = (* error here: undefined compare function *)
+end =
+  (* error here: undefined compare function *)
   Id
```