### PR TITLE
Prevent rpc to crash on version mismatch with `.ocamlformat`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,8 @@
   + RPC v2 (#1935, @panglesd):
     Define a 'Format' command parameterized with optionnal arguments to set or override the config and path, to format in the style of a file.
 
+  + Prevent RPC to crash on version mismatch with `.ocamlformat` (#2011, @panglesd, @Julow)
+
 ### 0.20.1 (2021-12-13)
 
 #### New features

--- a/bin/ocamlformat-rpc/main.ml
+++ b/bin/ocamlformat-rpc/main.ml
@@ -66,12 +66,12 @@ let run_config conf c =
   update conf c
 
 let run_path path =
-  try
-    Ok
-      (Ocamlformat_lib.Conf.build_config
-         ~enable_outside_detected_project:false ~root:None ~file:path
-         ~is_stdin:false )
-  with Ocamlformat_lib.Conf.Conf_error e -> Error (`Path_error e)
+  match
+    Ocamlformat_lib.Conf.build_config ~enable_outside_detected_project:false
+      ~root:None ~file:path ~is_stdin:false
+  with
+  | Ok _ as ok -> ok
+  | Error e -> Error (`Path_error e)
 
 let run_format conf x =
   List.fold_until ~init:()

--- a/bin/ocamlformat-rpc/main.ml
+++ b/bin/ocamlformat-rpc/main.ml
@@ -61,13 +61,17 @@ let run_config conf c =
     | (name, value) :: t -> (
       match Conf.update_value conf ~name ~value with
       | Ok c -> update c t
-      | Error e -> Error e )
+      | Error e -> Error (`Config_error e) )
   in
   update conf c
 
 let run_path path =
-  Ocamlformat_lib.Conf.build_config ~enable_outside_detected_project:false
-    ~root:None ~file:path ~is_stdin:false
+  try
+    Ok
+      (Ocamlformat_lib.Conf.build_config
+         ~enable_outside_detected_project:false ~root:None ~file:path
+         ~is_stdin:false )
+  with Ocamlformat_lib.Conf.Conf_error e -> Error (`Path_error e)
 
 let run_format conf x =
   List.fold_until ~init:()
@@ -93,17 +97,21 @@ let run_format conf x =
     ; format Use_file ]
 
 let run_format_with_args {path; config} conf x =
-  let temp_conf = Option.value_map path ~default:conf ~f:run_path in
-  match
-    Option.value_map config ~default:(Ok temp_conf) ~f:(fun c ->
-        run_config temp_conf c )
-  with
-  | Error e -> Error (`Config_error e)
-  | Ok temp_conf -> run_format temp_conf x
+  let open Result in
+  Option.value_map path ~default:(Ok conf) ~f:run_path
+  >>= fun conf ->
+  Option.value_map config ~default:(Ok conf) ~f:(fun c -> run_config conf c)
+  >>= fun conf -> run_format conf x
 
-let handle_format_error e = V1.Command.output stdout (`Error e)
+let handle_format_error e output =
+  output stdout (`Error e) ;
+  Out_channel.flush stdout
 
-let handle_config_error (e : Config_option.Error.t) =
+let handle_path_error e output =
+  output stdout (`Error e) ;
+  Out_channel.flush stdout
+
+let handle_config_error (e : Config_option.Error.t) output =
   let msg =
     match e with
     | Bad_value (x, y) ->
@@ -113,8 +121,14 @@ let handle_config_error (e : Config_option.Error.t) =
         Format.sprintf "Misplaced configuration value (%s, %s)" x y
     | Unknown (x, _) -> Format.sprintf "Unknown configuration option %s" x
   in
-  V1.Command.output stdout (`Error msg) ;
+  output stdout (`Error msg) ;
   Out_channel.flush stdout
+
+let handle_error e output =
+  match e with
+  | `Format_error e -> handle_format_error e output
+  | `Config_error e -> handle_config_error e output
+  | `Path_error e -> handle_path_error e output
 
 let rec rpc_main = function
   | Waiting_for_version -> (
@@ -144,8 +158,9 @@ let rec rpc_main = function
             | Ok (`Format formatted) ->
                 V1.Command.output stdout (`Format formatted) ;
                 conf
-            | Error (`Format_error e) -> handle_format_error e ; conf
-            | Error (`Config_error e) -> handle_config_error e ; conf
+            | Error e ->
+                handle_error e V1.Command.output ;
+                conf
           in
           rpc_main (Version_defined (v, conf))
       | `Config c -> (
@@ -154,7 +169,9 @@ let rec rpc_main = function
             V1.Command.output stdout (`Config c) ;
             Out_channel.flush stdout ;
             rpc_main (Version_defined (v, conf))
-        | Error e -> handle_config_error e ; rpc_main state ) )
+        | Error (`Config_error e) ->
+            handle_config_error e V1.Command.output ;
+            rpc_main state ) )
     | V2 -> (
       match V2.Command.read_input stdin with
       | `Halt -> Ok ()
@@ -165,8 +182,9 @@ let rec rpc_main = function
             | Ok (`Format formatted) ->
                 V2.Command.output stdout (`Format (formatted, format_args)) ;
                 conf
-            | Error (`Format_error e) -> handle_format_error e ; conf
-            | Error (`Config_error e) -> handle_config_error e ; conf
+            | Error e ->
+                handle_error e V2.Command.output ;
+                conf
           in
           rpc_main (Version_defined (v, conf)) ) )
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1849,6 +1849,7 @@ let parse_line config ~from s =
     | name -> update ~config ~from ~name ~value:"true" )
   | _ -> Error (Config_option.Error.Malformed s)
 
+(** Do not escape from [build_config] *)
 exception Conf_error of string
 
 let failwith_user_errors ~from errors =
@@ -1989,12 +1990,14 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
     | None -> conf
 
 let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
-  let conf, warn_now =
-    collect_warnings (fun () ->
-        build_config ~enable_outside_detected_project ~root ~file ~is_stdin )
-  in
-  if not conf.opr_opts.quiet then warn_now () ;
-  conf
+  try
+    let conf, warn_now =
+      collect_warnings (fun () ->
+          build_config ~enable_outside_detected_project ~root ~file ~is_stdin )
+    in
+    if not conf.opr_opts.quiet then warn_now () ;
+    Ok conf
+  with Conf_error msg -> Error msg
 
 let kind_of_ext fname =
   match Filename.extension fname with
@@ -2063,21 +2066,17 @@ type action =
   | Numeric of input * (int * int)
 
 let make_action ~enable_outside_detected_project ~root action inputs =
+  let open Result in
   let make_file ?(with_conf = fun c -> c) ?name kind file =
     let name = Option.value ~default:file name in
-    let conf =
-      with_conf
-        (build_config ~enable_outside_detected_project ~root ~file:name
-           ~is_stdin:false )
-    in
-    {kind; name; file= File file; conf}
+    build_config ~enable_outside_detected_project ~root ~file:name
+      ~is_stdin:false
+    >>= fun conf -> Ok {kind; name; file= File file; conf= with_conf conf}
   in
   let make_stdin ?(name = "<standard input>") kind =
-    let conf =
-      build_config ~enable_outside_detected_project ~root ~file:name
-        ~is_stdin:false
-    in
-    {kind; name; file= Stdin; conf}
+    build_config ~enable_outside_detected_project ~root ~file:name
+      ~is_stdin:false
+    >>= fun conf -> Ok {kind; name; file= Stdin; conf}
   in
   match (action, inputs) with
   | `Print_config, inputs ->
@@ -2089,10 +2088,8 @@ let make_action ~enable_outside_detected_project ~root action inputs =
         | `Several_files [] | `No_input ->
             (File_system.root_ocamlformat_file ~root |> Fpath.to_string, true)
       in
-      let conf =
-        build_config ~enable_outside_detected_project ~root ~file ~is_stdin
-      in
-      Ok (Print_config conf)
+      build_config ~enable_outside_detected_project ~root ~file ~is_stdin
+      >>= fun conf -> Ok (Print_config conf)
   | (`No_action | `Output _ | `Inplace | `Check | `Numeric _), `No_input ->
       Error "Must specify at least one input file, or `-` for stdin"
   | (`No_action | `Output _ | `Numeric _), `Several_files _ ->
@@ -2101,32 +2098,38 @@ let make_action ~enable_outside_detected_project ~root action inputs =
   | `Inplace, `Stdin _ ->
       Error "Cannot specify stdin together with --inplace"
   | `No_action, `Single_file (kind, name, f) ->
-      Ok (In_out (make_file ?name kind f, None))
+      make_file ?name kind f >>= fun inp -> Ok (In_out (inp, None))
   | `No_action, `Stdin (name, kind) ->
-      Ok (In_out (make_stdin ?name kind, None))
+      make_stdin ?name kind >>= fun inp -> Ok (In_out (inp, None))
   | `Output output, `Single_file (kind, name, f) ->
-      Ok (In_out (make_file ?name kind f, Some output))
+      make_file ?name kind f >>= fun inp -> Ok (In_out (inp, Some output))
   | `Output output, `Stdin (name, kind) ->
-      Ok (In_out (make_stdin ?name kind, Some output))
+      make_stdin ?name kind >>= fun inp -> Ok (In_out (inp, Some output))
   | `Inplace, `Single_file (kind, name, f) ->
-      Ok (Inplace [make_file ?name kind f])
-  | `Inplace, `Several_files files ->
-      Ok (Inplace (List.map files ~f:(fun (kind, f) -> make_file kind f)))
+      make_file ?name kind f >>= fun inp -> Ok (Inplace [inp])
+  | `Inplace, `Several_files files -> (
+      let f (kind, f) = make_file kind f in
+      match List.map files ~f |> List.partition_result with
+      | _, e :: _ -> Error e
+      | inputs, [] -> Ok (Inplace inputs) )
   | `Check, `Single_file (kind, name, f) ->
-      Ok (Check [make_file ?name kind f])
-  | `Check, `Several_files files ->
+      make_file ?name kind f >>= fun inp -> Ok (Check [inp])
+  | `Check, `Several_files files -> (
       let f (kind, f) =
         make_file
           ~with_conf:(fun c ->
             Operational.update c ~f:(fun f -> {f with max_iters= 1}) )
           kind f
       in
-      Ok (Check (List.map files ~f))
-  | `Check, `Stdin (name, kind) -> Ok (Check [make_stdin ?name kind])
+      match List.map files ~f |> List.partition_result with
+      | _, e :: _ -> Error e
+      | inputs, [] -> Ok (Check inputs) )
+  | `Check, `Stdin (name, kind) ->
+      make_stdin ?name kind >>= fun inp -> Ok (Check [inp])
   | `Numeric range, `Stdin (name, kind) ->
-      Ok (Numeric (make_stdin ?name kind, range))
+      make_stdin ?name kind >>= fun inp -> Ok (Numeric (inp, range))
   | `Numeric range, `Single_file (kind, name, f) ->
-      Ok (Numeric (make_file ?name kind f, range))
+      make_file ?name kind f >>= fun inp -> Ok (Numeric (inp, range))
 
 let validate () =
   let root =
@@ -2147,7 +2150,6 @@ let validate () =
     >>= fun inputs ->
     make_action ~enable_outside_detected_project ~root action inputs
   with
-  | exception Conf_error e -> `Error (false, e)
   | Error e -> `Error (false, e)
   | Ok action -> `Ok action
 

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -101,6 +101,8 @@ val default : t
 
 type input = {kind: Syntax.t; name: string; file: file; conf: t}
 
+exception Conf_error of string
+
 val build_config :
      enable_outside_detected_project:bool
   -> root:Ocamlformat_stdlib.Fpath.t option

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -101,14 +101,12 @@ val default : t
 
 type input = {kind: Syntax.t; name: string; file: file; conf: t}
 
-exception Conf_error of string
-
 val build_config :
      enable_outside_detected_project:bool
   -> root:Ocamlformat_stdlib.Fpath.t option
   -> file:string
   -> is_stdin:bool
-  -> t
+  -> (t, string) Result.t
 
 type action =
   | In_out of input * string option


### PR DESCRIPTION
When loading the configuration for a path, `ocamlformat_lib` raises a `Conf_error` if it encounters a `version = ...` that does not match its version.
This made the rpc server crash, when a V2 command encountered such exception.

This PR fixes this by making the `Conf_error` public in `ocamlformat_lib`, and catching it in the `rpc`.
The error handling is also refactored.

Finally, in the `V2` protocol, the `V1.Command.output` function was used to return the errors. Both `V1.Command.output` and `V2.Command.output` are currently the same, but I still fixed this for consistency.