### PR TITLE
Expose ocamlformat libraries

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -11,7 +11,7 @@
 
 open Bechamel
 open Toolkit
-open Ocamlformat_lib
+open Ocamlformat
 
 type range = int * int
 

--- a/bench/dune
+++ b/bench/dune
@@ -13,7 +13,7 @@
  (name bench)
  (public_name bench)
  (package ocamlformat-bench)
- (libraries bechamel bechamel-js ocamlformat_lib stdio yojson))
+ (libraries bechamel bechamel-js ocamlformat stdio yojson))
 
 (rule
  (alias runbench)

--- a/bin/ocamlformat-rpc/dune
+++ b/bin/ocamlformat-rpc/dune
@@ -17,7 +17,7 @@
   (:standard -open Ocamlformat_stdlib))
  (instrumentation
   (backend bisect_ppx))
- (libraries ocamlformat_lib ocamlformat-rpc-lib))
+ (libraries ocamlformat ocamlformat-rpc-lib))
 
 (rule
  (with-stdout-to

--- a/bin/ocamlformat-rpc/main.ml
+++ b/bin/ocamlformat-rpc/main.ml
@@ -245,8 +245,7 @@ let info =
          as a reply of the same form."
     ; `P "Unknown commands are ignored." ]
   in
-  Cmd.info "ocamlformat-rpc" ~version:Ocamlformat.Version.current ~doc
-    ~man
+  Cmd.info "ocamlformat-rpc" ~version:Ocamlformat.Version.current ~doc ~man
 
 let rpc_main_t = Term.(const rpc_main $ const ())
 

--- a/bin/ocamlformat-rpc/main.ml
+++ b/bin/ocamlformat-rpc/main.ml
@@ -11,7 +11,7 @@
 
 (** OCamlFormat-RPC *)
 
-open Ocamlformat_lib
+open Ocamlformat
 open Ocamlformat_rpc_lib ;;
 
 Caml.at_exit (Format.pp_print_flush Format.err_formatter) ;;
@@ -67,7 +67,7 @@ let run_config conf c =
 
 let run_path path =
   match
-    Ocamlformat_lib.Conf.build_config ~enable_outside_detected_project:false
+    Ocamlformat.Conf.build_config ~enable_outside_detected_project:false
       ~root:None ~file:path ~is_stdin:false
   with
   | Ok _ as ok -> ok
@@ -245,7 +245,7 @@ let info =
          as a reply of the same form."
     ; `P "Unknown commands are ignored." ]
   in
-  Cmd.info "ocamlformat-rpc" ~version:Ocamlformat_lib.Version.current ~doc
+  Cmd.info "ocamlformat-rpc" ~version:Ocamlformat.Version.current ~doc
     ~man
 
 let rpc_main_t = Term.(const rpc_main $ const ())

--- a/bin/ocamlformat/dune
+++ b/bin/ocamlformat/dune
@@ -18,7 +18,7 @@
   (:standard -open Ocamlformat_stdlib))
  (instrumentation
   (backend bisect_ppx))
- (libraries ocamlformat_lib))
+ (libraries ocamlformat))
 
 (rule
  (with-stdout-to

--- a/bin/ocamlformat/main.ml
+++ b/bin/ocamlformat/main.ml
@@ -11,7 +11,7 @@
 
 (** OCamlFormat *)
 
-open Ocamlformat_lib
+open Ocamlformat
 open Result.Monad_infix ;;
 
 Caml.at_exit (Format.pp_print_flush Format.err_formatter) ;;

--- a/dune-project
+++ b/dune-project
@@ -36,61 +36,10 @@
    (and
     (>= 4.08)
     (< 4.15)))
-  (alcotest :with-test)
   (base
    (and
     (>= v0.12.0)
     (< v0.15)))
-  (cmdliner
-   (>= 1.1.0))
-  dune
-  (dune
-   (and
-    :with-test
-    (< 3.0)))
-  dune-build-info
-  either
-  fix
-  fpath
-  (menhir
-   (>= 20201216))
-  (menhirLib
-   (>= 20201216))
-  (menhirSdk
-   (>= 20201216))
-  (ocaml-version
-   (>= 3.3.0))
-  ocp-indent
-  (odoc-parser
-   (>= 1.0.0))
-  (re
-   (>= 1.7.2))
-  (stdio
-   (< v0.15))
-  (uuseg
-   (>= 10.0.0))
-  (uutf
-   (>= 1.0.1))))
-
-(package
- (name ocamlformat-bench)
- (synopsis "Auto-formatter for OCaml code")
- (description
-  "OCamlFormat is a tool to automatically format OCaml code in a uniform style.")
- (depends
-  (ocaml
-   (and
-    (>= 4.08)
-    (< 4.15)))
-  (alcotest :with-test)
-  (base
-   (and
-    (>= v0.12.0)
-    (< v0.15)))
-  (bechamel
-   (>= 0.2.0))
-  (bechamel-js
-   (>= 0.2.0))
   (cmdliner
    (>= 1.1.0))
   dune-build-info
@@ -116,6 +65,31 @@
    (>= 10.0.0))
   (uutf
    (>= 1.0.1))
+  (alcotest :with-test)
+  (dune
+   (and
+    :with-test
+    (< 3.0)))))
+
+(package
+ (name ocamlformat-bench)
+ (synopsis "Auto-formatter for OCaml code")
+ (description
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style.")
+ (depends
+  (ocaml
+   (and
+    (>= 4.08)
+    (< 4.15)))
+  (alcotest :with-test)
+  (ocamlformat
+   (= :version))
+  (bechamel
+   (>= 0.2.0))
+  (bechamel-js
+   (>= 0.2.0))
+  (stdio
+   (< v0.15))
   yojson))
 
 (package
@@ -128,37 +102,11 @@
    (and
     (>= 4.08)
     (< 4.15)))
-  ocamlformat-rpc-lib
-  (alcotest :with-test)
-  (base
-   (and
-    (>= v0.12.0)
-    (< v0.15)))
-  (cmdliner
-   (>= 1.1.0))
-  dune-build-info
-  either
-  fix
-  fpath
-  (menhir
-   (>= 20201216))
-  (menhirLib
-   (>= 20201216))
-  (menhirSdk
-   (>= 20201216))
-  (ocaml-version
-   (>= 3.3.0))
-  ocp-indent
-  (odoc-parser
-   (>= 1.0.0))
-  (re
-   (>= 1.7.2))
-  (stdio
-   (< v0.15))
-  (uuseg
-   (>= 10.0.0))
-  (uutf
-   (>= 1.0.1))))
+  (ocamlformat
+   (= :version))
+  (ocamlformat-rpc-lib
+   (= :version))
+  (alcotest :with-test)))
 
 (package
  (name ocamlformat-rpc-lib)

--- a/dune-project
+++ b/dune-project
@@ -36,12 +36,18 @@
    (and
     (>= 4.08)
     (< 4.15)))
+  (alcotest :with-test)
   (base
    (and
     (>= v0.12.0)
     (< v0.15)))
   (cmdliner
    (>= 1.1.0))
+  dune
+  (dune
+   (and
+    :with-test
+    (< 3.0)))
   dune-build-info
   either
   fix
@@ -64,12 +70,7 @@
   (uuseg
    (>= 10.0.0))
   (uutf
-   (>= 1.0.1))
-  (alcotest :with-test)
-  (dune
-   (and
-    :with-test
-    (< 3.0)))))
+   (>= 1.0.1))))
 
 (package
  (name ocamlformat-bench)
@@ -82,12 +83,12 @@
     (>= 4.08)
     (< 4.15)))
   (alcotest :with-test)
-  (ocamlformat
-   (= :version))
   (bechamel
    (>= 0.2.0))
   (bechamel-js
    (>= 0.2.0))
+  (ocamlformat
+   (= :version))
   (stdio
    (< v0.15))
   yojson))
@@ -102,11 +103,11 @@
    (and
     (>= 4.08)
     (< 4.15)))
+  (alcotest :with-test)
   (ocamlformat
    (= :version))
   (ocamlformat-rpc-lib
-   (= :version))
-  (alcotest :with-test)))
+   (= :version))))
 
 (package
  (name ocamlformat-rpc-lib)

--- a/lib/dune
+++ b/lib/dune
@@ -14,7 +14,7 @@
 (ocamllex Toplevel_lexer)
 
 (library
- (name ocamlformat_lib)
+ (name ocamlformat)
  (public_name ocamlformat)
  (flags
   (:standard

--- a/lib/dune
+++ b/lib/dune
@@ -15,6 +15,7 @@
 
 (library
  (name ocamlformat_lib)
+ (public_name ocamlformat)
  (flags
   (:standard
    -open

--- a/ocamlformat-bench.opam
+++ b/ocamlformat-bench.opam
@@ -11,24 +11,10 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08" & < "4.15"}
   "alcotest" {with-test}
-  "base" {>= "v0.12.0" & < "v0.15"}
+  "ocamlformat" {= version}
   "bechamel" {>= "0.2.0"}
   "bechamel-js" {>= "0.2.0"}
-  "cmdliner" {>= "1.1.0"}
-  "dune-build-info"
-  "either"
-  "fix"
-  "fpath"
-  "menhir" {>= "20201216"}
-  "menhirLib" {>= "20201216"}
-  "menhirSdk" {>= "20201216"}
-  "ocaml-version" {>= "3.3.0"}
-  "ocp-indent"
-  "odoc-parser" {>= "1.0.0"}
-  "re" {>= "1.7.2"}
   "stdio" {< "v0.15"}
-  "uuseg" {>= "10.0.0"}
-  "uutf" {>= "1.0.1"}
   "yojson"
   "odoc" {with-doc}
 ]

--- a/ocamlformat-bench.opam
+++ b/ocamlformat-bench.opam
@@ -11,9 +11,9 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08" & < "4.15"}
   "alcotest" {with-test}
-  "ocamlformat" {= version}
   "bechamel" {>= "0.2.0"}
   "bechamel-js" {>= "0.2.0"}
+  "ocamlformat" {= version}
   "stdio" {< "v0.15"}
   "yojson"
   "odoc" {with-doc}

--- a/ocamlformat-rpc.opam
+++ b/ocamlformat-rpc.opam
@@ -10,24 +10,9 @@ bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08" & < "4.15"}
-  "ocamlformat-rpc-lib"
+  "ocamlformat" {= version}
+  "ocamlformat-rpc-lib" {= version}
   "alcotest" {with-test}
-  "base" {>= "v0.12.0" & < "v0.15"}
-  "cmdliner" {>= "1.1.0"}
-  "dune-build-info"
-  "either"
-  "fix"
-  "fpath"
-  "menhir" {>= "20201216"}
-  "menhirLib" {>= "20201216"}
-  "menhirSdk" {>= "20201216"}
-  "ocaml-version" {>= "3.3.0"}
-  "ocp-indent"
-  "odoc-parser" {>= "1.0.0"}
-  "re" {>= "1.7.2"}
-  "stdio" {< "v0.15"}
-  "uuseg" {>= "10.0.0"}
-  "uutf" {>= "1.0.1"}
   "odoc" {with-doc}
 ]
 build: [

--- a/ocamlformat-rpc.opam
+++ b/ocamlformat-rpc.opam
@@ -10,9 +10,9 @@ bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08" & < "4.15"}
+  "alcotest" {with-test}
   "ocamlformat" {= version}
   "ocamlformat-rpc-lib" {= version}
-  "alcotest" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -9,11 +9,8 @@ homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "ocaml" {>= "4.08" & < "4.15"}
-  "alcotest" {with-test}
   "base" {>= "v0.12.0" & < "v0.15"}
   "cmdliner" {>= "1.1.0"}
-  "dune" {>= "2.8"}
-  "dune" {with-test & < "3.0"}
   "dune-build-info"
   "either"
   "fix"
@@ -28,6 +25,8 @@ depends: [
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
+  "alcotest" {with-test}
+  "dune" {>= "2.8" & with-test & < "3.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -9,8 +9,11 @@ homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "ocaml" {>= "4.08" & < "4.15"}
+  "alcotest" {with-test}
   "base" {>= "v0.12.0" & < "v0.15"}
   "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8"}
+  "dune" {with-test & < "3.0"}
   "dune-build-info"
   "either"
   "fix"
@@ -25,8 +28,6 @@ depends: [
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
-  "alcotest" {with-test}
-  "dune" {>= "2.8" & with-test & < "3.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/test/projects/dune
+++ b/test/projects/dune
@@ -9,7 +9,8 @@
    enable_outside_detected_project.output
    (chdir
     enable_outside_detected_project
-    (run ocamlformat --enable-outside-detected-project main.ml)))))
+    ; Changed because submoduling ruins this
+    (run ocamlformat --name ../.ocamlformat main.ml)))))
 
 (rule
  (alias runtest)

--- a/test/projects/dune
+++ b/test/projects/dune
@@ -9,8 +9,7 @@
    enable_outside_detected_project.output
    (chdir
     enable_outside_detected_project
-    ; Changed because submoduling ruins this
-    (run ocamlformat --name ../.ocamlformat main.ml)))))
+    (run ocamlformat --enable-outside-detected-project main.ml)))))
 
 (rule
  (alias runtest)

--- a/test/unit/dune
+++ b/test/unit/dune
@@ -1,4 +1,4 @@
 (test
  (name test_unit)
  (package ocamlformat)
- (libraries alcotest base ocamlformat_lib))
+ (libraries alcotest base ocamlformat))

--- a/test/unit/test_ast.ml
+++ b/test/unit/test_ast.ml
@@ -1,5 +1,5 @@
 open! Base
-open Ocamlformat_lib
+open Ocamlformat
 
 let test_string_id ~f name ~pass ~fail =
   let test symbol ~expected =

--- a/test/unit/test_fmt.ml
+++ b/test/unit/test_fmt.ml
@@ -1,5 +1,5 @@
 open Base
-open Ocamlformat_lib
+open Ocamlformat
 
 let eval_fmt term =
   let buffer = Buffer.create 0 in

--- a/test/unit/test_indent.ml
+++ b/test/unit/test_indent.ml
@@ -1,4 +1,4 @@
-open Ocamlformat_lib
+open Ocamlformat
 
 let read_file f = Stdio.In_channel.with_file f ~f:Stdio.In_channel.input_all
 

--- a/test/unit/test_literal_lexer.ml
+++ b/test/unit/test_literal_lexer.ml
@@ -1,5 +1,5 @@
 open Base
-open Ocamlformat_lib
+open Ocamlformat
 
 let single_quote = '\''
 

--- a/test/unit/test_translation_unit.ml
+++ b/test/unit/test_translation_unit.ml
@@ -1,5 +1,5 @@
 open! Base
-open Ocamlformat_lib
+open Ocamlformat
 
 let err =
   Alcotest.testable Translation_unit.Error.print Translation_unit.Error.equal

--- a/test/unit/test_unit.ml
+++ b/test/unit/test_unit.ml
@@ -1,5 +1,5 @@
 open Base
-open Ocamlformat_lib
+open Ocamlformat
 
 module Test_location = struct
   let test_compare_width_decreasing =

--- a/vendor/ocaml-4.13-extended/dune
+++ b/vendor/ocaml-4.13-extended/dune
@@ -1,5 +1,6 @@
 (library
  (name ocaml_413_extended)
+ (public_name ocamlformat.ocaml_413_extended)
  (flags
   (:standard -w -9 -open Parser_shims -open Ocaml_common))
  (libraries compiler-libs.common menhirLib parser_shims ocaml_common))

--- a/vendor/ocaml-4.13/dune
+++ b/vendor/ocaml-4.13/dune
@@ -1,5 +1,6 @@
 (library
  (name ocaml_413)
+ (public_name ocamlformat.ocaml_413)
  (flags
   (:standard -w -9 -open Parser_shims -open Ocaml_common))
  (libraries compiler-libs.common menhirLib parser_shims ocaml_common))

--- a/vendor/ocaml-common/dune
+++ b/vendor/ocaml-common/dune
@@ -1,5 +1,6 @@
 (library
  (name ocaml_common)
+ (public_name ocamlformat.ocaml_common)
  (flags
   (:standard -w -9 -open Parser_shims))
  (libraries parser_shims))

--- a/vendor/ocamlformat-stdlib/cmdliner_ext.mli
+++ b/vendor/ocamlformat-stdlib/cmdliner_ext.mli
@@ -1,6 +1,6 @@
 (** Extension of Cmdliner supporting lighter-weight option definition *)
 
-include module type of Cmdliner
+include module type of struct include Cmdliner end
 
 val mk : default:'a -> 'a Term.t -> 'a ref
 (** [mk ~default term] is a ref which, after [parse] is called, contains

--- a/vendor/ocamlformat-stdlib/dune
+++ b/vendor/ocamlformat-stdlib/dune
@@ -1,5 +1,6 @@
 (library
  (name ocamlformat_stdlib)
+ (public_name ocamlformat.ocamlformat_stdlib)
  (flags
   (:standard -open Ocaml_common))
  (libraries base cmdliner ocaml_common fpath stdio))

--- a/vendor/ocamlformat_support/dune
+++ b/vendor/ocamlformat_support/dune
@@ -1,5 +1,6 @@
 (library
  (name format_)
+ (public_name ocamlformat.format_)
  (flags
   (:standard -open Parser_shims))
  (libraries either parser_shims))

--- a/vendor/parse-wyc/lib/dune
+++ b/vendor/parse-wyc/lib/dune
@@ -1,5 +1,6 @@
 (library
  (name parse_wyc)
+ (public_name ocamlformat.parse_wyc)
  (modules_without_implementation let_binding)
  (libraries menhirLib ocaml_common ocaml_413_extended)
  (flags

--- a/vendor/parser-shims/dune
+++ b/vendor/parser-shims/dune
@@ -1,3 +1,4 @@
 (library
  (name parser_shims)
+ (public_name ocamlformat.parser_shims)
  (libraries compiler-libs.common))


### PR DESCRIPTION
This allows users to use ocamlformat as a library.

We give a public name `ocamlformat` to the library and each library is exposed as a sublibrary of `ocamlformat` (e.g. `ocamlformat.parse_wyc` and `ocamlformat.parser_shims`).

I also cleanup the dune-project file to remove the duplicated dependencies. `ocamlformat-rpc-lib` and `ocamlformat-bench` now depends on `ocamlformat {= version}`. I can remove this part if needed.

