### PR TITLE
emacs: Remove temp files in the event of an error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 #### Bug fixes
 
+  + emacs: Remove temp files in the event of an error (#2003, @gpetiot)
+
 #### Changes
 
   + Qtest comments are not re-formatted (#2034, @gpetiot)

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -290,10 +290,10 @@ is nil."
                     (erase-buffer))
                   (ocamlformat--process-errors
                    (buffer-file-name) bufferfile errorfile errbuf)))
-            (message "Could not apply ocamlformat on %s" buffer-file-name))))
-    (delete-file errorfile)
-    (delete-file bufferfile)
-    (delete-file outputfile)))
+            (message "Could not apply ocamlformat on %s" buffer-file-name)))
+      (delete-file errorfile)
+      (delete-file bufferfile)
+      (delete-file outputfile))))
 
 (defun ocamlformat-args (name start-line end-line)
   (let*
@@ -356,13 +356,14 @@ is nil."
                      (buffer-file-name) bufferfile errorfile errbuf)))
                 (message "Could not apply ocamlformat")))))
        (indents (mapcar 'string-to-number (split-string indents-str))))
-    (save-excursion
-      (goto-char start)
-      (mapcar
-       #'(lambda (indent) (indent-line-to indent) (forward-line))
-       indents))
-    (delete-file errorfile)
-    (delete-file bufferfile)))
+    (unwind-protect
+      (save-excursion
+        (goto-char start)
+        (mapcar
+         #'(lambda (indent) (indent-line-to indent) (forward-line))
+         indents))
+      (delete-file errorfile)
+      (delete-file bufferfile))))
 
 (defun ocamlformat-line ()
   (interactive nil)


### PR DESCRIPTION
@mattiasdrp do you still experience the bug with this patch? I still can't reproduce the error with emacs 27.2 so I need someone to try this.

But based on `unwind-protect`'s documentation (https://www.gnu.org/software/emacs/manual/html_node/elisp/Cleanups.html) it should do the job.