### PR TITLE
Variant expressions with no argument are considered "simple"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 
 #### Changes
 
-  + Variant expressions with no argument are considered "simple" (not inducing a break e.g. as an argument of an application) (#<PR_NUMBER>, @gpetiot)
+  + Variant expressions with no argument are considered "simple" (not inducing a break e.g. as an argument of an application) (#1968, @gpetiot)
 
 #### New features
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 #### Changes
 
+  + Variant expressions with no argument are considered "simple" (not inducing a break e.g. as an argument of an application) (#<PR_NUMBER>, @gpetiot)
+
 #### New features
 
 ### 0.20.1 (2021-12-13)

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -313,6 +313,7 @@ module Exp = struct
     | Pexp_apply
         ({pexp_desc= Pexp_ident {txt= Lident "not"; _}; _}, [(_, e1)]) ->
         is_trivial e1
+    | Pexp_variant (_, None) -> true
     | _ -> false
 
   let rec exposed_left e =

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -304,8 +304,7 @@ let relocate_cmts_before (t : t) ~src ~sep ~dst =
     Multimap.partition_multi map ~src ~dst ~f:(fun Cmt.{loc; _} ->
         Location.compare_end loc sep < 0 )
   in
-  update_cmts t `Before ~f ;
-  update_cmts t `Within ~f
+  update_cmts t `Before ~f ; update_cmts t `Within ~f
 
 let relocate_pattern_matching_cmts (t : t) src tok ~whole_loc ~matched_loc =
   let kwd_loc =
@@ -617,9 +616,8 @@ let fmt_cmts t conf ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n") ?(adj = eol)
       fmt_opt pro $ fmt_cmts_aux t conf cmts ~fmt_code pos $ epi
 
 let fmt_before t conf ~fmt_code ?pro ?(epi = Fmt.break 1 0) ?eol ?adj loc =
-  fmt_cmts t conf
-    (find_cmts t `Before loc)
-    ~fmt_code ?pro ~epi ?eol ?adj loc Before
+  fmt_cmts t conf (find_cmts t `Before loc) ~fmt_code ?pro ~epi ?eol ?adj loc
+    Before
 
 let fmt_after t conf ~fmt_code ?(pro = Fmt.break 1 0) ?epi loc =
   let open Fmt in
@@ -627,17 +625,15 @@ let fmt_after t conf ~fmt_code ?(pro = Fmt.break 1 0) ?epi loc =
     fmt_cmts t conf (find_cmts t `Within loc) ~fmt_code ~pro ?epi loc Within
   in
   let after =
-    fmt_cmts t conf
-      (find_cmts t `After loc)
-      ~fmt_code ~pro ?epi ~eol:noop loc After
+    fmt_cmts t conf (find_cmts t `After loc) ~fmt_code ~pro ?epi ~eol:noop
+      loc After
   in
   within $ after
 
 let fmt_within t conf ~fmt_code ?(pro = Fmt.break 1 0) ?(epi = Fmt.break 1 0)
     loc =
-  fmt_cmts t conf
-    (find_cmts t `Within loc)
-    ~fmt_code ~pro ~epi ~eol:Fmt.noop loc Within
+  fmt_cmts t conf (find_cmts t `Within loc) ~fmt_code ~pro ~epi ~eol:Fmt.noop
+    loc Within
 
 module Toplevel = struct
   let fmt_cmts t conf ~fmt_code found (pos : Cmt.pos) =
@@ -687,9 +683,7 @@ let drop_inside t loc =
         (Multimap.filter ~f:(fun {Cmt.loc= cmt_loc; _} ->
              not (Location.contains loc cmt_loc) ) )
   in
-  clear `Before ;
-  clear `Within ;
-  clear `After
+  clear `Before ; clear `Within ; clear `After
 
 let drop_before t loc =
   update_cmts t `Before ~f:(fun m -> Map.remove m loc) ;

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1756,9 +1756,8 @@ let parse_line config ~from s =
           warn "Configuration in attribute %S ignored." s ;
           Ok config )
         else
-          C.update ~config
-            ~from:(`Parsed `Attribute)
-            ~name ~value ~inline:true
+          C.update ~config ~from:(`Parsed `Attribute) ~name ~value
+            ~inline:true
   in
   let update_ocp_indent_option ~config ~from ~name ~value =
     let equal = String.equal in

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7591,3 +7591,15 @@ let[@a (* .............................................. .......................
             | _ -> .) [@ocaml.warning (* ....................................... *) let x = a and y = b in x + y])
     -> y[@attr (* ... *) (* ... *) attr (* ... *)]
 ;;
+
+let x =
+  foo (`A b) ~f:(fun thing ->
+    something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
+;;
+
+let x =
+  foo
+    (`A `b)
+    ~f:(fun thing ->
+      something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
+;;

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9834,3 +9834,13 @@ let[@a
       (* ... *)
       attr (* ... *)]
 ;;
+
+let x =
+  foo (`A b) ~f:(fun thing ->
+      something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
+;;
+
+let x =
+  foo (`A `b) ~f:(fun thing ->
+      something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
+;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9834,3 +9834,13 @@ let[@a
         (* ... *)
         attr (* ... *)]
 ;;
+
+let x =
+  foo (`A b) ~f:(fun thing ->
+      something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
+;;
+
+let x =
+  foo (`A `b) ~f:(fun thing ->
+      something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
+;;


### PR DESCRIPTION
Taking care of the first part of #1938: the variants, since it's not controversial. #1943 will be rebased to only take care of the lists and arrays.