### PR TITLE
Fix position of comments attached to constructor decl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 
   + Fix position of `:=` when `assignment-operator=end-line` (#1985, @gpetiot)
 
-  + Fix position of comments attached to constructor decl (#<PR_NUMBER>, @gpetiot)
+  + Fix position of comments attached to constructor decl (#1986, @gpetiot)
 
 #### Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
   + Fix position of `:=` when `assignment-operator=end-line` (#1985, @gpetiot)
 
+  + Fix position of comments attached to constructor decl (#<PR_NUMBER>, @gpetiot)
+
 #### Changes
 
   + More expressions are considered "simple" (not inducing a break e.g. as an argument of an application):

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -211,6 +211,12 @@ end = struct
             | 0, 0 -> `Before_next
             | 0, _ when infix_symbol_before src loc -> `Before_next
             | 0, _ -> `After_prev
+            | 1, 1 ->
+                if
+                  Location.compare_start_col (List.last_exn cmtl).loc next
+                  <= 0
+                then `Before_next
+                else `After_prev
             | 1, y when y > 1 && Source.empty_line_after src loc ->
                 `After_prev
             | _, y

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3377,19 +3377,18 @@ and fmt_constructor_declaration c ctx ~max_len_name ~first ~last:_ cstr_decl
      eventual comment placed after the previous constructor *)
   fmt_if_k (not first) (fmt_or (sparse || has_cmt_before) "@;<1000 0>" "@ ")
   $ Cmts.fmt_before ~epi:(break 1000 0) c pcd_loc
-  $ Cmts.fmt_before c loc
   $ fmt_or_k first (if_newline "| ") (str "| ")
   $ hvbox ~name:"constructor_decl" 0
       ( hovbox 2
           ( hvbox 2
-              ( Cmts.fmt c loc
-                  (wrap_if (String_id.is_symbol txt) "( " " )" (str txt))
+              ( hovbox ~name:"constructor_decl_name" 0
+                  (Cmts.fmt c loc
+                     (wrap_if (String_id.is_symbol txt) "( " " )" (str txt)) )
               $ fmt_padding
               $ fmt_constructor_arguments_result c ctx pcd_vars pcd_args
                   pcd_res )
           $ fmt_attributes_and_docstrings c pcd_attributes )
-      $ Cmts.fmt_after c ~pro:(fmt_or c.conf.wrap_comments "@ " " ") pcd_loc
-      )
+      $ Cmts.fmt_after c pcd_loc )
 
 and fmt_constructor_arguments ?vars c ctx ~pre = function
   | Pcstr_tuple [] -> noop

--- a/test/passing/tests/align_cases-break_all.ml.ref
+++ b/test/passing/tests/align_cases-break_all.ml.ref
@@ -8,8 +8,7 @@ type x =
   | Fooooooooo          of padding * int array
   | Fooooooooooo        of padding * int array * int array
   (* fooooooooooooooooo *)
-  | Fooooooooooo
-      (* fooooooooooooooooooo *) of
+  | Fooooooooooo (* fooooooooooooooooooo *) of
       padding * int array * int array
   (* fooooooooooooooooo *)
   | Foooooooooo         of padding * int array * int array

--- a/test/passing/tests/align_cases.ml
+++ b/test/passing/tests/align_cases.ml
@@ -8,8 +8,7 @@ type x =
   | Fooooooooo          of padding * int array
   | Fooooooooooo        of padding * int array * int array
   (* fooooooooooooooooo *)
-  | Fooooooooooo
-      (* fooooooooooooooooooo *) of
+  | Fooooooooooo (* fooooooooooooooooooo *) of
       padding * int array * int array
   (* fooooooooooooooooo *)
   | Foooooooooo         of padding * int array * int array

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -187,8 +187,8 @@ let () =
 
 type t =
   | Aaaaaaaaaa
-  (* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-     tempor incididunt ut labore et dolore magna aliqua. *)
+    (* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+       eiusmod tempor incididunt ut labore et dolore magna aliqua. *)
   | Bbbbbbbbbb (* foo *)
   | Bbbbbbbbbb
 (* foo *)

--- a/test/passing/tests/wrap_comments.ml.err
+++ b/test/passing/tests/wrap_comments.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/wrap_comments.ml:35 exceeds the margin
+Warning: tests/wrap_comments.ml:36 exceeds the margin

--- a/test/passing/tests/wrap_comments.ml.ref
+++ b/test/passing/tests/wrap_comments.ml.ref
@@ -2,8 +2,8 @@
 
 type t =
   | Aaaaaaaaaa
-  (* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-     tempor incididunt ut labore et dolore magna aliqua. *)
+    (* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+       tempor incididunt ut labore et dolore magna aliqua. *)
   | Bbbbbbbbbb
 
 let _ =
@@ -33,7 +33,8 @@ let _ =
 [@@@ocamlformat "wrap-comments=false"]
 
 type t =
-  | Aaaaaaaaaa (* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. *)
+  | Aaaaaaaaaa
+    (* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. *)
   | Bbbbbbbbbb
 
 let rex =


### PR DESCRIPTION
Reduce the diff of #1667

Here is the diff for the `conventional` profile:

<details>

```diff
diff --git a/infer/src/erlang/ErlangAst.ml b/infer/src/erlang/ErlangAst.ml
index 825aa0573..e0f70bee6 100644
--- a/infer/src/erlang/ErlangAst.ml
+++ b/infer/src/erlang/ErlangAst.ml
@@ -113,7 +113,8 @@ and simple_expression =
   | Nil
   | Receive of { cases : case_clause list; timeout : timeout option }
   | RecordAccess of { record : expression; name : record_name; field : string }
-  | RecordIndex of { name : record_name; field : string } (* factor from above? *)
+  | RecordIndex of { name : record_name; field : string }
+    (* factor from above? *)
   | RecordUpdate of {
       record : expression option;
       name : record_name;
diff --git a/src/dune_engine/rules.mli b/src/dune_engine/rules.mli
index bf8183eff..c68fde9f6 100644
--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -26,7 +26,7 @@ module Dir_rules : sig
 
            When passing [--force] to Dune, these are exactly the actions that
            will be re-executed. *)
-          Action of
+        Action of
           Rule.Anonymous_action.t Action_builder.t
 
     type t = { expansions : (Loc.t * item) Appendable_list.t } [@@unboxed]
diff --git a/src/dune_engine/scheduler.ml b/src/dune_engine/scheduler.ml
index ae00ea8d7..f1534638d 100644
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -675,7 +675,7 @@ end
 type status =
   | (* We are not doing a build. Just accumulating invalidations until the next
        build starts. *)
-      Standing_by of {
+    Standing_by of {
       invalidation : Memo.Invalidation.t;
       saw_insignificant_changes : bool;
           (* Whether we saw build input changes that are insignificant for the
@@ -685,10 +685,10 @@ type status =
              change. *)
     }
   | (* Running a build *)
-      Building of Fiber_util.Cancellation.t
+    Building of Fiber_util.Cancellation.t
   | (* Cancellation requested. Build jobs are immediately rejected in this
        state *)
-      Restarting_build of
+    Restarting_build of
       Memo.Invalidation.t
 
 module Build_outcome = struct
diff --git a/src/dune_rules/dir_status.ml b/src/dune_rules/dir_status.ml
index 9e188e0a4..32f60bacf 100644
--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -12,15 +12,15 @@ module T = struct
     | Generated
     | Source_only of Source_tree.Dir.t
     | (* Directory not part of a multi-directory group *)
-        Standalone of
+      Standalone of
         Source_tree.Dir.t * Stanza.t list Dir_with_dune.t
     | (* Directory with [(include_subdirs x)] where [x] is not [no] *)
-        Group_root of
+      Group_root of
         Source_tree.Dir.t
         * (Loc.t * Include_subdirs.qualification)
         * Stanza.t list Dir_with_dune.t
     | (* Sub-directory of a [Group_root _] *)
-        Is_component_of_a_group_but_not_the_root of
+      Is_component_of_a_group_but_not_the_root of
         is_component_of_a_group_but_not_the_root
 end
 
diff --git a/src/dune_rules/lib.ml b/src/dune_rules/lib.ml
index 425f61327..b9078d14a 100644
--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -359,7 +359,7 @@ and resolve_result =
   | Hidden of Lib_info.external_ Hidden.t
   | Invalid of exn
   | (* Redirect (None, lib) looks up lib in the same database *)
-      Redirect of
+    Redirect of
       db option * (Loc.t * Lib_name.t)
 
 let lib_config (t : lib) = t.lib_config
diff --git a/asmcomp/amd64/arch.ml b/asmcomp/amd64/arch.ml
index a6050ac57..825773634 100644
--- a/asmcomp/amd64/arch.ml
+++ b/asmcomp/amd64/arch.ml
@@ -47,8 +47,9 @@ type specific_operation =
   | Ibswap of int (* endianness conversion *)
   | Isqrtf (* Float square root *)
   | Ifloatsqrtf of addressing_mode (* Float square root from memory *)
-  | Isextend32 (* 32 to 64 bit conversion with sign
-                  extension *)
+  | Isextend32
+    (* 32 to 64 bit conversion with sign
+       extension *)
   | Izextend32
 (* 32 to 64 bit conversion with zero
    extension *)
diff --git a/asmcomp/cmm.mli b/asmcomp/cmm.mli
index 58a90400b..84ad44c2e 100644
--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -184,10 +184,11 @@ and operation =
   | Cintoffloat
   | Ccmpf of float_comparison
   | Craise of Lambda.raise_kind
-  | Ccheckbound (* Takes two arguments : first the bound to check against,
-                   then the index.
-                   It results in a bounds error if the index is greater than
-                   or equal to the bound. *)
+  | Ccheckbound
+    (* Takes two arguments : first the bound to check against,
+       then the index.
+       It results in a bounds error if the index is greater than
+       or equal to the bound. *)
   | Copaque (* Sys.opaque_identity *)
   | Cdls_get
 
diff --git a/bytecomp/dll.mli b/bytecomp/dll.mli
index f2c513cd5..bb5cf1859 100644
--- a/bytecomp/dll.mli
+++ b/bytecomp/dll.mli
@@ -19,8 +19,9 @@
 val extract_dll_name : string -> string
 
 type dll_mode =
-  | For_checking (* will just check existence of symbols;
-                    no need to do full symbol resolution *)
+  | For_checking
+    (* will just check existence of symbols;
+       no need to do full symbol resolution *)
   | For_execution
 (* will call functions from this DLL;
    must resolve symbols completely *)
@@ -36,8 +37,9 @@ val close_all_dlls : unit -> unit
 type dll_address
 
 type primitive_address =
-  | Prim_loaded of dll_address (* Primitive found in a DLL opened
-                                  "for execution" *)
+  | Prim_loaded of dll_address
+    (* Primitive found in a DLL opened
+       "for execution" *)
   | Prim_exists
 (* Primitive found in a DLL opened "for checking" *)
 
diff --git a/middle_end/clambda_primitives.ml b/middle_end/clambda_primitives.ml
index 2e5eba9b8..8d404d4ac 100644
--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -170,7 +170,7 @@ and array_kind = Lambda.array_kind =
 
 and value_kind = Lambda.value_kind =
   | (* CR mshinwell: Pfloatval should be renamed to Pboxedfloatval *)
-      Pgenval
+    Pgenval
   | Pfloatval
   | Pboxedintval of boxed_integer
   | Pintval
diff --git a/middle_end/clambda_primitives.mli b/middle_end/clambda_primitives.mli
index 1e1e3854a..6465372b2 100644
--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -173,7 +173,7 @@ and array_kind = Lambda.array_kind =
 
 and value_kind = Lambda.value_kind =
   | (* CR mshinwell: Pfloatval should be renamed to Pboxedfloatval *)
-      Pgenval
+    Pgenval
   | Pfloatval
   | Pboxedintval of boxed_integer
   | Pintval
diff --git a/otherlibs/win32unix/unix.ml b/otherlibs/win32unix/unix.ml
index 238e43b71..610d04dce 100644
--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -26,7 +26,7 @@ let _ =
 
 type error =
   | (* Errors defined in the POSIX standard *)
-      E2BIG (* Argument list too long *)
+    E2BIG (* Argument list too long *)
   | EACCES (* Permission denied *)
   | EAGAIN (* Resource temporarily unavailable; try again *)
   | EBADF (* Bad file descriptor *)
diff --git a/parsing/parsetree.mli b/parsing/parsetree.mli
index d63b2127f..afeca64cf 100644
--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -124,26 +124,27 @@ and core_type_desc =
      [< `A|`B ]        (flag = Closed; labels = Some [])
      [< `A|`B > `X `Y ](flag = Closed; labels = Some ["X";"Y"])
   *)
-  | Ptyp_poly of string loc list * core_type (* 'a1 ... 'an. T
+  | Ptyp_poly of string loc list * core_type
+    (* 'a1 ... 'an. T
 
-                                                Can only appear in the following context:
+       Can only appear in the following context:
 
-                                                - As the core_type of a Ppat_constraint node corresponding
-                                                  to a constraint on a let-binding: let x : 'a1 ... 'an. T
-                                                  = e ...
+       - As the core_type of a Ppat_constraint node corresponding
+         to a constraint on a let-binding: let x : 'a1 ... 'an. T
+         = e ...
 
-                                                - Under Cfk_virtual for methods (not values).
+       - Under Cfk_virtual for methods (not values).
 
-                                                - As the core_type of a Pctf_method node.
+       - As the core_type of a Pctf_method node.
 
-                                                - As the core_type of a Pexp_poly node.
+       - As the core_type of a Pexp_poly node.
 
-                                                - As the pld_type field of a label_declaration.
+       - As the pld_type field of a label_declaration.
 
-                                                - As a core_type of a Ptyp_object node.
+       - As a core_type of a Ptyp_object node.
 
-                                                - As the pval_type field of a value_description.
-                                             *)
+       - As the pval_type field of a value_description.
+    *)
   | Ptyp_package of package_type
   (* (module S) *)
   | Ptyp_extension of extension
diff --git a/stdlib/arg.ml b/stdlib/arg.ml
index e8d85f054..9eb8e0a90 100644
--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -29,13 +29,15 @@ type spec =
   | Set_int of int ref (* Set the reference to the int argument *)
   | Float of (float -> unit) (* Call the function with a float argument *)
   | Set_float of float ref (* Set the reference to the float argument *)
-  | Tuple of spec list (* Take several arguments according to the
-                          spec list *)
+  | Tuple of spec list
+    (* Take several arguments according to the
+       spec list *)
   | Symbol of string list * (string -> unit)
   (* Take one of the symbols as argument and
      call the function with the symbol. *)
-  | Rest of (string -> unit) (* Stop interpreting keywords and call the
-                                function with each remaining argument *)
+  | Rest of (string -> unit)
+    (* Stop interpreting keywords and call the
+       function with each remaining argument *)
   | Rest_all of (string list -> unit)
   (* Stop interpreting keywords and call the
      function with all remaining arguments. *)
diff --git a/stdlib/camlinternalFormatBasics.ml b/stdlib/camlinternalFormatBasics.ml
index 8c63d5b39..708a6324f 100644
--- a/stdlib/camlinternalFormatBasics.ml
+++ b/stdlib/camlinternalFormatBasics.ml
@@ -247,13 +247,16 @@ type ('a, 'b, 'c) custom_arity =
 type block_type =
   | Pp_hbox (* Horizontal block no line breaking *)
   | Pp_vbox (* Vertical block each break leads to a new line *)
-  | Pp_hvbox (* Horizontal-vertical block: same as vbox, except if this block
-                is small enough to fit on a single line *)
-  | Pp_hovbox (* Horizontal or Vertical block: breaks lead to new line
-                 only when necessary to print the content of the block *)
-  | Pp_box (* Horizontal or Indent block: breaks lead to new line
-              only when necessary to print the content of the block, or
-              when it leads to a new indentation of the current line *)
+  | Pp_hvbox
+    (* Horizontal-vertical block: same as vbox, except if this block
+       is small enough to fit on a single line *)
+  | Pp_hovbox
+    (* Horizontal or Vertical block: breaks lead to new line
+       only when necessary to print the content of the block *)
+  | Pp_box
+    (* Horizontal or Indent block: breaks lead to new line
+       only when necessary to print the content of the block, or
+       when it leads to a new indentation of the current line *)
   | Pp_fits
 (* Internal usage: when a block fits on a single line *)
 
diff --git a/stdlib/format.ml b/stdlib/format.ml
index 1830cfd26..b6eb9c4ab 100644
--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -81,8 +81,9 @@ type pp_token =
   | Pp_tbegin of tbox (* beginning of a tabulation box *)
   | Pp_tend (* end of a tabulation box *)
   | Pp_newline (* to force a newline inside a box *)
-  | Pp_if_newline (* to do something only if this very
-                     line has been broken *)
+  | Pp_if_newline
+    (* to do something only if this very
+       line has been broken *)
   | Pp_open_tag of stag (* opening a tag name *)
   | Pp_close_tag
 (* closing the most recently open tag *)
```

</details>