### PR TITLE
Doc-comments code blocks with a language other than 'ocaml' (set in metadata) are not parsed as OCaml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
   + ocamlformat-rpc is now distributed through the ocamlformat package (#2035, @Julow)
 
+  + Doc-comments code blocks with a language other than 'ocaml' (set in metadata) are not parsed as OCaml (#2037, @gpetiot)
+
 #### New features
 
   + New syntax `(*= ... *)` for verbatim comments (#2028, @gpetiot)

--- a/test/passing/tests/doc_comments-no-parse-docstrings.mli.err
+++ b/test/passing/tests/doc_comments-no-parse-docstrings.mli.err
@@ -19,3 +19,4 @@ Warning: tests/doc_comments.mli:512 exceeds the margin
 Warning: tests/doc_comments.mli:547 exceeds the margin
 Warning: tests/doc_comments.mli:549 exceeds the margin
 Warning: tests/doc_comments.mli:551 exceeds the margin
+Warning: tests/doc_comments.mli:575 exceeds the margin

--- a/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
+++ b/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
@@ -572,3 +572,7 @@ type x =
            b *)]} *)
   | B of b  (** {[(* a
            b *)]} *)
+
+(** Set a different language name in the block metadata to not format as OCaml:
+
+    {@sh[ echo "this""is""only""a""single"(echo word)(echo also) ]} *)

--- a/test/passing/tests/doc_comments-no-wrap.mli.ref
+++ b/test/passing/tests/doc_comments-no-wrap.mli.ref
@@ -577,3 +577,10 @@ type x =
             (* a
                b *)
           ]} *)
+
+(** Set a different language name in the block metadata to not format as
+    OCaml:
+
+    {@sh[
+      echo "this""is""only""a""single"(echo word)(echo also)
+    ]} *)

--- a/test/passing/tests/doc_comments.mli
+++ b/test/passing/tests/doc_comments.mli
@@ -582,3 +582,7 @@ type x =
   | B of b
   (** {[(* a
            b *)]} *)
+
+(** Set a different language name in the block metadata to not format as OCaml:
+
+    {@sh[ echo "this""is""only""a""single"(echo word)(echo also) ]} *)

--- a/test/passing/tests/doc_comments.mli.ref
+++ b/test/passing/tests/doc_comments.mli.ref
@@ -571,3 +571,10 @@ type x =
       (** {[
             (* a b *)
           ]} *)
+
+(** Set a different language name in the block metadata to not format as
+    OCaml:
+
+    {@sh[
+      echo "this""is""only""a""single"(echo word)(echo also)
+    ]} *)


### PR DESCRIPTION
Fix #1597