### PR TITLE
Preserve position of comments located after the semi-colon of the last element of lists/arrays/records

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 
 - New syntax `(*= ... *)` for verbatim comments (#2028, @gpetiot)
 - Preserve the begin-end construction in the AST (#1785, @hhugo, @gpetiot)
+- Preserve position of comments located after the semi-colon of the last element of lists/arrays/records (#2032, @gpetiot)
 
 ## 0.21.0 (2022-02-25)
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -282,6 +282,8 @@ module Ext = struct
 end
 
 module Exp = struct
+  let location x = x.pexp_loc
+
   let test_id ~f = function
     | {pexp_desc= Pexp_ident {txt= i; _}; _} -> f i
     | _ -> false
@@ -356,6 +358,8 @@ module Exp = struct
 end
 
 module Pat = struct
+  let location x = x.ppat_loc
+
   let is_simple {ppat_desc; _} =
     match ppat_desc with
     | Ppat_any | Ppat_constant _ | Ppat_var _

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -87,6 +87,8 @@ module Longident : sig
 end
 
 module Exp : sig
+  val location : expression -> Location.t
+
   val is_prefix : expression -> bool
   (** Holds for prefix symbol expressions. *)
 
@@ -145,6 +147,8 @@ type cmt_checker =
   ; cmts_after: Location.t -> bool }
 
 module Pat : sig
+  val location : pattern -> Location.t
+
   val is_simple : pattern -> bool
 end
 

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -445,8 +445,8 @@ let pop_if_debug t loc =
 let find_cmts ?(filter = Fn.const true) t pos loc =
   pop_if_debug t loc ;
   Option.map (find_at_position t loc pos) ~f:(fun cmts ->
-      let picked, left = List.partition_tf cmts ~f:filter in
-      update_cmts t pos ~f:(Map.set ~key:loc ~data:left) ;
+      let picked, not_picked = List.partition_tf cmts ~f:filter in
+      update_cmts t pos ~f:(Map.set ~key:loc ~data:not_picked) ;
       picked )
 
 let break_comment_group source margin {Cmt.loc= a; _} {Cmt.loc= b; _} =

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -65,6 +65,7 @@ val fmt_after :
   -> fmt_code:(Conf.t -> Fmt.code_formatter)
   -> ?pro:Fmt.t
   -> ?epi:Fmt.t
+  -> ?filter:(Cmt.t -> bool)
   -> Location.t
   -> Fmt.t
 (** [fmt_after loc] formats the comments associated with [loc] that appear

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -867,6 +867,60 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to collections-conventional.ml.stdout
+   (with-stderr-to collections-conventional.ml.stderr
+     (run %{bin:ocamlformat} --margin-check --profile=conventional --max-iters=3 %{dep:tests/collections.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/collections-conventional.ml.ref collections-conventional.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/collections-conventional.ml.err collections-conventional.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to collections-janestreet.ml.stdout
+   (with-stderr-to collections-janestreet.ml.stderr
+     (run %{bin:ocamlformat} --margin-check --profile=janestreet --max-iters=3 %{dep:tests/collections.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/collections-janestreet.ml.ref collections-janestreet.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/collections-janestreet.ml.err collections-janestreet.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to collections.ml.stdout
+   (with-stderr-to collections.ml.stderr
+     (run %{bin:ocamlformat} --margin-check --profile=ocamlformat --max-iters=3 %{dep:tests/collections.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/collections.ml.ref collections.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/collections.ml.err collections.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to comment_breaking.ml.stdout
    (with-stderr-to comment_breaking.ml.stderr
      (run %{bin:ocamlformat} --margin-check %{dep:tests/comment_breaking.ml})))))

--- a/test/passing/tests/collections-conventional.ml.opts
+++ b/test/passing/tests/collections-conventional.ml.opts
@@ -1,0 +1,2 @@
+--profile=conventional
+--max-iters=3

--- a/test/passing/tests/collections-conventional.ml.ref
+++ b/test/passing/tests/collections-conventional.ml.ref
@@ -1,0 +1,48 @@
+let _ =
+  [
+    a;
+    b
+    (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo *);
+  ]
+
+let [
+      fooooooooooooooooooooooooooooooo;
+      fooooooooooooooooooooooooooooooo;
+      fooooooooooooooooooooooooooooooo;
+      (* before end of the list *)
+    ] =
+  [
+    fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+    (* after all elements *)
+    (* after all elements as well *)
+  ]
+
+let [|
+      fooooooooooooooooooooooooooooooo;
+      fooooooooooooooooooooooooooooooo;
+      fooooooooooooooooooooooooooooooo;
+      (* before end of the array *)
+    |] =
+  [|
+    fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+    (* after all elements *)
+    (* after all elements as well *)
+  |]
+
+let {
+      fooooooooooooooooooooooooooooooo;
+      fooooooooooooooooooooooooooooooo;
+      fooooooooooooooooooooooooooooooo;
+      _;
+      (* xxx *)
+    } =
+  {
+    fooooooooooooooooooooooooooooooo = x;
+    fooooooooooooooooooooooooooooooo = y;
+    fooooooooooooooooooooooooooooooo = z;
+    (* after all fields *)
+  }

--- a/test/passing/tests/collections-janestreet.ml.opts
+++ b/test/passing/tests/collections-janestreet.ml.opts
@@ -1,0 +1,2 @@
+--profile=janestreet
+--max-iters=3

--- a/test/passing/tests/collections-janestreet.ml.ref
+++ b/test/passing/tests/collections-janestreet.ml.ref
@@ -1,0 +1,42 @@
+let _ =
+  [ a; b (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo *) ]
+;;
+
+let [ fooooooooooooooooooooooooooooooo
+    ; fooooooooooooooooooooooooooooooo
+    ; fooooooooooooooooooooooooooooooo (* before end of the list *)
+    ]
+  =
+  [ fooooooooooooooooooooooooooooooo
+  ; fooooooooooooooooooooooooooooooo
+  ; fooooooooooooooooooooooooooooooo
+    (* after all elements *)
+    (* after all elements as well *)
+  ]
+;;
+
+let [| fooooooooooooooooooooooooooooooo
+     ; fooooooooooooooooooooooooooooooo
+     ; fooooooooooooooooooooooooooooooo (* before end of the array *)
+    |]
+  =
+  [| fooooooooooooooooooooooooooooooo
+   ; fooooooooooooooooooooooooooooooo
+   ; fooooooooooooooooooooooooooooooo
+     (* after all elements *)
+     (* after all elements as well *)
+  |]
+;;
+
+let { fooooooooooooooooooooooooooooooo
+    ; fooooooooooooooooooooooooooooooo
+    ; fooooooooooooooooooooooooooooooo
+    ; _
+      (* xxx *)
+    }
+  =
+  { fooooooooooooooooooooooooooooooo = x
+  ; fooooooooooooooooooooooooooooooo = y
+  ; fooooooooooooooooooooooooooooooo = z (* after all fields *)
+  }
+;;

--- a/test/passing/tests/collections.ml
+++ b/test/passing/tests/collections.ml
@@ -1,0 +1,37 @@
+let _ =
+  [
+    a;
+    b (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
+  ]
+
+let
+  [ fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+  (* before end of the list *) ] =
+  [ fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+  (* after all elements *)
+  (* after all elements as well *) ]
+
+let
+  [| fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+  (* before end of the array *) |] =
+  [| fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+  (* after all elements *)
+  (* after all elements as well *) |]
+
+let { fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+    fooooooooooooooooooooooooooooooo;
+    _
+    (* xxx *) } =
+  { fooooooooooooooooooooooooooooooo= x;
+    fooooooooooooooooooooooooooooooo= y;
+    fooooooooooooooooooooooooooooooo= z;
+  (* after all fields *) }

--- a/test/passing/tests/collections.ml.opts
+++ b/test/passing/tests/collections.ml.opts
@@ -1,0 +1,2 @@
+--profile=ocamlformat
+--max-iters=3

--- a/test/passing/tests/collections.ml.ref
+++ b/test/passing/tests/collections.ml.ref
@@ -1,0 +1,32 @@
+let _ =
+  [ a
+  ; b
+    (* foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo *)
+  ]
+
+let [ fooooooooooooooooooooooooooooooo
+    ; fooooooooooooooooooooooooooooooo
+    ; fooooooooooooooooooooooooooooooo (* before end of the list *) ] =
+  [ fooooooooooooooooooooooooooooooo
+  ; fooooooooooooooooooooooooooooooo
+  ; fooooooooooooooooooooooooooooooo
+    (* after all elements *)
+    (* after all elements as well *) ]
+
+let [| fooooooooooooooooooooooooooooooo
+     ; fooooooooooooooooooooooooooooooo
+     ; fooooooooooooooooooooooooooooooo (* before end of the array *) |] =
+  [| fooooooooooooooooooooooooooooooo
+   ; fooooooooooooooooooooooooooooooo
+   ; fooooooooooooooooooooooooooooooo
+     (* after all elements *)
+     (* after all elements as well *) |]
+
+let { fooooooooooooooooooooooooooooooo
+    ; fooooooooooooooooooooooooooooooo
+    ; fooooooooooooooooooooooooooooooo
+    ; _
+      (* xxx *) } =
+  { fooooooooooooooooooooooooooooooo= x
+  ; fooooooooooooooooooooooooooooooo= y
+  ; fooooooooooooooooooooooooooooooo= z (* after all fields *) }


### PR DESCRIPTION
Fix #2007
See also https://gitlab.com/tezos/tezos/-/merge_requests/4587

As it seems it's important to users I think we can afford to maintain this code, it's not that ugly. Although it's only useful when the semi-colons are printed after each element and not before.

No diff with test_branch.sh