### PR TITLE
Normalize comments and docstrings with the extended AST

### DIFF
--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -37,3 +37,160 @@ let dedup_cmts fragment ast comments =
     !docs
   in
   Set.(to_list (diff (of_list (module Cmt) comments) (of_ast ast)))
+
+let normalize_code conf (m : Ast_mapper.mapper) txt =
+  match Parse_with_comments.parse Parse.ast Structure conf ~source:txt with
+  | {ast; comments; _} ->
+      let comments = dedup_cmts Structure ast comments in
+      let print_comments fmt (l : Cmt.t list) =
+        List.sort l ~compare:(fun {Cmt.loc= a; _} {Cmt.loc= b; _} ->
+            Migrate_ast.Location.compare a b )
+        |> List.iter ~f:(fun {Cmt.txt; _} -> Format.fprintf fmt "%s," txt)
+      in
+      let ast = m.structure m ast in
+      Format.asprintf "AST,%a,COMMENTS,[%a]" Pprintast.structure ast
+        print_comments comments
+  | exception _ -> txt
+
+let docstring (c : Conf.t) =
+  Docstring.normalize ~parse_docstrings:c.parse_docstrings
+
+let sort_attributes : attributes -> attributes =
+  List.sort ~compare:Poly.compare
+
+let make_mapper conf ~ignore_doc_comments =
+  let open Ast_helper in
+  (* remove locations *)
+  let location _ _ = Location.none in
+  let attribute (m : Ast_mapper.mapper) (attr : attribute) =
+    match attr.attr_payload with
+    | PStr
+        [ ( { pstr_desc=
+                Pstr_eval
+                  ( ( { pexp_desc=
+                          Pexp_constant
+                            ( { pconst_desc=
+                                  Pconst_string (doc, str_loc, None)
+                              ; _ } as const )
+                      ; _ } as exp )
+                  , [] )
+            ; _ } as pstr ) ]
+      when Ast.Attr.is_doc attr ->
+        let normalize_code = normalize_code conf m in
+        let doc' = docstring conf ~normalize_code doc in
+        Ast_mapper.default_mapper.attribute m
+          { attr with
+            attr_payload=
+              PStr
+                [ { pstr with
+                    pstr_desc=
+                      Pstr_eval
+                        ( { exp with
+                            pexp_desc=
+                              Pexp_constant
+                                { const with
+                                  pconst_desc=
+                                    Pconst_string (doc', str_loc, None) }
+                          ; pexp_loc_stack= [] }
+                        , [] ) } ] }
+    | _ -> Ast_mapper.default_mapper.attribute m attr
+  in
+  (* sort attributes *)
+  let attributes (m : Ast_mapper.mapper) (atrs : attribute list) =
+    let atrs =
+      if ignore_doc_comments then
+        List.filter atrs ~f:(fun a -> not (Ast.Attr.is_doc a))
+      else atrs
+    in
+    Ast_mapper.default_mapper.attributes m (sort_attributes atrs)
+  in
+  let expr (m : Ast_mapper.mapper) exp =
+    let exp = {exp with pexp_loc_stack= []} in
+    let {pexp_desc; pexp_loc= loc1; pexp_attributes= attrs1; _} = exp in
+    match pexp_desc with
+    | Pexp_poly ({pexp_desc= Pexp_constraint (e, t); _}, None) ->
+        m.expr m {exp with pexp_desc= Pexp_poly (e, Some t)}
+    | Pexp_constraint (e, {ptyp_desc= Ptyp_poly ([], _t); _}) -> m.expr m e
+    | Pexp_sequence
+        ( exp1
+        , { pexp_desc= Pexp_sequence (exp2, exp3)
+          ; pexp_loc= loc2
+          ; pexp_attributes= attrs2
+          ; _ } ) ->
+        m.expr m
+          (Exp.sequence ~loc:loc1 ~attrs:attrs1
+             (Exp.sequence ~loc:loc2 ~attrs:attrs2 exp1 exp2)
+             exp3 )
+    | _ -> Ast_mapper.default_mapper.expr m exp
+  in
+  let pat (m : Ast_mapper.mapper) pat =
+    let pat = {pat with ppat_loc_stack= []} in
+    let {ppat_desc; ppat_loc= loc1; ppat_attributes= attrs1; _} = pat in
+    (* normalize nested or patterns *)
+    match ppat_desc with
+    | Ppat_or
+        ( pat1
+        , { ppat_desc= Ppat_or (pat2, pat3)
+          ; ppat_loc= loc2
+          ; ppat_attributes= attrs2
+          ; _ } ) ->
+        m.pat m
+          (Pat.or_ ~loc:loc1 ~attrs:attrs1
+             (Pat.or_ ~loc:loc2 ~attrs:attrs2 pat1 pat2)
+             pat3 )
+    | _ -> Ast_mapper.default_mapper.pat m pat
+  in
+  let typ (m : Ast_mapper.mapper) typ =
+    let typ = {typ with ptyp_loc_stack= []} in
+    Ast_mapper.default_mapper.typ m typ
+  in
+  { Ast_mapper.default_mapper with
+    location
+  ; attribute
+  ; attributes
+  ; expr
+  ; pat
+  ; typ }
+
+let ast fragment ~ignore_doc_comments c =
+  map fragment (make_mapper c ~ignore_doc_comments)
+
+let ast = ast ~ignore_doc_comments:false
+
+let docstring conf =
+  let mapper = make_mapper conf ~ignore_doc_comments:false in
+  let normalize_code = normalize_code conf mapper in
+  docstring conf ~normalize_code
+
+let diff_docstrings c x y =
+  let norm z =
+    let f Cmt.{txt; _} = docstring c txt in
+    Set.of_list (module String) (List.map ~f z)
+  in
+  Set.symmetric_diff (norm x) (norm y)
+
+let diff_cmts (conf : Conf.t) x y =
+  let norm z =
+    let norm_non_code {Cmt.txt; _} = Docstring.normalize_text txt in
+    let f z =
+      match Cmt.txt z with
+      | "" | "$" -> norm_non_code z
+      | str ->
+          if Char.equal str.[0] '$' then
+            let chars_removed =
+              if Char.equal str.[String.length str - 1] '$' then 2 else 1
+            in
+            let len = String.length str - chars_removed in
+            let source = String.sub ~pos:1 ~len str in
+            match
+              Parse_with_comments.parse Parse.ast Structure conf ~source
+            with
+            | exception _ -> norm_non_code z
+            | {ast= s; _} ->
+                Format.asprintf "%a" Pprintast.structure
+                  (ast Structure conf s)
+          else norm_non_code z
+    in
+    Set.of_list (module String) (List.map ~f z)
+  in
+  Set.symmetric_diff (norm x) (norm y)

--- a/lib/Normalize_extended_ast.mli
+++ b/lib/Normalize_extended_ast.mli
@@ -11,3 +11,11 @@
 
 val dedup_cmts : 'a Extended_ast.t -> 'a -> Cmt.t list -> Cmt.t list
 (** Remove comments that duplicate docstrings (or other comments). *)
+
+val diff_docstrings :
+  Conf.t -> Cmt.t list -> Cmt.t list -> (string, string) Either.t Sequence.t
+(** Difference between two lists of doc comments. *)
+
+val diff_cmts :
+  Conf.t -> Cmt.t list -> Cmt.t list -> (string, string) Either.t Sequence.t
+(** Difference between two lists of comments. *)

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -209,36 +209,3 @@ let moved_docstrings fragment c s1 s2 =
       List.map
         ~f:(fun ((loc, x), (_, y)) -> Docstring.Unstable (loc, x, y))
         l
-
-let diff_docstrings c x y =
-  let norm z =
-    let f Cmt.{txt; _} = docstring c txt in
-    Set.of_list (module String) (List.map ~f z)
-  in
-  Set.symmetric_diff (norm x) (norm y)
-
-let diff_cmts (conf : Conf.t) x y =
-  let norm z =
-    let norm_non_code {Cmt.txt; _} = Docstring.normalize_text txt in
-    let f z =
-      match Cmt.txt z with
-      | "" | "$" -> norm_non_code z
-      | str ->
-          if Char.equal str.[0] '$' then
-            let chars_removed =
-              if Char.equal str.[String.length str - 1] '$' then 2 else 1
-            in
-            let len = String.length str - chars_removed in
-            let source = String.sub ~pos:1 ~len str in
-            match
-              Parse_with_comments.parse Parse.ast Structure conf ~source
-            with
-            | exception _ -> norm_non_code z
-            | {ast= s; _} ->
-                Format.asprintf "%a" Pprintast.structure
-                  (ast Structure conf s)
-          else norm_non_code z
-    in
-    Set.of_list (module String) (List.map ~f z)
-  in
-  Set.symmetric_diff (norm x) (norm y)

--- a/lib/Normalize_std_ast.mli
+++ b/lib/Normalize_std_ast.mli
@@ -18,11 +18,3 @@ val equal :
 
 val moved_docstrings :
   'a Std_ast.t -> Conf.t -> 'a -> 'a -> Docstring.error list
-
-val diff_docstrings :
-  Conf.t -> Cmt.t list -> Cmt.t list -> (string, string) Either.t Sequence.t
-(** Difference between two lists of doc comments. *)
-
-val diff_cmts :
-  Conf.t -> Cmt.t list -> Cmt.t list -> (string, string) Either.t Sequence.t
-(** Difference between two lists of comments. *)

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -399,8 +399,8 @@ let format (type a b) (fg : a Extended_ast.t) (std_fg : b Std_ast.t)
         in
         let diff_cmts =
           Sequence.append
-            (Normalize_std_ast.diff_cmts conf old_comments t_newcomments)
-            (Normalize_std_ast.diff_docstrings conf old_docstrings
+            (Normalize_extended_ast.diff_cmts conf old_comments t_newcomments)
+            (Normalize_extended_ast.diff_docstrings conf old_docstrings
                t_newdocstrings )
         in
         if not (Sequence.is_empty diff_cmts) then


### PR DESCRIPTION
Moving around some code from `Normalize_std_ast` to `Normalize_extended_ast`, making the diff of #1941 more precise in `Normalize_extended_ast`.