### PR TITLE
Do not break between 2 module items when the first one has a comment attached on the same line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 
   + Do not wrap docstrings, `wrap-comments` should only impact non-documentation comments, wrapping invalid docstrings would cause the whole file to not be formatted (#1988, @gpetiot)
 
+  + Do not break between 2 module items when the first one has a comment attached on the same line. Only a comment on the next line should induce a break to make it clear to which element it is attached to (#1989, @gpetiot)
+
 #### Changes
 
   + More expressions are considered "simple" (not inducing a break e.g. as an argument of an application):

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -19,6 +19,9 @@ type cmt_checker =
   ; cmts_within: Location.t -> bool
   ; cmts_after: Location.t -> bool }
 
+let cmts_between s {cmts_before; cmts_after; _} loc1 loc2 =
+  (cmts_after loc1 && Source.ends_line s loc1) || cmts_before loc2
+
 let ( init
     , register_reset
     , leading_nested_match_parens
@@ -534,9 +537,9 @@ module Structure_item = struct
       | _ -> false )
     | _ -> true
 
-  let break_between s {cmts_before; cmts_after; _} (i1, c1) (i2, c2) =
-    cmts_after i1.pstr_loc || cmts_before i2.pstr_loc || has_doc i1
-    || has_doc i2
+  let break_between s cc (i1, c1) (i2, c2) =
+    cmts_between s cc i1.pstr_loc i2.pstr_loc
+    || has_doc i1 || has_doc i2
     ||
     match Conf.(c1.module_item_spacing, c2.module_item_spacing) with
     | `Preserve, `Preserve ->
@@ -615,9 +618,9 @@ module Signature_item = struct
       | _ -> false )
     | _ -> true
 
-  let break_between s {cmts_before; cmts_after; _} (i1, c1) (i2, c2) =
-    cmts_after i1.psig_loc || cmts_before i2.psig_loc || has_doc i1
-    || has_doc i2
+  let break_between s cc (i1, c1) (i2, c2) =
+    cmts_between s cc i1.psig_loc i2.psig_loc
+    || has_doc i1 || has_doc i2
     ||
     match Conf.(c1.module_item_spacing, c2.module_item_spacing) with
     | `Preserve, `Preserve ->
@@ -635,9 +638,9 @@ module Vb = struct
     Poly.(c.Conf.module_item_spacing = `Compact)
     && Location.is_single_line i.pvb_loc c.Conf.margin
 
-  let break_between {cmts_before; cmts_after; _} (i1, c1) (i2, c2) =
-    cmts_after i1.pvb_loc || cmts_before i2.pvb_loc || has_doc i1
-    || has_doc i2
+  let break_between s cc (i1, c1) (i2, c2) =
+    cmts_between s cc i1.pvb_loc i2.pvb_loc
+    || has_doc i1 || has_doc i2
     || (not (is_simple (i1, c1)))
     || not (is_simple (i2, c2))
 end
@@ -650,9 +653,9 @@ module Td = struct
     | `Compact | `Preserve -> Location.is_single_line i.ptype_loc c.margin
     | `Sparse -> false
 
-  let break_between s {cmts_before; cmts_after; _} (i1, c1) (i2, c2) =
-    cmts_after i1.ptype_loc || cmts_before i2.ptype_loc || has_doc i1
-    || has_doc i2
+  let break_between s cc (i1, c1) (i2, c2) =
+    cmts_between s cc i1.ptype_loc i2.ptype_loc
+    || has_doc i1 || has_doc i2
     ||
     match Conf.(c1.module_item_spacing, c2.module_item_spacing) with
     | `Preserve, `Preserve ->
@@ -675,9 +678,9 @@ module Class_field = struct
         Location.is_single_line itm.pcf_loc c.Conf.margin
     | `Sparse -> false
 
-  let break_between s {cmts_before; cmts_after; _} (i1, c1) (i2, c2) =
-    cmts_after i1.pcf_loc || cmts_before i2.pcf_loc || has_doc i1
-    || has_doc i2
+  let break_between s cc (i1, c1) (i2, c2) =
+    cmts_between s cc i1.pcf_loc i2.pcf_loc
+    || has_doc i1 || has_doc i2
     ||
     match Conf.(c1.module_item_spacing, c2.module_item_spacing) with
     | `Preserve, `Preserve ->
@@ -699,9 +702,9 @@ module Class_type_field = struct
         Location.is_single_line itm.pctf_loc c.Conf.margin
     | `Sparse -> false
 
-  let break_between s {cmts_before; cmts_after; _} (i1, c1) (i2, c2) =
-    cmts_after i1.pctf_loc || cmts_before i2.pctf_loc || has_doc i1
-    || has_doc i2
+  let break_between s cc (i1, c1) (i2, c2) =
+    cmts_between s cc i1.pctf_loc i2.pctf_loc
+    || has_doc i1 || has_doc i2
     ||
     match Conf.(c1.module_item_spacing, c2.module_item_spacing) with
     | `Preserve, `Preserve ->
@@ -795,13 +798,12 @@ let location = function
   | Tli (`Directive x) -> x.pdir_loc
   | Top -> Location.none
 
-let break_between_modules {cmts_before; cmts_after; _} (i1, c1) (i2, c2) =
+let break_between_modules s cc (i1, c1) (i2, c2) =
   let has_doc itm = List.exists ~f:Attr.is_doc (attributes itm) in
   let is_simple (itm, c) =
     Location.is_single_line (location itm) c.Conf.margin
   in
-  cmts_after (location i1)
-  || cmts_before (location i2)
+  cmts_between s cc (location i1) (location i2)
   || has_doc i1 || has_doc i2
   || (not (is_simple (i1, c1)))
   || not (is_simple (i2, c2))
@@ -810,9 +812,9 @@ let break_between s cc (i1, c1) (i2, c2) =
   match (i1, i2) with
   | Str i1, Str i2 -> Structure_item.break_between s cc (i1, c1) (i2, c2)
   | Sig i1, Sig i2 -> Signature_item.break_between s cc (i1, c1) (i2, c2)
-  | Vb i1, Vb i2 -> Vb.break_between cc (i1, c1) (i2, c2)
-  | Mty _, Mty _ -> break_between_modules cc (i1, c1) (i2, c2)
-  | Mod _, Mod _ -> break_between_modules cc (i1, c1) (i2, c2)
+  | Vb i1, Vb i2 -> Vb.break_between s cc (i1, c1) (i2, c2)
+  | Mty _, Mty _ -> break_between_modules s cc (i1, c1) (i2, c2)
+  | Mod _, Mod _ -> break_between_modules s cc (i1, c1) (i2, c2)
   | Tli (`Item i1), Tli (`Item i2) ->
       Structure_item.break_between s cc (i1, c1) (i2, c2)
   | Tli (`Directive _), Tli (`Directive _) | Tli _, Tli _ ->

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,9 +1,9 @@
 Warning: tests/js_source.ml:154 exceeds the margin
-Warning: tests/js_source.ml:3570 exceeds the margin
-Warning: tests/js_source.ml:9561 exceeds the margin
-Warning: tests/js_source.ml:9582 exceeds the margin
-Warning: tests/js_source.ml:9664 exceeds the margin
-Warning: tests/js_source.ml:9677 exceeds the margin
-Warning: tests/js_source.ml:9682 exceeds the margin
-Warning: tests/js_source.ml:9722 exceeds the margin
-Warning: tests/js_source.ml:9804 exceeds the margin
+Warning: tests/js_source.ml:3565 exceeds the margin
+Warning: tests/js_source.ml:9550 exceeds the margin
+Warning: tests/js_source.ml:9571 exceeds the margin
+Warning: tests/js_source.ml:9653 exceeds the margin
+Warning: tests/js_source.ml:9666 exceeds the margin
+Warning: tests/js_source.ml:9671 exceeds the margin
+Warning: tests/js_source.ml:9711 exceeds the margin
+Warning: tests/js_source.ml:9793 exceeds the margin

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -438,7 +438,6 @@ end
 
 type foo += private B2 = M.B1
 type foo += B3 = M.B1 (* Error: rebind private extension *)
-
 type foo += C = Unknown (* Error: unbound extension *)
 
 (* Extensions can be rebound even if type is closed *)
@@ -530,9 +529,7 @@ let extension_id e = Obj.extension_id (Obj.extension_constructor e)
 let n1 = extension_name Foo
 let n2 = extension_name (Bar 1)
 let t = extension_id (Bar 2) = extension_id (Bar 3) (* true *)
-
 let f = extension_id (Bar 2) = extension_id Foo (* false *)
-
 let is_foo x = extension_id Foo = extension_id x
 
 type foo += Foo
@@ -2762,7 +2759,6 @@ type _ t = I : int t
 let f (type a) (x : a t) =
   let module M = struct
     let (I : a t) = x (* fail because of toplevel let *)
-
     let x = (I : a t)
   end
   in
@@ -2779,7 +2775,6 @@ let bad (type a) =
       val e : (int, a) eq
     end = struct
       let (Refl : (int, a) eq) = M.e (* must fail for soundness *)
-
       let e : (int, a) eq = Refl
     end
   end
@@ -4993,7 +4988,6 @@ let _ = f (module A) (* ok *)
 module A_annotated_alias : S with type t = (module A.A_S) = A
 
 let _ = f (module A_annotated_alias) (* ok *)
-
 let _ = f (module A_annotated_alias : S with type t = (module A.A_S)) (* ok *)
 
 module A_alias = A
@@ -5003,11 +4997,8 @@ module A_alias_expanded = struct
 end
 
 let _ = f (module A_alias_expanded : S with type t = (module A.A_S)) (* ok *)
-
 let _ = f (module A_alias_expanded) (* ok *)
-
 let _ = f (module A_alias : S with type t = (module A.A_S)) (* doesn't type *)
-
 let _ = f (module A_alias) (* doesn't type either *)
 
 module Foo (Bar : sig
@@ -8217,9 +8208,7 @@ end
 
 module type VALUE = sig
   type value (* a Lua value *)
-
   type state (* the state of a Lua interpreter *)
-
   type usert (* a user-defined value *)
 end
 

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -438,7 +438,6 @@ end
 
 type foo += private B2 = M.B1
 type foo += B3 = M.B1 (* Error: rebind private extension *)
-
 type foo += C = Unknown (* Error: unbound extension *)
 
 (* Extensions can be rebound even if type is closed *)
@@ -530,9 +529,7 @@ let extension_id e = Obj.extension_id (Obj.extension_constructor e)
 let n1 = extension_name Foo
 let n2 = extension_name (Bar 1)
 let t = extension_id (Bar 2) = extension_id (Bar 3) (* true *)
-
 let f = extension_id (Bar 2) = extension_id Foo (* false *)
-
 let is_foo x = extension_id Foo = extension_id x
 
 type foo += Foo
@@ -2762,7 +2759,6 @@ type _ t = I : int t
 let f (type a) (x : a t) =
   let module M = struct
     let (I : a t) = x (* fail because of toplevel let *)
-
     let x = (I : a t)
   end
   in
@@ -2779,7 +2775,6 @@ let bad (type a) =
       val e : (int, a) eq
     end = struct
       let (Refl : (int, a) eq) = M.e (* must fail for soundness *)
-
       let e : (int, a) eq = Refl
     end
   end
@@ -4993,7 +4988,6 @@ let _ = f (module A) (* ok *)
 module A_annotated_alias : S with type t = (module A.A_S) = A
 
 let _ = f (module A_annotated_alias) (* ok *)
-
 let _ = f (module A_annotated_alias : S with type t = (module A.A_S)) (* ok *)
 
 module A_alias = A
@@ -5003,11 +4997,8 @@ module A_alias_expanded = struct
 end
 
 let _ = f (module A_alias_expanded : S with type t = (module A.A_S)) (* ok *)
-
 let _ = f (module A_alias_expanded) (* ok *)
-
 let _ = f (module A_alias : S with type t = (module A.A_S)) (* doesn't type *)
-
 let _ = f (module A_alias) (* doesn't type either *)
 
 module Foo (Bar : sig
@@ -8217,9 +8208,7 @@ end
 
 module type VALUE = sig
   type value (* a Lua value *)
-
   type state (* the state of a Lua interpreter *)
-
   type usert (* a user-defined value *)
 end
 


### PR DESCRIPTION
Reduce the diff of #1667, the behavior will now be the same whether there is no comment or there is a comment fitting at the end of the line. Only a comment on the next line should induce a break to make it clear to which element it is attached to.

Here is the diff for the `conventional` profile:

<details>

```diff
diff --git a/infer/src/topl/ToplAst.ml b/infer/src/topl/ToplAst.ml
index 0a749ec4f..6c1be44ff 100644
--- a/infer/src/topl/ToplAst.ml
+++ b/infer/src/topl/ToplAst.ml
@@ -22,7 +22,6 @@ type binop = (* all return booleans *)
 
 type predicate = Binop of binop * value * value | Value of (* bool *) value
 type condition = predicate list (* conjunction *)
-
 type assignment = register_name * variable_name
 
 type procedure_name_pattern = string
diff --git a/asmcomp/arm64/proc.ml b/asmcomp/arm64/proc.ml
index bf189358f..8b1efea35 100644
--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -218,7 +218,6 @@ let not_supported _ofs = fatal_error "Proc.loc_results: cannot call"
    Return values in r0...r15 or d0...d15. *)
 
 let max_arguments_for_tailcalls = 16 (* in regs *) + 64 (* in domain state *)
-
 let last_int_register = if macosx then 7 else 15
 
 let loc_arguments arg =
diff --git a/boot/menhir/menhirLib.ml b/boot/menhir/menhirLib.ml
index 36de0950b..41c0fd077 100644
--- a/boot/menhir/menhirLib.ml
+++ b/boot/menhir/menhirLib.ml
@@ -2194,7 +2194,6 @@ module InfiniteArray = struct
   }
 
   let default_size = 16384 (* must be non-zero *)
-
   let make x = { default = x; table = Array.make default_size x; extent = 0 }
 
   let rec new_length length i =
diff --git a/debugger/symbols.ml b/debugger/symbols.ml
index 89d88db8a..f6b1d8382 100644
--- a/debugger/symbols.ml
+++ b/debugger/symbols.ml
@@ -18,7 +18,6 @@
 
 open Instruct
 open Debugger_config (* Toplevel *)
-
 open Program_loading
 open Debugcom
 open Events
diff --git a/lambda/translmod.ml b/lambda/translmod.ml
index c623940a5..31f7805e3 100644
--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1571,9 +1571,7 @@ let transl_store_implementation module_name (str, restr) =
 
 let toploop_ident = Ident.create_persistent "Toploop"
 let toploop_getvalue_pos = 0 (* position of getvalue in module Toploop *)
-
 let toploop_setvalue_pos = 1 (* position of setvalue in module Toploop *)
-
 let aliased_idents = ref Ident.empty
 
 let set_toplevel_unique_name id =
diff --git a/lambda/translobj.mli b/lambda/translobj.mli
index dc28d3b08..3ece464a4 100644
--- a/lambda/translobj.mli
+++ b/lambda/translobj.mli
@@ -25,7 +25,6 @@ val transl_store_label_init :
   Ident.t -> int -> ('a -> lambda) -> 'a -> int * lambda
 
 val method_ids : Ident.Set.t ref (* reset when starting a new wrapper *)
-
 val oo_wrap : Env.t -> bool -> ('a -> lambda) -> 'a -> lambda
 val oo_add_class : Ident.t -> Env.t * bool
 val reset : unit -> unit
diff --git a/stdlib/camlinternalOO.ml b/stdlib/camlinternalOO.ml
index 757a76a4b..bb6abcd35 100644
--- a/stdlib/camlinternalOO.ml
+++ b/stdlib/camlinternalOO.ml
@@ -53,7 +53,6 @@ let initial_object_size = 2
 type item = DummyA | DummyB | DummyC of int
 
 let _ = [ DummyA; DummyB; DummyC 0 ] (* to avoid warnings *)
-
 let dummy_item = (magic () : item)
 
 (**** Types ****)
diff --git a/stdlib/obj.mli b/stdlib/obj.mli
index 861c7d4c5..ab7e1027c 100644
--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -60,7 +60,6 @@ external compare_and_swap_field : t -> int -> t -> t -> bool
 
 external is_shared : t -> bool = "caml_obj_is_shared"
 val double_field : t -> int -> float [@@inline always] (* @since 3.11.2 *)
-
 val set_double_field : t -> int -> float -> unit [@@inline always]
 (* @since 3.11.2 *)
 
@@ -90,7 +89,6 @@ val forward_tag : int
 val no_scan_tag : int
 val abstract_tag : int
 val string_tag : int (* both [string] and [bytes] *)
-
 val double_tag : int
 val double_array_tag : int
 val custom_tag : int
diff --git a/testsuite/tests/asmcomp/is_static.ml b/testsuite/tests/asmcomp/is_static.ml
index 5f61c2857..886c5f082 100644
--- a/testsuite/tests/asmcomp/is_static.ml
+++ b/testsuite/tests/asmcomp/is_static.ml
@@ -25,7 +25,6 @@ let () = (f [@inlined never]) ()
 
 (* Closed functions should be static *)
 let closed_function x = x + 1 (* + is a primitive, it cannot be in the closure*)
-
 let () = assert (is_in_static_data closed_function)
 
 (* And functions using closed functions *)
diff --git a/testsuite/tests/basic/patmatch.ml b/testsuite/tests/basic/patmatch.ml
index ca80485b4..4746ce57d 100644
--- a/testsuite/tests/basic/patmatch.ml
+++ b/testsuite/tests/basic/patmatch.ml
@@ -1649,7 +1649,6 @@ module GPR234HList = struct
 
   let sum l = fold_hlist { f = to_int_fold } 0 l
   let l = List [ 1; 2; 3 ] (* still fine to use normal list here *)
-
   let ll = [ Int 3; Pair (4, 5); StrInt "30"; l ]
   let test () = Printf.printf "%d\n" (sum ll)
 end
diff --git a/testsuite/tests/lib-dynlink-private/test.ml b/testsuite/tests/lib-dynlink-private/test.ml
index ca5c0314c..0f057615f 100644
--- a/testsuite/tests/lib-dynlink-private/test.ml
+++ b/testsuite/tests/lib-dynlink-private/test.ml
@@ -168,7 +168,6 @@
 *)
 
 let () = Sheep.baa Sheep.s (* Use Sheep module *)
-
 let _ = fun (x : Pig.t) -> x (* Reference Pig module *)
 
 (* Test that a privately loaded module cannot have the same name as a
diff --git a/testsuite/tests/misc-unsafe/almabench.ml b/testsuite/tests/misc-unsafe/almabench.ml
index 145bece43..6ae6893ca 100644
--- a/testsuite/tests/misc-unsafe/almabench.ml
+++ b/testsuite/tests/misc-unsafe/almabench.ml
@@ -45,7 +45,6 @@ and gaussk = 0.01720209895
 
 (* number of days to include in test *)
 let test_loops = 5 (* was: 20 *)
-
 and test_length = 36525
 
 (* sin and cos of j2000 mean obliquity (iau 1976) *)
diff --git a/testsuite/tests/no-alias-deps/aliases.ml b/testsuite/tests/no-alias-deps/aliases.ml
index d48459fa9..3add9f0b4 100644
--- a/testsuite/tests/no-alias-deps/aliases.ml
+++ b/testsuite/tests/no-alias-deps/aliases.ml
@@ -12,11 +12,8 @@
 *)
 
 module A' = A (* missing a.cmi *)
-
 module B' = B (* broken b.cmi *)
-
 module C' = C (* valid c.cmi *)
-
 module D' = D (* valid d.cmi *)
 
 let () = print_int D'.something
diff --git a/testsuite/tests/regression/pr9326/gc_set.ml b/testsuite/tests/regression/pr9326/gc_set.ml
index 1c52b13a7..adb0d4603 100644
--- a/testsuite/tests/regression/pr9326/gc_set.ml
+++ b/testsuite/tests/regression/pr9326/gc_set.ml
@@ -4,10 +4,8 @@
 open Gc
 
 let min_heap_sz = 524288 (* 512k *)
-
 let space_overhead = 70
 let stack_limit = 4194304 (* 4M *)
-
 let custom_major_ratio = 40
 let custom_minor_ratio = 99
 let custom_minor_max_size = 4096
diff --git a/testsuite/tests/typing-gadts/pr7214.ml b/testsuite/tests/typing-gadts/pr7214.ml
index 4c2243739..ed7523f81 100644
--- a/testsuite/tests/typing-gadts/pr7214.ml
+++ b/testsuite/tests/typing-gadts/pr7214.ml
@@ -7,7 +7,6 @@ type _ t = I : int t
 let f (type a) (x : a t) =
   let module M = struct
     let (I : a t) = x (* fail because of toplevel let *)
-
     let x = (I : a t)
   end in
   ()
@@ -33,7 +32,6 @@ let bad (type a) =
       val e : (int, a) eq
     end = struct
       let (Refl : (int, a) eq) = M.e (* must fail for soundness *)
-
       let e : (int, a) eq = Refl
     end
   end in
diff --git a/testsuite/tests/typing-misc/injectivity.ml b/testsuite/tests/typing-misc/injectivity.ml
index e2669c3e8..d048bd9a5 100644
--- a/testsuite/tests/typing-misc/injectivity.ml
+++ b/testsuite/tests/typing-misc/injectivity.ml
@@ -46,7 +46,6 @@ module M : sig type +!'a t end
 |}]
 
 type _ t = M : 'a -> 'a M.t t (* OK *)
-
 type 'a u = 'b constraint 'a = 'b M.t
 
 [%%expect
diff --git a/testsuite/tests/typing-modules-bugs/pr6982_ok.ml b/testsuite/tests/typing-modules-bugs/pr6982_ok.ml
index 1efa68b96..8b5c898fc 100644
--- a/testsuite/tests/typing-modules-bugs/pr6982_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6982_ok.ml
@@ -21,7 +21,6 @@ let _ = f (module A) (* ok *)
 module A_annotated_alias : S with type t = (module A.A_S) = A
 
 let _ = f (module A_annotated_alias) (* ok *)
-
 let _ = f (module A_annotated_alias : S with type t = (module A.A_S)) (* ok *)
 
 module A_alias = A
@@ -31,9 +30,6 @@ module A_alias_expanded = struct
 end
 
 let _ = f (module A_alias_expanded : S with type t = (module A.A_S)) (* ok *)
-
 let _ = f (module A_alias_expanded) (* ok *)
-
 let _ = f (module A_alias : S with type t = (module A.A_S)) (* doesn't type *)
-
 let _ = f (module A_alias) (* doesn't type either *)
diff --git a/testsuite/tests/typing-signatures/els.ml b/testsuite/tests/typing-signatures/els.ml
index a70101f2f..e7ded5f02 100644
--- a/testsuite/tests/typing-signatures/els.ml
+++ b/testsuite/tests/typing-signatures/els.ml
@@ -7,9 +7,7 @@
 
 module type VALUE = sig
   type value (* a Lua value *)
-
   type state (* the state of a Lua interpreter *)
-
   type usert (* a user-defined value *)
 end
 
diff --git a/testsuite/tests/warnings/w06.ml b/testsuite/tests/warnings/w06.ml
index a7cd1b256..d8c9b0a9a 100644
--- a/testsuite/tests/warnings/w06.ml
+++ b/testsuite/tests/warnings/w06.ml
@@ -9,8 +9,6 @@
 *)
 
 let foo ~bar = ignore bar (* one label *)
-
 let bar ~foo ~baz = ignore (foo, baz) (* two labels *)
-
 let () = foo 2
 let () = bar 4 2
diff --git a/testsuite/tests/warnings/w33.ml b/testsuite/tests/warnings/w33.ml
index 8c1a60206..f714f748b 100644
--- a/testsuite/tests/warnings/w33.ml
+++ b/testsuite/tests/warnings/w33.ml
@@ -22,9 +22,7 @@ module R = struct
 end
 
 let f M.(x) = x (* useless open *)
-
 let g N.(A | B) = () (* used open *)
-
 let h R.{ x } = R.{ x }
 
 open N (* used open *)
@@ -32,5 +30,4 @@ open N (* used open *)
 let i (A | B) = B
 
 open! M (* useless open! *)
-
 open M (* useless open *)
diff --git a/testsuite/tests/warnings/w45.ml b/testsuite/tests/warnings/w45.ml
index 3c99fbf7c..754bd5146 100644
--- a/testsuite/tests/warnings/w45.ml
+++ b/testsuite/tests/warnings/w45.ml
@@ -20,7 +20,6 @@ end
 
 module T3 = struct
   open T1 (* unused open *)
-
   open T2 (* shadow X, which is later used; but not A, see #6762 *)
 
   let _ = (A, X) (* X belongs to several types *)
diff --git a/testsuite/tests/warnings/w47_inline.ml b/testsuite/tests/warnings/w47_inline.ml
index 6cd07163a..f1a7c33c1 100644
--- a/testsuite/tests/warnings/w47_inline.ml
+++ b/testsuite/tests/warnings/w47_inline.ml
@@ -9,27 +9,16 @@
 *)
 
 let a = fun [@inline] x -> x (* accepted *)
-
 let b = fun [@inline never] x -> x (* accepted *)
-
 let c = fun [@inline always] x -> x (* accepted *)
-
 let d = fun [@inline malformed attribute] x -> x (* rejected *)
-
 let e = fun [@inline malformed_attribute] x -> x (* rejected *)
-
 let f = fun [@inline: malformed_attribute] x -> x (* rejected *)
-
 let g = fun [@inline? malformed_attribute] x -> x (* rejected *)
-
 let h x = (a [@inlined]) x (* accepted *)
-
 let i x = (a [@inlined never]) x (* accepted *)
-
 let j x = (a [@inlined always]) x (* accepted *)
-
 let k x = (a [@inlined malformed]) x (* rejected *)
-
 let l x = x [@@inline] (* accepted *)
 
 let test x =
diff --git a/testsuite/tests/warnings/w53.ml b/testsuite/tests/warnings/w53.ml
index 9e4d4abd5..7384b1df4 100644
--- a/testsuite/tests/warnings/w53.ml
+++ b/testsuite/tests/warnings/w53.ml
@@ -9,57 +9,33 @@
 *)
 
 let h x = (x [@inline]) (* rejected *)
-
 let h x = (x [@ocaml.inline]) (* rejected *)
-
 let i x = (x [@inlined]) (* rejected *)
-
 let j x = (x [@ocaml.inlined]) (* rejected *)
-
 let k x = (h [@inlined]) x (* accepted *)
-
 let k' x = (h [@ocaml.inlined]) x (* accepted *)
-
 let l x = (h x [@inlined]) (* rejected *)
-
 let m x = (x [@tailcall]) (* rejected *)
-
 let n x = (x [@ocaml.tailcall]) (* rejected *)
-
 let o x = (h [@tailcall]) x (* accepted *)
-
 let p x = (h [@ocaml.tailcall]) x (* accepted *)
-
 let q x = (h x [@tailcall]) (* rejected *)
 
 module type E = sig end
 
 module A (E : E) = struct end [@@inline] (* accepted *)
-
 module A' (E : E) = struct end [@@ocaml.inline] (* accepted *)
-
 module B = (functor [@inline] (E : E) -> struct end) (* accepted *)
-
 module B' = (functor [@ocaml.inline] (E : E) -> struct end) (* accepted *)
-
 module C = struct end [@@inline] (* rejected *)
-
 module C' = struct end [@@ocaml.inline] (* rejected *)
-
 module D = struct end [@@inlined] (* rejected *)
-
 module D' = struct end [@@ocaml.inlined] (* rejected *)
-
 module F = A [@inlined] () (* accepted *)
-
 module F' = A [@ocaml.inlined] () (* accepted *)
-
 module G = A [@inline] () (* rejected *)
-
 module G' = A [@ocaml.inline] () (* rejected *)
-
 module H = Set.Make [@inlined] (Int32) (* GPR#1808 *)
-
 module I = Set.Make [@inlined]
 module I' = Set.Make [@ocaml.inlined]
 module J = Set.Make [@@inlined]
diff --git a/testsuite/tests/warnings/w54.ml b/testsuite/tests/warnings/w54.ml
index f0a22c858..bc0827c5f 100644
--- a/testsuite/tests/warnings/w54.ml
+++ b/testsuite/tests/warnings/w54.ml
@@ -12,5 +12,4 @@ let f = fun [@inline] [@inline never] x -> x
 let g = fun [@inline] [@something_else] [@ocaml.inline] x -> x
 let h x = (g [@inlined] [@ocaml.inlined never]) x
 let v = (fun [@inline] [@inlined] x -> x) 1 (* accepted *)
-
 let i = fun [@inline] x -> x [@@inline]
diff --git a/tools/dumpobj.ml b/tools/dumpobj.ml
index aa2937299..f377cb230 100644
--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -50,13 +50,9 @@ let inputs ic =
 type global_table_entry = Empty | Global of Ident.t | Constant of Obj.t
 
 let start = ref 0 (* Position of beg. of code *)
-
 let reloc = ref ([] : (reloc_info * int) list) (* Relocation table *)
-
 let globals = ref ([||] : global_table_entry array) (* Global map *)
-
 let primitives = ref ([||] : string array) (* Table of primitives *)
-
 let objfile = ref false (* true if dumping a .cmo *)
 
 (* Events (indexed by PC) *)
diff --git a/tools/ocamlmklib.ml b/tools/ocamlmklib.ml
index 99fff7a25..c02119f62 100644
--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -33,42 +33,27 @@ let compiler_path name =
   if Sys.os_type = "Win32" then name else Filename.concat Config.bindir name
 
 let bytecode_objs = ref [] (* .cmo,.cma,.ml,.mli files to pass to ocamlc *)
-
 and native_objs = ref [] (* .cmx,.ml,.mli files to pass to ocamlopt *)
-
 and c_objs = ref []
 (* .o, .a, .obj, .lib, .dll, .dylib, .so files to
    pass to mksharedlib and ar *)
 
 and caml_libs = ref [] (* -cclib to pass to ocamlc, ocamlopt *)
-
 and caml_opts = ref [] (* -ccopt to pass to ocamlc, ocamlopt *)
-
 and dynlink = ref Config.supports_shared_libraries
 and failsafe = ref false (* whether to fall back on static build only *)
-
 and c_libs = ref [] (* libs to pass to mksharedlib and ocamlc -cclib *)
-
 and c_Lopts = ref [] (* options to pass to mksharedlib and ocamlc -cclib *)
-
 and c_opts = ref [] (* options to pass to mksharedlib and ocamlc -ccopt *)
-
 and ld_opts = ref [] (* options to pass only to the linker *)
-
 and ocamlc = ref (compiler_path "ocamlc")
 and ocamlc_opts = ref [] (* options to pass only to ocamlc *)
-
 and ocamlopt = ref (compiler_path "ocamlopt")
 and ocamlopt_opts = ref [] (* options to pass only to ocamlc *)
-
 and output = ref "a" (* Output name for OCaml part of library *)
-
 and output_c = ref "" (* Output name for C part of library *)
-
 and rpath = ref [] (* rpath options *)
-
 and debug = ref false (* -g option *)
-
 and verbose = ref false
 
 let starts_with s pref =
diff --git a/typing/ctype.ml b/typing/ctype.ml
index ea1a5b88f..6ac6a4eab 100644
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1711,7 +1711,6 @@ let rec occur_rec env allow_recursive visited ty0 ty =
         iter_type_expr (occur_rec env allow_recursive visited ty0) ty
 
 let type_changed = ref false (* trace possible changes to the studied type *)
-
 let merge r b = if b then r := true
 
 let occur env ty0 ty =
@@ -4354,7 +4353,6 @@ let match_class_declarations env patt_params patt_type subj_params subj_type =
    [level] number of expansions/enlargement allowed on this branch *)
 
 let warn = ref false (* whether double coercion might do better *)
-
 let pred_expand n = if n mod 2 = 0 && n > 0 then pred n else n
 let pred_enlarge n = if n mod 2 = 1 then pred n else n
 
diff --git a/typing/types.mli b/typing/types.mli
index f24719e88..1ad9bf9f5 100644
--- a/typing/types.mli
+++ b/typing/types.mli
@@ -402,13 +402,9 @@ module Variance : sig
   (* both negative and positive occurrences *)
 
   val null : t (* no occurrence *)
-
   val full : t (* strictly invariant (all flags) *)
-
   val covariant : t (* strictly covariant (May_pos, Pos and Inj) *)
-
   val unknown : t (* allow everything, guarantee nothing *)
-
   val union : t -> t -> t
   val inter : t -> t -> t
   val subset : t -> t -> bool
@@ -416,9 +412,7 @@ module Variance : sig
   val set : f -> bool -> t -> t
   val mem : f -> t -> bool
   val conjugate : t -> t (* exchange positive and negative *)
-
   val get_upper : t -> bool * bool (* may_pos, may_neg   *)
-
   val get_lower : t -> bool * bool * bool * bool (* pos, neg, inv, inj *)
 
   val unknown_signature : injective:bool -> arity:int -> t list
diff --git a/utils/clflags.ml b/utils/clflags.ml
index eaf749b52..96e295b91 100644
--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -44,207 +44,118 @@ module Float_arg_helper = Arg_helper.Make (struct
 end)
 
 let objfiles = ref ([] : string list) (* .cmo and .cma files *)
-
 and ccobjs = ref ([] : string list) (* .o, .a, .so and -cclib -lxxx *)
-
 and dllibs = ref ([] : string list)
 (* .so and -dllib -lxxx *)
 
 let compile_only = ref false (* -c *)
-
 and output_name = ref (None : string option) (* -o *)
-
 and include_dirs = ref ([] : string list) (* -I *)
-
 and no_std_include = ref false (* -nostdlib *)
-
 and print_types = ref false (* -i *)
-
 and make_archive = ref false (* -a *)
-
 and debug = ref false (* -g *)
-
 and debug_full = ref false (* For full DWARF support *)
-
 and unsafe = ref false (* -unsafe *)
-
 and use_linscan = ref false (* -linscan *)
-
 and link_everything = ref false (* -linkall *)
-
 and custom_runtime = ref false (* -custom *)
-
 and no_check_prims = ref false (* -no-check-prims *)
-
 and bytecode_compatible_32 = ref false (* -compat-32 *)
-
 and output_c_object = ref false (* -output-obj *)
-
 and output_complete_object = ref false (* -output-complete-obj *)
-
 and output_complete_executable = ref false (* -output-complete-exe *)
-
 and all_ccopts = ref ([] : string list) (* -ccopt *)
-
 and classic = ref false (* -nolabels *)
-
 and nopervasives = ref false (* -nopervasives *)
-
 and match_context_rows = ref 32 (* -match-context-rows *)
-
 and preprocessor = ref (None : string option) (* -pp *)
-
 and all_ppx = ref ([] : string list)
 (* -ppx *)
 
 let absname = ref false (* -absname *)
-
 let annotations = ref false (* -annot *)
 
 let binary_annotations = ref false (* -bin-annot *)
-
 and use_threads = ref false (* -thread *)
-
 and noassert = ref false (* -noassert *)
-
 and verbose = ref false (* -verbose *)
-
 and noversion = ref false (* -no-version *)
-
 and noprompt = ref false (* -noprompt *)
-
 and nopromptcont = ref false (* -nopromptcont *)
-
 and init_file = ref (None : string option) (* -init *)
-
 and noinit = ref false (* -noinit *)
-
 and open_modules = ref [] (* -open *)
-
 and use_prims = ref "" (* -use-prims ... *)
-
 and use_runtime = ref "" (* -use-runtime ... *)
-
 and plugin = ref false (* -plugin ... *)
-
 and principal = ref false (* -principal *)
-
 and real_paths = ref true (* -short-paths *)
-
 and recursive_types = ref false (* -rectypes *)
-
 and strict_sequence = ref false (* -strict-sequence *)
-
 and strict_formats = ref false (* -strict-formats *)
-
 and applicative_functors = ref true (* -no-app-funct *)
-
 and make_runtime = ref false (* -make-runtime *)
-
 and c_compiler = ref (None : string option) (* -cc *)
-
 and no_auto_link = ref false (* -noautolink *)
-
 and dllpaths = ref ([] : string list) (* -dllpath *)
-
 and make_package = ref false (* -pack *)
-
 and for_package = ref (None : string option) (* -for-pack *)
-
 and error_size = ref 500 (* -error-size *)
-
 and float_const_prop = ref true (* -no-float-const-prop *)
-
 and transparent_modules = ref false
 (* -trans-mod *)
 
 let unique_ids = ref true (* -d(no-)unique-ds *)
-
 let locations = ref true (* -d(no-)locations *)
-
 let dump_source = ref false (* -dsource *)
 
 let dump_parsetree = ref false (* -dparsetree *)
-
 and dump_typedtree = ref false (* -dtypedtree *)
-
 and dump_shape = ref false (* -dshape *)
-
 and dump_rawlambda = ref false (* -drawlambda *)
-
 and dump_lambda = ref false (* -dlambda *)
-
 and dump_rawclambda = ref false (* -drawclambda *)
-
 and dump_clambda = ref false (* -dclambda *)
-
 and dump_rawflambda = ref false (* -drawflambda *)
-
 and dump_flambda = ref false (* -dflambda *)
-
 and dump_flambda_let = ref (None : int option) (* -dflambda-let=... *)
-
 and dump_flambda_verbose = ref false (* -dflambda-verbose *)
-
 and dump_instr = ref false (* -dinstr *)
-
 and keep_camlprimc_file = ref false
 (* -dcamlprimc *)
 
 let keep_asm_file = ref false (* -S *)
 
 let optimize_for_speed = ref true (* -compact *)
-
 and opaque = ref false (* -opaque *)
-
 and dump_cmm = ref false
 (* -dcmm *)
 
 let dump_selection = ref false (* -dsel *)
-
 let dump_cse = ref false (* -dcse *)
-
 let dump_live = ref false (* -dlive *)
-
 let dump_spill = ref false (* -dspill *)
-
 let dump_split = ref false (* -dsplit *)
-
 let dump_interf = ref false (* -dinterf *)
-
 let dump_prefer = ref false (* -dprefer *)
-
 let dump_regalloc = ref false (* -dalloc *)
-
 let dump_reload = ref false (* -dreload *)
-
 let dump_scheduling = ref false (* -dscheduling *)
-
 let dump_linear = ref false (* -dlinear *)
-
 let dump_interval = ref false (* -dinterval *)
-
 let keep_startup_file = ref false (* -dstartup *)
-
 let dump_combine = ref false (* -dcombine *)
-
 let profile_columns : Profile.column list ref = ref [] (* -dprofile/-dtimings *)
-
 let native_code = ref false (* set to true under ocamlopt *)
-
 let force_tmc = ref false (* -force-tmc *)
-
 let force_slash = ref false (* for ocamldep *)
-
 let clambda_checks = ref false (* -clambda-checks *)
-
 let cmm_invariants = ref Config.with_cmm_invariants (* -dcmm-invariants *)
-
 let flambda_invariant_checks = ref Config.with_flambda_invariants
 (* -flambda-(no-)invariants *)
 
 let dont_write_files = ref false (* set to true under ocamldoc *)
-
 let insn_sched_default = true
 let insn_sched = ref insn_sched_default (* -[no-]insn-sched *)
 
@@ -256,7 +167,6 @@ let std_include_dir () =
   if !no_std_include then [] else [ Config.standard_library ]
 
 let shared = ref false (* -shared *)
-
 let dlcode = ref true (* not -nodynlink *)
 
 let pic_code =
@@ -275,7 +185,6 @@ let with_runtime = ref true
 (* -with-runtime *)
 
 let keep_docs = ref false (* -keep-docs *)
-
 let keep_locs = ref true (* -keep-locs *)
 
 let unsafe_string =
@@ -283,17 +192,11 @@ let unsafe_string =
 (* -safe-string / -unsafe-string *)
 
 let classic_inlining = ref false (* -Oclassic *)
-
 let inlining_report = ref false (* -inlining-report *)
-
 let afl_instrument = ref Config.afl_instrument (* -afl-instrument *)
-
 let afl_inst_ratio = ref 100 (* -afl-inst-ratio *)
-
 let function_sections = ref false (* -function-sections *)
-
 let simplify_rounds = ref None (* -rounds *)
-
 let default_simplify_rounds = ref 1 (* -rounds *)
 
 let rounds () =
@@ -336,10 +239,8 @@ let inline_lifting_benefit =
 let inline_max_unroll = ref (Int_arg_helper.default default_inline_max_unroll)
 let inline_max_depth = ref (Int_arg_helper.default default_inline_max_depth)
 let unbox_specialised_args = ref true (* -no-unbox-specialised-args *)
-
 let unbox_free_vars_of_closures = ref true
 let unbox_closures = ref false (* -unbox-closures *)
-
 let default_unbox_closures_factor = 10
 let unbox_closures_factor = ref default_unbox_closures_factor
 (* -unbox-closures-factor *)
@@ -478,7 +379,6 @@ let set_dumped_pass s enabled =
     dumped_passes_list := dumped_passes
 
 let dump_into_file = ref false (* -dump-into-file *)
-
 let dump_dir : string option ref = ref None (* -dump-dir *)
 
 type 'a env_reader = {
```

</details>

And the diff for the `janestreet` profile:

<details>

```diff
diff --git a/infer/src/topl/ToplAst.ml b/infer/src/topl/ToplAst.ml
index 3b606a25c..c964bc840 100644
--- a/infer/src/topl/ToplAst.ml
+++ b/infer/src/topl/ToplAst.ml
@@ -31,7 +31,6 @@ type predicate =
   | Value of (* bool *) value
 
 type condition = predicate list (* conjunction *)
-
 type assignment = register_name * variable_name
 
 (** a regular expression *)
diff --git a/asmcomp/arm64/proc.ml b/asmcomp/arm64/proc.ml
index a2b54ef4e..6bcdd6405 100644
--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -241,7 +241,6 @@ let not_supported _ofs = fatal_error "Proc.loc_results: cannot call"
    Return values in r0...r15 or d0...d15. *)
 
 let max_arguments_for_tailcalls = 16 (* in regs *) + 64 (* in domain state *)
-
 let last_int_register = if macosx then 7 else 15
 
 let loc_arguments arg =
diff --git a/boot/menhir/menhirLib.ml b/boot/menhir/menhirLib.ml
index d48b3f001..9a2f4ae73 100644
--- a/boot/menhir/menhirLib.ml
+++ b/boot/menhir/menhirLib.ml
@@ -2276,7 +2276,6 @@ module InfiniteArray = struct
     }
 
   let default_size = 16384 (* must be non-zero *)
-
   let make x = { default = x; table = Array.make default_size x; extent = 0 }
   let rec new_length length i = if i < length then length else new_length (2 * length) i
 
diff --git a/debugger/symbols.ml b/debugger/symbols.ml
index d38003292..09ab89331 100644
--- a/debugger/symbols.ml
+++ b/debugger/symbols.ml
@@ -18,7 +18,6 @@
 
 open Instruct
 open Debugger_config (* Toplevel *)
-
 open Program_loading
 open Debugcom
 open Events
diff --git a/lambda/translmod.ml b/lambda/translmod.ml
index b28306591..ded91041b 100644
--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1510,9 +1510,7 @@ let transl_store_implementation module_name (str, restr) =
 
 let toploop_ident = Ident.create_persistent "Toploop"
 let toploop_getvalue_pos = 0 (* position of getvalue in module Toploop *)
-
 let toploop_setvalue_pos = 1 (* position of setvalue in module Toploop *)
-
 let aliased_idents = ref Ident.empty
 
 let set_toplevel_unique_name id =
diff --git a/lambda/translobj.mli b/lambda/translobj.mli
index e642dadb1..7320d5091 100644
--- a/lambda/translobj.mli
+++ b/lambda/translobj.mli
@@ -22,7 +22,6 @@ val reset_labels : unit -> unit
 val transl_label_init : (unit -> lambda * 'a) -> lambda * 'a
 val transl_store_label_init : Ident.t -> int -> ('a -> lambda) -> 'a -> int * lambda
 val method_ids : Ident.Set.t ref (* reset when starting a new wrapper *)
-
 val oo_wrap : Env.t -> bool -> ('a -> lambda) -> 'a -> lambda
 val oo_add_class : Ident.t -> Env.t * bool
 val reset : unit -> unit
diff --git a/stdlib/camlinternalOO.ml b/stdlib/camlinternalOO.ml
index f018fffa7..70a8c7df4 100644
--- a/stdlib/camlinternalOO.ml
+++ b/stdlib/camlinternalOO.ml
@@ -57,7 +57,6 @@ type item =
   | DummyC of int
 
 let _ = [ DummyA; DummyB; DummyC 0 ] (* to avoid warnings *)
-
 let dummy_item = (magic () : item)
 
 (**** Types ****)
diff --git a/stdlib/obj.mli b/stdlib/obj.mli
index 7cc823ef0..e1cedb813 100644
--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -58,7 +58,6 @@ external set_field : t -> int -> t -> unit = "%obj_set_field"
 external compare_and_swap_field : t -> int -> t -> t -> bool = "caml_obj_compare_and_swap"
 external is_shared : t -> bool = "caml_obj_is_shared"
 val double_field : t -> int -> float [@@inline always] (* @since 3.11.2 *)
-
 val set_double_field : t -> int -> float -> unit [@@inline always]
 (* @since 3.11.2 *)
 
@@ -88,7 +87,6 @@ val forward_tag : int
 val no_scan_tag : int
 val abstract_tag : int
 val string_tag : int (* both [string] and [bytes] *)
-
 val double_tag : int
 val double_array_tag : int
 val custom_tag : int
diff --git a/testsuite/tests/asmcomp/is_static.ml b/testsuite/tests/asmcomp/is_static.ml
index 315070db7..3eee2bbcc 100644
--- a/testsuite/tests/asmcomp/is_static.ml
+++ b/testsuite/tests/asmcomp/is_static.ml
@@ -26,7 +26,6 @@ let () = (f [@inlined never]) ()
 
 (* Closed functions should be static *)
 let closed_function x = x + 1 (* + is a primitive, it cannot be in the closure*)
-
 let () = assert (is_in_static_data closed_function)
 
 (* And functions using closed functions *)
diff --git a/testsuite/tests/basic/patmatch.ml b/testsuite/tests/basic/patmatch.ml
index daf256991..db164462d 100644
--- a/testsuite/tests/basic/patmatch.ml
+++ b/testsuite/tests/basic/patmatch.ml
@@ -1688,7 +1688,6 @@ module GPR234HList = struct
 
   let sum l = fold_hlist { f = to_int_fold } 0 l
   let l = List [ 1; 2; 3 ] (* still fine to use normal list here *)
-
   let ll = [ Int 3; Pair (4, 5); StrInt "30"; l ]
   let test () = Printf.printf "%d\n" (sum ll)
 end
diff --git a/testsuite/tests/lib-dynlink-private/test.ml b/testsuite/tests/lib-dynlink-private/test.ml
index 7cd1c2e09..aef225431 100644
--- a/testsuite/tests/lib-dynlink-private/test.ml
+++ b/testsuite/tests/lib-dynlink-private/test.ml
@@ -168,7 +168,6 @@ all_modules = "sheep.cmx test.cmx"
 *)
 
 let () = Sheep.baa Sheep.s (* Use Sheep module *)
-
 let _ = fun (x : Pig.t) -> x (* Reference Pig module *)
 
 (* Test that a privately loaded module cannot have the same name as a
diff --git a/testsuite/tests/misc-unsafe/almabench.ml b/testsuite/tests/misc-unsafe/almabench.ml
index 50bb92ce2..3ba24f93e 100644
--- a/testsuite/tests/misc-unsafe/almabench.ml
+++ b/testsuite/tests/misc-unsafe/almabench.ml
@@ -45,7 +45,6 @@ and gaussk = 0.01720209895
 
 (* number of days to include in test *)
 let test_loops = 5 (* was: 20 *)
-
 and test_length = 36525
 
 (* sin and cos of j2000 mean obliquity (iau 1976) *)
diff --git a/testsuite/tests/no-alias-deps/aliases.ml b/testsuite/tests/no-alias-deps/aliases.ml
index ab01568b8..34702cb43 100644
--- a/testsuite/tests/no-alias-deps/aliases.ml
+++ b/testsuite/tests/no-alias-deps/aliases.ml
@@ -12,11 +12,8 @@ program = "aliases.cmo"
 *)
 
 module A' = A (* missing a.cmi *)
-
 module B' = B (* broken b.cmi *)
-
 module C' = C (* valid c.cmi *)
-
 module D' = D (* valid d.cmi *)
 
 let () = print_int D'.something
diff --git a/testsuite/tests/regression/pr9326/gc_set.ml b/testsuite/tests/regression/pr9326/gc_set.ml
index 80fc2a696..656d9e3c6 100644
--- a/testsuite/tests/regression/pr9326/gc_set.ml
+++ b/testsuite/tests/regression/pr9326/gc_set.ml
@@ -4,10 +4,8 @@
 open Gc
 
 let min_heap_sz = 524288 (* 512k *)
-
 let space_overhead = 70
 let stack_limit = 4194304 (* 4M *)
-
 let custom_major_ratio = 40
 let custom_minor_ratio = 99
 let custom_minor_max_size = 4096
diff --git a/testsuite/tests/typing-gadts/pr7214.ml b/testsuite/tests/typing-gadts/pr7214.ml
index ab059fe72..a7474e548 100644
--- a/testsuite/tests/typing-gadts/pr7214.ml
+++ b/testsuite/tests/typing-gadts/pr7214.ml
@@ -7,7 +7,6 @@ type _ t = I : int t
 let f (type a) (x : a t) =
   let module M = struct
     let (I : a t) = x (* fail because of toplevel let *)
-
     let x = (I : a t)
   end
   in
@@ -35,7 +34,6 @@ let bad (type a) =
       val e : (int, a) eq
     end = struct
       let (Refl : (int, a) eq) = M.e (* must fail for soundness *)
-
       let e : (int, a) eq = Refl
     end
   end
diff --git a/testsuite/tests/typing-misc/injectivity.ml b/testsuite/tests/typing-misc/injectivity.ml
index 33490a9d0..74d4aff76 100644
--- a/testsuite/tests/typing-misc/injectivity.ml
+++ b/testsuite/tests/typing-misc/injectivity.ml
@@ -46,7 +46,6 @@ module M : sig type +!'a t end
 |}]
 
 type _ t = M : 'a -> 'a M.t t (* OK *)
-
 type 'a u = 'b constraint 'a = 'b M.t
 
 [%%expect {|
diff --git a/testsuite/tests/typing-modules-bugs/pr6982_ok.ml b/testsuite/tests/typing-modules-bugs/pr6982_ok.ml
index 856ffeb74..f0278e14d 100644
--- a/testsuite/tests/typing-modules-bugs/pr6982_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6982_ok.ml
@@ -21,7 +21,6 @@ let _ = f (module A) (* ok *)
 module A_annotated_alias : S with type t = (module A.A_S) = A
 
 let _ = f (module A_annotated_alias) (* ok *)
-
 let _ = f (module A_annotated_alias : S with type t = (module A.A_S)) (* ok *)
 
 module A_alias = A
@@ -31,9 +30,6 @@ module A_alias_expanded = struct
 end
 
 let _ = f (module A_alias_expanded : S with type t = (module A.A_S)) (* ok *)
-
 let _ = f (module A_alias_expanded) (* ok *)
-
 let _ = f (module A_alias : S with type t = (module A.A_S)) (* doesn't type *)
-
 let _ = f (module A_alias) (* doesn't type either *)
diff --git a/testsuite/tests/typing-signatures/els.ml b/testsuite/tests/typing-signatures/els.ml
index a70101f2f..e7ded5f02 100644
--- a/testsuite/tests/typing-signatures/els.ml
+++ b/testsuite/tests/typing-signatures/els.ml
@@ -7,9 +7,7 @@
 
 module type VALUE = sig
   type value (* a Lua value *)
-
   type state (* the state of a Lua interpreter *)
-
   type usert (* a user-defined value *)
 end
 
diff --git a/testsuite/tests/warnings/w06.ml b/testsuite/tests/warnings/w06.ml
index dc4e6e6a6..4d62686f3 100644
--- a/testsuite/tests/warnings/w06.ml
+++ b/testsuite/tests/warnings/w06.ml
@@ -10,8 +10,6 @@ compile_only = "true"
 *)
 
 let foo ~bar = ignore bar (* one label *)
-
 let bar ~foo ~baz = ignore (foo, baz) (* two labels *)
-
 let () = foo 2
 let () = bar 4 2
diff --git a/testsuite/tests/warnings/w33.ml b/testsuite/tests/warnings/w33.ml
index 8fd254477..cea62d564 100644
--- a/testsuite/tests/warnings/w33.ml
+++ b/testsuite/tests/warnings/w33.ml
@@ -25,9 +25,7 @@ module R = struct
 end
 
 let f M.(x) = x (* useless open *)
-
 let g N.(A | B) = () (* used open *)
-
 let h R.{ x } = R.{ x }
 
 open N (* used open *)
@@ -35,5 +33,4 @@ open N (* used open *)
 let i (A | B) = B
 
 open! M (* useless open! *)
-
 open M (* useless open *)
diff --git a/testsuite/tests/warnings/w45.ml b/testsuite/tests/warnings/w45.ml
index 01a5b9f75..f80f62c0e 100644
--- a/testsuite/tests/warnings/w45.ml
+++ b/testsuite/tests/warnings/w45.ml
@@ -21,7 +21,6 @@ end
 
 module T3 = struct
   open T1 (* unused open *)
-
   open T2 (* shadow X, which is later used; but not A, see #6762 *)
 
   let _ = A, X (* X belongs to several types *)
diff --git a/testsuite/tests/warnings/w47_inline.ml b/testsuite/tests/warnings/w47_inline.ml
index dadcb8ab3..6409e9f9e 100644
--- a/testsuite/tests/warnings/w47_inline.ml
+++ b/testsuite/tests/warnings/w47_inline.ml
@@ -10,27 +10,16 @@ compile_only = "true"
 *)
 
 let a = fun [@inline] x -> x (* accepted *)
-
 let b = fun [@inline never] x -> x (* accepted *)
-
 let c = fun [@inline always] x -> x (* accepted *)
-
 let d = fun [@inline malformed attribute] x -> x (* rejected *)
-
 let e = fun [@inline malformed_attribute] x -> x (* rejected *)
-
 let f = fun [@inline: malformed_attribute] x -> x (* rejected *)
-
 let g = fun [@inline? malformed_attribute] x -> x (* rejected *)
-
 let h x = (a [@inlined]) x (* accepted *)
-
 let i x = (a [@inlined never]) x (* accepted *)
-
 let j x = (a [@inlined always]) x (* accepted *)
-
 let k x = (a [@inlined malformed]) x (* rejected *)
-
 let l x = x [@@inline] (* accepted *)
 
 let test x =
diff --git a/testsuite/tests/warnings/w53.ml b/testsuite/tests/warnings/w53.ml
index ffb5da173..50222f196 100644
--- a/testsuite/tests/warnings/w53.ml
+++ b/testsuite/tests/warnings/w53.ml
@@ -10,57 +10,33 @@ compile_only = "true"
 *)
 
 let h x = (x [@inline]) (* rejected *)
-
 let h x = (x [@ocaml.inline]) (* rejected *)
-
 let i x = (x [@inlined]) (* rejected *)
-
 let j x = (x [@ocaml.inlined]) (* rejected *)
-
 let k x = (h [@inlined]) x (* accepted *)
-
 let k' x = (h [@ocaml.inlined]) x (* accepted *)
-
 let l x = (h x [@inlined]) (* rejected *)
-
 let m x = (x [@tailcall]) (* rejected *)
-
 let n x = (x [@ocaml.tailcall]) (* rejected *)
-
 let o x = (h [@tailcall]) x (* accepted *)
-
 let p x = (h [@ocaml.tailcall]) x (* accepted *)
-
 let q x = (h x [@tailcall]) (* rejected *)
 
 module type E = sig end
 
 module A (E : E) = struct end [@@inline] (* accepted *)
-
 module A' (E : E) = struct end [@@ocaml.inline] (* accepted *)
-
 module B = (functor [@inline] (E : E) -> struct end) (* accepted *)
-
 module B' = (functor [@ocaml.inline] (E : E) -> struct end) (* accepted *)
-
 module C = struct end [@@inline] (* rejected *)
-
 module C' = struct end [@@ocaml.inline] (* rejected *)
-
 module D = struct end [@@inlined] (* rejected *)
-
 module D' = struct end [@@ocaml.inlined] (* rejected *)
-
 module F = A [@inlined] () (* accepted *)
-
 module F' = A [@ocaml.inlined] () (* accepted *)
-
 module G = A [@inline] () (* rejected *)
-
 module G' = A [@ocaml.inline] () (* rejected *)
-
 module H = Set.Make [@inlined] (Int32) (* GPR#1808 *)
-
 module I = Set.Make [@inlined]
 module I' = Set.Make [@ocaml.inlined]
 module J = Set.Make [@@inlined]
diff --git a/testsuite/tests/warnings/w54.ml b/testsuite/tests/warnings/w54.ml
index 0bb220fc3..32c26d747 100644
--- a/testsuite/tests/warnings/w54.ml
+++ b/testsuite/tests/warnings/w54.ml
@@ -13,5 +13,4 @@ let f = fun [@inline] [@inline never] x -> x
 let g = fun [@inline] [@something_else] [@ocaml.inline] x -> x
 let h x = (g [@inlined] [@ocaml.inlined never]) x
 let v = (fun [@inline] [@inlined] x -> x) 1 (* accepted *)
-
 let i = fun [@inline] x -> x [@@inline]
diff --git a/tools/dumpobj.ml b/tools/dumpobj.ml
index cb8712acf..993cc7d0d 100644
--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -55,13 +55,9 @@ type global_table_entry =
   | Constant of Obj.t
 
 let start = ref 0 (* Position of beg. of code *)
-
 let reloc = ref ([] : (reloc_info * int) list) (* Relocation table *)
-
 let globals = ref ([||] : global_table_entry array) (* Global map *)
-
 let primitives = ref ([||] : string array) (* Table of primitives *)
-
 let objfile = ref false (* true if dumping a .cmo *)
 
 (* Events (indexed by PC) *)
diff --git a/tools/ocamlmklib.ml b/tools/ocamlmklib.ml
index 26612b2b3..7b2d54ab4 100644
--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -33,42 +33,27 @@ let compiler_path name =
 ;;
 
 let bytecode_objs = ref [] (* .cmo,.cma,.ml,.mli files to pass to ocamlc *)
-
 and native_objs = ref [] (* .cmx,.ml,.mli files to pass to ocamlopt *)
-
 and c_objs = ref []
 (* .o, .a, .obj, .lib, .dll, .dylib, .so files to
                                pass to mksharedlib and ar *)
 
 and caml_libs = ref [] (* -cclib to pass to ocamlc, ocamlopt *)
-
 and caml_opts = ref [] (* -ccopt to pass to ocamlc, ocamlopt *)
-
 and dynlink = ref Config.supports_shared_libraries
 and failsafe = ref false (* whether to fall back on static build only *)
-
 and c_libs = ref [] (* libs to pass to mksharedlib and ocamlc -cclib *)
-
 and c_Lopts = ref [] (* options to pass to mksharedlib and ocamlc -cclib *)
-
 and c_opts = ref [] (* options to pass to mksharedlib and ocamlc -ccopt *)
-
 and ld_opts = ref [] (* options to pass only to the linker *)
-
 and ocamlc = ref (compiler_path "ocamlc")
 and ocamlc_opts = ref [] (* options to pass only to ocamlc *)
-
 and ocamlopt = ref (compiler_path "ocamlopt")
 and ocamlopt_opts = ref [] (* options to pass only to ocamlc *)
-
 and output = ref "a" (* Output name for OCaml part of library *)
-
 and output_c = ref "" (* Output name for C part of library *)
-
 and rpath = ref [] (* rpath options *)
-
 and debug = ref false (* -g option *)
-
 and verbose = ref false
 
 let starts_with s pref =
diff --git a/typing/ctype.ml b/typing/ctype.ml
index 2e66983fc..274ec80d9 100644
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1878,7 +1878,6 @@ let rec occur_rec env allow_recursive visited ty0 ty =
 ;;
 
 let type_changed = ref false (* trace possible changes to the studied type *)
-
 let merge r b = if b then r := true
 
 let occur env ty0 ty =
@@ -4675,7 +4674,6 @@ let match_class_declarations env patt_params patt_type subj_params subj_type =
    [level] number of expansions/enlargement allowed on this branch *)
 
 let warn = ref false (* whether double coercion might do better *)
-
 let pred_expand n = if n mod 2 = 0 && n > 0 then pred n else n
 let pred_enlarge n = if n mod 2 = 1 then pred n else n
 
diff --git a/typing/types.mli b/typing/types.mli
index 7b12a87d2..bbdb27137 100644
--- a/typing/types.mli
+++ b/typing/types.mli
@@ -404,13 +404,9 @@ module Variance : sig
   (* both negative and positive occurrences *)
 
   val null : t (* no occurrence *)
-
   val full : t (* strictly invariant (all flags) *)
-
   val covariant : t (* strictly covariant (May_pos, Pos and Inj) *)
-
   val unknown : t (* allow everything, guarantee nothing *)
-
   val union : t -> t -> t
   val inter : t -> t -> t
   val subset : t -> t -> bool
@@ -418,9 +414,7 @@ module Variance : sig
   val set : f -> bool -> t -> t
   val mem : f -> t -> bool
   val conjugate : t -> t (* exchange positive and negative *)
-
   val get_upper : t -> bool * bool (* may_pos, may_neg   *)
-
   val get_lower : t -> bool * bool * bool * bool (* pos, neg, inv, inj *)
 
   (** The most pessimistic variance for a completely unknown type. *)
diff --git a/utils/clflags.ml b/utils/clflags.ml
index 06144ab72..399f5b781 100644
--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -44,207 +44,118 @@ module Float_arg_helper = Arg_helper.Make (struct
 end)
 
 let objfiles = ref ([] : string list) (* .cmo and .cma files *)
-
 and ccobjs = ref ([] : string list) (* .o, .a, .so and -cclib -lxxx *)
-
 and dllibs = ref ([] : string list)
 (* .so and -dllib -lxxx *)
 
 let compile_only = ref false (* -c *)
-
 and output_name = ref (None : string option) (* -o *)
-
 and include_dirs = ref ([] : string list) (* -I *)
-
 and no_std_include = ref false (* -nostdlib *)
-
 and print_types = ref false (* -i *)
-
 and make_archive = ref false (* -a *)
-
 and debug = ref false (* -g *)
-
 and debug_full = ref false (* For full DWARF support *)
-
 and unsafe = ref false (* -unsafe *)
-
 and use_linscan = ref false (* -linscan *)
-
 and link_everything = ref false (* -linkall *)
-
 and custom_runtime = ref false (* -custom *)
-
 and no_check_prims = ref false (* -no-check-prims *)
-
 and bytecode_compatible_32 = ref false (* -compat-32 *)
-
 and output_c_object = ref false (* -output-obj *)
-
 and output_complete_object = ref false (* -output-complete-obj *)
-
 and output_complete_executable = ref false (* -output-complete-exe *)
-
 and all_ccopts = ref ([] : string list) (* -ccopt *)
-
 and classic = ref false (* -nolabels *)
-
 and nopervasives = ref false (* -nopervasives *)
-
 and match_context_rows = ref 32 (* -match-context-rows *)
-
 and preprocessor = ref (None : string option) (* -pp *)
-
 and all_ppx = ref ([] : string list)
 (* -ppx *)
 
 let absname = ref false (* -absname *)
-
 let annotations = ref false (* -annot *)
 
 let binary_annotations = ref false (* -bin-annot *)
-
 and use_threads = ref false (* -thread *)
-
 and noassert = ref false (* -noassert *)
-
 and verbose = ref false (* -verbose *)
-
 and noversion = ref false (* -no-version *)
-
 and noprompt = ref false (* -noprompt *)
-
 and nopromptcont = ref false (* -nopromptcont *)
-
 and init_file = ref (None : string option) (* -init *)
-
 and noinit = ref false (* -noinit *)
-
 and open_modules = ref [] (* -open *)
-
 and use_prims = ref "" (* -use-prims ... *)
-
 and use_runtime = ref "" (* -use-runtime ... *)
-
 and plugin = ref false (* -plugin ... *)
-
 and principal = ref false (* -principal *)
-
 and real_paths = ref true (* -short-paths *)
-
 and recursive_types = ref false (* -rectypes *)
-
 and strict_sequence = ref false (* -strict-sequence *)
-
 and strict_formats = ref false (* -strict-formats *)
-
 and applicative_functors = ref true (* -no-app-funct *)
-
 and make_runtime = ref false (* -make-runtime *)
-
 and c_compiler = ref (None : string option) (* -cc *)
-
 and no_auto_link = ref false (* -noautolink *)
-
 and dllpaths = ref ([] : string list) (* -dllpath *)
-
 and make_package = ref false (* -pack *)
-
 and for_package = ref (None : string option) (* -for-pack *)
-
 and error_size = ref 500 (* -error-size *)
-
 and float_const_prop = ref true (* -no-float-const-prop *)
-
 and transparent_modules = ref false
 (* -trans-mod *)
 
 let unique_ids = ref true (* -d(no-)unique-ds *)
-
 let locations = ref true (* -d(no-)locations *)
-
 let dump_source = ref false (* -dsource *)
 
 let dump_parsetree = ref false (* -dparsetree *)
-
 and dump_typedtree = ref false (* -dtypedtree *)
-
 and dump_shape = ref false (* -dshape *)
-
 and dump_rawlambda = ref false (* -drawlambda *)
-
 and dump_lambda = ref false (* -dlambda *)
-
 and dump_rawclambda = ref false (* -drawclambda *)
-
 and dump_clambda = ref false (* -dclambda *)
-
 and dump_rawflambda = ref false (* -drawflambda *)
-
 and dump_flambda = ref false (* -dflambda *)
-
 and dump_flambda_let = ref (None : int option) (* -dflambda-let=... *)
-
 and dump_flambda_verbose = ref false (* -dflambda-verbose *)
-
 and dump_instr = ref false (* -dinstr *)
-
 and keep_camlprimc_file = ref false
 (* -dcamlprimc *)
 
 let keep_asm_file = ref false (* -S *)
 
 let optimize_for_speed = ref true (* -compact *)
-
 and opaque = ref false (* -opaque *)
-
 and dump_cmm = ref false
 (* -dcmm *)
 
 let dump_selection = ref false (* -dsel *)
-
 let dump_cse = ref false (* -dcse *)
-
 let dump_live = ref false (* -dlive *)
-
 let dump_spill = ref false (* -dspill *)
-
 let dump_split = ref false (* -dsplit *)
-
 let dump_interf = ref false (* -dinterf *)
-
 let dump_prefer = ref false (* -dprefer *)
-
 let dump_regalloc = ref false (* -dalloc *)
-
 let dump_reload = ref false (* -dreload *)
-
 let dump_scheduling = ref false (* -dscheduling *)
-
 let dump_linear = ref false (* -dlinear *)
-
 let dump_interval = ref false (* -dinterval *)
-
 let keep_startup_file = ref false (* -dstartup *)
-
 let dump_combine = ref false (* -dcombine *)
-
 let profile_columns : Profile.column list ref = ref [] (* -dprofile/-dtimings *)
-
 let native_code = ref false (* set to true under ocamlopt *)
-
 let force_tmc = ref false (* -force-tmc *)
-
 let force_slash = ref false (* for ocamldep *)
-
 let clambda_checks = ref false (* -clambda-checks *)
-
 let cmm_invariants = ref Config.with_cmm_invariants (* -dcmm-invariants *)
-
 let flambda_invariant_checks = ref Config.with_flambda_invariants
 (* -flambda-(no-)invariants *)
 
 let dont_write_files = ref false (* set to true under ocamldoc *)
-
 let insn_sched_default = true
 let insn_sched = ref insn_sched_default (* -[no-]insn-sched *)
 
@@ -254,7 +165,6 @@ let std_include_flag prefix =
 
 let std_include_dir () = if !no_std_include then [] else [ Config.standard_library ]
 let shared = ref false (* -shared *)
-
 let dlcode = ref true (* not -nodynlink *)
 
 let pic_code =
@@ -278,7 +188,6 @@ let with_runtime = ref true
 (* -with-runtime *)
 
 let keep_docs = ref false (* -keep-docs *)
-
 let keep_locs = ref true (* -keep-locs *)
 
 let unsafe_string =
@@ -288,17 +197,11 @@ let unsafe_string =
 (* -safe-string / -unsafe-string *)
 
 let classic_inlining = ref false (* -Oclassic *)
-
 let inlining_report = ref false (* -inlining-report *)
-
 let afl_instrument = ref Config.afl_instrument (* -afl-instrument *)
-
 let afl_inst_ratio = ref 100 (* -afl-inst-ratio *)
-
 let function_sections = ref false (* -function-sections *)
-
 let simplify_rounds = ref None (* -rounds *)
-
 let default_simplify_rounds = ref 1 (* -rounds *)
 
 let rounds () =
@@ -339,13 +242,10 @@ let inline_lifting_benefit = ref (Int_arg_helper.default default_inline_lifting_
 let inline_max_unroll = ref (Int_arg_helper.default default_inline_max_unroll)
 let inline_max_depth = ref (Int_arg_helper.default default_inline_max_depth)
 let unbox_specialised_args = ref true (* -no-unbox-specialised-args *)
-
 let unbox_free_vars_of_closures = ref true
 let unbox_closures = ref false (* -unbox-closures *)
-
 let default_unbox_closures_factor = 10
 let unbox_closures_factor = ref default_unbox_closures_factor (* -unbox-closures-factor *)
-
 let remove_unused_arguments = ref false (* -remove-unused-arguments *)
 
 type inlining_arguments =
@@ -491,7 +391,6 @@ let set_dumped_pass s enabled =
 ;;
 
 let dump_into_file = ref false (* -dump-into-file *)
-
 let dump_dir : string option ref = ref None (* -dump-dir *)
 
 type 'a env_reader =
```

</details>