### PR TITLE
ocamlformat-rpc-lib: remove "config" from the generic client sig

### DIFF
--- a/bin/ocamlformat-rpc/main.ml
+++ b/bin/ocamlformat-rpc/main.ml
@@ -178,6 +178,9 @@ let info =
         "- $(b,Halt) to end the communication with the RPC server. The \
          caller must close the input and output channels."
     ; `P
+        "Some RPC versions offer specific commands, that are detailed below."
+    ; `P "Specific commands supported on version $(b,v1) are:"
+    ; `P
         "- $(b,Config) $(i,CSEXP): submits a list of (key, value) pairs (as \
          a canonical s-expression) to update OCamlFormat's configuration \
          (please refer to $(i,ocamlformat --help) to know more about the \

--- a/lib-rpc/ocamlformat_rpc_lib.ml
+++ b/lib-rpc/ocamlformat_rpc_lib.ml
@@ -40,9 +40,6 @@ module Make (IO : IO.S) = struct
     val query : cmd -> t -> cmd IO.t
 
     val halt : t -> (unit, [> `Msg of string]) result IO.t
-
-    val config :
-      (string * string) list -> t -> (unit, [> `Msg of string]) result IO.t
   end
 
   module Init :
@@ -78,6 +75,9 @@ module Make (IO : IO.S) = struct
 
     module Client : sig
       include Client_S with type cmd = Command.t
+
+      val config :
+        (string * string) list -> t -> (unit, [> `Msg of string]) result IO.t
 
       val format : string -> t -> (string, [> `Msg of string]) result IO.t
     end

--- a/lib-rpc/ocamlformat_rpc_lib.mli
+++ b/lib-rpc/ocamlformat_rpc_lib.mli
@@ -42,9 +42,6 @@ module Make (IO : IO.S) : sig
     val halt : t -> (unit, [> `Msg of string]) result IO.t
     (** The caller must close the input and output channels after calling
         [halt]. *)
-
-    val config :
-      (string * string) list -> t -> (unit, [> `Msg of string]) result IO.t
   end
 
   (** Version used to set the protocol version *)
@@ -63,6 +60,9 @@ module Make (IO : IO.S) : sig
 
     module Client : sig
       include Client_S with type cmd = Command.t
+
+      val config :
+        (string * string) list -> t -> (unit, [> `Msg of string]) result IO.t
 
       val format : string -> t -> (string, [> `Msg of string]) result IO.t
     end

--- a/ocamlformat-rpc-help.txt
+++ b/ocamlformat-rpc-help.txt
@@ -30,6 +30,10 @@ COMMANDS
        - Halt to end the communication with the RPC server. The caller must
        close the input and output channels.
 
+       Some RPC versions offer specific commands, that are detailed below.
+
+       Specific commands supported on version v1 are:
+
        - Config CSEXP: submits a list of (key, value) pairs (as a canonical
        s-expression) to update OCamlFormat's configuration (please refer to
        ocamlformat --help to know more about the available options). The


### PR DESCRIPTION
Reduce diff of #1935, add consistency regarding what was done with the `Format` command in #1977