### PR TITLE
README.md: Latest version of ocamlformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Alternatively, see [`ocamlformat.opam`](./ocamlformat.opam) for manual build ins
 Setting up your project to use the default profile and the OCamlFormat version you installed (hopefully the last one) in this `.ocamlformat` file is considered good practice:
 ```
 profile = default
-version = 0.20.0
+version = 0.20.1
 ```
 
 To manually invoke OCamlformat the general command is:


### PR DESCRIPTION
The newest version of ocamlformat is no longer the 0.20.0 but the 0.20.1.
I suggest to replace in .ocamlformat, the part where the version of is indicated.

`version = 0.20.0`

to 

`version = 0.20.1`