### PR TITLE
Improve consistency of 'struct' keyword position

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 
   + Fix indentation of module binding RHS (#1969, @gpetiot)
 
-  + Improve consistency of `struct` keyword position ("docked" at the end of the preceding line) (#<PR_NUMBER>, @gpetiot)
+  + Improve consistency of `struct` keyword position ("docked" at the end of the preceding line) (#1970, @gpetiot)
 
 #### Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
   + Fix indentation of module binding RHS (#1969, @gpetiot)
 
+  + Improve consistency of `struct` keyword position ("docked" at the end of the preceding line) (#<PR_NUMBER>, @gpetiot)
+
 #### Changes
 
   + Variant expressions with no argument are considered "simple" (not inducing a break e.g. as an argument of an application) (#1968, @gpetiot)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3765,12 +3765,23 @@ and fmt_module c ?ext ?epi ?(can_sparse = false) keyword ?(eqty = "=") name
     fmt_docstring_around_item c ~force_before:(not single_line) ~fit:true
       attributes
   in
+  let box_pro =
+    let last_blk =
+      match blk_t.pro with
+      | Some pro -> Some pro
+      | None -> (
+        match List.rev arg_blks with
+        | [] -> blk_t.pro
+        | {txt= `Unit; _} :: _ -> blk_t.pro
+        | {txt= `Named (_, blk); _} :: _ -> blk.pro )
+    in
+    if Option.is_some last_blk then hovbox else hvbox
+  in
   hvbox
     (if compact then 0 else 2)
     ( doc_before
     $ box_b
-        ( (if Option.is_some blk_t.epi then hovbox else hvbox)
-            0
+        ( box_pro 0
             ( box_t
                 ( hvbox_if
                     (Option.is_some blk_t.pro)

--- a/lib/Multimap.ml
+++ b/lib/Multimap.ml
@@ -15,8 +15,7 @@ module M (K : sig
   type t
 
   type comparator_witness
-end) =
-struct
+end) = struct
   type nonrec 'v t = (K.t, 'v, K.comparator_witness) t
 end
 

--- a/test/passing/tests/functor.ml
+++ b/test/passing/tests/functor.ml
@@ -77,8 +77,7 @@ module Make
              and type semantic_value = Obj.t)
     (E : sig
       type 'a env = (ET.state, ET.semantic_value, ET.token) EngineTypes.env
-    end) =
-struct
+    end) = struct
   type t = t
 end
 

--- a/test/passing/tests/hash_types.ml
+++ b/test/passing/tests/hash_types.ml
@@ -1,7 +1,6 @@
 module F (X : sig
   type t
-end) =
-struct
+end) = struct
   class type ['a] c =
     object
       method m : 'a -> X.t

--- a/test/passing/tests/injectivity.ml
+++ b/test/passing/tests/injectivity.ml
@@ -60,22 +60,19 @@ type !'a u = int constraint 'a = 'b t
 
 module F (X : sig
   type 'a t
-end) =
-struct
+end) = struct
   type !'a u = 'b constraint 'a = < b: 'b > constraint 'b = _ X.t
 end
 
 module F (X : sig
   type 'a t
-end) =
-struct
+end) = struct
   type !'a u = 'b X.t constraint 'a = < b: 'b X.t >
 end
 
 module F (X : sig
   type 'a t
-end) =
-struct
+end) = struct
   type !'a u = 'b constraint 'a = < b: (_ X.t as 'b) >
 end
 

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,9 +1,9 @@
 Warning: tests/js_source.ml:154 exceeds the margin
-Warning: tests/js_source.ml:3570 exceeds the margin
-Warning: tests/js_source.ml:9561 exceeds the margin
-Warning: tests/js_source.ml:9582 exceeds the margin
-Warning: tests/js_source.ml:9664 exceeds the margin
-Warning: tests/js_source.ml:9677 exceeds the margin
-Warning: tests/js_source.ml:9682 exceeds the margin
-Warning: tests/js_source.ml:9722 exceeds the margin
-Warning: tests/js_source.ml:9804 exceeds the margin
+Warning: tests/js_source.ml:3564 exceeds the margin
+Warning: tests/js_source.ml:9546 exceeds the margin
+Warning: tests/js_source.ml:9567 exceeds the margin
+Warning: tests/js_source.ml:9649 exceeds the margin
+Warning: tests/js_source.ml:9662 exceeds the margin
+Warning: tests/js_source.ml:9667 exceeds the margin
+Warning: tests/js_source.ml:9707 exceeds the margin
+Warning: tests/js_source.ml:9789 exceeds the margin

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -2374,8 +2374,7 @@ let inlineseq_from_astseq seq =
 
 module Add (T : sig
     type two
-  end) =
-struct
+  end) = struct
   type _ t =
     | One : [ `One ] t
     | Two : T.two t
@@ -2462,8 +2461,7 @@ let _ = example6 (WrapPoly AandBTags) `TagB (* This causes a seg fault *)
 
 module F (S : sig
     type 'a t
-  end) =
-struct
+  end) = struct
   type _ ab =
     | A : int S.t ab
     | B : float S.t ab
@@ -2477,8 +2475,7 @@ end
 
 module F (S : sig
     type 'a t
-  end) =
-struct
+  end) = struct
   type a = int * int
   type b = int -> int
 
@@ -2581,8 +2578,7 @@ let f : (int s, int t) eq -> unit = function
 module M (S : sig
     type 'a t = T of 'a
     type 'a s = T of 'a
-  end) =
-struct
+  end) = struct
   let f : ('a S.s, 'a S.t) eq -> unit = function
     | Refl -> ()
   ;;
@@ -2623,8 +2619,7 @@ module M (A : sig
     module type T
   end) (B : sig
           module type T
-        end) =
-struct
+        end) = struct
   let f : ((module A.T), (module B.T)) t -> string = function
     | B s -> s
   ;;
@@ -2824,8 +2819,7 @@ let f (type a) (Neq n : (a, a t) eq) = n
 
 module F (T : sig
     type _ t
-  end) =
-struct
+  end) = struct
   let f (type a) (Neq n : (a, a T.t) eq) = n (* warn! *)
 end
 
@@ -4709,8 +4703,7 @@ module F (M : sig
     type 'a u = string
 
     val f : unit -> _ u t
-  end) =
-struct
+  end) = struct
   let t = M.f ()
 end
 
@@ -5014,8 +5007,7 @@ module Foo (Bar : sig
     type a = private [> `A ]
   end) (Baz : module type of struct
           include Bar
-        end) =
-struct end
+        end) = struct end
 
 module Bazoinks = struct
   type a = [ `A ]
@@ -5030,8 +5022,7 @@ let cast : type a b. (a, b) eq -> a -> b = fun Eq x -> x
 
 module Fix (F : sig
     type 'a f
-  end) =
-struct
+  end) = struct
   type 'a fix = ('a, 'a F.f) eq
 
   let uniq (type a b) (Eq : a fix) (Eq : b fix) : (a, b) eq = Eq
@@ -5553,8 +5544,7 @@ include C
 
 module F (X : sig
     module C = Char
-  end) =
-struct
+  end) = struct
   module C = X.C
 end
 
@@ -5616,8 +5606,7 @@ module F (Y : sig
     type t
   end) (M : sig
           type t = Y.t
-        end) =
-struct end
+        end) = struct end
 
 module G = F (M.Y)
 
@@ -6710,8 +6699,7 @@ class ['a] s3object r : ['a] s3 =
 
 module M (T : sig
     type t
-  end) =
-struct
+  end) = struct
   type t = private { t : T.t }
 end
 
@@ -7839,8 +7827,7 @@ let _ = test 81 (Coerce2.f1 ()) 1
 
 module Coerce4 (A : sig
     val f : int -> int
-  end) =
-struct
+  end) = struct
   let x = 0
   let at a = A.f a
 end
@@ -7887,8 +7874,7 @@ let _ =
 (* PR#4316 *)
 module G (S : sig
     val x : int Lazy.t
-  end) =
-struct
+  end) = struct
   include S
 end
 
@@ -7981,8 +7967,7 @@ end
 
 module F (X : sig
     val x : (module S)
-  end) =
-struct
+  end) = struct
   module A = (val X.x)
 end
 

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -2374,8 +2374,7 @@ let inlineseq_from_astseq seq =
 
 module Add (T : sig
   type two
-end) =
-struct
+end) = struct
   type _ t =
     | One : [ `One ] t
     | Two : T.two t
@@ -2462,8 +2461,7 @@ let _ = example6 (WrapPoly AandBTags) `TagB (* This causes a seg fault *)
 
 module F (S : sig
   type 'a t
-end) =
-struct
+end) = struct
   type _ ab =
     | A : int S.t ab
     | B : float S.t ab
@@ -2477,8 +2475,7 @@ end
 
 module F (S : sig
   type 'a t
-end) =
-struct
+end) = struct
   type a = int * int
   type b = int -> int
 
@@ -2581,8 +2578,7 @@ let f : (int s, int t) eq -> unit = function
 module M (S : sig
   type 'a t = T of 'a
   type 'a s = T of 'a
-end) =
-struct
+end) = struct
   let f : ('a S.s, 'a S.t) eq -> unit = function
     | Refl -> ()
   ;;
@@ -2623,8 +2619,7 @@ module M (A : sig
   module type T
 end) (B : sig
   module type T
-end) =
-struct
+end) = struct
   let f : ((module A.T), (module B.T)) t -> string = function
     | B s -> s
   ;;
@@ -2824,8 +2819,7 @@ let f (type a) (Neq n : (a, a t) eq) = n
 
 module F (T : sig
   type _ t
-end) =
-struct
+end) = struct
   let f (type a) (Neq n : (a, a T.t) eq) = n (* warn! *)
 end
 
@@ -4709,8 +4703,7 @@ module F (M : sig
   type 'a u = string
 
   val f : unit -> _ u t
-end) =
-struct
+end) = struct
   let t = M.f ()
 end
 
@@ -5014,8 +5007,7 @@ module Foo (Bar : sig
   type a = private [> `A ]
 end) (Baz : module type of struct
   include Bar
-end) =
-struct end
+end) = struct end
 
 module Bazoinks = struct
   type a = [ `A ]
@@ -5030,8 +5022,7 @@ let cast : type a b. (a, b) eq -> a -> b = fun Eq x -> x
 
 module Fix (F : sig
   type 'a f
-end) =
-struct
+end) = struct
   type 'a fix = ('a, 'a F.f) eq
 
   let uniq (type a b) (Eq : a fix) (Eq : b fix) : (a, b) eq = Eq
@@ -5553,8 +5544,7 @@ include C
 
 module F (X : sig
   module C = Char
-end) =
-struct
+end) = struct
   module C = X.C
 end
 
@@ -5616,8 +5606,7 @@ module F (Y : sig
   type t
 end) (M : sig
   type t = Y.t
-end) =
-struct end
+end) = struct end
 
 module G = F (M.Y)
 
@@ -6710,8 +6699,7 @@ class ['a] s3object r : ['a] s3 =
 
 module M (T : sig
   type t
-end) =
-struct
+end) = struct
   type t = private { t : T.t }
 end
 
@@ -7839,8 +7827,7 @@ let _ = test 81 (Coerce2.f1 ()) 1
 
 module Coerce4 (A : sig
   val f : int -> int
-end) =
-struct
+end) = struct
   let x = 0
   let at a = A.f a
 end
@@ -7887,8 +7874,7 @@ let _ =
 (* PR#4316 *)
 module G (S : sig
   val x : int Lazy.t
-end) =
-struct
+end) = struct
   include S
 end
 
@@ -7981,8 +7967,7 @@ end
 
 module F (X : sig
   val x : (module S)
-end) =
-struct
+end) = struct
   module A = (val X.x)
 end
 

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -2338,8 +2338,7 @@ let inlineseq_from_astseq seq =
 
 module Add (T : sig
   type two
-end) =
-struct
+end) = struct
   type _ t = One : [`One] t | Two : T.two t
 
   let add (type a) : a t * a t -> string = function
@@ -2400,8 +2399,7 @@ let _ = example6 (WrapPoly AandBTags) `TagB (* This causes a seg fault *)
 
 module F (S : sig
   type 'a t
-end) =
-struct
+end) = struct
   type _ ab = A : int S.t ab | B : float S.t ab
 
   let f : int S.t ab -> float S.t ab -> string =
@@ -2411,8 +2409,7 @@ end
 
 module F (S : sig
   type 'a t
-end) =
-struct
+end) = struct
   type a = int * int
 
   type b = int -> int
@@ -2499,8 +2496,7 @@ module M (S : sig
   type 'a t = T of 'a
 
   type 'a s = T of 'a
-end) =
-struct
+end) = struct
   let f : ('a S.s, 'a S.t) eq -> unit = function Refl -> ()
 end
 
@@ -2531,8 +2527,7 @@ module M (A : sig
   module type T
 end) (B : sig
   module type T
-end) =
-struct
+end) = struct
   let f : ((module A.T), (module B.T)) t -> string = function B s -> s
 end
 
@@ -2707,8 +2702,7 @@ let f (type a) (Neq n : (a, a t) eq) = n
 
 module F (T : sig
   type _ t
-end) =
-struct
+end) = struct
   let f (type a) (Neq n : (a, a T.t) eq) = n (* warn! *)
 end
 
@@ -4449,8 +4443,7 @@ module F (M : sig
   type 'a u = string
 
   val f : unit -> _ u t
-end) =
-struct
+end) = struct
   let t = M.f ()
 end
 
@@ -4754,8 +4747,7 @@ module Foo (Bar : sig
   type a = private [> `A]
 end) (Baz : module type of struct
   include Bar
-end) =
-struct end
+end) = struct end
 
 module Bazoinks = struct
   type a = [`A]
@@ -4770,8 +4762,7 @@ let cast : type a b. (a, b) eq -> a -> b = fun Eq x -> x
 
 module Fix (F : sig
   type 'a f
-end) =
-struct
+end) = struct
   type 'a fix = ('a, 'a F.f) eq
 
   let uniq (type a b) (Eq : a fix) (Eq : b fix) : (a, b) eq = Eq
@@ -5286,8 +5277,7 @@ include C
 
 module F (X : sig
   module C = Char
-end) =
-struct
+end) = struct
   module C = X.C
 end
 
@@ -5351,8 +5341,7 @@ module F (Y : sig
   type t
 end) (M : sig
   type t = Y.t
-end) =
-struct end
+end) = struct end
 
 module G = F (M.Y)
 
@@ -6453,8 +6442,7 @@ class ['a] s3object r : ['a] s3 =
 
 module M (T : sig
   type t
-end) =
-struct
+end) = struct
   type t = private {t: T.t}
 end
 
@@ -7564,8 +7552,7 @@ let _ = test 81 (Coerce2.f1 ()) 1
 
 module Coerce4 (A : sig
   val f : int -> int
-end) =
-struct
+end) = struct
   let x = 0
 
   let at a = A.f a
@@ -7607,8 +7594,7 @@ let _ =
 (* PR#4316 *)
 module G (S : sig
   val x : int Lazy.t
-end) =
-struct
+end) = struct
   include S
 end
 
@@ -7687,8 +7673,7 @@ end
 
 module F (X : sig
   val x : (module S)
-end) =
-struct
+end) = struct
   module A = (val X.x)
 end
 


### PR DESCRIPTION
Currently, this example formats to itself:
```ocaml
module F = struct
   type x = t
end

module F (S : sig
   type 'a t
end) =
struct
   type x = t
end
```

With this change the last case is formatted as:
```ocaml
module F (S : sig
  type 'a t
end) = struct
  type x = t
end
```

Diff with test_branch.sh: (too big to display everything)

<details>

```diff
--- a/testsuite/tests/typing-gadts/pr5981.ml
+++ b/testsuite/tests/typing-gadts/pr5981.ml
@@ -4,8 +4,7 @@
 
 module F (S : sig
   type 'a t
-end) =
-struct
+end) = struct
   type _ ab =
     | A : int S.t ab
     | B : float S.t ab
@@ -35,8 +34,7 @@ module F :
 
 module F (S : sig
   type 'a t
-end) =
-struct
+end) = struct
   type a = int * int
   type b = int -> int
 
diff --git a/testsuite/tests/typing-gadts/pr5985.ml b/testsuite/tests/typing-gadts/pr5985.ml
index 2772e9b94..41c60b79b 100644
--- a/testsuite/tests/typing-gadts/pr5985.ml
+++ b/testsuite/tests/typing-gadts/pr5985.ml
@@ -5,8 +5,7 @@
 (* Report from Jeremy Yallop *)
 module F (S : sig
   type 'a s
-end) =
-struct
+end) = struct
   include S
 
   type _ t = T : 'a -> 'a s t
@@ -42,8 +41,7 @@ let M.T x = M.T 3 in x = 3;; (* ok *)
 (* Another version using OCaml 2.00 objects *)
 module F (T : sig
   type 'a t
-end) =
-struct
+end) = struct
   class ['a] c x =
     object
       constraint 'a = 'b T.t
diff --git a/testsuite/tests/typing-gadts/pr6158.ml b/testsuite/tests/typing-gadts/pr6158.ml
index f16bede9d..20132328c 100644
--- a/testsuite/tests/typing-gadts/pr6158.ml
+++ b/testsuite/tests/typing-gadts/pr6158.ml
@@ -13,8 +13,7 @@ let f : (int s, int t) eq -> unit = function
 module M (S : sig
   type 'a t = T of 'a
   type 'a s = T of 'a
-end) =
-struct
+end) = struct
   let f : ('a S.s, 'a S.t) eq -> unit = function
     | Refl -> ()
   ;;
diff --git a/testsuite/tests/typing-gadts/pr6241.ml b/testsuite/tests/typing-gadts/pr6241.ml
index 571b7c6d7..187f45fd3 100644
--- a/testsuite/tests/typing-gadts/pr6241.ml
+++ b/testsuite/tests/typing-gadts/pr6241.ml
@@ -10,8 +10,7 @@ module M (A : sig
   module type T
 end) (B : sig
   module type T
-end) =
-struct
+end) = struct
   let f : ((module A.T), (module B.T)) t -> string = function
     | B s -> s
   ;;
diff --git a/testsuite/tests/typing-gadts/pr7234.ml b/testsuite/tests/typing-gadts/pr7234.ml
index 9aab22ec8..ec0cb96ea 100644
--- a/testsuite/tests/typing-gadts/pr7234.ml
+++ b/testsuite/tests/typing-gadts/pr7234.ml
@@ -26,8 +26,7 @@ val f : ('a, 'a t) eq -> int = <fun>
 
 module F (T : sig
   type _ t
-end) =
-struct
+end) = struct
   let f (type a) (Neq n : (a, a T.t) eq) = n (* warn! *)
 end
 
diff --git a/testsuite/tests/typing-gadts/pr7374.ml b/testsuite/tests/typing-gadts/pr7374.ml
index 1ba6b8419..a99c3b1a5 100644
--- a/testsuite/tests/typing-gadts/pr7374.ml
+++ b/testsuite/tests/typing-gadts/pr7374.ml
@@ -61,8 +61,7 @@ Error: Unbound module Fix
 (* addendum: ensure that hidden paths are checked too *)
 module F (X : sig
   type 'a t
-end) =
-struct
+end) = struct
   open X
 
   let f : type a b. (a, b t) eq -> (b, a t) eq -> (a, a t t) eq = fun Refl Refl -> Refl
diff --git a/testsuite/tests/typing-misc/injectivity.ml b/testsuite/tests/typing-misc/injectivity.ml
index 33490a9d0..251afbc6f 100644
--- a/testsuite/tests/typing-misc/injectivity.ml
+++ b/testsuite/tests/typing-misc/injectivity.ml
@@ -250,8 +250,7 @@ Error: In this definition, expected parameter variances are not satisfied.
 (* One cannot assume that abstract types are not injective *)
 module F (X : sig
   type 'a t
-end) =
-struct
+end) = struct
   type 'a u = unit constraint 'a = 'b X.t
   type _ x = G : 'a -> 'a u x
 end
@@ -282,8 +281,7 @@ type 'a u = int constraint 'a = 'b t
 
 module F (X : sig
   type 'a t
-end) =
-struct
+end) = struct
   type !'a u = 'b constraint 'a = < b : 'b > constraint 'b = _ X.t
 end
 
@@ -297,8 +295,7 @@ module F :
 (* But not too clever *)
 module F (X : sig
   type 'a t
-end) =
-struct
+end) = struct
   type !'a u = 'b X.t constraint 'a = < b : 'b X.t >
 end
 
@@ -314,8 +311,7 @@ Error: In this definition, expected parameter variances are not satisfied.
 
 module F (X : sig
   type 'a t
-end) =
-struct
+end) = struct
   type !'a u = 'b constraint 'a = < b : (_ X.t as 'b) >
 end
 
diff --git a/testsuite/tests/typing-misc/pr8548.ml b/testsuite/tests/typing-misc/pr8548.ml
index aa95cba52..f021d7a73 100644
--- a/testsuite/tests/typing-misc/pr8548.ml
+++ b/testsuite/tests/typing-misc/pr8548.ml
@@ -61,8 +61,7 @@ module Assume (Given : sig
 
   module Make_ranged (Range : S) :
     Ranged with module Endpoint = Range.Endpoint and module Range = Range
-end) =
-struct
+end) = struct
   module Point = struct
     type t
   end
diff --git a/testsuite/tests/typing-misc/variant.ml b/testsuite/tests/typing-misc/variant.ml
index c81712415..2b55e9dfe 100644
--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -39,8 +39,7 @@ Error: Signature mismatch:
 
 module Make (X : sig
   val f : [ `A ] -> unit
-end) =
-struct
+end) = struct
   let make f1 f2 arg =
     match arg with
     | `A ->
diff --git a/testsuite/tests/typing-modules-bugs/pr5663_ok.ml b/testsuite/tests/typing-modules-bugs/pr5663_ok.ml
index d70b4f3ef..a34a4dfc4 100644
--- a/testsuite/tests/typing-modules-bugs/pr5663_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr5663_ok.ml
@@ -10,7 +10,6 @@ module F (M : sig
   type 'a u = string
 
   val f : unit -> _ u t
-end) =
-struct
+end) = struct
   let t = M.f ()
 end
diff --git a/testsuite/tests/typing-modules-bugs/pr6485_ok.ml b/testsuite/tests/typing-modules-bugs/pr6485_ok.ml
index c551107c6..7286445b9 100644
--- a/testsuite/tests/typing-modules-bugs/pr6485_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6485_ok.ml
@@ -32,8 +32,7 @@ end = struct
 
   module Make (M : sig
     val module_name : string
-  end) =
-  struct
+  end) = struct
     include String
 
     let of_string s =
diff --git a/testsuite/tests/typing-modules-bugs/pr6985_ok.ml b/testsuite/tests/typing-modules-bugs/pr6985_ok.ml
index 651c96460..448be3137 100644
--- a/testsuite/tests/typing-modules-bugs/pr6985_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6985_ok.ml
@@ -9,8 +9,7 @@ module Foo (Bar : sig
   type a = private [> `A ]
 end) (Baz : module type of struct
   include Bar
-end) =
-struct end
+end) = struct end
 
 module Bazoinks = struct
   type a = [ `A ]
diff --git a/testsuite/tests/typing-modules-bugs/pr6992_bad.ml b/testsuite/tests/typing-modules-bugs/pr6992_bad.ml
index ffa987ba5..b2baf008c 100644
--- a/testsuite/tests/typing-modules-bugs/pr6992_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6992_bad.ml
@@ -14,8 +14,7 @@ let cast : type a b. (a, b) eq -> a -> b = fun Eq x -> x
 
 module Fix (F : sig
   type 'a f
-end) =
-struct
+end) = struct
   type 'a fix = ('a, 'a F.f) eq
 
   let uniq (type a b) (Eq : a fix) (Eq : b fix) : (a, b) eq = Eq
diff --git a/testsuite/tests/typing-modules/aliases.ml b/testsuite/tests/typing-modules/aliases.ml
index b751fe90a..f31250a8f 100644
--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -424,8 +424,7 @@ val pow : t -> t -> t = <fun>
 
 module F (X : sig
   module C = Char
-end) =
-struct
+end) = struct
   module C = X.C
 end
 
@@ -658,8 +657,7 @@ module F (Y : sig
   type t
 end) (M : sig
   type t = Y.t
-end) =
-struct end
+end) = struct end
 
 module G = F (M.Y)
 module N = G (M)
@@ -1261,8 +1259,7 @@ end = struct
     module A : sig
       val x : string
     end
-  end) =
-  struct
+  end) = struct
     let s = X.A.x
   end
 end
diff --git a/testsuite/tests/typing-modules/applicative_functor_type.ml b/testsuite/tests/typing-modules/applicative_functor_type.ml
index e3f2c020f..cbec30454 100644
--- a/testsuite/tests/typing-modules/applicative_functor_type.ml
+++ b/testsuite/tests/typing-modules/applicative_functor_type.ml
@@ -39,8 +39,7 @@ module F (X : sig
   type t = M.t
 
   val equal : unit
-end) =
-struct
+end) = struct
   type t
 end
 
@@ -91,8 +90,7 @@ module F (X : sig
   module type S
 
   module F : S
-end) =
-struct
+end) = struct
   type t = X.F(Parsing).t
 end
 
diff --git a/testsuite/tests/typing-modules/functors.ml b/testsuite/tests/typing-modules/functors.ml
index 42f1000ac..a894e520f 100644
--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -114,8 +114,7 @@ module M : sig
 end = struct
   module F (X : sig
     type t
-  end) =
-  struct end
+  end) = struct end
 end
 
 [%%expect
@@ -143,8 +142,7 @@ Error: Signature mismatch:
 
 module F (X : sig
   type t
-end) =
-struct end
+end) = struct end
 
 module M = F (struct
   type x
@@ -166,8 +164,7 @@ end) (Y : sig
   type y
 end) (Z : sig
   type z
-end) =
-struct
+end) = struct
   type t =
     | X of X.x
     | Y of Y.y
@@ -229,8 +226,7 @@ module M : sig
 end = struct
   module F (X : sig
     type y
-  end) =
-  struct end
+  end) = struct end
 end
 
 [%%expect
@@ -263,8 +259,7 @@ module F (Ctx : sig
 
   module X : t
   module Y : u
-end) =
-struct
+end) = struct
   open Ctx
   module F (A : t) (B : u) = struct end
   module M = F (Y) (X)
@@ -320,8 +315,7 @@ end) (B : sig
   type x = A.x
 end) (C : sig
   type y = A.y
-end) =
-struct end
+end) = struct end
 
 module K = struct
   include X
@@ -707,8 +701,7 @@ module M = struct
 
   module G (P : sig
     module B : b
-  end) =
-  struct
+  end) = struct
     open P
 
     module U =
@@ -755,8 +748,7 @@ module M = struct
 
   module G (P : sig
     module X : a
-  end) =
-  struct
+  end) = struct
     open P
 
     type t = F(X).t
@@ -891,8 +883,7 @@ end = struct
                           (B : sig
                              type zbb
                            end)
-                          -> sig end) =
-  struct end
+                          -> sig end) = struct end
 end
 
 [%%expect
@@ -1008,8 +999,7 @@ end = struct
                  (B : sig
                     type yb
                   end)
-                 -> sig end) =
-  struct end
+                 -> sig end) = struct end
 end
 
 [%%expect
@@ -1109,8 +1099,7 @@ end = struct
                           (B : sig
                              type zbb
                            end)
-                          -> sig end) =
-  struct end
+                          -> sig end) = struct end
 end
 
 [%%expect
@@ -1223,8 +1212,7 @@ end = struct
             type y'
           end) (W : sig
             type w
-          end) =
-          struct end
+          end) = struct end
         end
       end
     end
@@ -1852,8 +1840,7 @@ end = struct
     type x
   end) (Z : sig
     type z
-  end) =
-  struct end
+  end) = struct end
 end
 
 [%%expect
@@ -2045,8 +2032,7 @@ end) (Y : sig
   type t = Y of X.t
 end) (Z : sig
   type t = Z of X.t
-end) =
-struct end
+end) = struct end
 
 module X = struct
   type t = U
diff --git a/testsuite/tests/typing-modules/nondep.ml b/testsuite/tests/typing-modules/nondep.ml
index 6c5bf1f15..621525184 100644
--- a/testsuite/tests/typing-modules/nondep.ml
+++ b/testsuite/tests/typing-modules/nondep.ml
@@ -4,8 +4,7 @@
 
 module F (X : sig
   type t
-end) =
-struct
+end) = struct
   let f (_ : X.t) = ()
 end
 
@@ -30,8 +29,7 @@ Error: This functor has type
 
 module M (X : sig
   type 'a t constraint 'a = float
-end) =
-struct
+end) = struct
   module type S = sig
     type t = float
 
@@ -55,8 +53,7 @@ type 'a always_int = int
 
 module F (X : sig
   type t
-end) =
-struct
+end) = struct
   type s = X.t always_int
 end
 
diff --git a/testsuite/tests/typing-modules/pr7348.ml b/testsuite/tests/typing-modules/pr7348.ml
index 28e051e8a..46dda8277 100644
--- a/testsuite/tests/typing-modules/pr7348.ml
+++ b/testsuite/tests/typing-modules/pr7348.ml
@@ -6,8 +6,7 @@ module F (X : sig
   type t = private < foo : int ; .. >
 
   val x : t
-end) =
-struct
+end) = struct
   let x : < foo : int ; .. > = X.x
 end
 
@@ -46,8 +45,7 @@ module A : sig end = struct
     type t = private < foo : int ; .. >
 
     val x : t
-  end) =
-  struct
+  end) = struct
     let x : < foo : int ; .. > = X.x
   end
 
diff --git a/testsuite/tests/typing-modules/pr7787.ml b/testsuite/tests/typing-modules/pr7787.ml
index 6120d8138..eeb6ff1e1 100644
--- a/testsuite/tests/typing-modules/pr7787.ml
+++ b/testsuite/tests/typing-modules/pr7787.ml
@@ -6,8 +6,7 @@ module O (T : sig
   module N : sig
     val foo : int -> int
   end
-end) =
-struct
+end) = struct
   open T
     module U =
@@ -755,8 +748,7 @@ module M = struct
 
   module G (P : sig
     module X : a
-  end) =
-  struct
+  end) = struct
     open P
 
     type t = F(X).t
@@ -891,8 +883,7 @@ end = struct
                           (B : sig
                              type zbb
                            end)
-                          -> sig end) =
-  struct end
+                          -> sig end) = struct end
 end
 
 [%%expect
@@ -1008,8 +999,7 @@ end = struct
                  (B : sig
                     type yb
                   end)
-                 -> sig end) =
-  struct end
+                 -> sig end) = struct end
 end
 
 [%%expect
@@ -1109,8 +1099,7 @@ end = struct
                           (B : sig
                              type zbb
                            end)
-                          -> sig end) =
-  struct end
+                          -> sig end) = struct end
 end
 
 [%%expect
@@ -1223,8 +1212,7 @@ end = struct
             type y'
           end) (W : sig
             type w
-          end) =
-          struct end
+          end) = struct end
         end
       end
     end
@@ -1852,8 +1840,7 @@ end = struct
     type x
   end) (Z : sig
     type z
-  end) =
-  struct end
+  end) = struct end
 end
 
 [%%expect
@@ -2045,8 +2032,7 @@ end) (Y : sig
   type t = Y of X.t
 end) (Z : sig
   type t = Z of X.t
-end) =
-struct end
+end) = struct end
 
 module X = struct
   type t = U
diff --git a/testsuite/tests/typing-modules/nondep.ml b/testsuite/tests/typing-modules/nondep.ml
index 6c5bf1f15..621525184 100644
--- a/testsuite/tests/typing-modules/nondep.ml
+++ b/testsuite/tests/typing-modules/nondep.ml
@@ -4,8 +4,7 @@
 
 module F (X : sig
   type t
-end) =
-struct
+end) = struct
   let f (_ : X.t) = ()
 end
 
@@ -30,8 +29,7 @@ Error: This functor has type
 
 module M (X : sig
   type 'a t constraint 'a = float
-end) =
-struct
+end) = struct
   module type S = sig
     type t = float
 
@@ -55,8 +53,7 @@ type 'a always_int = int
 
 module F (X : sig
   type t
-end) =
-struct
+end) = struct
   type s = X.t always_int
 end
 
diff --git a/testsuite/tests/typing-modules/pr7348.ml b/testsuite/tests/typing-modules/pr7348.ml
index 28e051e8a..46dda8277 100644
--- a/testsuite/tests/typing-modules/pr7348.ml
+++ b/testsuite/tests/typing-modules/pr7348.ml
@@ -6,8 +6,7 @@ module F (X : sig
   type t = private < foo : int ; .. >
 
   val x : t
-end) =
-struct
+end) = struct
   let x : < foo : int ; .. > = X.x
 end
 
@@ -46,8 +45,7 @@ module A : sig end = struct
     type t = private < foo : int ; .. >
 
     val x : t
-  end) =
-  struct
+  end) = struct
     let x : < foo : int ; .. > = X.x
   end
 
diff --git a/testsuite/tests/typing-modules/pr7787.ml b/testsuite/tests/typing-modules/pr7787.ml
index 6120d8138..eeb6ff1e1 100644
--- a/testsuite/tests/typing-modules/pr7787.ml
+++ b/testsuite/tests/typing-modules/pr7787.ml
@@ -6,8 +6,7 @@ module O (T : sig
   module N : sig
     val foo : int -> int
   end
-end) =
-struct
+end) = struct
   open T
 
   let go () = N.foo 42 (* finding N (from T) goes wrong *)
diff --git a/testsuite/tests/typing-modules/pr7851.ml b/testsuite/tests/typing-modules/pr7851.ml
index 562ac3541..4519cda3a 100644
--- a/testsuite/tests/typing-modules/pr7851.ml
+++ b/testsuite/tests/typing-modules/pr7851.ml
@@ -5,8 +5,7 @@
 (* Leo's version *)
 module F (X : sig
   type t
-end) =
-struct
+end) = struct
   type x = X.t
   type y = X.t
   type t = E of x
diff --git a/testsuite/tests/typing-modules/pr9384.ml b/testsuite/tests/typing-modules/pr9384.ml
index e3c64801a..8b81fdccf 100644
--- a/testsuite/tests/typing-modules/pr9384.ml
+++ b/testsuite/tests/typing-modules/pr9384.ml
@@ -25,8 +25,7 @@ type foo = { foo : 'a. ([< `A ] as 'a) -> 'a }
 module Foo (X : sig
   type 'a t := [< `A ] as 'a
   type foo2 = foo = { foo : 'a. 'a t -> 'a t }
-end) =
-struct
+end) = struct
   let f { X.foo } = foo
 end
 
@@ -46,8 +45,7 @@ type bar = { bar : 'a. ([< `A ] as 'a) -> 'a }
 module Bar (X : sig
   type 'a t := 'a
   type bar2 = bar = { bar : 'a. ([< `A ] as 'a) t -> 'a t }
-end) =
-struct
+end) = struct
   let f { X.bar } = bar
 end
 
diff --git a/testsuite/tests/typing-modules/printing.ml b/testsuite/tests/typing-modules/printing.ml
index 70b13a67a..8036a4e2c 100644
--- a/testsuite/tests/typing-modules/printing.ml
+++ b/testsuite/tests/typing-modules/printing.ml
@@ -53,8 +53,7 @@ module type E
 module type F
 
 module Test (X : functor (_ : functor (_ : A) (_ : functor (_ : B) -> C) -> D) (_ : E) ->
-  F) =
-struct end
+  F) = struct end
 
 [%%expect
 {|
diff --git a/testsuite/tests/typing-objects/Tests.ml b/testsuite/tests/typing-objects/Tests.ml
index 8a31af95d..da30c053e 100644
--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -97,8 +97,7 @@ and ['a] d : unit -> object constraint 'a = int #c end
 (* Class type constraint *)
 module F (X : sig
   type t
-end) =
-struct
+end) = struct
   class type ['a] c =
     object
       method m : 'a -> X.t
diff --git a/testsuite/tests/typing-private-bugs/pr5469_ok.ml b/testsuite/tests/typing-private-bugs/pr5469_ok.ml
index a5bb385a2..174486baa 100644
--- a/testsuite/tests/typing-private-bugs/pr5469_ok.ml
+++ b/testsuite/tests/typing-private-bugs/pr5469_ok.ml
@@ -7,8 +7,7 @@ flags = " -w -a "
 
 module M (T : sig
   type t
-end) =
-struct
+end) = struct
   type t = private { t : T.t }
 end
 
diff --git a/testsuite/tests/typing-recmod/t22ok.ml b/testsuite/tests/typing-recmod/t22ok.ml
index 2b54047b4..05660bfb0 100644
--- a/testsuite/tests/typing-recmod/t22ok.ml
+++ b/testsuite/tests/typing-recmod/t22ok.ml
@@ -534,8 +534,7 @@ let _ = test 81 (Coerce2.f1 ()) 1
 
 module Coerce4 (A : sig
   val f : int -> int
-end) =
-struct
+end) = struct
   let x = 0
   let at a = A.f a
 end
@@ -582,8 +581,7 @@ let _ =
 (* PR#4316 *)
 module G (S : sig
   val x : int Lazy.t
-end) =
-struct
+end) = struct
   include S
 end
 
diff --git a/testsuite/tests/typing-recordarg/recordarg.ml b/testsuite/tests/typing-recordarg/recordarg.ml
index 3b0eacef4..df85a43dc 100644
--- a/testsuite/tests/typing-recordarg/recordarg.ml
+++ b/testsuite/tests/typing-recordarg/recordarg.ml
@@ -69,8 +69,7 @@ end
 
 module F (X : sig
   val x : (module S)
-end) =
-struct
+end) = struct
   module A = (val X.x)
 end
 
diff --git a/testsuite/tests/typing-sigsubst/sig_local_aliases.ml b/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
index da32897aa..8c656eb01 100644
--- a/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
+++ b/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
@@ -28,8 +28,7 @@ module type Accepted = sig val f : int list -> (string * M.t) list end
 
 module F (X : sig
   type t
-end) =
-struct
+end) = struct
   type t = X.t
 end
 
diff --git a/testsuite/tests/typing-sigsubst/sigsubst.ml b/testsuite/tests/typing-sigsubst/sigsubst.ml
index cfa5ece8b..f548bf259 100644
--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -460,8 +460,7 @@ module type S2 =
 
 module Id (X : sig
   type t
-end) =
-struct
+end) = struct
   type t = X.t
 end
 
diff --git a/testsuite/tests/typing-warnings/pr9244.ml b/testsuite/tests/typing-warnings/pr9244.ml
index 1929c9e01..dfc5ed684 100644
--- a/testsuite/tests/typing-warnings/pr9244.ml
+++ b/testsuite/tests/typing-warnings/pr9244.ml
@@ -52,8 +52,7 @@ module N : sig module F2 : U -> U end
 module F (X : sig
   type t
   type s
-end) =
-struct
+end) = struct
   type t = X.t
 end
 
diff --git a/testsuite/tests/warnings/deprecated_module_assigment.ml b/testsuite/tests/warnings/deprecated_module_assigment.ml
index 9eee766d4..3fc0b9aff 100644
--- a/testsuite/tests/warnings/deprecated_module_assigment.ml
+++ b/testsuite/tests/warnings/deprecated_module_assigment.ml
@@ -26,8 +26,7 @@ end =
 
 module F (A : sig
   val x : int
-end) =
-struct
+end) = struct
   let _ = A.x
 end
 
diff --git a/testsuite/tests/warnings/w32.ml b/testsuite/tests/warnings/w32.ml
index f255d2426..f5173a907 100644
--- a/testsuite/tests/warnings/w32.ml
+++ b/testsuite/tests/warnings/w32.ml
@@ -60,8 +60,7 @@ end
 (* unused values in functor argument *)
 module F (X : sig
   val x : int
-end) =
-struct end
+end) = struct end
 
 module G (X : sig
   val x : int
diff --git a/testsuite/tests/warnings/w32b.ml b/testsuite/tests/warnings/w32b.ml
index a068383f4..1df4c8566 100644
--- a/testsuite/tests/warnings/w32b.ml
+++ b/testsuite/tests/warnings/w32b.ml
@@ -12,5 +12,4 @@ compile_only = "true"
 (* Check that [t] is considered unused without an .mli file (see GPR#1358) *)
 module Q (M : sig
   type t
-end) =
-struct end
+end) = struct end
diff --git a/testsuite/tests/warnings/w60.ml b/testsuite/tests/warnings/w60.ml
index 890224893..e88e3f30b 100644
--- a/testsuite/tests/warnings/w60.ml
+++ b/testsuite/tests/warnings/w60.ml
@@ -17,15 +17,13 @@ end
 
 module Make_graph (P : sig
   module Id : Comparable
-end) =
-struct
+end) = struct
   let foo = P.Id.id
 end
 
 module Fold_ordered (P : sig
   module Id : Comparable
-end) =
-struct
+end) = struct
   include Make_graph (struct
     module Id = P.Id
   end)
diff --git a/typing/parmatch.ml b/typing/parmatch.ml
index f3e59e09a..f4a375861 100644
--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -270,8 +270,7 @@ let records_args l1 l2 =
 
 module Compat (Constr : sig
   val equal : Types.constructor_description -> Types.constructor_description -> bool
-end) =
-struct
+end) = struct
   let rec compat p q =
     match p.pat_desc, q.pat_desc with
     (* Variables match any value *)
diff --git a/typing/shape.ml b/typing/shape.ml
index 847d9bdde..5e848192e 100644
--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -240,8 +240,7 @@ module Make_reduce (Params : sig
   val fuel : int
   val read_unit_shape : unit_name:string -> t option
   val find_shape : env -> Ident.t -> t
-end) =
-struct
+end) = struct
   let fuel = ref (-1)
 
   let rec reduce env t =
diff --git a/typing/typecore.ml b/typing/typecore.ml
index 2657bf526..8f0aa30db 100644
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -987,8 +987,7 @@ module NameChoice (Name : sig
       in the typing environment -- they behave as structural labels
       rather than nominal labels.*)
   val in_env : t -> bool
-end) =
-struct
+end) = struct
   open Name
 
   let get_type_path d = get_constr_type_path (get_type d)
diff --git a/utils/arg_helper.ml b/utils/arg_helper.ml
index ea6370fa2..a1e5c4a4d 100644
--- a/utils/arg_helper.ml
+++ b/utils/arg_helper.ml
@@ -33,8 +33,7 @@ module Make (S : sig
 
     val of_string : string -> t
   end
-end) =
-struct
+end) = struct
   type parsed =
     { base_default : S.Value.t
     ; base_override : S.Value.t S.Key.Map.t
diff --git a/utils/consistbl.ml b/utils/consistbl.ml
index 4920e64a2..6dcce7e33 100644
--- a/utils/consistbl.ml
+++ b/utils/consistbl.ml
@@ -25,8 +25,7 @@ module Make (Module_name : sig
   module Tbl : Hashtbl.S with type key = t
 
   val compare : t -> t -> int
-end) =
-struct
+end) = struct
   type t = (Digest.t * filepath) Module_name.Tbl.t
```

</details>


What do you think? cc @jberdine @samoht as it would be a change across all profiles