### PR TITLE
Format .mld files as odoc documentation files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 ### New features
 
 - Add a `break-colon` option to decide whether to break before or after the `:` symbol in value binding declarations and type constraints. This behavior is no longer ensured by `ocp-indent-compat`. (#2149, @gpetiot)
+- Format `.mld` files as odoc documentation files (#2008, @gpetiot)
 
 ## 0.24.1 (2022-07-18)
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1311,8 +1311,11 @@ let kind : Syntax.t option ref =
   let repl_file =
     (Some Syntax.Repl_file, Arg.info ["repl-file"] ~doc ~docs)
   in
+  let doc = "Parse input as an odoc documentation." in
+  let doc_file = (Some Syntax.Documentation, Arg.info ["doc"] ~doc ~docs) in
   let default = None in
-  mk ~default Arg.(value & vflag default [impl; intf; use_file; repl_file])
+  mk ~default
+    Arg.(value & vflag default [impl; intf; use_file; repl_file; doc_file])
 
 let name =
   let docv = "NAME" in
@@ -1904,6 +1907,7 @@ let kind_of_ext fname =
   match Filename.extension fname with
   | ".ml" | ".mlt" | ".eliom" -> Some Syntax.Use_file
   | ".mli" | ".eliomi" -> Some Syntax.Signature
+  | ".mld" -> Some Syntax.Documentation
   | _ -> None
 
 let validate_inputs () =

--- a/lib/Docstring.ml
+++ b/lib/Docstring.ml
@@ -20,6 +20,9 @@ let parse ~loc text =
   | [] -> Ok (Odoc_parser.ast v)
   | warnings -> Error warnings
 
+let parse_file location text =
+  Odoc_parser.ast (Odoc_parser.parse_comment ~location ~text)
+
 let warn fmt warning =
   Format.fprintf fmt "Warning: Invalid documentation comment:@,%s\n%!"
     (Odoc_parser.Warning.to_string warning)
@@ -155,3 +158,7 @@ let normalize ~parse_docstrings ~normalize_code text =
     let parsed = Odoc_parser.parse_comment ~location ~text in
     let c = {normalize_code} in
     Format.asprintf "Docstring(%a)%!" (odoc_docs c) (Odoc_parser.ast parsed)
+
+let dump fmt x =
+  let c = {normalize_code= Fn.id} in
+  Format.fprintf fmt "Docstring(%a)%!" (odoc_docs c) x

--- a/lib/Docstring.mli
+++ b/lib/Docstring.mli
@@ -14,6 +14,10 @@ val parse :
   -> string
   -> (Odoc_parser.Ast.t, Odoc_parser.Warning.t list) Result.t
 
+val parse_file : Lexing.position -> string -> Odoc_parser.Ast.t
+(** Used for parsing [.mld] files. Exceptions are caught in
+    [Translation_unit]. *)
+
 val warn : Format.formatter -> Odoc_parser.Warning.t -> unit
 
 type error =
@@ -32,3 +36,5 @@ val normalize :
   -> string
 
 val normalize_text : string -> string
+
+val dump : Format.formatter -> Odoc_parser.Ast.t -> unit

--- a/lib/Extended_ast.mli
+++ b/lib/Extended_ast.mli
@@ -25,9 +25,11 @@ type 'a t =
   | Module_type : module_type t
   | Expression : expression t
   | Repl_file : repl_file t
+  | Documentation : Odoc_parser.Ast.t t
 
 module Parse : sig
-  val ast : 'a t -> preserve_beginend:bool -> Lexing.lexbuf -> 'a
+  val ast :
+    'a t -> preserve_beginend:bool -> input_name:string -> string -> 'a
 end
 
 val equal_core_type : core_type -> core_type -> bool

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4428,6 +4428,7 @@ let fmt_file (type a) ~ctx ~fmt_code ~debug (fragment : a Extended_ast.t)
   | Expression, e ->
       fmt_expression c (sub_exp ~ctx:(Str (Ast_helper.Str.eval e)) e)
   | Repl_file, l -> fmt_repl_file c ctx l
+  | Documentation, d -> Fmt_odoc.fmt ~fmt_code:(c.fmt_code c.conf) d
 
 let fmt_parse_result conf ~debug ast_kind ast source comments ~fmt_code =
   let cmts = Cmts.init ast_kind ~debug source ast comments in
@@ -4437,7 +4438,8 @@ let fmt_parse_result conf ~debug ast_kind ast source comments ~fmt_code =
 let fmt_code ~debug =
   let rec fmt_code (conf : Conf.t) s =
     let warn = conf.fmt_opts.parse_toplevel_phrases in
-    match Parse_with_comments.parse_toplevel conf ~source:s with
+    let input_name = !Location.input_name in
+    match Parse_with_comments.parse_toplevel conf ~input_name ~source:s with
     | Either.First {ast; comments; source; prefix= _} ->
         fmt_parse_result conf ~debug Use_file ast source comments ~fmt_code
     | Second {ast; comments; source; prefix= _} ->

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -50,7 +50,8 @@ let normalize_parse_result ast_kind ast comments =
     comments
 
 let normalize_code conf (m : Ast_mapper.mapper) txt =
-  match Parse_with_comments.parse_toplevel conf ~source:txt with
+  let input_name = "<output>" in
+  match Parse_with_comments.parse_toplevel conf ~input_name ~source:txt with
   | First {ast; comments; _} ->
       normalize_parse_result Use_file
         (List.map ~f:(m.toplevel_phrase m) ast)

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -43,7 +43,11 @@ let dedup_cmts fragment ast comments =
   Set.(to_list (diff (of_list (module Cmt) comments) (of_ast ast)))
 
 let normalize_code conf (m : Ast_mapper.mapper) txt =
-  match Parse_with_comments.parse Parse.ast Structure conf ~source:txt with
+  let input_name = "<output>" in
+  match
+    Parse_with_comments.parse Parse.ast Structure conf ~input_name
+      ~source:txt
+  with
   | {ast; comments; _} ->
       let comments = dedup_cmts Structure ast comments in
       let print_comments fmt (l : Cmt.t list) =

--- a/lib/Parse_with_comments.mli
+++ b/lib/Parse_with_comments.mli
@@ -28,9 +28,10 @@ exception Warning50 of (Location.t * Warnings.t) list
 
 val parse :
      ?disable_w50:bool
-  -> ('b -> Lexing.lexbuf -> 'a)
+  -> ('b -> input_name:string -> string -> 'a)
   -> 'b
   -> Conf.t
+  -> input_name:string
   -> source:string
   -> 'a with_comments
 (** @raise [Warning50] on misplaced documentation comments. *)
@@ -38,6 +39,7 @@ val parse :
 val parse_toplevel :
      ?disable_w50:bool
   -> Conf.t
+  -> input_name:string
   -> source:string
   -> ( Extended_ast.use_file with_comments
      , Extended_ast.repl_file with_comments )

--- a/lib/Std_ast.ml
+++ b/lib/Std_ast.ml
@@ -21,7 +21,9 @@ type 'a t =
   | Core_type : core_type t
   | Module_type : module_type t
   | Expression : expression t
+  (* not implemented *)
   | Repl_file : unit t
+  | Documentation : unit t
 
 let equal (type a) (_ : a t) : a -> a -> bool = Poly.equal
 
@@ -34,9 +36,12 @@ let map (type a) (x : a t) (m : Ast_mapper.mapper) : a -> a =
   | Module_type -> m.module_type m
   | Expression -> m.expr m
   | Repl_file -> Fn.id
+  | Documentation -> Fn.id
 
 module Parse = struct
-  let ast (type a) (fg : a t) lexbuf : a =
+  let ast (type a) (fg : a t) ~input_name str : a =
+    let lexbuf = Lexing.from_string str in
+    Location.init lexbuf input_name ;
     match fg with
     | Structure -> Parse.implementation lexbuf
     | Signature -> Parse.interface lexbuf
@@ -45,6 +50,7 @@ module Parse = struct
     | Module_type -> Parse.module_type lexbuf
     | Expression -> Parse.expression lexbuf
     | Repl_file -> ()
+    | Documentation -> ()
 end
 
 module Printast = struct
@@ -60,4 +66,5 @@ module Printast = struct
     | Module_type -> module_type 0
     | Expression -> expression 0
     | Repl_file -> fun _ _ -> ()
+    | Documentation -> fun _ _ -> ()
 end

--- a/lib/Std_ast.mli
+++ b/lib/Std_ast.mli
@@ -26,9 +26,10 @@ type 'a t =
   | Expression : expression t
   (* not implemented *)
   | Repl_file : unit t
+  | Documentation : unit t
 
 module Parse : sig
-  val ast : 'a t -> Lexing.lexbuf -> 'a
+  val ast : 'a t -> input_name:string -> string -> 'a
 end
 
 val equal : 'a t -> 'a -> 'a -> bool

--- a/lib/Syntax.ml
+++ b/lib/Syntax.ml
@@ -17,3 +17,4 @@ type t =
   | Module_type
   | Expression
   | Repl_file
+  | Documentation

--- a/lib/Syntax.mli
+++ b/lib/Syntax.mli
@@ -17,3 +17,4 @@ type t =
   | Module_type
   | Expression
   | Repl_file
+  | Documentation

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -529,6 +529,9 @@ OPTIONS
        --disable-conf-files
            Disable .ocamlformat configuration files.
 
+       --doc
+           Parse input as an odoc documentation.
+
        --enable-outside-detected-project
            Read .ocamlformat config files outside the current project when no
            project root has been detected for the input file. The project

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1365,6 +1365,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to doc.mld.stdout
+   (with-stderr-to doc.mld.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/doc.mld})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/doc.mld.ref doc.mld.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/doc.mld.err doc.mld.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to doc_comments-after.ml.stdout
    (with-stderr-to doc_comments-after.ml.stderr
      (run %{bin:ocamlformat} --margin-check --doc-comments=after-when-possible %{dep:tests/doc_comments.ml})))))
@@ -1510,6 +1528,24 @@
  (alias runtest)
  (package ocamlformat)
  (action (diff tests/doc_comments_padding.ml.err doc_comments_padding.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to doc_repl.mld.stdout
+   (with-stderr-to doc_repl.mld.stderr
+     (run %{bin:ocamlformat} --margin-check --parse-toplevel-phrases %{dep:tests/doc_repl.mld})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/doc_repl.mld.ref doc_repl.mld.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/doc_repl.mld.err doc_repl.mld.stderr)))
 
 (rule
  (deps tests/.ocamlformat )
@@ -2182,6 +2218,24 @@
  (alias runtest)
  (package ocamlformat)
  (action (diff tests/generative.ml.err generative.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to hash_bang.ml.stdout
+   (with-stderr-to hash_bang.ml.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/hash_bang.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/hash_bang.ml hash_bang.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/hash_bang.ml.err hash_bang.ml.stderr)))
 
 (rule
  (deps tests/.ocamlformat )

--- a/test/passing/gen/gen.ml
+++ b/test/passing/gen/gen.ml
@@ -48,8 +48,9 @@ let add_test ?base_file map src_test_name =
 
 let register_file tests fname =
   match String.split_on_char '.' fname with
-  | test_name :: (("ml" | "mli" | "mlt" | "eliom" | "eliomi") as ext) :: rest
-    -> (
+  | test_name
+    :: (("ml" | "mli" | "mlt" | "mld" | "eliom" | "eliomi") as ext)
+    :: rest -> (
       let fname = "tests/" ^ fname in
       let src_test_name = test_name ^ "." ^ ext in
       let setup =

--- a/test/passing/tests/doc.mld
+++ b/test/passing/tests/doc.mld
@@ -1,0 +1,159 @@
+{0 Parent/Child Specification}
+This parent/child specification allows more flexible output support, e.g., per library documentation. See {{:https://v3.ocaml.org/packages}v3.ocaml.org/packages}.
+
+The rules are;
+
+{ul 
+{- [.mld] files may or may not have a parent [.mld].}
+{- Compilation units must have a parent [.mld].}
+{- The parent [.mld] file must be compiled before any of its children, and the children
+ must be specified at the parent's compilation time.}
+{- The output paths of [.mld] files and compilation units are subdirectories of their parent's
+ output directory.}
+{- The output directory of a [.mld] file [x.mld] with children is [<parent_output_directory>/x],
+   and its file name is [index.html]. That is to say, [<parent_output_directory>/x/index.html]}
+{- The output directory of a [.mld] file [x.mld] without children is [<parent_output_directory> /x.html]}
+{- The output directory of a compilation unit [X] is [<parent_output_directory>/X/index.html]}
+}
+
+{b Note:} The [--pkg <package>] option is still supported for backward compatibility in [odoc >= v2.0.0],
+although it's now equivalent to specifying a parent [.mld] file.
+
+For example, let's consider [John] whose is [Doe] and [Mark]'s father. [Doe] has
+children, [Max], and page [foo], whereas [Mark] has no children. That is to say,
+[john.mld], [doe.mld], [mark.mld], [max.mld], [foo.ml] respectively. For instance;
+
+[john.mld]
+
+{v
+{0 About John}
+
+I'm John the father to {{!page-doe}Doe} and {{!page-mark}Mark}.
+v}
+
+[doe.mld]
+
+{v
+{0 About Doe}
+
+I'm Doe, the;
+- son to {{!page-john}John}
+- brother to {{!page-mark}Mark}
+- father to {{!page-max}Max}
+
+I also own page {{!page-foo}foo}
+v}
+
+[mark.mld]
+
+{v
+{0 About Mark}
+
+I'm Mark {{!page-doe}Doe}'s brother and I have no children.
+v}
+
+[max.mld]
+
+{v
+{0 About Max}
+
+I'm Max, the child to {{!page-doe}Doe}
+v}
+
+[foo.ml]
+
+{[
+(** I'm foo, a page child to Doe *)
+]}
+
+{2 Compilation}
+
+{v
+$ ocamlc -c -bin-annot foo.ml
+  && odoc compile john.mld -c page-doe -c page-mark
+  && odoc compile doe.mld -I . --parent page-john -c page-max -c foo
+  && odoc compile max.mld -I . --parent page-doe
+  && odoc compile foo.cmt -I . --parent page-doe
+  && odoc compile mark.mld -I . --parent page-john
+v}
+
+The output of the compilation phase will be [.odoc] files, where each will be
+linked by invoking the [odoc link] command on them.
+
+{2 Linking}
+
+[odoc link -I . <file>.odoc]
+
+{v
+$ odoc link -I . page-john.odoc
+  && odoc link -I . page-doe.odoc
+  && odoc link -I . page-mark.odoc
+  && odoc link -I . page-max.odoc
+  && odoc link -I . foo.odoc
+v}
+
+The output of the [odoc link] command is an [.odocl] file, by default, in the same path as the original [.odoc] file.
+
+{2 Generating HTML}
+{v
+$ odoc html-generate --indent -o html page-john.odocl
+  && odoc html-generate --indent -o html page-doe.odocl
+  && odoc html-generate --indent -o html page-mark.odocl
+  && odoc html-generate --indent -o html page-max.odocl
+  && odoc html-generate --indent -o html foo.odocl
+  && odoc support-files -o html
+v}
+
+Then we inspect the contents of the [html] directory using;
+
+{v
+$ ls -R html
+  highlight.pack.js
+  john
+  odoc.css
+
+  html/john:
+  doe
+  index.html
+  mark.html
+
+  html/john/doe:
+  Foo
+  index.html
+  max.html
+
+  html/john/doe/Foo:
+  index.
+v}
+
+{b Note:} We generated HTML files only for this example, but it's very possible to
+generate files in other formats (i.e, latex and man-pages) using:
+
+{ul 
+{- [$ odoc latex-generate -o latex <file>.odocl]}
+{- [$ odoc man-generate -o man <file>.odocl]}
+}
+
+Of course there are different commands that [odoc] uses for other purposes; e.g.,
+for inspection:
+
+{ul 
+{- [odoc <html/latex/man>-targets ...] takes a glimpse of the expected targets}
+{- [odoc compile-deps ...] lists units (with their digest) that need to be
+ compiled in order to compile the current compilation unit. The unit itself and its
+ digest is also reported in the output.}
+}
+
+For example, inspecting the dependencies required to compile [foo.cmt], we run
+
+[odoc compile-deps foo.cmt]
+
+and we shall get
+
+{[
+  Stdlib aea3513d44d604b62eaff79ad12007b3
+  Foo x5ab79b5411a3c3476029260eda0b4a26
+  CamlinternalFormatBasics f562e7b79dbe1bb1591060d6b4e854cf
+]}
+
+For more about [odoc] commands, simply invoke [odoc --help] in your shell.

--- a/test/passing/tests/doc.mld.ref
+++ b/test/passing/tests/doc.mld.ref
@@ -1,0 +1,164 @@
+{0 Parent/Child Specification}
+
+This parent/child specification allows more flexible output support, e.g.,
+per library documentation. See
+{{:https://v3.ocaml.org/packages} v3.ocaml.org/packages}.
+
+The rules are;
+
+- [.mld] files may or may not have a parent [.mld].
+- Compilation units must have a parent [.mld].
+- The parent [.mld] file must be compiled before any of its children, and the
+  children must be specified at the parent's compilation time.
+- The output paths of [.mld] files and compilation units are subdirectories
+  of their parent's output directory.
+- The output directory of a [.mld] file [x.mld] with children is
+  [<parent_output_directory>/x], and its file name is [index.html]. That is
+  to say, [<parent_output_directory>/x/index.html]
+- The output directory of a [.mld] file [x.mld] without children is
+  [<parent_output_directory> /x.html]
+- The output directory of a compilation unit [X] is
+  [<parent_output_directory>/X/index.html]
+
+{b Note:} The [--pkg <package>] option is still supported for backward
+compatibility in [odoc >= v2.0.0], although it's now equivalent to specifying
+a parent [.mld] file.
+
+For example, let's consider [John] whose is [Doe] and [Mark]'s father. [Doe]
+has children, [Max], and page [foo], whereas [Mark] has no children. That is
+to say, [john.mld], [doe.mld], [mark.mld], [max.mld], [foo.ml] respectively.
+For instance;
+
+[john.mld]
+
+{v
+{0 About John}
+
+I'm John the father to {{!page-doe}Doe} and {{!page-mark}Mark}.
+v}
+
+[doe.mld]
+
+{v
+{0 About Doe}
+
+I'm Doe, the;
+- son to {{!page-john}John}
+- brother to {{!page-mark}Mark}
+- father to {{!page-max}Max}
+
+I also own page {{!page-foo}foo}
+v}
+
+[mark.mld]
+
+{v
+{0 About Mark}
+
+I'm Mark {{!page-doe}Doe}'s brother and I have no children.
+v}
+
+[max.mld]
+
+{v
+{0 About Max}
+
+I'm Max, the child to {{!page-doe}Doe}
+v}
+
+[foo.ml]
+
+{[
+  (** I'm foo, a page child to Doe *)
+]}
+
+{2 Compilation}
+
+{v
+$ ocamlc -c -bin-annot foo.ml
+  && odoc compile john.mld -c page-doe -c page-mark
+  && odoc compile doe.mld -I . --parent page-john -c page-max -c foo
+  && odoc compile max.mld -I . --parent page-doe
+  && odoc compile foo.cmt -I . --parent page-doe
+  && odoc compile mark.mld -I . --parent page-john
+v}
+
+The output of the compilation phase will be [.odoc] files, where each will be
+linked by invoking the [odoc link] command on them.
+
+{2 Linking}
+
+[odoc link -I . <file>.odoc]
+
+{v
+$ odoc link -I . page-john.odoc
+  && odoc link -I . page-doe.odoc
+  && odoc link -I . page-mark.odoc
+  && odoc link -I . page-max.odoc
+  && odoc link -I . foo.odoc
+v}
+
+The output of the [odoc link] command is an [.odocl] file, by default, in the
+same path as the original [.odoc] file.
+
+{2 Generating HTML}
+
+{v
+$ odoc html-generate --indent -o html page-john.odocl
+  && odoc html-generate --indent -o html page-doe.odocl
+  && odoc html-generate --indent -o html page-mark.odocl
+  && odoc html-generate --indent -o html page-max.odocl
+  && odoc html-generate --indent -o html foo.odocl
+  && odoc support-files -o html
+v}
+
+Then we inspect the contents of the [html] directory using;
+
+{v
+$ ls -R html
+  highlight.pack.js
+  john
+  odoc.css
+
+  html/john:
+  doe
+  index.html
+  mark.html
+
+  html/john/doe:
+  Foo
+  index.html
+  max.html
+
+  html/john/doe/Foo:
+  index.
+v}
+
+{b Note:} We generated HTML files only for this example, but it's very
+possible to generate files in other formats (i.e, latex and man-pages) using:
+
+- [$ odoc latex-generate -o latex <file>.odocl]
+- [$ odoc man-generate -o man <file>.odocl]
+
+Of course there are different commands that [odoc] uses for other purposes;
+e.g., for inspection:
+
+- [odoc <html/latex/man>-targets ...] takes a glimpse of the expected targets
+- [odoc compile-deps ...] lists units (with their digest) that need to be
+  compiled in order to compile the current compilation unit. The unit itself
+  and its digest is also reported in the output.
+
+For example, inspecting the dependencies required to compile [foo.cmt], we
+run
+
+[odoc compile-deps foo.cmt]
+
+and we shall get
+
+{[
+  Stdlib aea3513d44d604b62eaff79ad12007b3
+  Foo x5ab79b5411a3c3476029260eda0b4a26
+  CamlinternalFormatBasics f562e7b79dbe1bb1591060d6b4e854cf
+]}
+
+For more about [odoc] commands, simply invoke [odoc --help] in your shell.

--- a/test/passing/tests/doc_repl.mld
+++ b/test/passing/tests/doc_repl.mld
@@ -1,0 +1,80 @@
+Block delimiters should be on their own line:
+
+{[
+  let x = 1
+]}
+
+As of odoc 2.1, a block can carry metadata:
+
+{@ocaml[
+  let x = 2
+]}
+
+An OCaml block that should break:
+
+{[
+  let x = 2 in
+  x + x
+]}
+
+A toplevel phrase with no output:
+
+{[
+  # let x = 2 and y = 3 in x+y;;
+]}
+
+A toplevel phrase with output:
+
+{[
+  # let x = 2;;
+  val x : int = 2
+]}
+
+Many toplevel phrases without output:
+
+{[
+  # let x = 2;;
+  # x + 2;;
+  # let x = 2 and y = 3 in x+y;;
+]}
+
+Many toplevel phrases with output:
+
+{[
+  # let x = 2;;
+  val x : int = 2
+  # x + 2;;
+  - : int = 4
+  # let x = 2 and y = 3 in x+y;;
+]}
+
+Output are printed after a newline:
+
+{[
+  # let x = 2;; val x : int = 2
+  # let x = 3;;
+  # let x = 4;; val x : int = 4
+]}
+
+Excessive linebreaks are removed:
+
+{[
+  # let x = 2 in x+1;;
+
+  output
+
+  # let y = 3 in y+1;;
+]}
+
+Linebreak after `#`:
+
+{[
+  #
+    let x = 2 in x+1;;
+]}
+
+Invalid toplevel phrase/ocaml block:
+{[
+    - : int =
+     4
+]}

--- a/test/passing/tests/doc_repl.mld.opts
+++ b/test/passing/tests/doc_repl.mld.opts
@@ -1,0 +1,1 @@
+--parse-toplevel-phrases

--- a/test/passing/tests/doc_repl.mld.ref
+++ b/test/passing/tests/doc_repl.mld.ref
@@ -1,0 +1,84 @@
+Block delimiters should be on their own line:
+
+{[
+  let x = 1
+]}
+
+As of odoc 2.1, a block can carry metadata:
+
+{@ocaml[
+  let x = 2
+]}
+
+An OCaml block that should break:
+
+{[
+  let x = 2 in
+  x + x
+]}
+
+A toplevel phrase with no output:
+
+{[
+  # let x = 2 and y = 3 in
+    x + y ;;
+]}
+
+A toplevel phrase with output:
+
+{[
+  # let x = 2;;
+  val x : int = 2
+]}
+
+Many toplevel phrases without output:
+
+{[
+  # let x = 2 ;;
+  # x + 2 ;;
+  # let x = 2 and y = 3 in
+    x + y ;;
+]}
+
+Many toplevel phrases with output:
+
+{[
+  # let x = 2 ;;
+  val x : int = 2
+  # x + 2 ;;
+  - : int = 4
+  # let x = 2 and y = 3 in
+    x + y ;;
+]}
+
+Output are printed after a newline:
+
+{[
+  # let x = 2;; val x : int = 2
+  # let x = 3;;
+  # let x = 4;; val x : int = 4
+]}
+
+Excessive linebreaks are removed:
+
+{[
+  # let x = 2 in
+    x + 1 ;;
+  output
+  # let y = 3 in
+    y + 1 ;;
+]}
+
+Linebreak after `#`:
+
+{[
+  # let x = 2 in
+    x + 1 ;;
+]}
+
+Invalid toplevel phrase/ocaml block:
+
+{[
+  - : int =
+   4
+]}

--- a/test/passing/tests/hash_bang.ml
+++ b/test/passing/tests/hash_bang.ml
@@ -1,0 +1,3 @@
+#!/usr/bin/env ocaml
+
+let _ = sprintf "[%s]" s


### PR DESCRIPTION
Closes #1965 
Just reusing the docstring parsing&formatting for .mld files.