### PR TITLE
tests: Setting the ocaml-version after it has been overriden by a profile

### DIFF
--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -113,7 +113,7 @@
  (action
   (with-stdout-to args_grouped-conventional.ml.stdout
    (with-stderr-to args_grouped-conventional.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --profile=conventional --margin=30 %{dep:tests/args_grouped.ml})))))
+     (run %{bin:ocamlformat} --margin-check --profile=conventional --margin=30 --ocaml-version=4.13.0 %{dep:tests/args_grouped.ml})))))
 
 (rule
  (alias runtest)
@@ -131,7 +131,7 @@
  (action
   (with-stdout-to args_grouped.ml.stdout
    (with-stderr-to args_grouped.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --profile=ocamlformat --margin=100 %{dep:tests/args_grouped.ml})))))
+     (run %{bin:ocamlformat} --margin-check --profile=ocamlformat --margin=100 --ocaml-version=4.13.0 %{dep:tests/args_grouped.ml})))))
 
 (rule
  (alias runtest)
@@ -2888,7 +2888,7 @@
  (action
   (with-stdout-to js_sig.mli.stdout
    (with-stderr-to js_sig.mli.stderr
-     (run %{bin:ocamlformat} --margin-check --profile=janestreet %{dep:tests/js_sig.mli})))))
+     (run %{bin:ocamlformat} --margin-check --profile=janestreet --ocaml-version=4.13.0 %{dep:tests/js_sig.mli})))))
 
 (rule
  (alias runtest)
@@ -2906,7 +2906,7 @@
  (action
   (with-stdout-to js_source.ml.stdout
    (with-stderr-to js_source.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --max-iters=3 --profile=janestreet %{dep:tests/js_source.ml})))))
+     (run %{bin:ocamlformat} --margin-check --max-iters=3 --profile=janestreet --ocaml-version=4.13.0 %{dep:tests/js_source.ml})))))
 
 (rule
  (alias runtest)
@@ -4036,7 +4036,7 @@
  (action
   (with-stdout-to polytypes-default.ml.stdout
    (with-stderr-to polytypes-default.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --profile=default %{dep:tests/polytypes.ml})))))
+     (run %{bin:ocamlformat} --margin-check --profile=default --ocaml-version=4.13.0 %{dep:tests/polytypes.ml})))))
 
 (rule
  (alias runtest)
@@ -4054,7 +4054,7 @@
  (action
   (with-stdout-to polytypes-janestreet.ml.stdout
    (with-stderr-to polytypes-janestreet.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --profile=janestreet %{dep:tests/polytypes.ml})))))
+     (run %{bin:ocamlformat} --margin-check --profile=janestreet --ocaml-version=4.13.0 %{dep:tests/polytypes.ml})))))
 
 (rule
  (alias runtest)
@@ -4165,7 +4165,7 @@
  (action
   (with-stdout-to profiles.ml.stdout
    (with-stderr-to profiles.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --config=margin=20 --profile=janestreet --module-item-spacing=sparse %{dep:tests/profiles.ml})))))
+     (run %{bin:ocamlformat} --margin-check --config=margin=20 --profile=janestreet --module-item-spacing=sparse --ocaml-version=4.13.0 %{dep:tests/profiles.ml})))))
 
 (rule
  (alias runtest)
@@ -4183,7 +4183,7 @@
  (action
   (with-stdout-to profiles2.ml.stdout
    (with-stderr-to profiles2.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --profile=janestreet %{dep:tests/profiles2.ml})))))
+     (run %{bin:ocamlformat} --margin-check --profile=janestreet --ocaml-version=4.13.0 %{dep:tests/profiles2.ml})))))
 
 (rule
  (alias runtest)
@@ -5014,7 +5014,7 @@
  (action
   (with-stdout-to wrap_comments.ml.stdout
    (with-stderr-to wrap_comments.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --profile=ocamlformat %{dep:tests/wrap_comments.ml})))))
+     (run %{bin:ocamlformat} --margin-check --profile=ocamlformat --ocaml-version=4.13.0 %{dep:tests/wrap_comments.ml})))))
 
 (rule
  (alias runtest)

--- a/test/passing/tests/args_grouped-conventional.ml.opts
+++ b/test/passing/tests/args_grouped-conventional.ml.opts
@@ -1,2 +1,3 @@
 --profile=conventional
 --margin=30
+--ocaml-version=4.13.0

--- a/test/passing/tests/args_grouped.ml.opts
+++ b/test/passing/tests/args_grouped.ml.opts
@@ -1,2 +1,3 @@
 --profile=ocamlformat
 --margin=100
+--ocaml-version=4.13.0

--- a/test/passing/tests/js_sig.mli.opts
+++ b/test/passing/tests/js_sig.mli.opts
@@ -1,1 +1,2 @@
 --profile=janestreet
+--ocaml-version=4.13.0

--- a/test/passing/tests/js_source.ml.opts
+++ b/test/passing/tests/js_source.ml.opts
@@ -1,2 +1,3 @@
 --max-iters=3
 --profile=janestreet
+--ocaml-version=4.13.0

--- a/test/passing/tests/polytypes-default.ml.opts
+++ b/test/passing/tests/polytypes-default.ml.opts
@@ -1,1 +1,2 @@
 --profile=default
+--ocaml-version=4.13.0

--- a/test/passing/tests/polytypes-janestreet.ml.opts
+++ b/test/passing/tests/polytypes-janestreet.ml.opts
@@ -1,1 +1,2 @@
 --profile=janestreet
+--ocaml-version=4.13.0

--- a/test/passing/tests/profiles.ml.opts
+++ b/test/passing/tests/profiles.ml.opts
@@ -1,3 +1,4 @@
 --config=margin=20
 --profile=janestreet
 --module-item-spacing=sparse
+--ocaml-version=4.13.0

--- a/test/passing/tests/profiles2.ml.opts
+++ b/test/passing/tests/profiles2.ml.opts
@@ -1,1 +1,2 @@
 --profile=janestreet
+--ocaml-version=4.13.0

--- a/test/passing/tests/wrap_comments.ml.opts
+++ b/test/passing/tests/wrap_comments.ml.opts
@@ -1,1 +1,2 @@
 --profile=ocamlformat
+--ocaml-version=4.13.0


### PR DESCRIPTION
Fix #1991 (@kit-ty-kate can you confirm?)

@Julow We could also move `ocaml-version` from `Conf.t` to `Conf.opts` but that means rewriting all the functions updating the config (this would also allow to set `debug` and `margin-check` in .ocamlformat files), but that's a much bigger change. But I think eventualy we should do that.
And also move `comment-check`, `max-iters` and `quiet` out of `Conf.t` in the same way.