### PR TITLE
test_branch.sh: Include janestreet and community projects to the list

### DIFF
--- a/test-extra/Makefile
+++ b/test-extra/Makefile
@@ -9,10 +9,12 @@
 #                                                                    #
 ######################################################################
 
+JS_DIRS=code/base code/base_bigstring code/base_quickcheck code/core code/core_bench code/core_compat code/core_extended code/core_kernel code/core_profiler code/core_unix
+
 # To test all source files below a directory
 #       make DIRS=<directory> test
 # By default, test projects used as regression tests
-DIRS=code/ocamlformat code/infer code/js_of_ocaml code/dune
+DIRS=code/ocamlformat code/infer code/js_of_ocaml code/dune $(JS_DIRS)
 
 # Extra test directories, for which looser checking is done
 XDIRS=code/ocaml
@@ -52,6 +54,18 @@ code/dune: URI = https://github.com/ocaml/dune.git
 # code/mirage: URI = https://github.com/mirage/mirage
 # code/alcotest: URI = https://github.com/mirage/alcotest
 # code/citty: URI = https://github.com/ocurrent/citty
+
+code/base: URI = https://github.com/janestreet/base.git
+code/base_bigstring: URI = https://github.com/janestreet/base_bigstring.git
+code/base_quickcheck: URI = https://github.com/janestreet/base_quickcheck.git
+
+code/core: URI = https://github.com/janestreet/core.git
+code/core_bench: URI = https://github.com/janestreet/core_bench.git
+code/core_compat: URI = https://github.com/janestreet/core_compat.git
+code/core_extended: URI = https://github.com/janestreet/core_extended.git
+code/core_kernel: URI = https://github.com/janestreet/core_kernel.git
+code/core_profiler: URI = https://github.com/janestreet/core_profiler.git
+code/core_unix: URI = https://github.com/janestreet/core_unix.git
 
 .PHONY: test_setup
 test_setup: $(ALL_DIRS)

--- a/test-extra/Makefile
+++ b/test-extra/Makefile
@@ -14,7 +14,7 @@ JS_DIRS=code/base code/base_bigstring code/base_quickcheck code/core code/core_b
 # To test all source files below a directory
 #       make DIRS=<directory> test
 # By default, test projects used as regression tests
-DIRS=code/ocamlformat code/infer code/js_of_ocaml code/dune $(JS_DIRS)
+DIRS=code/ocamlformat code/infer code/js_of_ocaml code/dune code/owl code/irmin code/index code/dune-release code/mirage $(JS_DIRS)
 
 # Extra test directories, for which looser checking is done
 XDIRS=code/ocaml
@@ -41,19 +41,11 @@ code/infer: URI = https://github.com/facebook/infer.git
 code/js_of_ocaml: URI = https://github.com/ocsigen/js_of_ocaml.git
 code/ocaml: URI = https://github.com/ocaml/ocaml.git
 code/dune: URI = https://github.com/ocaml/dune.git
-
-# DIRS += code/owl code/irmin code/index code/duniverse code/dune-release \
-# 	code/coq code/mirage code/alcotest code/citty
-# PRUNE_DIRS += code/duniverse/duniverse code/duniverse/examples
-# code/owl: URI = https://github.com/owlbarn/owl
-# code/irmin: URI = https://github.com/mirage/irmin
-# code/index: URI = https://github.com/mirage/index
-# code/duniverse: URI = https://github.com/ocamllabs/duniverse
-# code/dune-release: URI = https://github.com/ocamllabs/dune-release
-# code/coq: URI = https://github.com/coq/coq
-# code/mirage: URI = https://github.com/mirage/mirage
-# code/alcotest: URI = https://github.com/mirage/alcotest
-# code/citty: URI = https://github.com/ocurrent/citty
+code/irmin: URI = https://github.com/mirage/irmin
+code/index: URI = https://github.com/mirage/index
+code/mirage: URI = https://github.com/mirage/mirage
+code/dune-release: URI = https://github.com/ocamllabs/dune-release
+code/owl: URI = https://github.com/owlbarn/owl
 
 code/base: URI = https://github.com/janestreet/base.git
 code/base_bigstring: URI = https://github.com/janestreet/base_bigstring.git

--- a/test-extra/Makefile
+++ b/test-extra/Makefile
@@ -47,6 +47,8 @@ code/mirage: URI = https://github.com/mirage/mirage
 code/dune-release: URI = https://github.com/ocamllabs/dune-release
 code/owl: URI = https://github.com/owlbarn/owl
 
+PRUNE_DIRS += code/mirage/test code/owl/examples
+
 code/base: URI = https://github.com/janestreet/base.git
 code/base_bigstring: URI = https://github.com/janestreet/base_bigstring.git
 code/base_quickcheck: URI = https://github.com/janestreet/base_quickcheck.git


### PR DESCRIPTION
The goal is to add all the projects from https://github.com/janestreet/opam-repository/tree/master/packages to the list curated for test_branch.sh, but I would like to generate it automatically since it's kinda big.
The `grep+sed` commands are doing what they're supposed to do, the whole script is not working yet (WIP), should work but doesn't (as usual).

@Julow let's replace this Makefile by some OCaml codesome day? we're the only ones running this script anyway!