### PR TITLE
Tests: adjacent docstrings

### DIFF
--- a/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
+++ b/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
@@ -576,3 +576,7 @@ type x =
 (** Set a different language name in the block metadata to not format as OCaml:
 
     {@sh[ echo "this""is""only""a""single"(echo word)(echo also) ]} *)
+
+(**a*)
+
+(**b*)

--- a/test/passing/tests/doc_comments-no-wrap.mli.ref
+++ b/test/passing/tests/doc_comments-no-wrap.mli.ref
@@ -584,3 +584,7 @@ type x =
     {@sh[
       echo "this""is""only""a""single"(echo word)(echo also)
     ]} *)
+
+(**a*)
+
+(**b*)

--- a/test/passing/tests/doc_comments.mli
+++ b/test/passing/tests/doc_comments.mli
@@ -586,3 +586,5 @@ type x =
 (** Set a different language name in the block metadata to not format as OCaml:
 
     {@sh[ echo "this""is""only""a""single"(echo word)(echo also) ]} *)
+
+(**a*)(**b*)

--- a/test/passing/tests/doc_comments.mli.ref
+++ b/test/passing/tests/doc_comments.mli.ref
@@ -578,3 +578,7 @@ type x =
     {@sh[
       echo "this""is""only""a""single"(echo word)(echo also)
     ]} *)
+
+(**a*)
+
+(**b*)


### PR DESCRIPTION
Closes #1266 (already fixed on the dev branch), adding a non-regression test.