### PR TITLE
[nebuchadnezzar][opam] force odoc-parser < 1.0

### DIFF
--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml-version" {>= "3.2.0"}
   "ocp-indent"
   "bisect_ppx" {with-test & >= "2.5.0"}
-  "odoc-parser" {>= "0.9.0"}
+  "odoc-parser" {>= "0.9.0" & < "1.0.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}


### PR DESCRIPTION
This is needed to build the nebuchadnezzar branch that infer currently uses (temporarily).