### PR TITLE
Add missing parentheses around variant class arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 #### Bug fixes
 
+  + Add missing parentheses around variant class arguments (#<PR_NUMBER>, @gpetiot)
+
 #### Changes
 
 #### New features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 #### Bug fixes
 
-  + Add missing parentheses around variant class arguments (#<PR_NUMBER>, @gpetiot)
+  + Add missing parentheses around variant class arguments (#1967, @gpetiot)
 
 #### Changes
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2001,6 +2001,7 @@ end = struct
      |Pat _, Ppat_lazy _
      |Pat _, Ppat_exception _
      |Exp {pexp_desc= Pexp_fun _; _}, Ppat_or _
+     |Cl {pcl_desc= Pcl_fun _; _}, Ppat_variant (_, Some _)
      |Cl {pcl_desc= Pcl_fun _; _}, Ppat_tuple _
      |Cl {pcl_desc= Pcl_fun _; _}, Ppat_construct _
      |Cl {pcl_desc= Pcl_fun _; _}, Ppat_alias _

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -831,6 +831,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to class_expr.ml.stdout
+   (with-stderr-to class_expr.ml.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/class_expr.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/class_expr.ml class_expr.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/class_expr.ml.err class_expr.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to cmdline_override.ml.stdout
    (with-stderr-to cmdline_override.ml.stderr
      (run %{bin:ocamlformat} --margin-check --config=module-item-spacing=compact --module-item-spacing=sparse %{dep:tests/cmdline_override.ml})))))

--- a/test/passing/tests/class_expr.ml
+++ b/test/passing/tests/class_expr.ml
@@ -1,0 +1,5 @@
+class c (`I i) = x
+
+class c `I = x
+
+class c i = x


### PR DESCRIPTION
Fix #1964, no diff with test_branch.sh

There is no similar bug for class types as there is no equivalent syntax.