### PR TITLE
Empty or singleton array/list expressions are considered "simple"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 #### Changes
 
   + More expressions are considered "simple" (not inducing a break e.g. as an argument of an application):
-    - Variant with no argument (#1968, @gpetiot)
+    - Variants with no argument (#1968, @gpetiot)
     - Empty or singleton arrays/lists (#1943, @gpetiot)
 
   + Print odoc code block delimiters on their own line (#1980, @gpetiot)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,9 @@
 
 #### Changes
 
-  + Variant expressions with no argument are considered "simple" (not inducing a break e.g. as an argument of an application) (#1968, @gpetiot)
+  + More expressions are considered "simple" (not inducing a break e.g. as an argument of an application):
+    - Variant with no argument (#1968, @gpetiot)
+    - Empty or singleton arrays/lists (#1943, @gpetiot)
 
   + Print odoc code block delimiters on their own line (#1980, @gpetiot)
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -314,6 +314,8 @@ module Exp = struct
         ({pexp_desc= Pexp_ident {txt= Lident "not"; _}; _}, [(_, e1)]) ->
         is_trivial e1
     | Pexp_variant (_, None) -> true
+    | Pexp_array [] | Pexp_list [] -> true
+    | Pexp_array [x] | Pexp_list [x] -> is_trivial x
     | _ -> false
 
   let rec exposed_left e =

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7603,3 +7603,15 @@ let x =
     ~f:(fun thing ->
       something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
 ;;
+
+let x =
+  foo [ A; B ] ~f:(fun thing ->
+    something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
+;;
+
+let x =
+  foo
+    [ [ A ]; B ]
+    ~f:(fun thing ->
+      something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
+;;

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9844,3 +9844,13 @@ let x =
   foo (`A `b) ~f:(fun thing ->
       something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
 ;;
+
+let x =
+  foo [ A; B ] ~f:(fun thing ->
+      something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
+;;
+
+let x =
+  foo [ [ A ]; B ] ~f:(fun thing ->
+      something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
+;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9844,3 +9844,13 @@ let x =
   foo (`A `b) ~f:(fun thing ->
       something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
 ;;
+
+let x =
+  foo [ A; B ] ~f:(fun thing ->
+      something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
+;;
+
+let x =
+  foo [ [ A ]; B ] ~f:(fun thing ->
+      something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
+;;

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -8967,9 +8967,7 @@ let h ?l:(p = 1) ?y:u ?(x = 3) = 2
 let _ = function
   | a, s, ba1, ba2, ba3, bg ->
       ignore
-        ( Array.get x 1
-        + Array.get [||] 0
-        + Array.get [|1|] 1
+        ( Array.get x 1 + Array.get [||] 0 + Array.get [|1|] 1
         + Array.get [|1; 2|] 2 ) ;
       ignore [String.get s 1; String.get "" 2; String.get "123" 3] ;
       ignore (ba1.{0} + ba2.{1, 2} + ba3.{3, 4, 5}) ignore bg.{1, 2, 3, 4}


### PR DESCRIPTION
Fix #1938 

Here is the diff with the conventional profile:

<details>

```diff
diff --git a/lib/Cmts.ml b/lib/Cmts.ml
index e99e28d7..154a2db0 100644
--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -464,9 +464,8 @@ let fmt_cmts t conf ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n") ?(adj = eol)
       fmt_opt pro $ fmt_cmts_aux t conf cmts ~fmt_code pos $ epi
 
 let fmt_before t conf ~fmt_code ?pro ?(epi = Fmt.break 1 0) ?eol ?adj loc =
-  fmt_cmts t conf
-    (find_cmts t `Before loc)
-    ~fmt_code ?pro ~epi ?eol ?adj loc Cmt.Before
+  fmt_cmts t conf (find_cmts t `Before loc) ~fmt_code ?pro ~epi ?eol ?adj loc
+    Cmt.Before
 
 let fmt_after t conf ~fmt_code ?(pro = Fmt.break 1 0) ?epi loc =
   let open Fmt in
@@ -474,17 +473,15 @@ let fmt_after t conf ~fmt_code ?(pro = Fmt.break 1 0) ?epi loc =
     fmt_cmts t conf (find_cmts t `Within loc) ~fmt_code ~pro ?epi loc Cmt.Within
   in
   let after =
-    fmt_cmts t conf
-      (find_cmts t `After loc)
-      ~fmt_code ~pro ?epi ~eol:noop loc Cmt.After
+    fmt_cmts t conf (find_cmts t `After loc) ~fmt_code ~pro ?epi ~eol:noop loc
+      Cmt.After
   in
   within $ after
 
 let fmt_within t conf ~fmt_code ?(pro = Fmt.break 1 0) ?(epi = Fmt.break 1 0)
     loc =
-  fmt_cmts t conf
-    (find_cmts t `Within loc)
-    ~fmt_code ~pro ~epi ~eol:Fmt.noop loc Cmt.Within
+  fmt_cmts t conf (find_cmts t `Within loc) ~fmt_code ~pro ~epi ~eol:Fmt.noop
+    loc Cmt.Within
 
 module Toplevel = struct
   let fmt_cmts t conf ~fmt_code found (pos : Cmt.pos) =
diff --git a/infer/src/base/Config.ml b/infer/src/base/Config.ml
index 462d0a7f3..29d456904 100644
--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -659,8 +659,7 @@ and biabduction_join_cond =
 
 and biabduction_memleak_buckets =
   CLOpt.mk_symbol_seq ~deprecated:[ "-ml-buckets" ]
-    ~long:"biabduction-memleak-buckets"
-    ~default:[ `MLeak_cf ]
+    ~long:"biabduction-memleak-buckets" ~default:[ `MLeak_cf ]
     ~symbols:ml_bucket_symbols ~eq:PolyVariantEqual.( = )
     "Specify the memory leak buckets to be checked in C++."
 
diff --git a/infer/src/clang/cTrans.ml b/infer/src/clang/cTrans.ml
index 57d35d743..897992c82 100644
--- a/infer/src/clang/cTrans.ml
+++ b/infer/src/clang/cTrans.ml
@@ -3243,8 +3243,7 @@ struct
             match Procdesc.Node.get_kind try_end with
             | Stmt_node ReturnStmt -> ()
             | _ ->
-                Procdesc.set_succs try_end
-                  ~normal:(Some [ try_exit_node ])
+                Procdesc.set_succs try_end ~normal:(Some [ try_exit_node ])
                   ~exn:None)
           try_ends;
         {
diff --git a/infer/src/nullsafe/unit/ThirdPartyAnnotationInfoTests.ml b/infer/src/nullsafe/unit/ThirdPartyAnnotationInfoTests.ml
index eaf2c62c5..842def6ce 100644
--- a/infer/src/nullsafe/unit/ThirdPartyAnnotationInfoTests.ml
+++ b/infer/src/nullsafe/unit/ThirdPartyAnnotationInfoTests.ml
@@ -88,8 +88,8 @@ let basic_find =
   (* Make sure we can find what we just stored *)
   assert_has_nullability_info storage
     { class_name = "a.A"; method_name = Method "foo"; param_types = [ "b.B" ] }
-    ~expected_nullability:(Nonnull, [ Nonnull ])
     { class_name = "a.A"; method_name = Method "foo"; param_types = [ "b.B" ] }
     { class_name = "a.A"; method_name = Method "foo"; param_types = [ "b.B" ] }
-    ~expected_nullability:(Nonnull, [ Nonnull ])
-    ~expected_file:"test.sig" ~expected_line:1;
+    ~expected_nullability:(Nonnull, [ Nonnull ]) ~expected_file:"test.sig"
+    ~expected_line:1;
   assert_has_nullability_info storage
     {
       class_name = "b.B";
@@ -133,8 +133,8 @@ let disregards_whitespace_lines_and_comments =
   in
   assert_has_nullability_info storage
     { class_name = "a.A"; method_name = Method "foo"; param_types = [ "b.B" ] }
-    ~expected_nullability:(Nonnull, [ Nonnull ])
-    ~expected_file:"test.sig" ~expected_line:2;
+    ~expected_nullability:(Nonnull, [ Nonnull ]) ~expected_file:"test.sig"
+    ~expected_line:2;
   (* Commented out signatures should be ignored *)
   assert_no_info storage
     { class_name = "a.A"; method_name = Method "bar"; param_types = [ "b.B" ] }
@@ -260,8 +260,8 @@ let can_add_several_files =
   in
   assert_has_nullability_info storage
     { class_name = "a.A"; method_name = Method "foo"; param_types = [ "b.B" ] }
-    ~expected_nullability:(Nonnull, [ Nonnull ])
-    ~expected_file:"file1.sig" ~expected_line:1;
+    ~expected_nullability:(Nonnull, [ Nonnull ]) ~expected_file:"file1.sig"
+    ~expected_line:1;
   (* 2. Add another file and check if we added info *)
   let file2 = [ "e.E#baz(f.F)"; "g.G#<init>(h.H, @Nullable i.I) @Nullable" ] in
   let storage =
@@ -270,13 +270,13 @@ let can_add_several_files =
   in
   assert_has_nullability_info storage
     { class_name = "e.E"; method_name = Method "baz"; param_types = [ "f.F" ] }
-    ~expected_nullability:(Nonnull, [ Nonnull ])
-    ~expected_file:"file2.sig" ~expected_line:1;
+    ~expected_nullability:(Nonnull, [ Nonnull ]) ~expected_file:"file2.sig"
+    ~expected_line:1;
   (* 3. Ensure we did not forget the content from the first file *)
   assert_has_nullability_info storage
     { class_name = "a.A"; method_name = Method "foo"; param_types = [ "b.B" ] }
-    ~expected_nullability:(Nonnull, [ Nonnull ])
-    ~expected_file:"file1.sig" ~expected_line:1
+    ~expected_nullability:(Nonnull, [ Nonnull ]) ~expected_file:"file1.sig"
+    ~expected_line:1
 
 let should_not_forgive_unparsable_strings =
   "should_not_forgive_unparsable_strings" >:: fun _ ->
diff --git a/infer/src/pulse/PulseCallOperations.ml b/infer/src/pulse/PulseCallOperations.ml
index ff767ed62..52901bca9 100644
--- a/infer/src/pulse/PulseCallOperations.ml
+++ b/infer/src/pulse/PulseCallOperations.ml
@@ -37,8 +37,7 @@ let unknown_call tenv path call_loc (reason : CallEvent.t) ~ret ~actuals
             List.fold fields ~init:astate ~f:(fun acc (field, field_typ, _) ->
                 let fresh_value = AbstractValue.mk_fresh () in
                 Memory.add_edge addr (FieldAccess field)
-                  (fresh_value, [ event ])
-                  call_loc acc
+                  (fresh_value, [ event ]) call_loc acc
                 |> havoc_fields (fresh_value, history) field_typ)
         | None -> astate)
     | _ -> astate
@@ -57,9 +56,8 @@ let unknown_call tenv path call_loc (reason : CallEvent.t) ~ret ~actuals
            raising issues when havoc'ing pointer parameters (which normally causes a [check_valid]
            call). *)
         let fresh_value = AbstractValue.mk_fresh () in
-        Memory.add_edge actual Dereference
-          (fresh_value, [ event ])
-          call_loc astate
+        Memory.add_edge actual Dereference (fresh_value, [ event ]) call_loc
+          astate
         |> havoc_fields actual typ
     | _ -> astate
   in
diff --git a/infer/src/pulse/PulseModels.ml b/infer/src/pulse/PulseModels.ml
index 2a702aaf4..00dea8e5c 100644
--- a/infer/src/pulse/PulseModels.ml
+++ b/infer/src/pulse/PulseModels.ml
@@ -1037,8 +1037,7 @@ module StdFunction = struct
       let empty_target = AbstractValue.mk_fresh () in
       let<+> astate =
         PulseOperations.write_deref path location ~ref:dest
-          ~obj:(empty_target, [ event ])
-          astate
+          ~obj:(empty_target, [ event ]) astate
       in
       PulseOperations.havoc_id ret_id [ event ] astate
     else
@@ -1505,14 +1504,12 @@ module JavaCollection = struct
     let init_value = AbstractValue.mk_fresh () in
     (* The two internal fields are initially set to null *)
     let<*> astate =
-      Java.write_field path fst_field
-        (init_value, [ event ])
-        location fresh_val astate
+      Java.write_field path fst_field (init_value, [ event ]) location fresh_val
+        astate
     in
     let<*> astate =
-      Java.write_field path snd_field
-        (init_value, [ event ])
-        location fresh_val astate
+      Java.write_field path snd_field (init_value, [ event ]) location fresh_val
+        astate
     in
     (* The empty field is initially set to true *)
     let<*> astate =
@@ -1581,9 +1578,8 @@ module JavaCollection = struct
     in
     let is_empty_val = AbstractValue.mk_fresh () in
     let<*> astate' =
-      Java.write_field path is_empty_field
-        (is_empty_val, [ event ])
-        location coll_val astate
+      Java.write_field path is_empty_field (is_empty_val, [ event ]) location
+        coll_val astate
     in
     (* case1: fst_field is updated *)
     let astate1 =
@@ -1626,9 +1622,8 @@ module JavaCollection = struct
     let ret_val = AbstractValue.mk_fresh () in
     let is_empty_val = AbstractValue.mk_fresh () in
     let* astate =
-      Java.write_field path is_empty_field
-        (is_empty_val, [ event ])
-        location coll_val astate
+      Java.write_field path is_empty_field (is_empty_val, [ event ]) location
+        coll_val astate
--- a/infer/src/pulse/PulseCallOperations.ml
+++ b/infer/src/pulse/PulseCallOperations.ml
@@ -37,8 +37,7 @@ let unknown_call tenv path call_loc (reason : CallEvent.t) ~ret ~actuals
             List.fold fields ~init:astate ~f:(fun acc (field, field_typ, _) ->
                 let fresh_value = AbstractValue.mk_fresh () in
                 Memory.add_edge addr (FieldAccess field)
-                  (fresh_value, [ event ])
-                  call_loc acc
+                  (fresh_value, [ event ]) call_loc acc
                 |> havoc_fields (fresh_value, history) field_typ)
         | None -> astate)
     | _ -> astate
@@ -57,9 +56,8 @@ let unknown_call tenv path call_loc (reason : CallEvent.t) ~ret ~actuals
            raising issues when havoc'ing pointer parameters (which normally causes a [check_valid]
            call). *)
         let fresh_value = AbstractValue.mk_fresh () in
-        Memory.add_edge actual Dereference
-          (fresh_value, [ event ])
-          call_loc astate
+        Memory.add_edge actual Dereference (fresh_value, [ event ]) call_loc
+          astate
         |> havoc_fields actual typ
     | _ -> astate
   in
diff --git a/infer/src/pulse/PulseModels.ml b/infer/src/pulse/PulseModels.ml
index 2a702aaf4..00dea8e5c 100644
--- a/infer/src/pulse/PulseModels.ml
+++ b/infer/src/pulse/PulseModels.ml
@@ -1037,8 +1037,7 @@ module StdFunction = struct
       let empty_target = AbstractValue.mk_fresh () in
       let<+> astate =
         PulseOperations.write_deref path location ~ref:dest
-          ~obj:(empty_target, [ event ])
-          astate
+          ~obj:(empty_target, [ event ]) astate
       in
       PulseOperations.havoc_id ret_id [ event ] astate
     else
@@ -1505,14 +1504,12 @@ module JavaCollection = struct
     let init_value = AbstractValue.mk_fresh () in
     (* The two internal fields are initially set to null *)
     let<*> astate =
-      Java.write_field path fst_field
-        (init_value, [ event ])
-        location fresh_val astate
+      Java.write_field path fst_field (init_value, [ event ]) location fresh_val
+        astate
     in
     let<*> astate =
-      Java.write_field path snd_field
-        (init_value, [ event ])
-        location fresh_val astate
+      Java.write_field path snd_field (init_value, [ event ]) location fresh_val
+        astate
     in
     (* The empty field is initially set to true *)
     let<*> astate =
@@ -1581,9 +1578,8 @@ module JavaCollection = struct
     in
     let is_empty_val = AbstractValue.mk_fresh () in
     let<*> astate' =
-      Java.write_field path is_empty_field
-        (is_empty_val, [ event ])
-        location coll_val astate
+      Java.write_field path is_empty_field (is_empty_val, [ event ]) location
+        coll_val astate
     in
     (* case1: fst_field is updated *)
     let astate1 =
@@ -1626,9 +1622,8 @@ module JavaCollection = struct
     let ret_val = AbstractValue.mk_fresh () in
     let is_empty_val = AbstractValue.mk_fresh () in
     let* astate =
-      Java.write_field path is_empty_field
-        (is_empty_val, [ event ])
-        location coll_val astate
+      Java.write_field path is_empty_field (is_empty_val, [ event ]) location
+        coll_val astate
     in
     let* astate =
       PulseArithmetic.and_eq_int null_val IntLit.zero astate
@@ -1640,8 +1635,7 @@ module JavaCollection = struct
     in
     let+ astate =
       PulseOperations.write_deref path location ~ref:field_addr
-        ~obj:(null_val, [ event ])
-        astate
+        ~obj:(null_val, [ event ]) astate
     in
     PulseOperations.write_id ret_id (ret_val, [ event ]) astate
 
@@ -1715,19 +1709,16 @@ module JavaCollection = struct
       PulseOperations.eval_access path Read location coll Dereference astate
     in
     let<*> astate =
-      Java.write_field path fst_field
-        (null_val, [ event ])
-        location coll_val astate
+      Java.write_field path fst_field (null_val, [ event ]) location coll_val
+        astate
     in
     let<*> astate =
-      Java.write_field path snd_field
-        (null_val, [ event ])
-        location coll_val astate
+      Java.write_field path snd_field (null_val, [ event ]) location coll_val
+        astate
     in
     let<*> astate =
-      Java.write_field path is_empty_field
-        (is_empty_val, [ event ])
-        location coll_val astate
+      Java.write_field path is_empty_field (is_empty_val, [ event ]) location
+        coll_val astate
     in
     let<+> astate =
       PulseArithmetic.and_eq_int null_val IntLit.zero astate
@@ -1752,8 +1743,7 @@ module JavaCollection = struct
     let astate = PulseOperations.write_id ret_id (not_found_val, hist) astate in
     PulseOperations.invalidate path
       (StackAddress (Var.of_id ret_id, hist))
-      location (ConstantDereference IntLit.zero)
-      (not_found_val, [ event ])
+      location (ConstantDereference IntLit.zero) (not_found_val, [ event ])
       astate
 
   (* Auxiliary function that splits the state into three, considering the case that
diff --git a/infer/src/unit/IListTests.ml b/infer/src/unit/IListTests.ml
index 9f85bba97..6f1a40127 100644
--- a/infer/src/unit/IListTests.ml
+++ b/infer/src/unit/IListTests.ml
@@ -55,8 +55,7 @@ let traverse_test =
            Option.some_if (Int.equal n 42) n))
   in
   let test_some _ =
-    assert_equal
-      (Some [ 42; 43 ])
+    assert_equal (Some [ 42; 43 ])
       (IList.traverse_opt [ 42; 43 ] ~f:Option.some)
   in
   [
diff --git a/sledge/cli/sledge_buck.ml b/sledge/cli/sledge_buck.ml
index 2d6750417..19b6ccb9f 100644
--- a/sledge/cli/sledge_buck.ml
+++ b/sledge/cli/sledge_buck.ml
@@ -95,8 +95,7 @@ let expand_arch_archive ~context archive_name =
                     (run_exit_status
                        (Lazy.force llvm_bin ^ "llvm-ar")
                        [ "p"; archive_name; name ]
-                    |+ run "head" [ "-c2" ]
-                    |+ read_all)
+                    |+ run "head" [ "-c2" ] |+ read_all)
                 in
                 if String.equal is_bc "BC" then (
                   warn "found bc file %s in %s" name archive_name ();
diff --git a/sledge/src/fol/context.ml b/sledge/src/fol/context.ml
index d10772687..1ef84e12f 100644
--- a/sledge/src/fol/context.ml
+++ b/sledge/src/fol/context.ml
@@ -758,9 +758,7 @@ let inter wrt r s =
   else
     let merge_mems rs r s =
       Trm.Map.fold s.cls rs ~f:(fun ~key:rep ~data:cls rs ->
-          Cls.fold cls
-            ([ rep ], rs)
-            ~f:(fun exp (reps, rs) ->
+          Cls.fold cls ([ rep ], rs) ~f:(fun exp (reps, rs) ->
               match
                 List.find ~f:(fun rep -> implies r (Fml.eq exp rep)) reps
               with
diff --git a/sledge/src/test/sh_test.ml b/sledge/src/test/sh_test.ml
index 72ca2699d..d11774fc9 100644
--- a/sledge/src/test/sh_test.ml
+++ b/sledge/src/test/sh_test.ml
@@ -86,8 +86,7 @@ let%test_module _ =
       let q =
         or_
           (pure (x = !0))
-          (exists
-             ~$[ x_ ]
+          (exists ~$[ x_ ]
              (or_
                 (and_ (x = !1) (pure (y = !1)))
                 (exists ~$[ x_ ] (pure (x = !2)))))
@@ -105,12 +104,10 @@ let%test_module _ =
 
     let%expect_test _ =
       let q =
-        exists
-          ~$[ x_ ]
+        exists ~$[ x_ ]
           (or_
              (pure (x = !0))
-             (exists
-                ~$[ x_ ]
+             (exists ~$[ x_ ]
                 (or_
                    (and_ (x = !1) (pure (y = !1)))
                    (exists ~$[ x_ ] (pure (x = !2))))))
@@ -130,12 +127,10 @@ let%test_module _ =
 
     let%expect_test _ =
       let q =
-        exists
-          ~$[ x_ ]
+        exists ~$[ x_ ]
           (or_
              (pure (x = !0))
-             (exists
-                ~$[ x_ ]
+             (exists ~$[ x_ ]
                 (or_
                    (and_ (x = !1) (pure (y = !1)))
                    (exists ~$[ x_ ] (pure (x = !2))))))
@@ -164,14 +159,12 @@ let%test_module _ =
 
     let%expect_test _ =
       let q =
-        exists
-          ~$[ a_; c_; d_; e_ ]
+        exists ~$[ a_; c_; d_; e_ ]
           (star
              (pure (eq_concat (!16, e) [| (!8, a); (!8, d) |]))
              (or_
                 (pure (Formula.dq x !0))
-                (exists
-                   (Var.Set.of_list [ b_ ])
+                (exists (Var.Set.of_list [ b_ ])
                    (pure (eq_concat (!8, a) [| (!4, c); (!4, b) |])))))
       in
       pp_raw q;
@@ -198,8 +191,7 @@ let%test_module _ =
 
     let%expect_test _ =
       let q =
-        exists
-          ~$[ b_; m_ ]
+        exists ~$[ b_; m_ ]
           (star
              (seg { loc = x; bas = b; len = m; siz = !8; cnt = !0 })
              (or_ (of_eqs [ (b, y); (m, c) ]) (of_eqs [ (b, z); (m, c) ])))
diff --git a/sledge/src/test/solver_test.ml b/sledge/src/test/solver_test.ml
index c77dba2d8..120b44db7 100644
--- a/sledge/src/test/solver_test.ml
+++ b/sledge/src/test/solver_test.ml
@@ -105,8 +105,7 @@ let%test_module _ =
       let minued = Sh.star common seg1 in
       let subtrahend =
         Sh.and_ (Formula.eq m n)
-          (Sh.exists
-             (Var.Set.of_list [ m_ ])
+          (Sh.exists (Var.Set.of_list [ m_ ])
              (Sh.extend_us (Var.Set.of_list [ m_ ]) common))
       in
       infer_frame minued [ n_; m_ ] subtrahend;
diff --git a/compiler/tests-ocaml/basic-modules/recursive_module_init.ml b/compiler/tests-ocaml/basic-modules/recursive_module_init.ml
index f3e08baef7..00e8f9c131 100644
--- a/compiler/tests-ocaml/basic-modules/recursive_module_init.ml
+++ b/compiler/tests-ocaml/basic-modules/recursive_module_init.ml
@@ -8,9 +8,7 @@ let check ~stub txt f =
   in
   Printf.printf "%5s[%s]: nonrec => %s, self => %s, mod => %s\n%!" txt
     (if f == stub then "stub" else "real")
-    (run `Nonrec f)
-    (run `Self f)
-    (run `Mod f)
+    (run `Nonrec f) (run `Self f) (run `Mod f)
 
 module rec M : sig
   val f1 : [ `Nonrec | `Self | `Mod ] -> int
diff --git a/src/dune_rules/merlin.ml b/src/dune_rules/merlin.ml
index e5faf75dc..350be031f 100644
--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -170,14 +170,15 @@ module Processed = struct
                 init.config.src_dirs,
                 [ init.config.flags ],
                 init.config.extensions )
-            ~f:
-              (fun (acc_pp, acc_obj, acc_src, acc_flags, acc_ext)
-                   {
-                     modules = _;
-                     pp_config;
-                     config =
-                       { stdlib_dir = _; obj_dirs; src_dirs; flags; extensions };
-                   } ->
+            ~f:(fun
+                 (acc_pp, acc_obj, acc_src, acc_flags, acc_ext)
+                 {
+                   modules = _;
+                   pp_config;
+                   config =
+                     { stdlib_dir = _; obj_dirs; src_dirs; flags; extensions };
+                 }
+               ->
               ( pp_config :: acc_pp,
                 Path.Set.union acc_obj obj_dirs,
                 Path.Set.union acc_src src_dirs,
diff --git a/src/memo/memo.ml b/src/memo/memo.ml
index bafb0f426..aa3df984c 100644
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -80,9 +80,7 @@ module Spec = struct
     let name =
       match name with
       | None when !Debug.track_locations_of_lazy_values ->
-          Option.map
-            (Caller_id.get ~skip:[ __FILE__ ])
-            ~f:(fun loc ->
+          Option.map (Caller_id.get ~skip:[ __FILE__ ]) ~f:(fun loc ->
               sprintf "lazy value created at %s" (Loc.to_file_colon_line loc))
       | _ -> name
     in
diff --git a/ocamldoc/odoc_ast.ml b/ocamldoc/odoc_ast.ml
index 75b6c45b5..feec131a4 100644
--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -564,8 +564,7 @@ functor
                     ic_text = text_opt;
                   }
                 in
-                iter
-                  (acc_inher @ [ inher ])
+                iter (acc_inher @ [ inher ])
                   (acc_fields @ ele_comments)
                   p_clexp.Parsetree.pcl_loc.Location.loc_end.Lexing.pos_cnum q
             | Parsetree.Pcf_val ({ txt = label }, mutable_flag, k) ->
diff --git a/ocamldoc/odoc_to_text.ml b/ocamldoc/odoc_to_text.ml
index c2a15d542..baaafcdd4 100644
--- a/ocamldoc/odoc_to_text.ml
+++ b/ocamldoc/odoc_to_text.ml
@@ -98,8 +98,7 @@ class virtual info =
       match l with
       | [] -> []
       | [ see ] ->
-          Bold [ Raw Odoc_messages.see_also ]
-          :: Raw " " :: self#text_of_see see
+          Bold [ Raw Odoc_messages.see_also ] :: Raw " " :: self#text_of_see see
           @ [ Newline ]
       | _ ->
           Bold [ Raw Odoc_messages.see_also ]
diff --git a/parsing/location.ml b/parsing/location.ml
index 0944aac90..88b1cb439 100644
--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -277,8 +277,7 @@ end = struct
           | `E, `Outside -> assert false
           | `E, `Inside (s, 0) -> (`Outside, (s, a) :: acc)
           | `E, `Inside (s, n) -> (`Inside (s, n - 1), acc))
-        (`Outside, [])
-        pos
+        (`Outside, []) pos
     in
     assert (nesting = `Outside);
     List.rev acc
diff --git a/testsuite/tests/basic-modules/recursive_module_init.ml b/testsuite/tests/basic-modules/recursive_module_init.ml
index f3e08baef..00e8f9c13 100644
--- a/testsuite/tests/basic-modules/recursive_module_init.ml
+++ b/testsuite/tests/basic-modules/recursive_module_init.ml
@@ -8,9 +8,7 @@ let check ~stub txt f =
   in
   Printf.printf "%5s[%s]: nonrec => %s, self => %s, mod => %s\n%!" txt
     (if f == stub then "stub" else "real")
-    (run `Nonrec f)
-    (run `Self f)
-    (run `Mod f)
+    (run `Nonrec f) (run `Self f) (run `Mod f)
 
 module rec M : sig
   val f1 : [ `Nonrec | `Self | `Mod ] -> int
diff --git a/testsuite/tests/basic-more/morematch.ml b/testsuite/tests/basic-more/morematch.ml
index 4d0950ee2..685d50587 100644
--- a/testsuite/tests/basic-more/morematch.ml
+++ b/testsuite/tests/basic-more/morematch.ml
@@ -544,34 +544,26 @@ let replicaContent2shortString rc =
       "assert false"
 ;;
 
           Bold [ Raw Odoc_messages.see_also ]
diff --git a/parsing/location.ml b/parsing/location.ml
index 0944aac90..88b1cb439 100644
--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -277,8 +277,7 @@ end = struct
           | `E, `Outside -> assert false
           | `E, `Inside (s, 0) -> (`Outside, (s, a) :: acc)
           | `E, `Inside (s, n) -> (`Inside (s, n - 1), acc))
-        (`Outside, [])
-        pos
+        (`Outside, []) pos
     in
     assert (nesting = `Outside);
     List.rev acc
diff --git a/testsuite/tests/basic-modules/recursive_module_init.ml b/testsuite/tests/basic-modules/recursive_module_ini
t.ml
index f3e08baef..00e8f9c13 100644
--- a/testsuite/tests/basic-modules/recursive_module_init.ml
+++ b/testsuite/tests/basic-modules/recursive_module_init.ml
@@ -8,9 +8,7 @@ let check ~stub txt f =
   in
   Printf.printf "%5s[%s]: nonrec => %s, self => %s, mod => %s\n%!" txt
     (if f == stub then "stub" else "real")
-    (run `Nonrec f)
-    (run `Self f)
-    (run `Mod f)
+    (run `Nonrec f) (run `Self f) (run `Mod f)
 
 module rec M : sig
   val f1 : [ `Nonrec | `Self | `Mod ] -> int
diff --git a/testsuite/tests/basic-more/morematch.ml b/testsuite/tests/basic-more/morematch.ml
index 4d0950ee2..685d50587 100644
--- a/testsuite/tests/basic-more/morematch.ml
+++ b/testsuite/tests/basic-more/morematch.ml
@@ -544,34 +544,26 @@ let replicaContent2shortString rc =
       "assert false"
 ;;
 
-test "jerome_variant" replicaContent2shortString
-  (`ABSENT, `Unchanged)
+test "jerome_variant" replicaContent2shortString (`ABSENT, `Unchanged)
   "        ";
 test "jerome_variant" replicaContent2shortString (`ABSENT, `Deleted) "deleted ";
 test "jerome_variant" replicaContent2shortString (`FILE, `Modified) "changed ";
 test "jerome_variant" replicaContent2shortString
   (`DIRECTORY, `PropsChanged)
   "props   ";
-test "jerome_variant" replicaContent2shortString
-  (`FILE, `Deleted)
+test "jerome_variant" replicaContent2shortString (`FILE, `Deleted)
   "assert false";
-test "jerome_variant" replicaContent2shortString
-  (`SYMLINK, `Deleted)
+test "jerome_variant" replicaContent2shortString (`SYMLINK, `Deleted)
   "assert false";
-test "jerome_variant" replicaContent2shortString
-  (`SYMLINK, `PropsChanged)
+test "jerome_variant" replicaContent2shortString (`SYMLINK, `PropsChanged)
   "assert false";
-test "jerome_variant" replicaContent2shortString
-  (`DIRECTORY, `Deleted)
+test "jerome_variant" replicaContent2shortString (`DIRECTORY, `Deleted)
   "assert false";
-test "jerome_variant" replicaContent2shortString
-  (`ABSENT, `Created)
+test "jerome_variant" replicaContent2shortString (`ABSENT, `Created)
   "assert false";
-test "jerome_variant" replicaContent2shortString
-  (`ABSENT, `Modified)
+test "jerome_variant" replicaContent2shortString (`ABSENT, `Modified)
   "assert false";
-test "jerome_variant" replicaContent2shortString
-  (`ABSENT, `PropsChanged)
+test "jerome_variant" replicaContent2shortString (`ABSENT, `PropsChanged)
   "assert false"
```

</details>

Here is the diff with the `janestreet` profile:

<details>

```diff
diff --git a/sledge/src/fol/context.ml b/sledge/src/fol/context.ml
index 228d7a94a..a4b341193 100644
--- a/sledge/src/fol/context.ml
+++ b/sledge/src/fol/context.ml
@@ -853,10 +853,7 @@ let inter wrt r s =
   else (
     let merge_mems rs r s =
       Trm.Map.fold s.cls rs ~f:(fun ~key:rep ~data:cls rs ->
-          Cls.fold
-            cls
-            ([ rep ], rs)
-            ~f:(fun exp (reps, rs) ->
+          Cls.fold cls ([ rep ], rs) ~f:(fun exp (reps, rs) ->
               match List.find ~f:(fun rep -> implies r (Fml.eq exp rep)) reps with
               | Some rep -> reps, and_eq ~wrt exp rep rs
               | None -> exp :: reps, rs)
diff --git a/src/dune_rules/merlin.ml b/src/dune_rules/merlin.ml
index c758768e9..0e3672027 100644
--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -179,12 +179,13 @@ module Processed = struct
             , init.config.src_dirs
             , [ init.config.flags ]
             , init.config.extensions )
-          ~f:
-            (fun (acc_pp, acc_obj, acc_src, acc_flags, acc_ext)
-                 { modules = _
-                 ; pp_config
-                 ; config = { stdlib_dir = _; obj_dirs; src_dirs; flags; extensions }
-                 } ->
+          ~f:(fun
+               (acc_pp, acc_obj, acc_src, acc_flags, acc_ext)
+               { modules = _
+               ; pp_config
+               ; config = { stdlib_dir = _; obj_dirs; src_dirs; flags; extensions }
+               }
+             ->
             ( pp_config :: acc_pp
             , Path.Set.union acc_obj obj_dirs
             , Path.Set.union acc_src src_dirs
diff --git a/src/memo/memo.ml b/src/memo/memo.ml
index 606ab2560..a682e1e41 100644
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -103,9 +103,8 @@ module Spec = struct
     let name =
       match name with
       | None when !Debug.track_locations_of_lazy_values ->
-        Option.map
-          (Caller_id.get ~skip:[ __FILE__ ])
-          ~f:(fun loc -> sprintf "lazy value created at %s" (Loc.to_file_colon_line loc))
+        Option.map (Caller_id.get ~skip:[ __FILE__ ]) ~f:(fun loc ->
+            sprintf "lazy value created at %s" (Loc.to_file_colon_line loc))
       | _ -> name
     in
     let allow_cutoff =
```

</details>

And the `ocamlformat` profile:

<details>

```diff
diff --git a/lib/Cmts.ml b/lib/Cmts.ml
index 5823a06d..6283c328 100644
--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -307,8 +307,7 @@ let relocate_cmts_before (t : t) ~src ~sep ~dst =
     Multimap.partition_multi map ~src ~dst ~f:(fun Cmt.{loc; _} ->
         Location.compare_end loc sep < 0 )
   in
-  update_cmts t `Before ~f ;
-  update_cmts t `Within ~f
+  update_cmts t `Before ~f ; update_cmts t `Within ~f
 
 let relocate_pattern_matching_cmts (t : t) src tok ~whole_loc ~matched_loc =
   let kwd_loc =
@@ -480,9 +479,8 @@ let fmt_cmts t conf ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n") ?(adj = eol)
       fmt_opt pro $ fmt_cmts_aux t conf cmts ~fmt_code pos $ epi
 
 let fmt_before t conf ~fmt_code ?pro ?(epi = Fmt.break 1 0) ?eol ?adj loc =
-  fmt_cmts t conf
-    (find_cmts t `Before loc)
-    ~fmt_code ?pro ~epi ?eol ?adj loc Cmt.Before
+  fmt_cmts t conf (find_cmts t `Before loc) ~fmt_code ?pro ~epi ?eol ?adj loc
+    Cmt.Before
 
 let fmt_after t conf ~fmt_code ?(pro = Fmt.break 1 0) ?epi loc =
   let open Fmt in
@@ -490,17 +488,15 @@ let fmt_after t conf ~fmt_code ?(pro = Fmt.break 1 0) ?epi loc =
     fmt_cmts t conf (find_cmts t `Within loc) ~fmt_code ~pro ?epi loc Cmt.Within
   in
   let after =
-    fmt_cmts t conf
-      (find_cmts t `After loc)
-      ~fmt_code ~pro ?epi ~eol:noop loc Cmt.After
+    fmt_cmts t conf (find_cmts t `After loc) ~fmt_code ~pro ?epi ~eol:noop loc
+      Cmt.After
   in
   within $ after
 
 let fmt_within t conf ~fmt_code ?(pro = Fmt.break 1 0) ?(epi = Fmt.break 1 0)
     loc =
-  fmt_cmts t conf
-    (find_cmts t `Within loc)
-    ~fmt_code ~pro ~epi ~eol:Fmt.noop loc Cmt.Within
+  fmt_cmts t conf (find_cmts t `Within loc) ~fmt_code ~pro ~epi ~eol:Fmt.noop
+    loc Cmt.Within
 
 module Toplevel = struct
   let fmt_cmts t conf ~fmt_code found (pos : Cmt.pos) =
@@ -553,9 +549,7 @@ let drop_inside t loc =
         (Multimap.filter ~f:(fun {Cmt.loc= cmt_loc; _} ->
              not (Location.contains loc cmt_loc) ) )
   in
-  clear `Before ;
-  clear `Within ;
-  clear `After
+  clear `Before ; clear `Within ; clear `After
 
 let drop_before t loc =
   update_cmts t `Before ~f:(fun m -> Map.remove m loc) ;
diff --git a/facebook-clang-plugins/clang-ocaml/process.ml b/facebook-clang-plugins/clang-ocaml/process.ml
index 0ae8ff0ee..0c41c13aa 100644
--- a/facebook-clang-plugins/clang-ocaml/process.ml
+++ b/facebook-clang-plugins/clang-ocaml/process.ml
@@ -8,10 +8,7 @@
 module U = Unix
 
 let file_exists name =
-  try
-    U.access name [U.F_OK] ;
-    true
-  with U.Unix_error _ -> false
+  try U.access name [U.F_OK] ; true with U.Unix_error _ -> false
 
 (* Forked processes will not start from 0 but this is inessential. *)
 let tmp_counter = ref 0
diff --git a/infer/src/base/CommandLineOption.ml b/infer/src/base/CommandLineOption.ml
index ab16ec7ae..803cbe141 100644
--- a/infer/src/base/CommandLineOption.ml
+++ b/infer/src/base/CommandLineOption.ml
@@ -261,10 +261,7 @@ let deprecate_desc parse_mode ~long ~short ~deprecated doc desc =
           "WARNING:%s '-%s' is deprecated. Here is its documentation:@\n%s@."
           source_s deprecated doc
   in
-  let warn_then_f f x =
-    warn `CLI ;
-    f x
-  in
+  let warn_then_f f x = warn `CLI ; f x in
   let deprecated_spec =
     match desc.spec with
     | Unit f ->
diff --git a/infer/src/base/Config.ml b/infer/src/base/Config.ml
index 106d6c288..db1c0b03f 100644
--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -695,8 +695,7 @@ and biabduction_join_cond =
 
 and biabduction_memleak_buckets =
   CLOpt.mk_symbol_seq ~deprecated:["-ml-buckets"]
-    ~long:"biabduction-memleak-buckets"
-    ~default:[`MLeak_cf]
+    ~long:"biabduction-memleak-buckets" ~default:[`MLeak_cf]
     ~symbols:ml_bucket_symbols ~eq:PolyVariantEqual.( = )
     "Specify the memory leak buckets to be checked in C++."
 
diff --git a/infer/src/clang/cTrans.ml b/infer/src/clang/cTrans.ml
index 2e132c388..b255afb9e 100644
--- a/infer/src/clang/cTrans.ml
+++ b/infer/src/clang/cTrans.ml
@@ -3142,8 +3142,7 @@ struct
             | Stmt_node ReturnStmt ->
                 ()
             | _ ->
-                Procdesc.set_succs try_end
-                  ~normal:(Some [try_exit_node])
+                Procdesc.set_succs try_end ~normal:(Some [try_exit_node])
                   ~exn:None )
           try_ends ;
         { try_trans_result with
diff --git a/infer/src/erlang/ErlangBlock.ml b/infer/src/erlang/ErlangBlock.ml
index 3309499fc..da951101a 100644
--- a/infer/src/erlang/ErlangBlock.ml
+++ b/infer/src/erlang/ErlangBlock.ml
@@ -39,10 +39,7 @@ let sequence ~(continue : t -> Procdesc.Node.t) ~(stop : t -> Procdesc.Node.t)
       (one_block.start, continue one_block, stop one_block)
   | first_block :: next_blocks ->
       let continue_node =
-        let f previous b =
-          previous |~~> [b.start] ;
-          continue b
-        in
+        let f previous b = previous |~~> [b.start] ; continue b in
         List.fold ~f ~init:(continue first_block) next_blocks
       in
       let new_stop = Node.make_join env in
diff --git a/infer/src/nullsafe/unit/ThirdPartyAnnotationInfoTests.ml b/infer/src/nullsafe/unit/ThirdPartyAnnotationInfoTests.ml
index 977941f6c..0b648ebdb 100644
--- a/infer/src/nullsafe/unit/ThirdPartyAnnotationInfoTests.ml
+++ b/infer/src/nullsafe/unit/ThirdPartyAnnotationInfoTests.ml
@@ -89,8 +89,8 @@ let basic_find =
   (* Make sure we can find what we just stored *)
   assert_has_nullability_info storage
     {class_name= "a.A"; method_name= Method "foo"; param_types= ["b.B"]}
-    ~expected_nullability:(Nonnull, [Nonnull])
-    ~expected_file:"test.sig" ~expected_line:1 ;
+    ~expected_nullability:(Nonnull, [Nonnull]) ~expected_file:"test.sig"
+    ~expected_line:1 ;
   assert_has_nullability_info storage
     {class_name= "b.B"; method_name= Method "bar"; param_types= ["c.C"; "d.D"]}
     ~expected_nullability:(Nullable, [Nonnull; Nullable])
@@ -125,8 +125,8 @@ let disregards_whitespace_lines_and_comments =
   in
   assert_has_nullability_info storage
     {class_name= "a.A"; method_name= Method "foo"; param_types= ["b.B"]}
-    ~expected_nullability:(Nonnull, [Nonnull])
-    ~expected_file:"test.sig" ~expected_line:2 ;
+    ~expected_nullability:(Nonnull, [Nonnull]) ~expected_file:"test.sig"
+    ~expected_line:2 ;
   (* Commented out signatures should be ignored *)
   assert_no_info storage
     {class_name= "a.A"; method_name= Method "bar"; param_types= ["b.B"]}
@@ -226,8 +226,8 @@ let can_add_several_files =
   in
   assert_has_nullability_info storage
     {class_name= "a.A"; method_name= Method "foo"; param_types= ["b.B"]}
-    ~expected_nullability:(Nonnull, [Nonnull])
-    ~expected_file:"file1.sig" ~expected_line:1 ;
+    ~expected_nullability:(Nonnull, [Nonnull]) ~expected_file:"file1.sig"
+    ~expected_line:1 ;
   (* 2. Add another file and check if we added info *)
   let file2 = ["e.E#baz(f.F)"; "g.G#<init>(h.H, @Nullable i.I) @Nullable"] in
   let storage =
@@ -236,13 +236,13 @@ let can_add_several_files =
   in
   assert_has_nullability_info storage
     {class_name= "e.E"; method_name= Method "baz"; param_types= ["f.F"]}
-    ~expected_nullability:(Nonnull, [Nonnull])
-    ~expected_file:"file2.sig" ~expected_line:1 ;
+    ~expected_nullability:(Nonnull, [Nonnull]) ~expected_file:"file2.sig"
+    ~expected_line:1 ;
   (* 3. Ensure we did not forget the content from the first file *)
   assert_has_nullability_info storage
     {class_name= "a.A"; method_name= Method "foo"; param_types= ["b.B"]}
-    ~expected_nullability:(Nonnull, [Nonnull])
-    ~expected_file:"file1.sig" ~expected_line:1
+    ~expected_nullability:(Nonnull, [Nonnull]) ~expected_file:"file1.sig"
+    ~expected_line:1
 
 let should_not_forgive_unparsable_strings =
   "should_not_forgive_unparsable_strings"
diff --git a/infer/src/pulse/PulseCallOperations.ml b/infer/src/pulse/PulseCallOperations.ml
index a11246b51..ee1f3ec92 100644
--- a/infer/src/pulse/PulseCallOperations.ml
+++ b/infer/src/pulse/PulseCallOperations.ml
@@ -36,8 +36,7 @@ let unknown_call tenv path call_loc (reason : CallEvent.t) ~ret ~actuals
       | Some {fields} ->
           List.fold fields ~init:astate ~f:(fun acc (field, field_typ, _) ->
               let fresh_value = AbstractValue.mk_fresh () in
-              Memory.add_edge addr (FieldAccess field)
-                (fresh_value, [event])
+              Memory.add_edge addr (FieldAccess field) (fresh_value, [event])
                 call_loc acc
               |> havoc_fields (fresh_value, history) field_typ )
       | None ->
@@ -59,9 +58,8 @@ let unknown_call tenv path call_loc (reason : CallEvent.t) ~ret ~actuals
            raising issues when havoc'ing pointer parameters (which normally causes a [check_valid]
            call). *)
         let fresh_value = AbstractValue.mk_fresh () in
-        Memory.add_edge actual Dereference
-          (fresh_value, [event])
-          call_loc astate
+        Memory.add_edge actual Dereference (fresh_value, [event]) call_loc
+          astate
         |> havoc_fields actual typ
     | _ ->
         astate
diff --git a/infer/src/pulse/PulseModels.ml b/infer/src/pulse/PulseModels.ml
index ea85ba371..3ff3251ff 100644
--- a/infer/src/pulse/PulseModels.ml
+++ b/infer/src/pulse/PulseModels.ml
@@ -1028,8 +1028,7 @@ module StdFunction = struct
       let empty_target = AbstractValue.mk_fresh () in
       let<+> astate =
         PulseOperations.write_deref path location ~ref:dest
-          ~obj:(empty_target, [event])
-          astate
+          ~obj:(empty_target, [event]) astate
       in
       PulseOperations.havoc_id ret_id [event] astate
     else
@@ -1490,20 +1489,17 @@ module JavaCollection = struct
     let init_value = AbstractValue.mk_fresh () in
     (* The two internal fields are initially set to null *)
     let<*> astate =
-      Java.write_field path fst_field
-        (init_value, [event])
-        location fresh_val astate
+      Java.write_field path fst_field (init_value, [event]) location fresh_val
+        astate
     in
     let<*> astate =
-      Java.write_field path snd_field
-        (init_value, [event])
-        location fresh_val astate
+      Java.write_field path snd_field (init_value, [event]) location fresh_val
+        astate
     in
     (* The empty field is initially set to true *)
     let<*> astate =
-      Java.write_field path is_empty_field
-        (is_empty_value, [event])
-        location fresh_val astate
+      Java.write_field path is_empty_field (is_empty_value, [event]) location
+        fresh_val astate
     in
     let<*> astate =
       PulseOperations.write_deref path location ~ref:this ~obj:fresh_val astate
@@ -1566,9 +1562,8 @@ module JavaCollection = struct
     in
     let is_empty_val = AbstractValue.mk_fresh () in
     let<*> astate' =
-      Java.write_field path is_empty_field
-        (is_empty_val, [event])
-        location coll_val astate
+      Java.write_field path is_empty_field (is_empty_val, [event]) location
+        coll_val astate
     in
     (* case1: fst_field is updated *)
     let astate1 =
@@ -1611,9 +1606,8 @@ module JavaCollection = struct
     let ret_val = AbstractValue.mk_fresh () in
     let is_empty_val = AbstractValue.mk_fresh () in
     let* astate =
-      Java.write_field path is_empty_field
-        (is_empty_val, [event])
-        location coll_val astate
+      Java.write_field path is_empty_field (is_empty_val, [event]) location
+        coll_val astate
     in
     let* astate =
       PulseArithmetic.and_eq_int null_val IntLit.zero astate
@@ -1625,8 +1619,7 @@ module JavaCollection = struct
     in
     let+ astate =
       PulseOperations.write_deref path location ~ref:field_addr
-        ~obj:(null_val, [event])
-        astate
+        ~obj:(null_val, [event]) astate
     in
     PulseOperations.write_id ret_id (ret_val, [event]) astate
 
@@ -1699,19 +1692,16 @@ module JavaCollection = struct
       PulseOperations.eval_access path Read location coll Dereference astate
     in
     let<*> astate =
-      Java.write_field path fst_field
-        (null_val, [event])
-        location coll_val astate
+      Java.write_field path fst_field (null_val, [event]) location coll_val
+        astate
     in
     let<*> astate =
-      Java.write_field path snd_field
-        (null_val, [event])
-        location coll_val astate
+      Java.write_field path snd_field (null_val, [event]) location coll_val
+        astate
     in
     let<*> astate =
-      Java.write_field path is_empty_field
-        (is_empty_val, [event])
-        location coll_val astate
+      Java.write_field path is_empty_field (is_empty_val, [event]) location
+        coll_val astate
     in
     let<+> astate =
       PulseArithmetic.and_eq_int null_val IntLit.zero astate
@@ -1736,9 +1726,7 @@ module JavaCollection = struct
     let astate = PulseOperations.write_id ret_id (not_found_val, hist) astate in
     PulseOperations.invalidate path
       (StackAddress (Var.of_id ret_id, hist))
-      location (ConstantDereference IntLit.zero)
-      (not_found_val, [event])
-      astate
+      location (ConstantDereference IntLit.zero) (not_found_val, [event]) astate
 
   (* Auxiliary function that splits the state into three, considering the case that
      the internal is_empty field is not known to have value 1 *)
diff --git a/infer/src/pulse/PulseOperations.ml b/infer/src/pulse/PulseOperations.ml
index d09434c7d..d8efbaeaf 100644
--- a/infer/src/pulse/PulseOperations.ml
+++ b/infer/src/pulse/PulseOperations.ml
@@ -272,8 +272,7 @@ let eval path mode location exp0 astate =
     | Const (Cstr s) ->
         let v = AbstractValue.mk_fresh () in
         let* astate, (len_addr, hist) =
-          eval_access path Write location
-            (v, [Assignment location])
+          eval_access path Write location (v, [Assignment location])
             (FieldAccess ModeledField.string_length) astate
         in
         let len_int = IntLit.of_int (String.length s) in
diff --git a/sledge/cli/frontend.ml b/sledge/cli/frontend.ml
index d25a7942c..852a629ea 100644
--- a/sledge/cli/frontend.ml
+++ b/sledge/cli/frontend.ml
@@ -1154,8 +1154,7 @@ let xlate_jump :
       let src_lbl = label_of_block (Llvm.instr_parent instr) in
       let lbl = src_lbl ^ ".jmp." ^ dst_lbl in
       let blk =
-        Block.mk ~lbl
-          ~cmnd:(IArray.of_array [|mov|])
+        Block.mk ~lbl ~cmnd:(IArray.of_array [|mov|])
           ~term:(Term.goto ~dst:jmp ~loc)
       in
       let blocks =
@@ -1563,8 +1562,7 @@ let xlate_instr :
         let mov = Inst.move ~reg_exps:(IArray.of_array [|(reg, exp)|]) ~loc in
         let lbl_i = lbl ^ "." ^ Int.to_string i in
         let blk =
-          Block.mk ~lbl:lbl_i
-            ~cmnd:(IArray.of_array [|mov|])
+          Block.mk ~lbl:lbl_i ~cmnd:(IArray.of_array [|mov|])
             ~term:(Term.goto ~dst:(Jump.mk lbl) ~loc)
         in
         (Jump.mk lbl_i, blk :: rev_blocks)
diff --git a/sledge/cli/sledge_buck.ml b/sledge/cli/sledge_buck.ml
index bc5fde6dd..c2a07be64 100644
--- a/sledge/cli/sledge_buck.ml
+++ b/sledge/cli/sledge_buck.ml
@@ -94,8 +94,7 @@ let expand_arch_archive ~context archive_name =
                     ( run_exit_status
                         (Lazy.force llvm_bin ^ "llvm-ar")
                         ["p"; archive_name; name]
-                    |+ run "head" ["-c2"]
-                    |+ read_all )
+                    |+ run "head" ["-c2"] |+ read_all )
                 in
                 if String.equal is_bc "BC" then (
                   warn "found bc file %s in %s" name archive_name () ;
diff --git a/sledge/src/domain_sh.ml b/sledge/src/domain_sh.ml
index eda12bc92..171e7bef3 100644
--- a/sledge/src/domain_sh.ml
+++ b/sledge/src/domain_sh.ml
@@ -397,8 +397,7 @@ let%test_module _ =
 
     let%expect_test _ =
       pp
-        (garbage_collect (Sh.star seg_a seg_main)
-           ~wrt:(Term.Set.of_list [main]) ) ;
+        (garbage_collect (Sh.star seg_a seg_main) ~wrt:(Term.Set.of_list [main])) ;
       [%expect
         {|
           %main_1 -[ %b_4, %n_3 )-> ⟨%n_3,%a_2⟩
diff --git a/sledge/src/fol/context.ml b/sledge/src/fol/context.ml
index 491e3fb5c..8e709f85c 100644
--- a/sledge/src/fol/context.ml
+++ b/sledge/src/fol/context.ml
@@ -841,9 +841,7 @@ let inter wrt r s =
   else
     let merge_mems rs r s =
       Trm.Map.fold s.cls rs ~f:(fun ~key:rep ~data:cls rs ->
-          Cls.fold cls
-            ([rep], rs)
-            ~f:(fun exp (reps, rs) ->
+          Cls.fold cls ([rep], rs) ~f:(fun exp (reps, rs) ->
               match
                 List.find ~f:(fun rep -> implies r (Fml.eq exp rep)) reps
               with
diff --git a/sledge/src/test/sh_test.ml b/sledge/src/test/sh_test.ml
index d5bdc3e53..8ab62f2be 100644
--- a/sledge/src/test/sh_test.ml
+++ b/sledge/src/test/sh_test.ml
@@ -115,8 +115,7 @@ let%test_module _ =
       let q =
         or_
           (pure (x = !0))
-          (exists
-             ~$[x_]
+          (exists ~$[x_]
              (or_
                 (and_ (x = !1) (pure (y = !1)))
                 (exists ~$[x_] (pure (x = !2))) ) )
@@ -134,12 +133,10 @@ let%test_module _ =
 
     let%expect_test _ =
       let q =
-        exists
-          ~$[x_]
+        exists ~$[x_]
           (or_
              (pure (x = !0))
-             (exists
-                ~$[x_]
+             (exists ~$[x_]
                 (or_
                    (and_ (x = !1) (pure (y = !1)))
                    (exists ~$[x_] (pure (x = !2))) ) ) )
@@ -159,12 +156,10 @@ let%test_module _ =
 
     let%expect_test _ =
       let q =
-        exists
-          ~$[x_]
+        exists ~$[x_]
           (or_
              (pure (x = !0))
-             (exists
-                ~$[x_]
+             (exists ~$[x_]
                 (or_
                    (and_ (x = !1) (pure (y = !1)))
                    (exists ~$[x_] (pure (x = !2))) ) ) )
@@ -193,14 +188,12 @@ let%test_module _ =
 
     let%expect_test _ =
       let q =
-        exists
-          ~$[a_; c_; d_; e_]
+        exists ~$[a_; c_; d_; e_]
           (star
              (pure (eq_concat (!16, e) [|(!8, a); (!8, d)|]))
              (or_
                 (pure (Formula.dq x !0))
-                (exists
-                   (Var.Set.of_list [b_])
+                (exists (Var.Set.of_list [b_])
                    (pure (eq_concat (!8, a) [|(!4, c); (!4, b)|])) ) ) )
       in
       pp_raw q ;
@@ -227,8 +220,7 @@ let%test_module _ =
 
     let%expect_test _ =
       let q =
-        exists
-          ~$[b_; m_]
+        exists ~$[b_; m_]
           (star
              (seg {loc= x; bas= b; len= m; siz= !8; cnt= !0})
              (or_ (of_eqs [(b, y); (m, c)]) (of_eqs [(b, z); (m, c)])) )
diff --git a/sledge/src/test/solver_test.ml b/sledge/src/test/solver_test.ml
index 13a147dbe..821ff50ba 100644
--- a/sledge/src/test/solver_test.ml
+++ b/sledge/src/test/solver_test.ml
@@ -123,8 +123,7 @@ let%test_module _ =
       let minued = Sh.star common seg1 in
       let subtrahend =
         Sh.and_ (Formula.eq m n)
-          (Sh.exists
-             (Var.Set.of_list [m_])
+          (Sh.exists (Var.Set.of_list [m_])
              (Sh.extend_us (Var.Set.of_list [m_]) common) )
       in
       infer_frame minued [n_; m_] subtrahend ;
diff --git a/compiler/tests-ocaml/basic-modules/recursive_module_init.ml b/compiler/tests-ocaml/basic-modules/recursive_module_init.ml
index a90a1ff019..d374e28c0f 100644
--- a/compiler/tests-ocaml/basic-modules/recursive_module_init.ml
+++ b/compiler/tests-ocaml/basic-modules/recursive_module_init.ml
@@ -10,9 +10,7 @@ let check ~stub txt f =
   in
   Printf.printf "%5s[%s]: nonrec => %s, self => %s, mod => %s\n%!" txt
     (if f == stub then "stub" else "real")
-    (run `Nonrec f)
-    (run `Self f)
-    (run `Mod f)
+    (run `Nonrec f) (run `Self f) (run `Mod f)
 
 module rec M : sig
   val f1 : [`Nonrec | `Self | `Mod] -> int
diff --git a/boot/duneboot.ml b/boot/duneboot.ml
index a6a1958aa..a2a619811 100644
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -816,11 +816,9 @@ module Library = struct
             let dst = build_dir ^/ mangled in
             match kind with
             | C ->
-                copy fn dst ;
-                Fiber.return [mangled]
+                copy fn dst ; Fiber.return [mangled]
             | Ml | Mli ->
-                copy fn dst ~header ;
-                Fiber.return [mangled]
+                copy fn dst ~header ; Fiber.return [mangled]
             | Mll ->
                 copy_lexer fn dst ~header >>> Fiber.return [mangled]
             | Mly ->
diff --git a/src/dune_rules/merlin.ml b/src/dune_rules/merlin.ml
index 42c69ceb4..c614d1895 100644
--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -177,12 +177,13 @@ module Processed = struct
               , init.config.src_dirs
               , [init.config.flags]
               , init.config.extensions )
-            ~f:(fun (acc_pp, acc_obj, acc_src, acc_flags, acc_ext)
-                    { modules= _
-                    ; pp_config
-                    ; config=
-                        {stdlib_dir= _; obj_dirs; src_dirs; flags; extensions}
-                    } ->
+            ~f:(fun
+                 (acc_pp, acc_obj, acc_src, acc_flags, acc_ext)
+                 { modules= _
+                 ; pp_config
+                 ; config= {stdlib_dir= _; obj_dirs; src_dirs; flags; extensions}
+                 }
+               ->
               ( pp_config :: acc_pp
               , Path.Set.union acc_obj obj_dirs
               , Path.Set.union acc_src src_dirs
diff --git a/src/memo/memo.ml b/src/memo/memo.ml
index 1c9243046..32e1d6470 100644
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -88,9 +88,7 @@ module Spec = struct
     let name =
       match name with
       | None when !Debug.track_locations_of_lazy_values ->
-          Option.map
-            (Caller_id.get ~skip:[__FILE__])
-            ~f:(fun loc ->
+          Option.map (Caller_id.get ~skip:[__FILE__]) ~f:(fun loc ->
               sprintf "lazy value created at %s" (Loc.to_file_colon_line loc) )
       | _ ->
           name
diff --git a/asmcomp/i386/selection.ml b/asmcomp/i386/selection.ml
index 5d89a6ccd..810e55841 100644
--- a/asmcomp/i386/selection.ml
+++ b/asmcomp/i386/selection.ml
@@ -344,8 +344,7 @@ class selector =
             | Some r ->
                 self#insert env (Iop op) r [||] )
       in
-      emit_pushes args ;
-      ([||], sz2)
+      emit_pushes args ; ([||], sz2)
   end
 
 let fundecl ~future_funcnames f =
diff --git a/debugger/unix_tools.ml b/debugger/unix_tools.ml
index a80b015bb..b2cf9b0d8 100644
--- a/debugger/unix_tools.ml
+++ b/debugger/unix_tools.ml
@@ -64,10 +64,7 @@ let report_error = function
 let search_in_path name =
   Printf.fprintf Real_stdlib.stderr "search_in_path [%s]\n%!" name ;
   let check name =
-    try
-      access name [X_OK] ;
-      name
-    with Unix_error _ -> raise Not_found
+    try access name [X_OK] ; name with Unix_error _ -> raise Not_found
   in
   if not (Filename.is_implicit name) then check name
   else
diff --git a/ocamldoc/odoc_ast.ml b/ocamldoc/odoc_ast.ml
index a1ae80ebc..5776f9772 100644
--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -582,8 +582,7 @@ functor
                   ; ic_class= None
                   ; ic_text= text_opt }
                 in
-                iter
-                  (acc_inher @ [inher])
+                iter (acc_inher @ [inher])
                   (acc_fields @ ele_comments)
                   p_clexp.Parsetree.pcl_loc.Location.loc_end.Lexing.pos_cnum q
             | Parsetree.Pcf_val ({txt= label}, mutable_flag, k) ->
diff --git a/parsing/location.ml b/parsing/location.ml
index e15f782f9..d23034250 100644
--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -271,8 +271,7 @@ end = struct
               (`Outside, (s, a) :: acc)
           | `E, `Inside (s, n) ->
               (`Inside (s, n - 1), acc) )
-        (`Outside, [])
-        pos
+        (`Outside, []) pos
     in
     assert (nesting = `Outside) ;
     List.rev acc
diff --git a/stdlib/weak.ml b/stdlib/weak.ml
index fd4d4acf6..94eea20e1 100644
--- a/stdlib/weak.ml
+++ b/stdlib/weak.ml
@@ -143,8 +143,7 @@ module Make (H : Hashtbl.HashedType) : S with type data = H.t = struct
 
   let clear t =
     for i = 0 to Array.length t.table - 1 do
-      t.table.(i) <- emptybucket ;
-      t.hashes.(i) <- [||]
+      t.table.(i) <- emptybucket ; t.hashes.(i) <- [||]
     done ;
     t.limit <- limit ;
     t.oversize <- 0
diff --git a/testsuite/tests/backtrace/backtrace_deprecated.ml b/testsuite/tests/backtrace/backtrace_deprecated.ml
index 1c61efdd9..4ca1851b8 100644
--- a/testsuite/tests/backtrace/backtrace_deprecated.ml
+++ b/testsuite/tests/backtrace/backtrace_deprecated.ml
@@ -41,9 +41,4 @@ let run args =
                 print_endline line )
           trace )
 
-let _ =
-  run [|"a"|] ;
-  run [|"b"|] ;
-  run [|"c"|] ;
-  run [|"d"|] ;
-  run [||]
+let _ = run [|"a"|] ; run [|"b"|] ; run [|"c"|] ; run [|"d"|] ; run [||]
diff --git a/testsuite/tests/backtrace/backtrace_slots.ml b/testsuite/tests/backtrace/backtrace_slots.ml
index 483f2a328..5a87bb578 100644
--- a/testsuite/tests/backtrace/backtrace_slots.ml
+++ b/testsuite/tests/backtrace/backtrace_slots.ml
@@ -66,9 +66,4 @@ let run args =
            | Some line ->
                print_endline line )
 
-let _ =
-  run [|"a"|] ;
-  run [|"b"|] ;
-  run [|"c"|] ;
-  run [|"d"|] ;
-  run [||]
+let _ = run [|"a"|] ; run [|"b"|] ; run [|"c"|] ; run [|"d"|] ; run [||]
diff --git a/testsuite/tests/basic-modules/recursive_module_init.ml b/testsuite/tests/basic-modules/recursive_module_init.ml
index a90a1ff01..d374e28c0 100644
--- a/testsuite/tests/basic-modules/recursive_module_init.ml
+++ b/testsuite/tests/basic-modules/recursive_module_init.ml
@@ -10,9 +10,7 @@ let check ~stub txt f =
   in
   Printf.printf "%5s[%s]: nonrec => %s, self => %s, mod => %s\n%!" txt
     (if f == stub then "stub" else "real")
-    (run `Nonrec f)
-    (run `Self f)
-    (run `Mod f)
+    (run `Nonrec f) (run `Self f) (run `Mod f)
 
 module rec M : sig
   val f1 : [`Nonrec | `Self | `Mod] -> int
diff --git a/testsuite/tests/basic-more/morematch.ml b/testsuite/tests/basic-more/morematch.ml
index 35dc58699..a4aa4498f 100644
--- a/testsuite/tests/basic-more/morematch.ml
+++ b/testsuite/tests/basic-more/morematch.ml
@@ -227,9 +227,7 @@ test "foo1" f (1, 2) (-1)
 
 let f = function (([] | [_]) as x) | _ :: ([] as x) | _ :: _ :: x -> x;;
 
-test "zob" f [] [] ;
-test "zob" f [1] [1] ;
-test "zob" f [1; 2; 3] [3]
+test "zob" f [] [] ; test "zob" f [1] [1] ; test "zob" f [1; 2; 3] [3]
 
 type zob = A | B | C | D of zob * int | E of zob * zob
 
@@ -647,34 +645,26 @@ let replicaContent2shortString rc =
       "assert false"
 ;;
 
-test "jerome_variant" replicaContent2shortString
-  (`ABSENT, `Unchanged)
+test "jerome_variant" replicaContent2shortString (`ABSENT, `Unchanged)
   "        " ;
 test "jerome_variant" replicaContent2shortString (`ABSENT, `Deleted) "deleted " ;
 test "jerome_variant" replicaContent2shortString (`FILE, `Modified) "changed " ;
 test "jerome_variant" replicaContent2shortString
   (`DIRECTORY, `PropsChanged)
   "props   " ;
-test "jerome_variant" replicaContent2shortString
-  (`FILE, `Deleted)
+test "jerome_variant" replicaContent2shortString (`FILE, `Deleted)
   "assert false" ;
-test "jerome_variant" replicaContent2shortString
-  (`SYMLINK, `Deleted)
+test "jerome_variant" replicaContent2shortString (`SYMLINK, `Deleted)
   "assert false" ;
-test "jerome_variant" replicaContent2shortString
-  (`SYMLINK, `PropsChanged)
+test "jerome_variant" replicaContent2shortString (`SYMLINK, `PropsChanged)
   "assert false" ;
-test "jerome_variant" replicaContent2shortString
-  (`DIRECTORY, `Deleted)
+test "jerome_variant" replicaContent2shortString (`DIRECTORY, `Deleted)
   "assert false" ;
-test "jerome_variant" replicaContent2shortString
-  (`ABSENT, `Created)
+test "jerome_variant" replicaContent2shortString (`ABSENT, `Created)
   "assert false" ;
-test "jerome_variant" replicaContent2shortString
-  (`ABSENT, `Modified)
+test "jerome_variant" replicaContent2shortString (`ABSENT, `Modified)
   "assert false" ;
-test "jerome_variant" replicaContent2shortString
-  (`ABSENT, `PropsChanged)
+test "jerome_variant" replicaContent2shortString (`ABSENT, `PropsChanged)
   "assert false"
 
 (* bug 319 *)
diff --git a/testsuite/tests/letrec-compilation/evaluation_order_1.ml b/testsuite/tests/letrec-compilation/evaluation_order_1.ml
index d4f34ba29..18691677f 100644
--- a/testsuite/tests/letrec-compilation/evaluation_order_1.ml
+++ b/testsuite/tests/letrec-compilation/evaluation_order_1.ml
@@ -9,14 +9,9 @@
 type tree = Tree of tree list
 
 let test =
-  let rec x =
-    print_endline "effect" ;
-    Tree [y; z]
+  let rec x = print_endline "effect" ; Tree [y; z]
   and y = print_endline "effect" ; Tree []
-  and z =
-    print_endline "effect" ;
-    Tree [x]
-  in
+  and z = print_endline "effect" ; Tree [x] in
   match (x, y, z) with
   | Tree [y1; z1], Tree [], Tree [x1] ->
       assert (y1 == y) ;
diff --git a/testsuite/tests/lib-dynlink-native/plugin.ml b/testsuite/tests/lib-dynlink-native/plugin.ml
index 2552f1351..3d6c6102d 100644
--- a/testsuite/tests/lib-dynlink-native/plugin.ml
+++ b/testsuite/tests/lib-dynlink-native/plugin.ml
@@ -1,6 +1,4 @@
-let rec f x =
-  ignore [x] ;
-  f x
+let rec f x = ignore [x] ; f x
 
 let rec fact n = if n = 0 then 1 else n * fact (n - 1)
 
diff --git a/testsuite/tests/parsing/multi_indices.ml b/testsuite/tests/parsing/multi_indices.ml
index 60dc47d7d..b3ff68ab0 100644
--- a/testsuite/tests/parsing/multi_indices.ml
+++ b/testsuite/tests/parsing/multi_indices.ml
@@ -99,8 +99,7 @@ a.%{0; 0; 1} <- 5.
 - : unit = ()
 |}];;
 
-a.![0; 1; 2] <- 7. ;
-a.![0; 1; 2]
+a.![0; 1; 2] <- 7. ; a.![0; 1; 2]
 
 [%%expect
 {|
diff --git a/typing/printtyp.ml b/typing/printtyp.ml
index f6e82f30a..1fb194c6f 100644
--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1365,8 +1365,7 @@ let prepared_type_expr ppf ty = typexp Type ppf ty
 let type_expr ppf ty =
   (* [type_expr] is used directly by error message printers,
      we mark eventual loops ourself to avoid any misuse and stack overflow *)
-  prepare_for_printing [ty] ;
-  prepared_type_expr ppf ty
+  prepare_for_printing [ty] ; prepared_type_expr ppf ty
 
 (* "Half-prepared" type expression: [ty] should have had its names reserved, but
    should not have had its loops marked. *)
@@ -1375,9 +1374,7 @@ let type_expr_with_reserved_names ppf ty =
 
 let shared_type_scheme ppf ty = prepare_type ty ; typexp Type_scheme ppf ty
 
-let type_scheme ppf ty =
-  prepare_for_printing [ty] ;
-  typexp Type_scheme ppf ty
+let type_scheme ppf ty = prepare_for_printing [ty] ; typexp Type_scheme ppf ty
```

</details>

The diff looks like an improvement to me (cc @jberdine) but since it's a lot of changes maybe we should delay this PR until 0.20.0 is already released?

@cwong-ocaml @ceastlund let us know if you have any feedback regarding this change