### PR TITLE
Remove incorrect parentheses around polymorphic type constraint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@
 
   + Do not override the values of the following non-formatting options when a profile is set: `comment-check`, `disable`, `max-iters`, `ocaml-version`, and `quiet` (#1995, @gpetiot).
 
+  + Remove incorrect parentheses around polymorphic type constraint (#<PR_NUMBER>, @gpetiot)
+
 #### Changes
 
   + More expressions are considered "simple" (not inducing a break e.g. as an argument of an application):

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1984,10 +1984,7 @@ end = struct
         | Ppat_variant (_, Some _)
         | Ppat_or _ | Ppat_alias _ ) ) ->
         true
-    | ( ( Exp {pexp_desc= Pexp_let _ | Pexp_letop _; _}
-        | Str {pstr_desc= Pstr_value _; _} )
-      , Ppat_constraint (_, {ptyp_desc= Ptyp_poly _; _}) ) ->
-        false
+    | _, Ppat_constraint (_, {ptyp_desc= Ptyp_poly _; _}) -> false
     | ( ( Exp {pexp_desc= Pexp_let _ | Pexp_letop _; _}
         | Str {pstr_desc= Pstr_value _; _} )
       , Ppat_constraint ({ppat_desc= Ppat_any; _}, _) ) ->

--- a/test/passing/tests/polytypes-default.ml.ref
+++ b/test/passing/tests/polytypes-default.ml.ref
@@ -25,3 +25,11 @@ let t4 :
 let foo : type a. a =
   (* aaaaaa *)
   failwith "foo"
+
+class c =
+  let id : 'a. 'a -> 'a = fun x -> x in
+  object end
+
+let _ =
+  let id : 'a. 'a -> 'a = fun x -> x in
+  ()

--- a/test/passing/tests/polytypes-janestreet.ml.ref
+++ b/test/passing/tests/polytypes-janestreet.ml.ref
@@ -29,3 +29,12 @@ let foo : type a. a =
   (* aaaaaa *)
   failwith "foo"
 ;;
+
+class c =
+  let id : 'a. 'a -> 'a = fun x -> x in
+  object end
+
+let _ =
+  let id : 'a. 'a -> 'a = fun x -> x in
+  ()
+;;

--- a/test/passing/tests/polytypes.ml
+++ b/test/passing/tests/polytypes.ml
@@ -25,3 +25,11 @@ let t4 :
 let foo : type a. a =
   (* aaaaaa *)
   failwith "foo"
+
+class c =
+  let id : 'a. 'a -> 'a = fun x -> x in
+  object end
+
+let _ =
+  let id : 'a. 'a -> 'a = fun x -> x in
+  ()


### PR DESCRIPTION
Fix #2000, was broken by #1734.
It looks like this change is correct for any context, I didn't find any issue. No change with test_branch.sh.