### PR TITLE
Do not merge global .ocamlformat config file with project configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - ocamlformat-rpc is now distributed through the ocamlformat package (#2035, @Julow)
 - Doc-comments code blocks with a language other than 'ocaml' (set in metadata) are not parsed as OCaml (#2037, @gpetiot)
 - More comprehensible error message in case of version mismatch (#2042, @gpetiot)
+- The global configuration file (`$XDG_CONFIG_HOME` or `$HOME/.config`) is only applied when no project is detected, `--enable-outside-detected-project` is set, and no applicable `.ocamlformat` file has been found. Global and local configurations are no longer used at the same time. (#2039, @gpetiot)
 
 ### New features
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -157,13 +157,14 @@ let info =
          the processed file."
     ; `P
         "(*) $(b,.ocamlformat) files in current and all ancestor \
-         directories for each input file are used, as well as the global \
-         $(b,ocamlformat) file defined in $(b,\\$XDG_CONFIG_HOME) or in \
-         $(b,\\$HOME/.config) if $(b,\\$XDG_CONFIG_HOME) is undefined. The \
-         global $(b,ocamlformat) file has the lowest priority, then the \
-         closer the directory is to the processed file, the higher the \
-         priority. The global $(b,ocamlformat) file is only used when the \
-         option $(b,enable-outside-detected-project) is set."
+         directories for each input file are used, applied from top to \
+         bottom, overriding the settings each time a file is applied, \
+         stopping at the project root. If no project root and no \
+         $(b,ocamlformat) file has been found, and if the option \
+         $(b,enable-outside-detected-project) is set, the global \
+         $(b,ocamlformat) file defined in $(b,\\$XDG_CONFIG_HOME) (or in \
+         $(b,\\$HOME/.config) if $(b,\\$XDG_CONFIG_HOME) is undefined) is \
+         used."
     ; `P
         "If the $(b,disable) option is not set, an $(b,.ocamlformat-ignore) \
          file specifies files that OCamlFormat should ignore. Each line in \
@@ -1232,10 +1233,15 @@ let enable_outside_detected_project =
   in
   let doc =
     Format.sprintf
-      "Read $(b,.ocamlformat) config files outside the current project. The \
-       project root of an input file is taken to be the nearest ancestor \
-       directory that contains a %s file. Formatting is enabled even if no \
-       $(b,.ocamlformat) configuration file is found."
+      "Read $(b,.ocamlformat) config files outside the current project when \
+       no project root has been detected for the input file. The project \
+       root of an input file is taken to be the nearest ancestor directory \
+       that contains a %s file. If $(b,.ocamlformat) config files are \
+       located in the same directory or parents they are applied, if no \
+       $(b,.ocamlformat) file is found then the global configuration \
+       defined in $(b,\\$XDG_CONFIG_HOME/.ocamlformat) (or in \
+       $(b,\\$HOME/.config/.ocamlformat) if $(b,\\$XDG_CONFIG_HOME) is \
+       undefined) is applied."
       witness
   in
   let default = false in

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -22,12 +22,12 @@ OPTIONS (CODE FORMATTING STYLE)
        file.
 
        (*) .ocamlformat files in current and all ancestor directories for
-       each input file are used, as well as the global ocamlformat file
-       defined in $XDG_CONFIG_HOME or in $HOME/.config if $XDG_CONFIG_HOME is
-       undefined. The global ocamlformat file has the lowest priority, then
-       the closer the directory is to the processed file, the higher the
-       priority. The global ocamlformat file is only used when the option
-       enable-outside-detected-project is set.
+       each input file are used, applied from top to bottom, overriding the
+       settings each time a file is applied, stopping at the project root. If
+       no project root and no ocamlformat file has been found, and if the
+       option enable-outside-detected-project is set, the global ocamlformat
+       file defined in $XDG_CONFIG_HOME (or in $HOME/.config if
+       $XDG_CONFIG_HOME is undefined) is used.
 
        If the disable option is not set, an .ocamlformat-ignore file
        specifies files that OCamlFormat should ignore. Each line in an
@@ -586,11 +586,15 @@ OPTIONS
            Disable .ocamlformat configuration files.
 
        --enable-outside-detected-project
-           Read .ocamlformat config files outside the current project. The
-           project root of an input file is taken to be the nearest ancestor
-           directory that contains a .git or .hg or dune-project file.
-           Formatting is enabled even if no .ocamlformat configuration file
-           is found.
+           Read .ocamlformat config files outside the current project when no
+           project root has been detected for the input file. The project
+           root of an input file is taken to be the nearest ancestor
+           directory that contains a .git or .hg or dune-project file. If
+           .ocamlformat config files are located in the same directory or
+           parents they are applied, if no .ocamlformat file is found then
+           the global configuration defined in $XDG_CONFIG_HOME/.ocamlformat
+           (or in $HOME/.config/.ocamlformat if $XDG_CONFIG_HOME is
+           undefined) is applied.
 
        -g, --debug
            Generate debugging output. The flag is unset by default.

--- a/test/projects/enable_outside_detected_project.expected
+++ b/test/projects/enable_outside_detected_project.expected
@@ -1,2 +1,2 @@
-(* The following code should be formatted using OCamlformat's config and not default *)
-type t = {foooooo: string; baaaaar: Baaaaar.t}
+(* The following code should be formatted using the default profile and ignore parent directories .ocamlformat files. *)
+type t = { foooooo : string; baaaaar : Baaaaar.t }

--- a/test/projects/enable_outside_detected_project/main.ml
+++ b/test/projects/enable_outside_detected_project/main.ml
@@ -1,4 +1,4 @@
-(* The following code should be formatted using OCamlformat's config and not default *)
+(* The following code should be formatted using the default profile and ignore parent directories .ocamlformat files. *)
 type t = {
   foooooo : string;
   baaaaar : Baaaaar.t;


### PR DESCRIPTION
Fix #1459 (cc @CraigFe)

The doc should reflect the changes, the behavior is what has been discussed in #1459 

<details>

- if a project root is found:
  * apply the local .ocamlformat files, not the global conf
- else
  * if `enable-outside-detected-project` is set
    + apply .ocamlformat files up to `/`
    + if no file has been found then apply the global conf if it exists

</details>