### PR TITLE
tests: Add a project root (.ocamlformat) to cli tests

### DIFF
--- a/test/cli/bad_kind.t
+++ b/test/cli/bad_kind.t
@@ -1,3 +1,5 @@
+  $ touch .ocamlformat
+
   $ echo 'module X : S' > a.mli
 
   $ ocamlformat --impl a.mli

--- a/test/cli/check.t
+++ b/test/cli/check.t
@@ -1,3 +1,5 @@
+  $ touch .ocamlformat
+
   $ echo 'let x = 1' > a.ml
   $ ocamlformat --check a.ml
 

--- a/test/cli/debug.t
+++ b/test/cli/debug.t
@@ -1,3 +1,5 @@
+  $ touch .ocamlformat
+
   $ cat > a.ml << EOF
   > (* Intentionally not formatted *)
   > let () =

--- a/test/cli/deprecated_option.t
+++ b/test/cli/deprecated_option.t
@@ -1,3 +1,5 @@
+  $ touch .ocamlformat
+
   $ echo 'let x = y' > a.ml
 
 Setting a deprecated option or a deprecated option value on the command line should display a warning message:

--- a/test/cli/large_string.t
+++ b/test/cli/large_string.t
@@ -1,3 +1,5 @@
+  $ touch .ocamlformat
+
   $ echo "let _ = \"$(printf '%*s' 300000 | sed 's/ /_ _/g')\"" > a.ml
 
   $ ocamlformat --impl a.ml -o /dev/null

--- a/test/cli/max_iters.t
+++ b/test/cli/max_iters.t
@@ -1,3 +1,5 @@
+  $ touch .ocamlformat
+
   $ echo 'let x = 1' > a.ml
   $ ocamlformat --max-iters=1 a.ml
   let x = 1

--- a/test/cli/name.t
+++ b/test/cli/name.t
@@ -1,3 +1,5 @@
+  $ touch .ocamlformat
+
   $ echo 'let x =     1' > a.ml
   $ ocamlformat --name a.cpp a.ml
   let x = 1

--- a/test/cli/stdin.t
+++ b/test/cli/stdin.t
@@ -1,3 +1,5 @@
+  $ touch .ocamlformat
+
 One of '--impl', '--intf' or '--name' is required when the input is read from stdin:
 
   $ ocamlformat -


### PR DESCRIPTION
Using the `main` branch of dune would produce results like:

```diff
-  ocamlformat: ignoring "a.mli" (syntax error)
-  File "a.mli", line 2, characters 0-0:
-  Error: Syntax error
-  [1]
+  File a.mli
+  Warning: Ocamlformat disabled because [--enable-outside-detected-project] is not set and no [.ocamlformat] was found within the project (root: ../../../../../.sandbox)
+  module X : S
```