### PR TITLE
[RFC] Make RPC server stateless: specify version for each command

### DIFF
--- a/bin/ocamlformat-rpc/main.ml
+++ b/bin/ocamlformat-rpc/main.ml
@@ -18,105 +18,80 @@ Caml.at_exit (Format.pp_print_flush Format.err_formatter);;
 
 Caml.at_exit (Format_.pp_print_flush Format_.err_formatter)
 
-module V = struct
-  type t = V1
-
-  let handshake = function
-    | "v1" | "V1" -> `Handled V1
-    | _ -> `Propose_another V1
-
-  let to_string = function V1 -> "v1"
-end
-
-type state = Waiting_for_version | Version_defined of (V.t * Conf.t)
-
 let format fg conf source =
   let input_name = "<rpc input>" in
   let opts = Conf.{debug= false; margin_check= false} in
   Translation_unit.parse_and_format fg ~input_name ~source conf opts
 
-let rec rpc_main = function
-  | Waiting_for_version -> (
-    match Init.read_input stdin with
-    | `Halt -> Ok ()
-    | `Unknown -> Ok ()
-    | `Version vstr -> (
-      match V.handshake vstr with
-      | `Handled v ->
-          Init.output stdout (`Version vstr) ;
-          Out_channel.flush stdout ;
-          rpc_main (Version_defined (v, Conf.default_profile))
-      | `Propose_another v ->
-          let vstr = V.to_string v in
-          Init.output stdout (`Version vstr) ;
-          Out_channel.flush stdout ;
-          rpc_main Waiting_for_version ) )
-  | Version_defined (v, conf) as state -> (
-    match v with
-    | V1 -> (
-      match V1.Command.read_input stdin with
-      | `Halt -> Ok ()
-      | `Unknown | `Error _ -> rpc_main state
-      | `Format x ->
-          List.fold_until ~init:()
-            ~finish:(fun () ->
-              V1.Command.output stdout
-                (`Error (Format.flush_str_formatter ())) )
-            ~f:(fun () try_formatting ->
-              match try_formatting conf x with
-              | Ok formatted ->
-                  ignore (Format.flush_str_formatter ()) ;
-                  V1.Command.output stdout (`Format formatted) ;
-                  Stop ()
-              | Error e ->
-                  Translation_unit.Error.print Format.str_formatter e ;
-                  Continue () )
-            (* The formatting functions are ordered in such a way that the
-               ones expecting a keyword first (like signatures) are placed
-               before the more general ones (like toplevel phrases). Parsing
-               a file as `--impl` with `ocamlformat` processes it as a use
-               file (toplevel phrases) anyway.
+let rec rpc_main () =
+  match V1.Command.read_input stdin with
+  | Ok ((`Halt | `Format _ | `Config _) as cmd) -> v1 cmd
+  | Ok (`Unknown | `Error _) | Error _ ->
+      (* TODO: try the version V-1, when the last one failed, just call
+         [rpc_main ()] to wait for the next input. *)
+      rpc_main ()
 
-               `ocaml-lsp` should use core types, module types and
-               signatures. `ocaml-mdx` should use toplevel phrases,
-               expressions and signatures. *)
-            [ format Core_type
-            ; format Signature
-            ; format Module_type
-            ; format Expression
-            ; format Use_file ] ;
-          rpc_main state
-      | `Config c -> (
-          let rec update conf = function
-            | [] -> Ok conf
-            | (name, value) :: t -> (
-              match Conf.update_value conf ~name ~value with
-              | Ok c -> update c t
-              | Error e -> Error e )
-          in
-          match update conf c with
-          | Ok conf ->
-              V1.Command.output stdout (`Config c) ;
-              Out_channel.flush stdout ;
-              rpc_main (Version_defined (v, conf))
+and v1 = function
+  | `Halt -> Ok ()
+  | `Format x ->
+      let conf = Conf.default_profile in
+      List.fold_until ~init:()
+        ~finish:(fun () ->
+          V1.Command.output stdout (`Error (Format.flush_str_formatter ()))
+          )
+        ~f:(fun () try_formatting ->
+          match try_formatting conf x with
+          | Ok formatted ->
+              ignore (Format.flush_str_formatter ()) ;
+              V1.Command.output stdout (`Format formatted) ;
+              Stop ()
           | Error e ->
-              let msg =
-                match e with
-                | `Bad_value (x, y) ->
-                    Format.sprintf "Bad configuration value (%s, %s)" x y
-                | `Malformed x ->
-                    Format.sprintf "Malformed configuration value %s" x
-                | `Misplaced (x, y) ->
-                    Format.sprintf "Misplaced configuration value (%s, %s)" x
-                      y
-                | `Unknown (x, _) ->
-                    Format.sprintf "Unknown configuration option %s" x
-              in
-              V1.Command.output stdout (`Error msg) ;
-              Out_channel.flush stdout ;
-              rpc_main state ) ) )
+              Translation_unit.Error.print Format.str_formatter e ;
+              Continue () )
+        (* The formatting functions are ordered in such a way that the ones
+           expecting a keyword first (like signatures) are placed before the
+           more general ones (like toplevel phrases). Parsing a file as
+           `--impl` with `ocamlformat` processes it as a use file (toplevel
+           phrases) anyway.
 
-let rpc_main () = rpc_main Waiting_for_version
+           `ocaml-lsp` should use core types, module types and signatures.
+           `ocaml-mdx` should use toplevel phrases, expressions and
+           signatures. *)
+        [ format Core_type
+        ; format Signature
+        ; format Module_type
+        ; format Expression
+        ; format Use_file ] ;
+      rpc_main ()
+  | `Config c -> (
+      let rec update conf = function
+        | [] -> Ok conf
+        | (name, value) :: t -> (
+          match Conf.update_value conf ~name ~value with
+          | Ok c -> update c t
+          | Error e -> Error e )
+      in
+      let conf = Conf.default_profile in
+      match update conf c with
+      | Ok _conf ->
+          V1.Command.output stdout (`Config c) ;
+          Out_channel.flush stdout ;
+          rpc_main ()
+      | Error e ->
+          let msg =
+            match e with
+            | `Bad_value (x, y) ->
+                Format.sprintf "Bad configuration value (%s, %s)" x y
+            | `Malformed x ->
+                Format.sprintf "Malformed configuration value %s" x
+            | `Misplaced (x, y) ->
+                Format.sprintf "Misplaced configuration value (%s, %s)" x y
+            | `Unknown (x, _) ->
+                Format.sprintf "Unknown configuration option %s" x
+          in
+          V1.Command.output stdout (`Error msg) ;
+          Out_channel.flush stdout ;
+          rpc_main () )
 
 open Cmdliner
 

--- a/lib-rpc/ocamlformat_rpc_lib.mli
+++ b/lib-rpc/ocamlformat_rpc_lib.mli
@@ -12,7 +12,7 @@
 module type Command_S = sig
   type t
 
-  val read_input : Stdlib.in_channel -> t
+  val read_input : Stdlib.in_channel -> (t, [`Msg of string]) result
 
   val to_sexp : t -> Sexplib0.Sexp.t
 
@@ -28,7 +28,7 @@ module type Client_S = sig
 
   val mk : pid:int -> in_channel -> out_channel -> t
 
-  val query : cmd -> t -> cmd
+  val query : cmd -> t -> (cmd, [`Msg of string]) result
 
   val halt : t -> (unit, [> `Msg of string]) result
 
@@ -44,9 +44,6 @@ module type V = sig
   module Client : Client_S with type cmd = Command.t
 end
 
-(** Version used to set the protocol version *)
-module Init : Command_S with type t = [`Halt | `Unknown | `Version of string]
-
 module V1 :
   V
     with type Command.t =
@@ -55,24 +52,3 @@ module V1 :
       | `Error of string
       | `Config of (string * string) list
       | `Format of string ]
-
-type client = [`V1 of V1.Client.t]
-
-val pick_client :
-     pid:int
-  -> in_channel
-  -> out_channel
-  -> string list
-  -> (client, [`Msg of string]) result
-(** [pick_client ~pid in out versions] returns the most-fitting client
-    according to a list of [versions], that is a list ordered from the most
-    to the least wished version. *)
-
-val pid : client -> int
-
-val halt : client -> (unit, [> `Msg of string]) result
-
-val config :
-  (string * string) list -> client -> (unit, [> `Msg of string]) result
-
-val format : string -> client -> (string, [> `Msg of string]) result

--- a/test/rpc/rpc_test.expected
+++ b/test/rpc/rpc_test.expected
@@ -18,13 +18,7 @@ Output: int (* foo *) -> int (* bar *)
 Error: Unknown configuration option foo
 [ocf] Config
 [ocf] Format 'aaa -> bbb -> ccc -> ddd -> eee -> fff -> ggg'
-Output: aaa ->
-bbb ->
-ccc ->
-ddd ->
-eee ->
-fff ->
-ggg
+Output: aaa -> bbb -> ccc -> ddd -> eee -> fff -> ggg
 
 [ocf] Config
 [ocf] Format 'aaa -> bbb -> ccc -> ddd -> eee -> fff -> ggg'
@@ -95,11 +89,12 @@ let ssmap
   ()
 '
 Output:
-let ssmap
-    :  (module MapT with type key = string and type data = string and type map = SSMap.map)
-    -> unit
-  =
+let ssmap :
+    (module MapT
+       with type key = string
+        and type data = string
+        and type map = SSMap.map) ->
+    unit =
   ()
-;;
 
 [ocf] Halt

--- a/test/rpc/rpc_test.ml
+++ b/test/rpc/rpc_test.ml
@@ -15,7 +15,7 @@ let log = Format.printf
 
 let supported_versions = ["v1"]
 
-type state = Uninitialized | Running of Ocf.client | Errored
+type state = Uninitialized | Running of Ocf.V1.Client.t | Errored
 
 let state : state ref = ref Uninitialized
 
@@ -25,9 +25,8 @@ let start () =
   ( match
       let input, output = Unix.open_process_args prog argv in
       let pid = Unix.process_pid (input, output) in
-      Ocf.pick_client ~pid input output supported_versions
-      >>| fun client ->
-      (match client with `V1 _ -> log "[ocf] client V1 selected\n%!") ;
+      let client = Ocf.V1.Client.mk ~pid input output in
+      log "[ocf] client V1 selected\n%!" ;
       state := Running client ;
       client
     with
@@ -37,7 +36,7 @@ let start () =
           "OCamlFormat-RPC did not respond. Check that a compatible version \
            of the OCamlFormat RPC server (ocamlformat-rpc >= 0.18.0) is \
            installed." )
-  | x -> x )
+  | x -> Ok x )
   |> Result.map_error ~f:(fun (`Msg msg) ->
          state := Errored ;
          log
@@ -51,24 +50,25 @@ let get_client () =
   match !state with
   | Uninitialized -> start ()
   | Running cl ->
-      let i, _ = Unix.waitpid [WNOHANG] (Ocf.pid cl) in
+      let i, _ = Unix.waitpid [WNOHANG] (Ocf.V1.Client.pid cl) in
       if i = 0 then Ok cl else start ()
   | Errored -> Error `No_process
 
 let config c =
-  get_client () >>= fun cl -> log "[ocf] Config\n%!" ; Ocf.config c cl
+  get_client ()
+  >>= fun cl -> log "[ocf] Config\n%!" ; Ocf.V1.Client.config c cl
 
 let format x =
   get_client ()
   >>= fun cl ->
   log "[ocf] Format '%s'\n%!" x ;
-  Ocf.format x cl
+  Ocf.V1.Client.format x cl
 
 let halt () =
   get_client ()
   >>= fun cl ->
   log "[ocf] Halt\n%!" ;
-  Ocf.halt cl >>| fun () -> state := Uninitialized
+  Ocf.V1.Client.halt cl >>| fun () -> state := Uninitialized
 
 let protect_unit x =
   match x with

--- a/test/rpc/rpc_test_fail.expected
+++ b/test/rpc/rpc_test_fail.expected
@@ -1,8 +1,12 @@
 Starting then doing nothing
-An error occured while initializing and configuring ocamlformat:
-OCamlFormat-RPC did not respond. Check that a compatible version of the OCamlFormat RPC server (ocamlformat-rpc >= 0.18.0) is installed.
-No process
+[ocf] client V1 selected
+[ocf] Halt
 Sending requests
-No process
-No process
-No process
+[ocf] client V1 selected
+[ocf] Config
+Error: failing to set configuration: unknown error
+[ocf] client V1 selected
+[ocf] Format 'char -> string'
+Error: failing to format input: unknown error
+[ocf] client V1 selected
+[ocf] Halt

--- a/test/rpc/rpc_test_fail.ml
+++ b/test/rpc/rpc_test_fail.ml
@@ -15,7 +15,7 @@ let log = Format.printf
 
 let supported_versions = ["v1"]
 
-type state = Uninitialized | Running of Ocf.client | Errored
+type state = Uninitialized | Running of Ocf.V1.Client.t | Errored
 
 let state : state ref = ref Uninitialized
 
@@ -25,9 +25,8 @@ let start () =
   ( match
       let input, output = Unix.open_process_args prog argv in
       let pid = Unix.process_pid (input, output) in
-      Ocf.pick_client ~pid input output supported_versions
-      >>| fun client ->
-      (match client with `V1 _ -> log "[ocf] client V1 selected\n%!") ;
+      let client = Ocf.V1.Client.mk ~pid input output in
+      log "[ocf] client V1 selected\n%!" ;
       state := Running client ;
       client
     with
@@ -37,7 +36,7 @@ let start () =
           "OCamlFormat-RPC did not respond. Check that a compatible version \
            of the OCamlFormat RPC server (ocamlformat-rpc >= 0.18.0) is \
            installed." )
-  | x -> x )
+  | x -> Ok x )
   |> Result.map_error ~f:(fun (`Msg msg) ->
          state := Errored ;
          log
@@ -51,24 +50,25 @@ let get_client () =
   match !state with
   | Uninitialized -> start ()
   | Running cl ->
-      let i, _ = Unix.waitpid [WNOHANG] (Ocf.pid cl) in
+      let i, _ = Unix.waitpid [WNOHANG] (Ocf.V1.Client.pid cl) in
       if i = 0 then Ok cl else start ()
   | Errored -> Error `No_process
 
 let config c =
-  get_client () >>= fun cl -> log "[ocf] Config\n%!" ; Ocf.config c cl
+  get_client ()
+  >>= fun cl -> log "[ocf] Config\n%!" ; Ocf.V1.Client.config c cl
 
 let format x =
   get_client ()
   >>= fun cl ->
   log "[ocf] Format '%s'\n%!" x ;
-  Ocf.format x cl
+  Ocf.V1.Client.format x cl
 
 let halt () =
   get_client ()
   >>= fun cl ->
   log "[ocf] Halt\n%!" ;
-  Ocf.halt cl >>| fun () -> state := Uninitialized
+  Ocf.V1.Client.halt cl >>| fun () -> state := Uninitialized
 
 let protect_unit x =
   match x with


### PR DESCRIPTION
Following up #1935, here is what the RPC could look like if we removed the internal state keeping the version of the RPC and the configuration, the goal is to ease the maintenance and make it less error prone for users.
cc @rgrinberg @Julow @panglesd @voodoos

By making the red_input functions return a result type, we could get rid of the Unknown and Error commands, but I kept them for now for retro-compatibility.

Todo: the tests have to be updated once the config is included in the Format command.