### PR TITLE
Make formatting of cons-list patterns consistent with cons-list expressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@
 
   + Print odoc code block delimiters on their own line (#1980, @gpetiot)
 
-  + Make formatting of cons-list patterns consistent with cons-list expressions, (::) operators are aligned when possible, comments position also improved (#<PR_NUMBER>, @gpetiot)
+  + Make formatting of cons-list patterns consistent with cons-list expressions, (::) operators are aligned when possible, comments position also improved (#1983, @gpetiot)
 
 #### New features
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
 
   + Print odoc code block delimiters on their own line (#1980, @gpetiot)
 
+  + Make formatting of cons-list patterns consistent with cons-list expressions, (::) operators are aligned when possible, comments position also improved (#<PR_NUMBER>, @gpetiot)
+
 #### New features
 
 #### RPC

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -564,7 +564,7 @@ module Signature_item = struct
      |Psig_class ({pci_attributes= atrs; _} :: _) ->
         List.exists ~f:Attr.is_doc atrs
     | Psig_recmodule
-        ({pmd_type= {pmty_attributes= atrs1; _}; pmd_attributes= atrs2; _}
+        ( {pmd_type= {pmty_attributes= atrs1; _}; pmd_attributes= atrs2; _}
         :: _ )
      |Psig_include
         {pincl_mod= {pmty_attributes= atrs1; _}; pincl_attributes= atrs2; _}

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1018,7 +1018,7 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
       ( {txt= Lident "::"; loc= _}
       , Some ([], {ppat_desc= Ppat_tuple [_; _]; ppat_attributes= []; _}) )
     ->
-      let loc_args = Sugar.infix_cons_pat c.cmts xpat in
+      let loc_args = Sugar.Pat.infix_cons c.cmts xpat in
       Cmts.fmt c ppat_loc
       @@ hvbox 0
            (fmt_infix_op_args_pat c ~parens xpat
@@ -1866,7 +1866,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         ; _ }
       , [(Nolabel, _); (Nolabel, _)] )
     when Longident.is_infix id && not (Longident.is_monadic_binding id) ->
-      let op_args = Sugar.infix c.cmts (prec_ast (Exp exp)) xexp in
+      let op_args = Sugar.Exp.infix c.cmts (prec_ast (Exp exp)) xexp in
       let inner_wrap = parens || has_attr in
       let outer_wrap =
         match ctx0 with
@@ -2123,7 +2123,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
   | Pexp_construct
       ( {txt= Lident "::"; loc= _}
       , Some {pexp_desc= Pexp_tuple [_; _]; pexp_attributes= []; _} ) ->
-      let loc_args = Sugar.infix_cons c.cmts xexp in
+      let loc_args = Sugar.Exp.infix_cons c.cmts xexp in
       Cmts.fmt c pexp_loc
       @@ hvbox indent_wrap
            ( fmt_infix_op_args c ~parens xexp

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -118,111 +118,115 @@ let cl_fun ?(will_keep_first_ast_node = true) cmts xexp =
   in
   fun_ ~will_keep_first_ast_node xexp
 
-let infix cmts prec xexp =
-  let assoc = Option.value_map prec ~default:Assoc.Non ~f:Assoc.of_prec in
-  let rec infix_ ?(relocate = true) xop ((lbl, {ast= exp; _}) as xexp) =
-    assert (Poly.(lbl = Nolabel)) ;
-    let ctx = Exp exp in
-    match (assoc, exp) with
-    | Left, {pexp_desc= Pexp_apply (e0, [(l1, e1); (l2, e2)]); pexp_loc; _}
-      when Option.equal Prec.equal prec (prec_ast (Exp exp)) ->
-        let op_args1 = infix_ None (l1, sub_exp ~ctx e1) in
-        let src = pexp_loc in
-        let after = e2.pexp_loc in
-        ( match op_args1 with
-        | (Some {ast= {pexp_loc= before; _}; _}, _) :: _
-         |(None, (_, {ast= {pexp_loc= before; _}; _}) :: _) :: _ ->
+module Exp = struct
+  let infix cmts prec xexp =
+    let assoc = Option.value_map prec ~default:Assoc.Non ~f:Assoc.of_prec in
+    let rec infix_ ?(relocate = true) xop ((lbl, {ast= exp; _}) as xexp) =
+      assert (Poly.(lbl = Nolabel)) ;
+      let ctx = Exp exp in
+      match (assoc, exp) with
+      | Left, {pexp_desc= Pexp_apply (e0, [(l1, e1); (l2, e2)]); pexp_loc; _}
+        when Option.equal Prec.equal prec (prec_ast (Exp exp)) ->
+          let op_args1 = infix_ None (l1, sub_exp ~ctx e1) in
+          let src = pexp_loc in
+          let after = e2.pexp_loc in
+          ( match op_args1 with
+          | (Some {ast= {pexp_loc= before; _}; _}, _) :: _
+           |(None, (_, {ast= {pexp_loc= before; _}; _}) :: _) :: _ ->
+              if relocate then Cmts.relocate cmts ~src ~before ~after
+          | _ ->
+              if relocate then
+                Cmts.relocate cmts ~src ~before:e0.pexp_loc ~after ) ;
+          op_args1 @ [(Some (sub_exp ~ctx e0), [(l2, sub_exp ~ctx e2)])]
+      | Right, {pexp_desc= Pexp_apply (e0, [(l1, e1); (l2, e2)]); pexp_loc; _}
+        when Option.equal Prec.equal prec (prec_ast (Exp exp)) ->
+          let op_args2 =
+            infix_ (Some (sub_exp ~ctx e0)) (l2, sub_exp ~ctx e2)
+          in
+          let src = pexp_loc in
+          let after = e1.pexp_loc in
+          let before =
+            match xop with
+            | Some {ast; _} -> ast.pexp_loc
+            | None -> e1.pexp_loc
+          in
+          let may_relocate ~after =
             if relocate then Cmts.relocate cmts ~src ~before ~after
-        | _ ->
-            if relocate then
-              Cmts.relocate cmts ~src ~before:e0.pexp_loc ~after ) ;
-        op_args1 @ [(Some (sub_exp ~ctx e0), [(l2, sub_exp ~ctx e2)])]
-    | Right, {pexp_desc= Pexp_apply (e0, [(l1, e1); (l2, e2)]); pexp_loc; _}
-      when Option.equal Prec.equal prec (prec_ast (Exp exp)) ->
-        let op_args2 =
-          infix_ (Some (sub_exp ~ctx e0)) (l2, sub_exp ~ctx e2)
-        in
-        let src = pexp_loc in
-        let after = e1.pexp_loc in
-        let before =
-          match xop with
-          | Some {ast; _} -> ast.pexp_loc
-          | None -> e1.pexp_loc
-        in
-        let may_relocate ~after =
-          if relocate then Cmts.relocate cmts ~src ~before ~after
-        in
-        ( match List.last op_args2 with
-        | Some (_, args2) -> (
-          match List.last args2 with
-          | Some (_, {ast= {pexp_loc= after; _}; _}) -> may_relocate ~after
-          | None -> may_relocate ~after )
-        | _ -> may_relocate ~after ) ;
-        (xop, [(l1, sub_exp ~ctx e1)]) :: op_args2
-    | _ -> [(xop, [xexp])]
-  in
-  infix_ None ~relocate:false (Nolabel, xexp)
+          in
+          ( match List.last op_args2 with
+          | Some (_, args2) -> (
+            match List.last args2 with
+            | Some (_, {ast= {pexp_loc= after; _}; _}) -> may_relocate ~after
+            | None -> may_relocate ~after )
+          | _ -> may_relocate ~after ) ;
+          (xop, [(l1, sub_exp ~ctx e1)]) :: op_args2
+      | _ -> [(xop, [xexp])]
+    in
+    infix_ None ~relocate:false (Nolabel, xexp)
 
-let infix_cons cmts xexp =
-  let rec infix_cons_ ?cons_opt ({ast= exp; _} as xexp) acc =
-    let ctx = Exp exp in
-    let {pexp_desc; pexp_loc= l1; _} = exp in
-    match pexp_desc with
-    | Pexp_construct
-        ( ({txt= Lident "::"; _} as cons)
-        , Some
-            { pexp_desc= Pexp_tuple [hd; tl]
-            ; pexp_loc= l3
-            ; pexp_attributes= []
-            ; _ } ) -> (
-        ( match acc with
-        | [] -> ()
-        | _ ->
-            Cmts.relocate cmts ~src:l1 ~before:hd.pexp_loc ~after:tl.pexp_loc
-        ) ;
-        Cmts.relocate cmts ~src:l3 ~before:hd.pexp_loc ~after:tl.pexp_loc ;
-        match tl.pexp_attributes with
-        | [] ->
-            infix_cons_ ~cons_opt:cons (sub_exp ~ctx tl)
-              ((cons_opt, sub_exp ~ctx hd) :: acc)
-        | _ ->
-            (Some cons, sub_exp ~ctx tl)
-            :: (cons_opt, sub_exp ~ctx hd)
-            :: acc )
-    | _ -> (cons_opt, xexp) :: acc
-  in
-  List.rev @@ infix_cons_ xexp []
+  let infix_cons cmts xexp =
+    let rec infix_cons_ ?cons_opt ({ast= exp; _} as xexp) acc =
+      let ctx = Exp exp in
+      let {pexp_desc; pexp_loc= l1; _} = exp in
+      match pexp_desc with
+      | Pexp_construct
+          ( ({txt= Lident "::"; _} as cons)
+          , Some
+              { pexp_desc= Pexp_tuple [hd; tl]
+              ; pexp_loc= l3
+              ; pexp_attributes= []
+              ; _ } ) -> (
+          ( match acc with
+          | [] -> ()
+          | _ ->
+              Cmts.relocate cmts ~src:l1 ~before:hd.pexp_loc
+                ~after:tl.pexp_loc ) ;
+          Cmts.relocate cmts ~src:l3 ~before:hd.pexp_loc ~after:tl.pexp_loc ;
+          match tl.pexp_attributes with
+          | [] ->
+              infix_cons_ ~cons_opt:cons (sub_exp ~ctx tl)
+                ((cons_opt, sub_exp ~ctx hd) :: acc)
+          | _ ->
+              (Some cons, sub_exp ~ctx tl)
+              :: (cons_opt, sub_exp ~ctx hd)
+              :: acc )
+      | _ -> (cons_opt, xexp) :: acc
+    in
+    List.rev @@ infix_cons_ xexp []
+end
 
-let infix_cons_pat cmts xpat =
-  let rec infix_cons_ ?cons_opt ({ast= pat; _} as xpat) acc =
-    let ctx = Pat pat in
-    let {ppat_desc; ppat_loc= l1; _} = pat in
-    match ppat_desc with
-    | Ppat_construct
-        ( ({txt= Lident "::"; _} as cons)
-        , Some
-            ( []
-            , { ppat_desc= Ppat_tuple [hd; tl]
-              ; ppat_loc= l3
-              ; ppat_attributes= []
-              ; _ } ) ) -> (
-        ( match acc with
-        | [] -> ()
-        | _ ->
-            Cmts.relocate cmts ~src:l1 ~before:hd.ppat_loc ~after:tl.ppat_loc
-        ) ;
-        Cmts.relocate cmts ~src:l3 ~before:hd.ppat_loc ~after:tl.ppat_loc ;
-        match tl.ppat_attributes with
-        | [] ->
-            infix_cons_ ~cons_opt:cons (sub_pat ~ctx tl)
-              ((cons_opt, sub_pat ~ctx hd) :: acc)
-        | _ ->
-            (Some cons, sub_pat ~ctx tl)
-            :: (cons_opt, sub_pat ~ctx hd)
-            :: acc )
-    | _ -> (cons_opt, xpat) :: acc
-  in
-  List.rev @@ infix_cons_ xpat []
+module Pat = struct
+  let infix_cons cmts xpat =
+    let rec infix_cons_ ?cons_opt ({ast= pat; _} as xpat) acc =
+      let ctx = Pat pat in
+      let {ppat_desc; ppat_loc= l1; _} = pat in
+      match ppat_desc with
+      | Ppat_construct
+          ( ({txt= Lident "::"; _} as cons)
+          , Some
+              ( []
+              , { ppat_desc= Ppat_tuple [hd; tl]
+                ; ppat_loc= l3
+                ; ppat_attributes= []
+                ; _ } ) ) -> (
+          ( match acc with
+          | [] -> ()
+          | _ ->
+              Cmts.relocate cmts ~src:l1 ~before:hd.ppat_loc
+                ~after:tl.ppat_loc ) ;
+          Cmts.relocate cmts ~src:l3 ~before:hd.ppat_loc ~after:tl.ppat_loc ;
+          match tl.ppat_attributes with
+          | [] ->
+              infix_cons_ ~cons_opt:cons (sub_pat ~ctx tl)
+                ((cons_opt, sub_pat ~ctx hd) :: acc)
+          | _ ->
+              (Some cons, sub_pat ~ctx tl)
+              :: (cons_opt, sub_pat ~ctx hd)
+              :: acc )
+      | _ -> (cons_opt, xpat) :: acc
+    in
+    List.rev @@ infix_cons_ xpat []
+end
 
 let rec ite cmts ({ast= exp; _} as xexp) =
   let ctx = Exp exp in

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -193,6 +193,37 @@ let infix_cons cmts xexp =
   in
   List.rev @@ infix_cons_ xexp []
 
+let infix_cons_pat cmts xpat =
+  let rec infix_cons_ ?cons_opt ({ast= pat; _} as xpat) acc =
+    let ctx = Pat pat in
+    let {ppat_desc; ppat_loc= l1; _} = pat in
+    match ppat_desc with
+    | Ppat_construct
+        ( ({txt= Lident "::"; _} as cons)
+        , Some
+            ( []
+            , { ppat_desc= Ppat_tuple [hd; tl]
+              ; ppat_loc= l3
+              ; ppat_attributes= []
+              ; _ } ) ) -> (
+        ( match acc with
+        | [] -> ()
+        | _ ->
+            Cmts.relocate cmts ~src:l1 ~before:hd.ppat_loc ~after:tl.ppat_loc
+        ) ;
+        Cmts.relocate cmts ~src:l3 ~before:hd.ppat_loc ~after:tl.ppat_loc ;
+        match tl.ppat_attributes with
+        | [] ->
+            infix_cons_ ~cons_opt:cons (sub_pat ~ctx tl)
+              ((cons_opt, sub_pat ~ctx hd) :: acc)
+        | _ ->
+            (Some cons, sub_pat ~ctx tl)
+            :: (cons_opt, sub_pat ~ctx hd)
+            :: acc )
+    | _ -> (cons_opt, xpat) :: acc
+  in
+  List.rev @@ infix_cons_ xpat []
+
 let rec ite cmts ({ast= exp; _} as xexp) =
   let ctx = Exp exp in
   let {pexp_desc; pexp_loc; pexp_attributes; _} = exp in

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -74,6 +74,11 @@ val infix_cons :
 (** [infix_cons exp] returns a list of expressions if [exp] is an expression
     corresponding to a list ((::) application). *)
 
+val infix_cons_pat :
+  Cmts.t -> pattern Ast.xt -> (Longident.t loc option * pattern Ast.xt) list
+(** [infix_cons_pat pat] returns a list of patterns if [pat] is a pattern
+    corresponding to a list ((::) application). *)
+
 val ite :
      Cmts.t
   -> expression Ast.xt

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -58,26 +58,32 @@ val cl_fun :
     and the body of the function [exp]. [will_keep_first_ast_node] is set by
     default, otherwise the [exp] is returned without modification. *)
 
-val infix :
-     Cmts.t
-  -> Prec.t option
-  -> expression Ast.xt
-  -> (expression Ast.xt option * (arg_label * expression Ast.xt) list) list
-(** [infix cmts prec exp] returns the infix operator and the list of operands
-    applied to this operator from expression [exp]. [prec] is the precedence
-    of the infix operator. *)
+module Exp : sig
+  val infix :
+       Cmts.t
+    -> Prec.t option
+    -> expression Ast.xt
+    -> (expression Ast.xt option * (arg_label * expression Ast.xt) list) list
+  (** [infix cmts prec exp] returns the infix operator and the list of
+      operands applied to this operator from expression [exp]. [prec] is the
+      precedence of the infix operator. *)
 
-val infix_cons :
-     Cmts.t
-  -> expression Ast.xt
-  -> (Longident.t loc option * expression Ast.xt) list
-(** [infix_cons exp] returns a list of expressions if [exp] is an expression
-    corresponding to a list ((::) application). *)
+  val infix_cons :
+       Cmts.t
+    -> expression Ast.xt
+    -> (Longident.t loc option * expression Ast.xt) list
+  (** [infix_cons exp] returns a list of expressions if [exp] is an
+      expression corresponding to a list ((::) application). *)
+end
 
-val infix_cons_pat :
-  Cmts.t -> pattern Ast.xt -> (Longident.t loc option * pattern Ast.xt) list
-(** [infix_cons_pat pat] returns a list of patterns if [pat] is a pattern
-    corresponding to a list ((::) application). *)
+module Pat : sig
+  val infix_cons :
+       Cmts.t
+    -> pattern Ast.xt
+    -> (Longident.t loc option * pattern Ast.xt) list
+  (** [infix_cons pat] returns a list of patterns if [pat] is a pattern
+      corresponding to a list ((::) application). *)
+end
 
 val ite :
      Cmts.t

--- a/test/passing/tests/comments.ml.err
+++ b/test/passing/tests/comments.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/comments.ml:252 exceeds the margin
+Warning: tests/comments.ml:248 exceeds the margin

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -228,12 +228,10 @@ let rec fooooooooooo = function
   (* AA*)
   (*BB*)
   (* CC *)
-  | x
-    (* DD *)
+  | x (* DD *)
     (* XX *)
     :: (* YY *)
-       (* EE *)
-    t
+       (* EE *) t
   (* FF *)
   (* GG *)
   (* HH *) ->
@@ -242,9 +240,7 @@ let rec fooooooooooo = function
   (* BB *)
   | (module (* CC *)
             (* DD *) F (* EE *) : (* FF *) M (* GG *) )
-    (* HH *)
-    :: (* II *)
-    t
+    (* HH *) :: (* II *) t
   (* JJ *)
   (* KK *) ->
       foo

--- a/test/passing/tests/list-space_around.ml.ref
+++ b/test/passing/tests/list-space_around.ml.ref
@@ -3,9 +3,9 @@ let f x = match x with P ({ xxxxxx } :: { yyyyyyyy } :: zzzzzzz) -> true
 let f x =
   match x with
   | P
-      ({ xxxxxxxxxxxxxxxxxxxxxx }
+      ( { xxxxxxxxxxxxxxxxxxxxxx }
       :: { yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy }
-         :: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz ) ->
+      :: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz ) ->
       true
 
 let f x = match x with P [ { xxxxxx }; { yyyyyyyy } ] -> true

--- a/test/passing/tests/list.ml
+++ b/test/passing/tests/list.ml
@@ -3,9 +3,9 @@ let f x = match x with P ({xxxxxx} :: {yyyyyyyy} :: zzzzzzz) -> true
 let f x =
   match x with
   | P
-      ({xxxxxxxxxxxxxxxxxxxxxx}
+      ( {xxxxxxxxxxxxxxxxxxxxxx}
       :: {yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy}
-         :: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz ) ->
+      :: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz ) ->
       true
 
 let f x = match x with P [{xxxxxx}; {yyyyyyyy}] -> true


### PR DESCRIPTION
Reduce the diff of #1667, but adding more consistency with what is already done for expressions is worth it. However the code looks difficult to factorize between patterns and expressions (lots of pattern matching on pexp_desc/ppat_desc).

Here is the diff for the `conventional` profile:

<details>

```diff
diff --git a/infer/src/biabduction/Prop.ml b/infer/src/biabduction/Prop.ml
index ace9b2191..a05ecf802 100644
--- a/infer/src/biabduction/Prop.ml
+++ b/infer/src/biabduction/Prop.ml
@@ -509,13 +509,15 @@ let replace_array_contents (hpred : Predicates.hpred) esel : Predicates.hpred =
 let rec pi_sorted_remove_redundant (pi : pi) =
   match pi with
   | (Aeq (BinOp (Le, e1, Const (Cint n1)), Const (Cint i1)) as a1)
-    :: Aeq (BinOp (Le, e2, Const (Cint n2)), Const (Cint i2)) :: rest
+    :: Aeq (BinOp (Le, e2, Const (Cint n2)), Const (Cint i2))
+    :: rest
     when IntLit.isone i1 && IntLit.isone i2 && Exp.equal e1 e2
          && IntLit.lt n1 n2 ->
       (* second inequality redundant *)
       pi_sorted_remove_redundant (a1 :: rest)
   | Aeq (BinOp (Lt, Const (Cint n1), e1), Const (Cint i1))
-    :: (Aeq (BinOp (Lt, Const (Cint n2), e2), Const (Cint i2)) as a2) :: rest
+    :: (Aeq (BinOp (Lt, Const (Cint n2), e2), Const (Cint i2)) as a2)
+    :: rest
     when IntLit.isone i1 && IntLit.isone i2 && Exp.equal e1 e2
          && IntLit.lt n1 n2 ->
       (* first inequality redundant *)
diff --git a/infer/src/cost/costModels.ml b/infer/src/cost/costModels.ml
index c51781659..2a26be10d 100644
--- a/infer/src/cost/costModels.ml
+++ b/infer/src/cost/costModels.ml
@@ -169,9 +169,9 @@ module NSAttributedString = struct
       ~ret inferbo_mem =
     let pname = model_env.pname in
     match List.rev args with
-    | _attr
-      :: _inRange :: _options :: _usingBlock :: { exp = str } :: _captured_args
-      -> (
+    | _attr :: _inRange :: _options :: _usingBlock
+      :: { exp = str }
+      :: _captured_args -> (
         let length =
           BoundsOfCString.linear_length
             ~of_function:(Procname.to_simplified_string pname)
diff --git a/infer/src/nullsafe/ThirdPartyMethod.ml b/infer/src/nullsafe/ThirdPartyMethod.ml
index ac5dc2847..61f78886f 100644
--- a/infer/src/nullsafe/ThirdPartyMethod.ml
+++ b/infer/src/nullsafe/ThirdPartyMethod.ml
@@ -142,7 +142,10 @@ let parse str =
     Str.full_split (Lazy.force hashsign_and_parentheses) (String.rstrip str)
   with
   | Text class_name_str
-    :: Delim "#" :: Text method_name_str :: Delim "(" :: rest ->
+    :: Delim "#"
+    :: Text method_name_str
+    :: Delim "("
+    :: rest ->
       parse_class class_name_str >>= fun class_name ->
       parse_method_name method_name_str >>= fun method_name ->
       match_after_open_brace rest >>= fun (params, ret_nullability) ->
diff --git a/infer/src/nullsafe/typeCheck.ml b/infer/src/nullsafe/typeCheck.ml
index f5693337f..25d3fdece 100644
--- a/infer/src/nullsafe/typeCheck.ml
+++ b/infer/src/nullsafe/typeCheck.ml
@@ -690,7 +690,9 @@ let do_map_put
   in
   match call_params with
   | ((_, Exp.Lvar pv_map), _)
-    :: ((_, exp_key), _) :: ((_, exp_value), typ_value) :: _ -> (
+    :: ((_, exp_key), _)
+    :: ((_, exp_value), typ_value)
+    :: _ -> (
       (* Convert the dexp for k to the dexp for m.get(k) *)
       let convert_dexp_key_to_dexp_get dopt =
         match dopt with
diff --git a/src/upgrader/dune_upgrader.ml b/src/upgrader/dune_upgrader.ml
index 7d15b87d1..9a2960e9f 100644
--- a/src/upgrader/dune_upgrader.ml
+++ b/src/upgrader/dune_upgrader.ml
@@ -76,7 +76,9 @@ module Common = struct
       | List
           ( loc,
             (Atom (_, A "lang") as lang)
-            :: (Atom (_, A "dune") as dune) :: Atom (loc3, A _) :: tll )
+            :: (Atom (_, A "dune") as dune)
+            :: Atom (loc3, A _)
+            :: tll )
         :: tl ->
           List
             (loc, lang :: dune :: Atom (loc3, Dune_lang.Atom.of_string v) :: tll)
diff --git a/bytecomp/emitcode.ml b/bytecomp/emitcode.ml
index fbc126d94..b5fd9c47e 100644
--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -468,13 +468,15 @@ let rec emit = function
       emit c
   | Kpush
     :: Kevent ({ ev_kind = Event_before } as ev)
-       :: (Kgetglobal _ as instr1) :: (Kgetfield _ as instr2) :: c ->
+    :: (Kgetglobal _ as instr1)
+    :: (Kgetfield _ as instr2)
+    :: c ->
       emit (Kpush :: instr1 :: instr2 :: remerge_events ev c)
   | Kpush
     :: Kevent ({ ev_kind = Event_before } as ev)
-       :: ((Kacc _ | Kenvacc _ | Koffsetclosure _ | Kgetglobal _ | Kconst _) as
-          instr)
-          :: c ->
+    :: ((Kacc _ | Kenvacc _ | Koffsetclosure _ | Kgetglobal _ | Kconst _) as
+       instr)
+    :: c ->
       emit (Kpush :: instr :: remerge_events ev c)
   | Kgetglobal id :: Kgetfield n :: c ->
       out opGETGLOBALFIELD;
diff --git a/ocamldoc/odoc_sig.ml b/ocamldoc/odoc_sig.ml
index 377bdf13c..12e954772 100644
--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -298,7 +298,8 @@ functor
                         let _, comment_opt = just_after_special pos pos_end in
                         [ (name, comment_opt) ]
                     | Otag ({ txt = name }, ct)
-                      :: ((Oinherit ct2 | Otag (_, ct2)) as ele2) :: q ->
+                      :: ((Oinherit ct2 | Otag (_, ct2)) as ele2)
+                      :: q ->
                         let pos = Loc.ptyp_end ct in
                         let pos2 = Loc.ptyp_start ct2 in
                         let _, comment_opt = just_after_special pos pos2 in
diff --git a/testsuite/tests/letrec-compilation/lists.ml b/testsuite/tests/letrec-compilation/lists.ml
index 3fcc8db9c..d927aa0a8 100644
--- a/testsuite/tests/letrec-compilation/lists.ml
+++ b/testsuite/tests/letrec-compilation/lists.ml
@@ -4,21 +4,7 @@
 let test =
   let rec li = 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: 9 :: li in
   match li with
-  | 0
-    :: 1
-       :: 2
-          :: 3
-             :: 4
-                :: 5
-                   :: 6
-                      :: 7
-                         :: 8
-                            :: 9
-                               :: 0
-                                  :: 1
-                                     :: 2
-                                        :: 3
-                                           :: 4 :: 5 :: 6 :: 7 :: 8 :: 9 :: li'
-    ->
+  | 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: 9 :: 0 :: 1 :: 2 :: 3 :: 4 :: 5
+    :: 6 :: 7 :: 8 :: 9 :: li' ->
       assert (li == li')
   | _ -> assert false
```

</details>

Here is the diff for the `janestreet` profile:

<details>

```diff
diff --git a/infer/src/biabduction/Prop.ml b/infer/src/biabduction/Prop.ml
index 77b1d2b3e..e920f6e1d 100644
--- a/infer/src/biabduction/Prop.ml
+++ b/infer/src/biabduction/Prop.ml
@@ -583,12 +583,14 @@ let replace_array_contents (hpred : Predicates.hpred) esel : Predicates.hpred =
 let rec pi_sorted_remove_redundant (pi : pi) =
   match pi with
   | (Aeq (BinOp (Le, e1, Const (Cint n1)), Const (Cint i1)) as a1)
-    :: Aeq (BinOp (Le, e2, Const (Cint n2)), Const (Cint i2)) :: rest
+    :: Aeq (BinOp (Le, e2, Const (Cint n2)), Const (Cint i2))
+    :: rest
     when IntLit.isone i1 && IntLit.isone i2 && Exp.equal e1 e2 && IntLit.lt n1 n2 ->
     (* second inequality redundant *)
     pi_sorted_remove_redundant (a1 :: rest)
   | Aeq (BinOp (Lt, Const (Cint n1), e1), Const (Cint i1))
-    :: (Aeq (BinOp (Lt, Const (Cint n2), e2), Const (Cint i2)) as a2) :: rest
+    :: (Aeq (BinOp (Lt, Const (Cint n2), e2), Const (Cint i2)) as a2)
+    :: rest
     when IntLit.isone i1 && IntLit.isone i2 && Exp.equal e1 e2 && IntLit.lt n1 n2 ->
     (* first inequality redundant *)
     pi_sorted_remove_redundant (a2 :: rest)
diff --git a/src/upgrader/dune_upgrader.ml b/src/upgrader/dune_upgrader.ml
index e44615152..b6594e7f3 100644
--- a/src/upgrader/dune_upgrader.ml
+++ b/src/upgrader/dune_upgrader.ml
@@ -79,7 +79,9 @@ module Common = struct
       | List
           ( loc
           , (Atom (_, A "lang") as lang)
-            :: (Atom (_, A "dune") as dune) :: Atom (loc3, A _) :: tll )
+            :: (Atom (_, A "dune") as dune)
+            :: Atom (loc3, A _)
+            :: tll )
         :: tl ->
         List (loc, lang :: dune :: Atom (loc3, Dune_lang.Atom.of_string v) :: tll) :: tl
       | sexp -> sexp
diff --git a/bytecomp/emitcode.ml b/bytecomp/emitcode.ml
index b6a722231..61ad4eed7 100644
--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -508,12 +508,13 @@ let rec emit = function
     emit c
   | Kpush
     :: Kevent ({ ev_kind = Event_before } as ev)
-       :: (Kgetglobal _ as instr1) :: (Kgetfield _ as instr2) :: c ->
-    emit (Kpush :: instr1 :: instr2 :: remerge_events ev c)
+    :: (Kgetglobal _ as instr1)
+    :: (Kgetfield _ as instr2)
+    :: c -> emit (Kpush :: instr1 :: instr2 :: remerge_events ev c)
   | Kpush
     :: Kevent ({ ev_kind = Event_before } as ev)
-       :: ((Kacc _ | Kenvacc _ | Koffsetclosure _ | Kgetglobal _ | Kconst _) as instr)
-          :: c -> emit (Kpush :: instr :: remerge_events ev c)
+    :: ((Kacc _ | Kenvacc _ | Koffsetclosure _ | Kgetglobal _ | Kconst _) as instr)
+    :: c -> emit (Kpush :: instr :: remerge_events ev c)
   | Kgetglobal id :: Kgetfield n :: c ->
     out opGETGLOBALFIELD;
     slot_for_getglobal id;
diff --git a/testsuite/tests/letrec-compilation/lists.ml b/testsuite/tests/letrec-compilation/lists.ml
index 9ab75a68f..19bccfc54 100644
--- a/testsuite/tests/letrec-compilation/lists.ml
+++ b/testsuite/tests/letrec-compilation/lists.ml
@@ -6,14 +6,24 @@ let test =
   match li with
   | 0
     :: 1
-       :: 2
-          :: 3
-             :: 4
-                :: 5
-                   :: 6
-                      :: 7
-                         :: 8
-                            :: 9 :: 0 :: 1 :: 2 :: 3 :: 4 :: 5 :: 6 :: 7 :: 8 :: 9 :: li'
-    -> assert (li == li')
+    :: 2
+    :: 3
+    :: 4
+    :: 5
+    :: 6
+    :: 7
+    :: 8
+    :: 9
+    :: 0
+    :: 1
+    :: 2
+    :: 3
+    :: 4
+    :: 5
+    :: 6
+    :: 7
+    :: 8
+    :: 9
+    :: li' -> assert (li == li')
   | _ -> assert false
 ;;
```

</details>