### PR TITLE
Update vendored parser and libs from upstream ocaml

### DIFF
--- a/vendor/diff-parsers-std-ext.patch
+++ b/vendor/diff-parsers-std-ext.patch
@@ -654,10 +654,10 @@
 --- ocaml-4.13/printast.ml
 +++ ocaml-4.13-extended/printast.ml
 @@@@
+   if l.pos_lnum = -1
    then fprintf f "%s[%d]" fname l.pos_cnum
    else fprintf f "%s[%d,%d+%d]" fname l.pos_lnum l.pos_bol
                 (l.pos_cnum - l.pos_bol)
- ;;
  
 +let curr_indent : int ref = ref 0
 +
@@ -665,7 +665,6 @@
 +  curr_indent := i;
 +  fprintf f "%s" (String.make ((2*i) mod 72) ' ');
 +  fprintf f s (*...*)
-+;;
 +
 +type cmts =
 +  { before: Location.t -> string list option
@@ -704,10 +703,10 @@
 +            fmt_cmts i f "within" w;
 +            fmt_cmts i f " after" a )
    end
- ;;
  
  let rec fmt_longident_aux f x =
    match x with
+   | Longident.Lident (s) -> fprintf f "%s" s
 @@@@
  
  let fmt_char_option f = function
@@ -716,31 +715,31 @@
  
 -let fmt_constant f x =
 -  match x with
--  | Pconst_integer (i,m) -> fprintf f "PConst_int (%s,%a)" i fmt_char_option m;
--  | Pconst_char (c) -> fprintf f "PConst_char %02x" (Char.code c);
+-  | Pconst_integer (i,m) -> fprintf f "PConst_int (%s,%a)" i fmt_char_option m
+-  | Pconst_char (c) -> fprintf f "PConst_char %02x" (Char.code c)
 +let fmt_constant i f x =
 +  line i f "constant %a\n" fmt_location x.pconst_loc;
 +  let i = i+1 in
 +  match x.pconst_desc with
-+  | Pconst_integer (j,m) -> line i f "PConst_int (%s,%a)" j fmt_char_option m;
-+  | Pconst_char (c) -> line i f "PConst_char %02x" (Char.code c);
++  | Pconst_integer (j,m) -> line i f "PConst_int (%s,%a)" j fmt_char_option m
++  | Pconst_char (c) -> line i f "PConst_char %02x" (Char.code c)
    | Pconst_string (s, strloc, None) ->
--      fprintf f "PConst_string(%S,%a,None)" s fmt_location strloc ;
-+      line i f "PConst_string(%S,%a,None)" s fmt_location strloc ;
+-      fprintf f "PConst_string(%S,%a,None)" s fmt_location strloc
++      line i f "PConst_string(%S,%a,None)" s fmt_location strloc
    | Pconst_string (s, strloc, Some delim) ->
--      fprintf f "PConst_string (%S,%a,Some %S)" s fmt_location strloc delim;
--  | Pconst_float (s,m) -> fprintf f "PConst_float (%s,%a)" s fmt_char_option m;
-+      line i f "PConst_string (%S,%a,Some %S)" s fmt_location strloc delim;
-+  | Pconst_float (s,m) -> line i f "PConst_float (%s,%a)" s fmt_char_option m;
- ;;
+-      fprintf f "PConst_string (%S,%a,Some %S)" s fmt_location strloc delim
+-  | Pconst_float (s,m) -> fprintf f "PConst_float (%s,%a)" s fmt_char_option m
++      line i f "PConst_string (%S,%a,Some %S)" s fmt_location strloc delim
++  | Pconst_float (s,m) -> line i f "PConst_float (%s,%a)" s fmt_char_option m
  
  let fmt_mutable_flag f x =
    match x with
-   | Immutable -> fprintf f "Immutable";
+   | Immutable -> fprintf f "Immutable"
+   | Mutable -> fprintf f "Mutable"
 @@@@
-   | Override -> fprintf f "Override";
-   | Fresh -> fprintf f "Fresh";
- ;;
+   match x with
+   | Override -> fprintf f "Override"
+   | Fresh -> fprintf f "Fresh"
  
  let fmt_closed_flag f x =
 -  match x with
@@ -755,29 +754,28 @@
 +
  let fmt_rec_flag f x =
    match x with
-   | Nonrecursive -> fprintf f "Nonrec";
-   | Recursive -> fprintf f "Rec";
- ;;
+   | Nonrecursive -> fprintf f "Nonrec"
+   | Recursive -> fprintf f "Rec"
+ 
 @@@@
+ let fmt_private_flag f x =
    match x with
-   | Public -> fprintf f "Public";
-   | Private -> fprintf f "Private";
- ;;
+   | Public -> fprintf f "Public"
+   | Private -> fprintf f "Private"
  
 -let line i f s (*...*) =
 -  fprintf f "%s" (String.make ((2*i) mod 72) ' ');
 -  fprintf f s (*...*)
--;;
 -
  let list i f ppf l =
    match l with
-   | [] -> line i ppf "[]\n";
+   | [] -> line i ppf "[]\n"
    | _ :: _ ->
       line i ppf "[\n";
 @@@@
+   | Nolabel -> line i ppf "Nolabel\n"
    | Optional s -> line i ppf "Optional \"%s\"\n" s
    | Labelled s -> line i ppf "Labelled \"%s\"\n" s
- ;;
  
  let typevars ppf vs =
 -  List.iter (fun x -> fprintf ppf " %a" Pprintast.tyvar x.txt) vs
@@ -1314,7 +1312,6 @@
        line i ppf "Rinherit\n";
 -      core_type (i+1) ppf ct
 +      core_type i ppf ct
- ;;
  
  let rec toplevel_phrase i ppf x =
    match x with
@@ -1334,12 +1331,11 @@
 +  line i ppf "directive_argument %a\n" fmt_location x.pdira_loc;
 +  let i = i+1 in
    match x.pdira_desc with
-   | Pdir_string (s) -> line i ppf "Pdir_string \"%s\"\n" s;
-   | Pdir_int (n, None) -> line i ppf "Pdir_int %s\n" n;
-   | Pdir_int (n, Some m) -> line i ppf "Pdir_int %s%c\n" n m;
-   | Pdir_ident (li) -> line i ppf "Pdir_ident %a\n" fmt_longident li;
-   | Pdir_bool (b) -> line i ppf "Pdir_bool %s\n" (string_of_bool b);
- ;;
+   | Pdir_string (s) -> line i ppf "Pdir_string \"%s\"\n" s
+   | Pdir_int (n, None) -> line i ppf "Pdir_int %s\n" n
+   | Pdir_int (n, Some m) -> line i ppf "Pdir_int %s%c\n" n m
+   | Pdir_ident (li) -> line i ppf "Pdir_ident %a\n" fmt_longident li
+   | Pdir_bool (b) -> line i ppf "Pdir_bool %s\n" (string_of_bool b)
  
 +let repl_phrase i ppf x =
 +  line i ppf "repl_phrase\n";
@@ -1347,22 +1343,22 @@
 +  toplevel_phrase i ppf x.prepl_phrase;
 +  line i ppf "output %S\n" x.prepl_output
 +
- let interface ppf x = list 0 signature_item ppf x;;
+ let interface ppf x = list 0 signature_item ppf x
  
- let implementation ppf x = list 0 structure_item ppf x;;
+ let implementation ppf x = list 0 structure_item ppf x
  
- let top_phrase ppf x = toplevel_phrase 0 ppf x;;
+ let top_phrase ppf x = toplevel_phrase 0 ppf x
 +
-+let repl_phrase ppf x = repl_phrase 0 ppf x;;
++let repl_phrase ppf x = repl_phrase 0 ppf x
 --- ocaml-4.13/printast.mli
 +++ ocaml-4.13-extended/printast.mli
 @@@@
- open Format;;
+ open Format
  
- val interface : formatter -> signature_item list -> unit;;
- val implementation : formatter -> structure_item list -> unit;;
- val top_phrase : formatter -> toplevel_phrase -> unit;;
-+val repl_phrase : formatter -> repl_phrase -> unit;;
+ val interface : formatter -> signature_item list -> unit
+ val implementation : formatter -> structure_item list -> unit
+ val top_phrase : formatter -> toplevel_phrase -> unit
++val repl_phrase : formatter -> repl_phrase -> unit
  
  val expression: int -> formatter -> expression -> unit
  val structure: int -> formatter -> structure -> unit

--- a/vendor/diff-stdlib-format.patch
+++ b/vendor/diff-stdlib-format.patch
@@ -156,6 +156,33 @@
  (* Push a token on pretty-printer scanning stack.
     If b is true set_size is called. *)
 @@@@
+     match Stack.pop_opt state.pp_tag_stack with
+     | None -> () (* No more tag to close. *)
+     | Some tag_name ->
+       state.pp_print_close_tag tag_name
+ 
++let pp_open_tag state s = pp_open_stag state (String_tag s)
++let pp_close_tag state () = pp_close_stag state ()
++
+ let pp_set_print_tags state b = state.pp_print_tags <- b
+ let pp_set_mark_tags state b = state.pp_mark_tags <- b
+ let pp_get_print_tags state () = state.pp_print_tags
+ let pp_get_mark_tags state () = state.pp_mark_tags
+ let pp_set_tags state b =
+@@@@
+   state.pp_curr_depth <- 0;
+   state.pp_space_left <- state.pp_margin;
+   pp_open_sys_box state
+ 
+ let clear_tag_stack state =
+-  Stack.iter (fun _ -> pp_close_stag state ()) state.pp_tag_stack
++  Stack.iter (fun _ -> pp_close_tag state ()) state.pp_tag_stack
+ 
+ 
+ (* Flushing pretty-printer queue. *)
+ let pp_flush_queue state b =
+   clear_tag_stack state;
+@@@@
      let token = Pp_break { fits; breaks } in
      let length = String.length before + width + String.length after in
      let elem = { size; token; length } in
@@ -204,8 +231,458 @@
     split the line;
     a cut is a break hint that prints nothing if the break does not split the
     line. *)
+@@@@
+    to [Stdlib.stdout], [Stdlib.stderr], and {!stdbuf}. *)
+ let std_formatter = formatter_of_out_channel Stdlib.stdout
+ and err_formatter = formatter_of_out_channel Stdlib.stderr
+ and str_formatter = formatter_of_buffer stdbuf
+ 
+-(* Initialise domain local state *)
+-module DLS = Domain.DLS
+-
+-let stdbuf_key = DLS.new_key pp_make_buffer
+-let _ = DLS.set stdbuf_key stdbuf
+-
+-let str_formatter_key = DLS.new_key (fun () ->
+-  formatter_of_buffer (DLS.get stdbuf_key))
+-let _ = DLS.set str_formatter_key str_formatter
+-
+-let buffered_out_string key str ofs len =
+-  Buffer.add_substring (Domain.DLS.get key) str ofs len
+-
+-let buffered_out_flush oc key () =
+-  let buf = Domain.DLS.get key in
+-  let len = Buffer.length buf in
+-  let str = Buffer.contents buf in
+-  output_substring oc str 0 len ;
+-  Stdlib.flush oc;
+-  Buffer.clear buf
+-
+-let std_buf_key = Domain.DLS.new_key (fun () -> Buffer.create pp_buffer_size)
+-let err_buf_key = Domain.DLS.new_key (fun () -> Buffer.create pp_buffer_size)
+-
+-let std_formatter_key = DLS.new_key (fun () ->
+-  let ppf =
+-    pp_make_formatter (buffered_out_string std_buf_key)
+-      (buffered_out_flush Stdlib.stdout std_buf_key) ignore ignore ignore
+-  in
+-  ppf.pp_out_newline <- display_newline ppf;
+-  ppf.pp_out_spaces <- display_blanks ppf;
+-  ppf.pp_out_indent <- display_indent ppf;
+-  ppf)
+-let _ = DLS.set std_formatter_key std_formatter
+-
+-let err_formatter_key = DLS.new_key (fun () ->
+-  let ppf =
+-    pp_make_formatter (buffered_out_string err_buf_key)
+-      (buffered_out_flush Stdlib.stderr err_buf_key) ignore ignore ignore
+-  in
+-  ppf.pp_out_newline <- display_newline ppf;
+-  ppf.pp_out_spaces <- display_blanks ppf;
+-  ppf.pp_out_indent <- display_indent ppf;
+-  ppf)
+-let _ = DLS.set err_formatter_key err_formatter
+-
+-let get_std_formatter () = DLS.get std_formatter_key
+-let get_err_formatter () = DLS.get err_formatter_key
+-let get_str_formatter () = DLS.get str_formatter_key
+-let get_stdbuf () = DLS.get stdbuf_key
+ 
+ (* [flush_buffer_formatter buf ppf] flushes formatter [ppf],
+    then returns the contents of buffer [buf] that is reset.
+    Formatter [ppf] is supposed to print to buffer [buf], otherwise this
+    function is not really useful. *)
+@@@@
+   pp_flush_queue ppf false;
+   let s = Buffer.contents buf in
+   Buffer.reset buf;
+   s
+ 
+-(* Flush [str_formatter] and get the contents of [stdbuf]. *)
+-let flush_str_formatter () =
+-  let stdbuf = DLS.get stdbuf_key in
+-  let str_formatter = DLS.get str_formatter_key in
+-  flush_buffer_formatter stdbuf str_formatter
+-
+-let make_synchronized_formatter output flush =
+-  DLS.new_key (fun () ->
+-    let buf = Buffer.create pp_buffer_size in
+-    let output' = Buffer.add_substring buf in
+-    let flush' () =
+-      output (Buffer.contents buf) 0 (Buffer.length buf);
+-      Buffer.clear buf;
+-      flush ()
+-    in
+-    make_formatter output' flush')
+ 
+-let synchronized_formatter_of_out_channel oc =
+-  make_synchronized_formatter (output_substring oc) (fun () -> flush oc)
++(* Flush [str_formatter] and get the contents of [stdbuf]. *)
++let flush_str_formatter () = flush_buffer_formatter stdbuf str_formatter
+ 
+ (*
+   Symbolic pretty-printing
+ *)
+ 
+@@@@
+   Basic functions on the 'standard' formatter
+   (the formatter that prints to [Stdlib.stdout]).
+ 
+ *)
+ 
+-let open_hbox v = pp_open_hbox (DLS.get std_formatter_key) v
+-and open_vbox v = pp_open_vbox (DLS.get std_formatter_key) v
+-and open_hvbox v = pp_open_hvbox (DLS.get std_formatter_key) v
+-and open_hovbox v = pp_open_hovbox (DLS.get std_formatter_key) v
+-and open_box v = pp_open_box (DLS.get std_formatter_key) v
+-and close_box v = pp_close_box (DLS.get std_formatter_key) v
+-and open_stag v = pp_open_stag (DLS.get std_formatter_key) v
+-and close_stag v = pp_close_stag (DLS.get std_formatter_key) v
+-and print_as v w = pp_print_as (DLS.get std_formatter_key) v w
+-and print_string v = pp_print_string (DLS.get std_formatter_key) v
+-and print_bytes v = pp_print_bytes (DLS.get std_formatter_key) v
+-and print_int v = pp_print_int (DLS.get std_formatter_key) v
+-and print_float v = pp_print_float (DLS.get std_formatter_key) v
+-and print_char v = pp_print_char (DLS.get std_formatter_key) v
+-and print_bool v = pp_print_bool (DLS.get std_formatter_key) v
+-and print_break v w = pp_print_break (DLS.get std_formatter_key) v w
+-and print_cut v = pp_print_cut (DLS.get std_formatter_key) v
+-and print_space v = pp_print_space (DLS.get std_formatter_key) v
+-and force_newline v = pp_force_newline (DLS.get std_formatter_key) v
+-and print_flush v = pp_print_flush (DLS.get std_formatter_key) v
+-and print_newline v = pp_print_newline (DLS.get std_formatter_key) v
+-and print_if_newline v = pp_print_if_newline (DLS.get std_formatter_key) v
+-
+-and open_tbox v = pp_open_tbox (DLS.get std_formatter_key) v
+-and close_tbox v = pp_close_tbox (DLS.get std_formatter_key) v
+-and print_tbreak v w = pp_print_tbreak (DLS.get std_formatter_key) v w
+-
+-and set_tab v = pp_set_tab (DLS.get std_formatter_key) v
+-and print_tab v = pp_print_tab (DLS.get std_formatter_key) v
+-
+-and set_margin v = pp_set_margin (DLS.get std_formatter_key) v
+-and get_margin v = pp_get_margin (DLS.get std_formatter_key) v
+-
+-and set_max_indent v = pp_set_max_indent (DLS.get std_formatter_key) v
+-and get_max_indent v = pp_get_max_indent (DLS.get std_formatter_key) v
+-
+-and set_geometry ~max_indent ~margin =
+-  pp_set_geometry (DLS.get std_formatter_key) ~max_indent ~margin
+-and safe_set_geometry ~max_indent ~margin =
+-  pp_safe_set_geometry (DLS.get std_formatter_key) ~max_indent ~margin
+-and get_geometry v = pp_get_geometry (DLS.get std_formatter_key) v
+-and update_geometry v = pp_update_geometry (DLS.get std_formatter_key) v
+-
+-and set_max_boxes v = pp_set_max_boxes (DLS.get std_formatter_key) v
+-and get_max_boxes v = pp_get_max_boxes (DLS.get std_formatter_key) v
+-and over_max_boxes v = pp_over_max_boxes (DLS.get std_formatter_key) v
+-
+-and set_ellipsis_text v = pp_set_ellipsis_text (DLS.get std_formatter_key) v
+-and get_ellipsis_text v = pp_get_ellipsis_text (DLS.get std_formatter_key) v
+-
+-and set_formatter_out_channel v =
+-  pp_set_formatter_out_channel (DLS.get std_formatter_key) v
+-
+-and set_formatter_out_functions v =
+-  pp_set_formatter_out_functions (DLS.get std_formatter_key) v
+-and get_formatter_out_functions v =
+-  pp_get_formatter_out_functions (DLS.get std_formatter_key) v
+-
+-and set_formatter_output_functions v w =
+-  pp_set_formatter_output_functions (DLS.get std_formatter_key) v w
+-and get_formatter_output_functions v =
+-  pp_get_formatter_output_functions (DLS.get std_formatter_key) v
+-
+-and set_formatter_stag_functions v =
+-  pp_set_formatter_stag_functions (DLS.get std_formatter_key) v
+-and get_formatter_stag_functions v =
+-  pp_get_formatter_stag_functions (DLS.get std_formatter_key) v
+-and set_print_tags v =
+-  pp_set_print_tags (DLS.get std_formatter_key) v
+-and get_print_tags v =
+-  pp_get_print_tags (DLS.get std_formatter_key) v
+-and set_mark_tags v =
+-  pp_set_mark_tags (DLS.get std_formatter_key) v
+-and get_mark_tags v =
+-  pp_get_mark_tags (DLS.get std_formatter_key) v
+-and set_tags v =
+-  pp_set_tags (DLS.get std_formatter_key) v
++let open_hbox = pp_open_hbox std_formatter
++and open_vbox = pp_open_vbox std_formatter
++and open_hvbox = pp_open_hvbox std_formatter
++and open_hovbox = pp_open_hovbox std_formatter
++and open_box = pp_open_box std_formatter
++and close_box = pp_close_box std_formatter
++and open_tag = pp_open_tag std_formatter
++and close_tag = pp_close_tag std_formatter
++and open_stag = pp_open_stag std_formatter
++and close_stag = pp_close_stag std_formatter
++and print_as = pp_print_as std_formatter
++and print_string = pp_print_string std_formatter
++and print_bytes = pp_print_bytes std_formatter
++and print_int = pp_print_int std_formatter
++and print_float = pp_print_float std_formatter
++and print_char = pp_print_char std_formatter
++and print_bool = pp_print_bool std_formatter
++and print_break = pp_print_break std_formatter
++and print_cut = pp_print_cut std_formatter
++and print_space = pp_print_space std_formatter
++and force_newline = pp_force_newline std_formatter
++and print_flush = pp_print_flush std_formatter
++and print_newline = pp_print_newline std_formatter
++and print_if_newline = pp_print_if_newline std_formatter
++
++and open_tbox = pp_open_tbox std_formatter
++and close_tbox = pp_close_tbox std_formatter
++and print_tbreak = pp_print_tbreak std_formatter
++
++and set_tab = pp_set_tab std_formatter
++and print_tab = pp_print_tab std_formatter
++
++and set_margin = pp_set_margin std_formatter
++and get_margin = pp_get_margin std_formatter
++
++and set_max_indent = pp_set_max_indent std_formatter
++and get_max_indent = pp_get_max_indent std_formatter
++
++and set_geometry = pp_set_geometry std_formatter
++and safe_set_geometry = pp_safe_set_geometry std_formatter
++and get_geometry = pp_get_geometry std_formatter
++and update_geometry = pp_update_geometry std_formatter
++
++and set_max_boxes = pp_set_max_boxes std_formatter
++and get_max_boxes = pp_get_max_boxes std_formatter
++and over_max_boxes = pp_over_max_boxes std_formatter
++
++and set_ellipsis_text = pp_set_ellipsis_text std_formatter
++and get_ellipsis_text = pp_get_ellipsis_text std_formatter
++
++and set_formatter_out_channel =
++  pp_set_formatter_out_channel std_formatter
++
++and set_formatter_out_functions =
++  pp_set_formatter_out_functions std_formatter
++and get_formatter_out_functions =
++  pp_get_formatter_out_functions std_formatter
++
++and set_formatter_output_functions =
++  pp_set_formatter_output_functions std_formatter
++and get_formatter_output_functions =
++  pp_get_formatter_output_functions std_formatter
++
++and set_formatter_stag_functions =
++  pp_set_formatter_stag_functions std_formatter
++and get_formatter_stag_functions =
++  pp_get_formatter_stag_functions std_formatter
++and set_print_tags =
++  pp_set_print_tags std_formatter
++and get_print_tags =
++  pp_get_print_tags std_formatter
++and set_mark_tags =
++  pp_set_mark_tags std_formatter
++and get_mark_tags =
++  pp_get_mark_tags std_formatter
++and set_tags =
++  pp_set_tags std_formatter
+ 
+ 
+ (* Convenience functions *)
+ 
+ (* To format a list *)
+@@@@
+ open CamlinternalFormat
+ 
+ (* Interpret a formatting entity on a formatter. *)
+ let output_formatting_lit ppf fmting_lit = match fmting_lit with
+   | Close_box                 -> pp_close_box ppf ()
+-  | Close_tag                 -> pp_close_stag ppf ()
++  | Close_tag                 -> pp_close_tag ppf ()
+   | Break (_, width, offset)  -> pp_print_break ppf width offset
+   | FFlush                    -> pp_print_flush ppf ()
+   | Force_newline             -> pp_force_newline ppf ()
+   | Flush_newline             -> pp_print_newline ppf ()
+   | Magic_size (_, _)         -> ()
+@@@@
+ 
+ let ifprintf _ppf (Format (fmt, _)) =
+   make_iprintf ignore () fmt
+ 
+ let fprintf ppf = kfprintf ignore ppf
+-
+-let printf (Format (fmt, _)) =
+-  make_printf
+-    (fun acc -> output_acc (DLS.get std_formatter_key) acc)
+-    End_of_acc fmt
+-
+-let eprintf (Format (fmt, _)) =
+-  make_printf
+-    (fun acc -> output_acc (DLS.get err_formatter_key) acc)
+-    End_of_acc fmt
++let printf fmt = fprintf std_formatter fmt
++let eprintf fmt = fprintf err_formatter fmt
+ 
+ let kdprintf k (Format (fmt, _)) =
+   make_printf
+     (fun acc -> k (fun ppf -> output_acc ppf acc))
+     End_of_acc fmt
+@@@@
+ let asprintf fmt = kasprintf id fmt
+ 
+ (* Flushing standard formatters at end of execution. *)
+ 
+ let flush_standard_formatters () =
+-  pp_print_flush (DLS.get std_formatter_key) ();
+-  pp_print_flush (DLS.get err_formatter_key) ()
++  pp_print_flush std_formatter ();
++  pp_print_flush err_formatter ()
+ 
+ let () = at_exit flush_standard_formatters
+ 
+-let () = Domain.at_first_spawn (fun () ->
+-  flush_standard_formatters ();
++(*
+ 
+-  let fs = pp_get_formatter_out_functions std_formatter () in
+-  pp_set_formatter_out_functions std_formatter
+-    {fs with out_string = buffered_out_string std_buf_key;
+-             out_flush = buffered_out_flush Stdlib.stdout std_buf_key};
++  Deprecated stuff.
++
++*)
++
++(* Deprecated : subsumed by pp_set_formatter_out_functions *)
++let pp_set_all_formatter_output_functions state
++    ~out:f ~flush:g ~newline:h ~spaces:i =
++  pp_set_formatter_output_functions state f g;
++  state.pp_out_newline <- h;
++  state.pp_out_spaces <- i
++
++(* Deprecated : subsumed by pp_get_formatter_out_functions *)
++let pp_get_all_formatter_output_functions state () =
++  (state.pp_out_string, state.pp_out_flush,
++   state.pp_out_newline, state.pp_out_spaces)
++
++
++(* Deprecated : subsumed by set_formatter_out_functions *)
++let set_all_formatter_output_functions =
++  pp_set_all_formatter_output_functions std_formatter
++
++
++(* Deprecated : subsumed by get_formatter_out_functions *)
++let get_all_formatter_output_functions =
++  pp_get_all_formatter_output_functions std_formatter
++
++
++(* Deprecated : error prone function, do not use it.
++   This function is neither compositional nor incremental, since it flushes
++   the pretty-printer queue at each call.
++   To get the same functionality, define a formatter of your own writing to
++   the buffer argument, as in
++   let ppf = formatter_of_buffer b
++   then use {!fprintf ppf} as usual. *)
++let bprintf b (Format (fmt, _) : ('a, formatter, unit) format) =
++  let ppf = formatter_of_buffer b in
++  let k acc = output_acc ppf acc; pp_flush_queue ppf false in
++  make_printf k End_of_acc fmt
++
++
++(* Deprecated : alias for ksprintf. *)
++let kprintf = ksprintf
++
++
++
++(* Deprecated tag functions *)
++
++type formatter_tag_functions = {
++  mark_open_tag : tag -> string;
++  mark_close_tag : tag -> string;
++  print_open_tag : tag -> unit;
++  print_close_tag : tag -> unit;
++}
+ 
+-  let fs = pp_get_formatter_out_functions err_formatter () in
+-  pp_set_formatter_out_functions err_formatter
+-    {fs with out_string = buffered_out_string err_buf_key;
+-             out_flush = buffered_out_flush Stdlib.stderr err_buf_key};
+ 
+-  Domain.at_exit flush_standard_formatters)
++let pp_set_formatter_tag_functions state {
++     mark_open_tag = mot;
++     mark_close_tag = mct;
++     print_open_tag = pot;
++     print_close_tag = pct;
++   } =
++  let stringify f e = function String_tag s -> f s | _ -> e in
++  state.pp_mark_open_tag <- stringify mot "";
++  state.pp_mark_close_tag <- stringify mct "";
++  state.pp_print_open_tag <- stringify pot ();
++  state.pp_print_close_tag <- stringify pct ()
++
++let pp_get_formatter_tag_functions fmt () =
++  let funs = pp_get_formatter_stag_functions fmt () in
++  let mark_open_tag s = funs.mark_open_stag (String_tag s) in
++  let mark_close_tag s = funs.mark_close_stag (String_tag s) in
++  let print_open_tag s = funs.print_open_stag (String_tag s) in
++  let print_close_tag s = funs.print_close_stag (String_tag s) in
++  {mark_open_tag; mark_close_tag; print_open_tag; print_close_tag}
++
++let set_formatter_tag_functions =
++  pp_set_formatter_tag_functions std_formatter
++and get_formatter_tag_functions =
++  pp_get_formatter_tag_functions std_formatter
 --- ocaml-4.13-upstream/format.mli
 +++ ocamlformat_support/format.mli
+@@@@
+    functions.
+    Some formatters are predefined, notably:
+    - {!std_formatter} outputs to {{!Stdlib.stdout}stdout}
+    - {!err_formatter} outputs to {{!Stdlib.stderr}stderr}
+ 
+-   Most functions in the {!Format} module come in two variants: a short version
+-   that operates on the current domain's standard formatter as obtained using
+-   {!get_std_formatter} and the generic version prefixed by [pp_] that takes a
+-   formatter as its first argument. For the version that operates on the
+-   current domain's standard formatter, the call to {!get_std_formatter} is
+-   delayed until the last argument is received.
++   Most functions in the {!Format} module come in two variants:
++   a short version that operates on {!std_formatter} and the
++   generic version prefixed by [pp_] that takes a formatter
++   as its first argument.
+ 
+    More formatters can be created with {!formatter_of_out_channel},
+-   {!formatter_of_buffer}, {!formatter_of_symbolic_output_buffer} or using
+-   {{!section:formatter}custom formatters}.
++   {!formatter_of_buffer}, {!formatter_of_symbolic_output_buffer}
++   or using {{!section:formatter}custom formatters}.
+ 
+-   Warning: Since {{!section:formatter}formatters} contain mutable state, it is
+-   not thread-safe to use the same formatter on multiple domains in parallel
+-   without synchronization.
+-
+-   If multiple domains write to the same output channel using the
+-   predefined formatters (as obtained by {!get_std_formatter} or
+-   {!get_err_formatter}), the output from the domains will be interleaved with
+-   each other at points where the formatters are flushed, such as with
+-   {!print_flush}. This synchronization is not performed by formatters obtained
+-   from {!formatter_of_out_channel} (on the standard out channels or others).
+ *)
+ 
+ (** {1 Introduction}
+ 
+    You may consider this module as providing an extension to the
+@@@@
+    for a custom formatter that handles indentation distinctly, for example,
+    outputs [<br/>] tags or [&nbsp;] entities.
+ 
+    The custom break is useful if you want to change which visible
+    (non-whitespace) characters are printed in case of break or no break. For
+-   example, when printing a list [ [a; b; c] ], you might want to add a
++   example, when printing a list {[ [a; b; c] ]}, you might want to add a
+    trailing semicolon when it is printed vertically:
+ 
+    {[
+ [
+   a;
 @@@@
  (** Execute the next formatting command if the preceding line
    has just been split. Otherwise, ignore the next formatting
@@ -233,3 +710,265 @@
  val pp_print_flush : formatter -> unit -> unit
  val print_flush : unit -> unit
  (** End of pretty-printing: resets the pretty-printer to initial state.
+@@@@
+   formatter using those functions for output.
+ *)
+ 
+ val formatter_of_out_channel : out_channel -> formatter
+ (** [formatter_of_out_channel oc] returns a new formatter writing
+-    to the corresponding output channel [oc].
+-*)
+-
+-val synchronized_formatter_of_out_channel :
+-  out_channel -> formatter Domain.DLS.key
+-(** [synchronized_formatter_of_out_channel oc] returns the key to the
+-    domain-local state that holds the domain-local formatter for writing to the
+-    corresponding output channel [oc].
+-
+-    When the formatter is used with multiple domains, the output from the
+-    domains will be interleaved with each other at points where the formatter
+-    is flushed, such as with {!print_flush}.
++  to the corresponding output channel [oc].
+ *)
+ 
+-
+ val std_formatter : formatter
+-(** The initial domain's standard formatter to write to standard output.
++(** The standard formatter to write to standard output.
+ 
+   It is defined as {!formatter_of_out_channel} {!Stdlib.stdout}.
+ *)
+ 
+-val get_std_formatter : unit -> formatter
+-(** [get_std_formatter ()] returns the current domain's standard formatter used
+-    to write to standard output.
+-*)
+-
+ val err_formatter : formatter
+-(** The initial domain's formatter to write to standard error.
++(** A formatter to write to standard error.
+ 
+   It is defined as {!formatter_of_out_channel} {!Stdlib.stderr}.
+ *)
+ 
+-val get_err_formatter : unit -> formatter
+-(* [get_err_formatter ()] returns the current domain's formatter used to write
+-   to standard error.
+-*)
+-
+ val formatter_of_buffer : Buffer.t -> formatter
+ (** [formatter_of_buffer b] returns a new formatter writing to
+   buffer [b]. At the end of pretty-printing, the formatter must be flushed
+   using {!pp_print_flush} or {!pp_print_newline}, to print all the
+   pending material into the buffer.
+ *)
+ 
+ val stdbuf : Buffer.t
+-(** The initial domain's string buffer in which [str_formatter] writes. *)
+-
+-val get_stdbuf : unit -> Buffer.t
+-(** [get_stdbuf ()] returns the current domain's string buffer in which the
+-    current domain's string formatter writes. *)
++(** The string buffer in which [str_formatter] writes. *)
+ 
+ val str_formatter : formatter
+-(** The initial domain's formatter to output to the {!stdbuf} string buffer.
++(** A formatter to output to the {!stdbuf} string buffer.
+ 
+   [str_formatter] is defined as {!formatter_of_buffer} {!stdbuf}.
+ *)
+ 
+-val get_str_formatter : unit -> formatter
+-(** The current domain's formatter to output to the current domains string
+-    buffer.
+-*)
+-
+ val flush_str_formatter : unit -> string
+-(** Returns the material printed with [str_formatter] of the current domain,
+-    flushes the formatter and resets the corresponding buffer.
++(** Returns the material printed with [str_formatter], flushes
++  the formatter and resets the corresponding buffer.
+ *)
+ 
+ val make_formatter :
+   (string -> int -> int -> unit) -> (unit -> unit) -> formatter
+ (** [make_formatter out flush] returns a new formatter that outputs with
+   function [out], and flushes with function [flush].
+ 
+-  For instance,
+-  {[
++  For instance, {[
+     make_formatter
+       (Stdlib.output oc)
+-      (fun () -> Stdlib.flush oc)
+-  ]}
++      (fun () -> Stdlib.flush oc) ]}
+   returns a formatter to the {!Stdlib.out_channel} [oc].
+ *)
+ 
+-val make_synchronized_formatter :
+-  (string -> int -> int -> unit) -> (unit -> unit) -> formatter Domain.DLS.key
+-(** [make_synchronized_formatter out flush] returns the key to the domain-local
+-    state that holds the domain-local formatter that outputs with function
+-    [out], and flushes with function [flush].
+-
+-    When the formatter is used with multiple domains, the output from the
+-    domains will be interleaved with each other at points where the formatter
+-    is flushed, such as with {!print_flush}.
+-*)
+-
+ val formatter_of_out_functions :
+   formatter_out_functions -> formatter
+ (** [formatter_of_out_functions out_funs] returns a new formatter that writes
+   with the set of output functions [out_funs].
+ 
+@@@@
+   [out_funs].
+ 
+   @since 4.06.0
+ *)
+ 
+-
+-
+ (** {2:symbolic Symbolic pretty-printing} *)
+ 
+ (**
+   Symbolic pretty-printing is pretty-printing using a symbolic formatter,
+   i.e. a formatter that outputs symbolic pretty-printing items.
+@@@@
+   It prints [x = 1] within a pretty-printing 'horizontal-or-vertical' box.
+ 
+ *)
+ 
+ val printf : ('a, formatter, unit) format -> 'a
+-(** Same as [fprintf] above, but output on [get_std_formatter ()].
+-
+-    It is defined similarly to [fun fmt -> fprintf (get_std_formatter ()) fmt]
+-    but delays calling [get_std_formatter] until after the final argument
+-    required by the [format] is received. When used with multiple domains, the
+-    output from the domains will be interleaved with each other at points where
+-    the formatter is flushed, such as with {!print_flush}.
+-*)
++(** Same as [fprintf] above, but output on [std_formatter]. *)
+ 
+ val eprintf : ('a, formatter, unit) format -> 'a
+-(** Same as [fprintf] above, but output on [get_err_formatter ()].
+-
+-    It is defined similarly to [fun fmt -> fprintf (get_err_formatter ()) fmt]
+-    but delays calling [get_err_formatter] until after the final argument
+-    required by the [format] is received. When used with multiple domains, the
+-    output from the domains will be interleaved with each other at points where
+-    the formatter is flushed, such as with {!print_flush}.
+-*)
++(** Same as [fprintf] above, but output on [err_formatter]. *)
+ 
+ val sprintf : ('a, unit, string) format -> 'a
+ (** Same as [printf] above, but instead of printing on a formatter,
+   returns a string containing the result of formatting the arguments.
+   Note that the pretty-printer queue is flushed at the end of {e each
+@@@@
+ (** Same as [asprintf] above, but instead of returning the string,
+   passes it to the first argument.
+ 
+   @since 4.03
+ *)
++
++(** {1 Deprecated} *)
++
++val bprintf : Buffer.t -> ('a, formatter, unit) format -> 'a
++  [@@ocaml.deprecated]
++(** @deprecated This function is error prone. Do not use it.
++  This function is neither compositional nor incremental, since it flushes
++  the pretty-printer queue at each call.
++
++  If you need to print to some buffer [b], you must first define a
++  formatter writing to [b], using [let to_b = formatter_of_buffer b]; then
++  use regular calls to [Format.fprintf] with formatter [to_b].
++*)
++
++val kprintf : (string -> 'a) -> ('b, unit, string, 'a) format4 -> 'b
++  [@@ocaml.deprecated "Use Format.ksprintf instead."]
++(** @deprecated An alias for [ksprintf]. *)
++
++val set_all_formatter_output_functions :
++  out:(string -> int -> int -> unit) ->
++  flush:(unit -> unit) ->
++  newline:(unit -> unit) ->
++  spaces:(int -> unit) ->
++  unit
++[@@ocaml.deprecated "Use Format.set_formatter_out_functions instead."]
++(** @deprecated Subsumed by [set_formatter_out_functions]. *)
++
++val get_all_formatter_output_functions :
++  unit ->
++  (string -> int -> int -> unit) *
++  (unit -> unit) *
++  (unit -> unit) *
++  (int -> unit)
++[@@ocaml.deprecated "Use Format.get_formatter_out_functions instead."]
++(** @deprecated Subsumed by [get_formatter_out_functions]. *)
++
++val pp_set_all_formatter_output_functions :
++  formatter -> out:(string -> int -> int -> unit) -> flush:(unit -> unit) ->
++  newline:(unit -> unit) -> spaces:(int -> unit) -> unit
++[@@ocaml.deprecated "Use Format.pp_set_formatter_out_functions instead."]
++(** @deprecated Subsumed by [pp_set_formatter_out_functions]. *)
++
++val pp_get_all_formatter_output_functions :
++  formatter -> unit ->
++  (string -> int -> int -> unit) * (unit -> unit) * (unit -> unit) *
++  (int -> unit)
++[@@ocaml.deprecated "Use Format.pp_get_formatter_out_functions instead."]
++(** @deprecated Subsumed by [pp_get_formatter_out_functions]. *)
++
++(** {2 String tags} *)
++
++val pp_open_tag : formatter -> tag -> unit
++[@@ocaml.deprecated "Use Format.pp_open_stag."]
++(** @deprecated Subsumed by {!pp_open_stag}. *)
++
++val open_tag : tag -> unit
++[@@ocaml.deprecated "Use Format.open_stag."]
++(** @deprecated Subsumed by {!open_stag}. *)
++
++val pp_close_tag : formatter -> unit -> unit
++[@@ocaml.deprecated "Use Format.pp_close_stag."]
++(** @deprecated Subsumed by {!pp_close_stag}. *)
++
++val close_tag : unit -> unit
++[@@ocaml.deprecated "Use Format.close_stag."]
++(** @deprecated Subsumed by {!close_stag}. *)
++
++type formatter_tag_functions = {
++  mark_open_tag : tag -> string;
++  mark_close_tag : tag -> string;
++  print_open_tag : tag -> unit;
++  print_close_tag : tag -> unit;
++}
++[@@ocaml.deprecated "Use formatter_stag_functions."]
++(** @deprecated Subsumed by {!formatter_stag_functions}. *)
++
++val pp_set_formatter_tag_functions :
++  formatter -> formatter_tag_functions -> unit
++[@@ocaml.deprecated
++  "This function will erase non-string tag formatting functions. \
++   Use Format.pp_set_formatter_stag_functions."]
++[@@warning "-3"]
++(** This function will erase non-string tag formatting functions.
++    @deprecated Subsumed by {!pp_set_formatter_stag_functions}. *)
++
++val set_formatter_tag_functions : formatter_tag_functions -> unit
++[@@ocaml.deprecated "Use Format.set_formatter_stag_functions."]
++[@@warning "-3"]
++(** @deprecated Subsumed by {!set_formatter_stag_functions}. *)
++
++val pp_get_formatter_tag_functions :
++  formatter -> unit -> formatter_tag_functions
++[@@ocaml.deprecated "Use Format.pp_get_formatter_stag_functions."]
++[@@warning "-3"]
++(** @deprecated Subsumed by {!pp_get_formatter_stag_functions}. *)
++
++val get_formatter_tag_functions : unit -> formatter_tag_functions
++[@@ocaml.deprecated "Use Format.get_formatter_stag_functions."]
++[@@warning "-3"]
++(** @deprecated Subsumed by {!get_formatter_stag_functions}. *)

--- a/vendor/import-ocaml-upstream.sh
+++ b/vendor/import-ocaml-upstream.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-dune exec ../tools/diff-ocaml/diff_ocaml.exe -- import 0be3ae6 ocaml-4.13-upstream
+dune exec ../tools/diff-ocaml/diff_ocaml.exe -- import 814f12f ocaml-4.13-upstream

--- a/vendor/ocaml-4.13-extended/ast_mapper.ml
+++ b/vendor/ocaml-4.13-extended/ast_mapper.ml
@@ -880,7 +880,7 @@ module PpxContext = struct
         lid "principal", make_bool !Clflags.principal;
         lid "transparent_modules", make_bool !Clflags.transparent_modules;
         lid "unboxed_types", make_bool !Clflags.unboxed_types;
-        lid "unsafe_string", make_bool !Clflags.unsafe_string;
+        lid "unsafe_string", make_bool false; (* kept for compatibility *)
         get_cookies ()
       ]
     in
@@ -960,8 +960,6 @@ module PpxContext = struct
           Clflags.transparent_modules := get_bool payload
       | "unboxed_types" ->
           Clflags.unboxed_types := get_bool payload
-      | "unsafe_string" ->
-          Clflags.unsafe_string := get_bool payload
       | "cookies" ->
           let l = get_list (get_pair get_string (fun x -> x)) payload in
           cookies :=

--- a/vendor/ocaml-4.13-extended/lexer.mll
+++ b/vendor/ocaml-4.13-extended/lexer.mll
@@ -31,9 +31,8 @@ type error =
   | Keyword_as_label of string
   | Invalid_literal of string
   | Invalid_directive of string * string option
-;;
 
-exception Error of error * Location.t;;
+exception Error of error * Location.t
 
 (* The table of keywords *)
 
@@ -111,9 +110,9 @@ let store_string s = Buffer.add_string string_buffer s
 let store_lexeme lexbuf = store_string (Lexing.lexeme lexbuf)
 
 (* To store the position of the beginning of a string and comment *)
-let string_start_loc = ref Location.none;;
-let comment_start_loc = ref [];;
-let in_comment () = !comment_start_loc <> [];;
+let string_start_loc = ref Location.none
+let comment_start_loc = ref []
+let in_comment () = !comment_start_loc <> []
 let is_in_string = ref false
 let in_string () = !is_in_string
 let print_warnings = ref true
@@ -278,7 +277,6 @@ let update_loc lexbuf file line absolute chars =
     pos_lnum = if absolute then line else pos.pos_lnum + line;
     pos_bol = pos.pos_cnum - chars;
   }
-;;
 
 let preprocessor = ref None
 

--- a/vendor/ocaml-4.13-extended/parser.mly
+++ b/vendor/ocaml-4.13-extended/parser.mly
@@ -98,13 +98,13 @@ let push_loc x acc =
 
 let reloc_pat ~loc x =
   { x with ppat_loc = make_loc loc;
-           ppat_loc_stack = push_loc x.ppat_loc x.ppat_loc_stack };;
+           ppat_loc_stack = push_loc x.ppat_loc x.ppat_loc_stack }
 let reloc_exp ~loc x =
   { x with pexp_loc = make_loc loc;
-           pexp_loc_stack = push_loc x.pexp_loc x.pexp_loc_stack };;
+           pexp_loc_stack = push_loc x.pexp_loc x.pexp_loc_stack }
 let reloc_typ ~loc x =
   { x with ptyp_loc = make_loc loc;
-           ptyp_loc_stack = push_loc x.ptyp_loc x.ptyp_loc_stack };;
+           ptyp_loc_stack = push_loc x.ptyp_loc x.ptyp_loc_stack }
 
 let mkexpvar ~loc (name : string) =
   mkexp ~loc (Pexp_ident(mkrhs (Lident name) loc))

--- a/vendor/ocaml-4.13-extended/parsetree.mli
+++ b/vendor/ocaml-4.13-extended/parsetree.mli
@@ -817,6 +817,7 @@ and module_substitution =
      pms_attributes: attributes; (* ... [@@id1] [@@id2] *)
      pms_loc: Location.t;
     }
+(* S := M *)
 
 and module_type_declaration =
     {

--- a/vendor/ocaml-4.13-extended/pprintast.ml
+++ b/vendor/ocaml-4.13-extended/pprintast.ml
@@ -28,7 +28,7 @@ open Longident
 open Parsetree
 open Ast_helper
 
-let prefix_symbols  = [ '!'; '?'; '~' ] ;;
+let prefix_symbols  = [ '!'; '?'; '~' ]
 let infix_symbols = [ '='; '<'; '>'; '@'; '^'; '|'; '&'; '+'; '-'; '*'; '/';
                       '$'; '%'; '#' ]
 

--- a/vendor/ocaml-4.13-extended/printast.ml
+++ b/vendor/ocaml-4.13-extended/printast.ml
@@ -13,11 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Asttypes;;
-open Format;;
-open Lexing;;
-open Location;;
-open Parsetree;;
+open Asttypes
+open Format
+open Lexing
+open Location
+open Parsetree
 
 let fmt_position with_name f l =
   let fname = if with_name then l.pos_fname else "" in
@@ -25,7 +25,6 @@ let fmt_position with_name f l =
   then fprintf f "%s[%d]" fname l.pos_cnum
   else fprintf f "%s[%d,%d+%d]" fname l.pos_lnum l.pos_bol
                (l.pos_cnum - l.pos_bol)
-;;
 
 let curr_indent : int ref = ref 0
 
@@ -33,7 +32,6 @@ let line i f s (*...*) =
   curr_indent := i;
   fprintf f "%s" (String.make ((2*i) mod 72) ' ');
   fprintf f s (*...*)
-;;
 
 type cmts =
   { before: Location.t -> string list option
@@ -72,29 +70,24 @@ let fmt_location f loc =
             fmt_cmts i f "within" w;
             fmt_cmts i f " after" a )
   end
-;;
 
 let rec fmt_longident_aux f x =
   match x with
-  | Longident.Lident (s) -> fprintf f "%s" s;
-  | Longident.Ldot (y, s) -> fprintf f "%a.%s" fmt_longident_aux y s;
+  | Longident.Lident (s) -> fprintf f "%s" s
+  | Longident.Ldot (y, s) -> fprintf f "%a.%s" fmt_longident_aux y s
   | Longident.Lapply (y, z) ->
-      fprintf f "%a(%a)" fmt_longident_aux y fmt_longident_aux z;
-;;
+      fprintf f "%a(%a)" fmt_longident_aux y fmt_longident_aux z
 
-let fmt_longident f x = fprintf f "\"%a\"" fmt_longident_aux x;;
+let fmt_longident f x = fprintf f "\"%a\"" fmt_longident_aux x
 
 let fmt_longident_loc f (x : Longident.t loc) =
-  fprintf f "\"%a\" %a" fmt_longident_aux x.txt fmt_location x.loc;
-;;
+  fprintf f "\"%a\" %a" fmt_longident_aux x.txt fmt_location x.loc
 
 let fmt_string_loc f (x : string loc) =
-  fprintf f "\"%s\" %a" x.txt fmt_location x.loc;
-;;
+  fprintf f "\"%s\" %a" x.txt fmt_location x.loc
 
 let fmt_str_opt_loc f (x : string option loc) =
-  fprintf f "\"%s\" %a" (Option.value x.txt ~default:"_") fmt_location x.loc;
-;;
+  fprintf f "\"%s\" %a" (Option.value x.txt ~default:"_") fmt_location x.loc
 
 let fmt_char_option f = function
   | None -> fprintf f "None"
@@ -104,32 +97,28 @@ let fmt_constant i f x =
   line i f "constant %a\n" fmt_location x.pconst_loc;
   let i = i+1 in
   match x.pconst_desc with
-  | Pconst_integer (j,m) -> line i f "PConst_int (%s,%a)" j fmt_char_option m;
-  | Pconst_char (c) -> line i f "PConst_char %02x" (Char.code c);
+  | Pconst_integer (j,m) -> line i f "PConst_int (%s,%a)" j fmt_char_option m
+  | Pconst_char (c) -> line i f "PConst_char %02x" (Char.code c)
   | Pconst_string (s, strloc, None) ->
-      line i f "PConst_string(%S,%a,None)" s fmt_location strloc ;
+      line i f "PConst_string(%S,%a,None)" s fmt_location strloc
   | Pconst_string (s, strloc, Some delim) ->
-      line i f "PConst_string (%S,%a,Some %S)" s fmt_location strloc delim;
-  | Pconst_float (s,m) -> line i f "PConst_float (%s,%a)" s fmt_char_option m;
-;;
+      line i f "PConst_string (%S,%a,Some %S)" s fmt_location strloc delim
+  | Pconst_float (s,m) -> line i f "PConst_float (%s,%a)" s fmt_char_option m
 
 let fmt_mutable_flag f x =
   match x with
-  | Immutable -> fprintf f "Immutable";
-  | Mutable -> fprintf f "Mutable";
-;;
+  | Immutable -> fprintf f "Immutable"
+  | Mutable -> fprintf f "Mutable"
 
 let fmt_virtual_flag f x =
   match x with
-  | Virtual -> fprintf f "Virtual";
-  | Concrete -> fprintf f "Concrete";
-;;
+  | Virtual -> fprintf f "Virtual"
+  | Concrete -> fprintf f "Concrete"
 
 let fmt_override_flag f x =
   match x with
-  | Override -> fprintf f "Override";
-  | Fresh -> fprintf f "Fresh";
-;;
+  | Override -> fprintf f "Override"
+  | Fresh -> fprintf f "Fresh"
 
 let fmt_closed_flag f x =
   match (x : closed_flag) with
@@ -143,48 +132,42 @@ let fmt_closed_flag_loc f x =
 
 let fmt_rec_flag f x =
   match x with
-  | Nonrecursive -> fprintf f "Nonrec";
-  | Recursive -> fprintf f "Rec";
-;;
+  | Nonrecursive -> fprintf f "Nonrec"
+  | Recursive -> fprintf f "Rec"
 
 let fmt_direction_flag f x =
   match x with
-  | Upto -> fprintf f "Up";
-  | Downto -> fprintf f "Down";
-;;
+  | Upto -> fprintf f "Up"
+  | Downto -> fprintf f "Down"
 
 let fmt_private_flag f x =
   match x with
-  | Public -> fprintf f "Public";
-  | Private -> fprintf f "Private";
-;;
+  | Public -> fprintf f "Public"
+  | Private -> fprintf f "Private"
 
 let list i f ppf l =
   match l with
-  | [] -> line i ppf "[]\n";
+  | [] -> line i ppf "[]\n"
   | _ :: _ ->
      line i ppf "[\n";
      List.iter (f (i+1) ppf) l;
-     line i ppf "]\n";
-;;
+     line i ppf "]\n"
 
 let option i f ppf x =
   match x with
-  | None -> line i ppf "None\n";
+  | None -> line i ppf "None\n"
   | Some x ->
       line i ppf "Some\n";
-      f (i+1) ppf x;
-;;
+      f (i+1) ppf x
 
-let longident_loc i ppf li = line i ppf "%a\n" fmt_longident_loc li;;
-let string i ppf s = line i ppf "\"%s\"\n" s;;
-let string_loc i ppf s = line i ppf "%a\n" fmt_string_loc s;;
-let str_opt_loc i ppf s = line i ppf "%a\n" fmt_str_opt_loc s;;
+let longident_loc i ppf li = line i ppf "%a\n" fmt_longident_loc li
+let string i ppf s = line i ppf "\"%s\"\n" s
+let string_loc i ppf s = line i ppf "%a\n" fmt_string_loc s
+let str_opt_loc i ppf s = line i ppf "%a\n" fmt_str_opt_loc s
 let arg_label i ppf = function
   | Nolabel -> line i ppf "Nolabel\n"
   | Optional s -> line i ppf "Optional \"%s\"\n" s
   | Labelled s -> line i ppf "Labelled \"%s\"\n" s
-;;
 
 let typevars ppf vs =
   List.iter (fun x ->
@@ -1043,7 +1026,6 @@ and row_field i ppf x =
   | Rinherit (ct) ->
       line i ppf "Rinherit\n";
       core_type i ppf ct
-;;
 
 let rec toplevel_phrase i ppf x =
   match x with
@@ -1061,12 +1043,11 @@ and directive_argument i ppf x =
   line i ppf "directive_argument %a\n" fmt_location x.pdira_loc;
   let i = i+1 in
   match x.pdira_desc with
-  | Pdir_string (s) -> line i ppf "Pdir_string \"%s\"\n" s;
-  | Pdir_int (n, None) -> line i ppf "Pdir_int %s\n" n;
-  | Pdir_int (n, Some m) -> line i ppf "Pdir_int %s%c\n" n m;
-  | Pdir_ident (li) -> line i ppf "Pdir_ident %a\n" fmt_longident li;
-  | Pdir_bool (b) -> line i ppf "Pdir_bool %s\n" (string_of_bool b);
-;;
+  | Pdir_string (s) -> line i ppf "Pdir_string \"%s\"\n" s
+  | Pdir_int (n, None) -> line i ppf "Pdir_int %s\n" n
+  | Pdir_int (n, Some m) -> line i ppf "Pdir_int %s%c\n" n m
+  | Pdir_ident (li) -> line i ppf "Pdir_ident %a\n" fmt_longident li
+  | Pdir_bool (b) -> line i ppf "Pdir_bool %s\n" (string_of_bool b)
 
 let repl_phrase i ppf x =
   line i ppf "repl_phrase\n";
@@ -1074,10 +1055,10 @@ let repl_phrase i ppf x =
   toplevel_phrase i ppf x.prepl_phrase;
   line i ppf "output %S\n" x.prepl_output
 
-let interface ppf x = list 0 signature_item ppf x;;
+let interface ppf x = list 0 signature_item ppf x
 
-let implementation ppf x = list 0 structure_item ppf x;;
+let implementation ppf x = list 0 structure_item ppf x
 
-let top_phrase ppf x = toplevel_phrase 0 ppf x;;
+let top_phrase ppf x = toplevel_phrase 0 ppf x
 
-let repl_phrase ppf x = repl_phrase 0 ppf x;;
+let repl_phrase ppf x = repl_phrase 0 ppf x

--- a/vendor/ocaml-4.13-extended/printast.mli
+++ b/vendor/ocaml-4.13-extended/printast.mli
@@ -20,13 +20,13 @@
 
 *)
 
-open Parsetree;;
-open Format;;
+open Parsetree
+open Format
 
-val interface : formatter -> signature_item list -> unit;;
-val implementation : formatter -> structure_item list -> unit;;
-val top_phrase : formatter -> toplevel_phrase -> unit;;
-val repl_phrase : formatter -> repl_phrase -> unit;;
+val interface : formatter -> signature_item list -> unit
+val implementation : formatter -> structure_item list -> unit
+val top_phrase : formatter -> toplevel_phrase -> unit
+val repl_phrase : formatter -> repl_phrase -> unit
 
 val expression: int -> formatter -> expression -> unit
 val structure: int -> formatter -> structure -> unit

--- a/vendor/ocaml-4.13-upstream/ast_mapper.ml
+++ b/vendor/ocaml-4.13-upstream/ast_mapper.ml
@@ -843,7 +843,7 @@ module PpxContext = struct
         lid "principal", make_bool !Clflags.principal;
         lid "transparent_modules", make_bool !Clflags.transparent_modules;
         lid "unboxed_types", make_bool !Clflags.unboxed_types;
-        lid "unsafe_string", make_bool !Clflags.unsafe_string;
+        lid "unsafe_string", make_bool false; (* kept for compatibility *)
         get_cookies ()
       ]
     in
@@ -923,8 +923,6 @@ module PpxContext = struct
           Clflags.transparent_modules := get_bool payload
       | "unboxed_types" ->
           Clflags.unboxed_types := get_bool payload
-      | "unsafe_string" ->
-          Clflags.unsafe_string := get_bool payload
       | "cookies" ->
           let l = get_list (get_pair get_string (fun x -> x)) payload in
           cookies :=

--- a/vendor/ocaml-4.13-upstream/format.ml
+++ b/vendor/ocaml-4.13-upstream/format.ml
@@ -557,9 +557,6 @@ let pp_close_stag state () =
     | Some tag_name ->
       state.pp_print_close_tag tag_name
 
-let pp_open_tag state s = pp_open_stag state (String_tag s)
-let pp_close_tag state () = pp_close_stag state ()
-
 let pp_set_print_tags state b = state.pp_print_tags <- b
 let pp_set_mark_tags state b = state.pp_mark_tags <- b
 let pp_get_print_tags state () = state.pp_print_tags
@@ -603,7 +600,7 @@ let pp_rinit state =
   pp_open_sys_box state
 
 let clear_tag_stack state =
-  Stack.iter (fun _ -> pp_close_tag state ()) state.pp_tag_stack
+  Stack.iter (fun _ -> pp_close_stag state ()) state.pp_tag_stack
 
 
 (* Flushing pretty-printer queue. *)
@@ -1022,6 +1019,56 @@ let std_formatter = formatter_of_out_channel Stdlib.stdout
 and err_formatter = formatter_of_out_channel Stdlib.stderr
 and str_formatter = formatter_of_buffer stdbuf
 
+(* Initialise domain local state *)
+module DLS = Domain.DLS
+
+let stdbuf_key = DLS.new_key pp_make_buffer
+let _ = DLS.set stdbuf_key stdbuf
+
+let str_formatter_key = DLS.new_key (fun () ->
+  formatter_of_buffer (DLS.get stdbuf_key))
+let _ = DLS.set str_formatter_key str_formatter
+
+let buffered_out_string key str ofs len =
+  Buffer.add_substring (Domain.DLS.get key) str ofs len
+
+let buffered_out_flush oc key () =
+  let buf = Domain.DLS.get key in
+  let len = Buffer.length buf in
+  let str = Buffer.contents buf in
+  output_substring oc str 0 len ;
+  Stdlib.flush oc;
+  Buffer.clear buf
+
+let std_buf_key = Domain.DLS.new_key (fun () -> Buffer.create pp_buffer_size)
+let err_buf_key = Domain.DLS.new_key (fun () -> Buffer.create pp_buffer_size)
+
+let std_formatter_key = DLS.new_key (fun () ->
+  let ppf =
+    pp_make_formatter (buffered_out_string std_buf_key)
+      (buffered_out_flush Stdlib.stdout std_buf_key) ignore ignore ignore
+  in
+  ppf.pp_out_newline <- display_newline ppf;
+  ppf.pp_out_spaces <- display_blanks ppf;
+  ppf.pp_out_indent <- display_indent ppf;
+  ppf)
+let _ = DLS.set std_formatter_key std_formatter
+
+let err_formatter_key = DLS.new_key (fun () ->
+  let ppf =
+    pp_make_formatter (buffered_out_string err_buf_key)
+      (buffered_out_flush Stdlib.stderr err_buf_key) ignore ignore ignore
+  in
+  ppf.pp_out_newline <- display_newline ppf;
+  ppf.pp_out_spaces <- display_blanks ppf;
+  ppf.pp_out_indent <- display_indent ppf;
+  ppf)
+let _ = DLS.set err_formatter_key err_formatter
+
+let get_std_formatter () = DLS.get std_formatter_key
+let get_err_formatter () = DLS.get err_formatter_key
+let get_str_formatter () = DLS.get str_formatter_key
+let get_stdbuf () = DLS.get stdbuf_key
 
 (* [flush_buffer_formatter buf ppf] flushes formatter [ppf],
    then returns the contents of buffer [buf] that is reset.
@@ -1033,9 +1080,25 @@ let flush_buffer_formatter buf ppf =
   Buffer.reset buf;
   s
 
-
 (* Flush [str_formatter] and get the contents of [stdbuf]. *)
-let flush_str_formatter () = flush_buffer_formatter stdbuf str_formatter
+let flush_str_formatter () =
+  let stdbuf = DLS.get stdbuf_key in
+  let str_formatter = DLS.get str_formatter_key in
+  flush_buffer_formatter stdbuf str_formatter
+
+let make_synchronized_formatter output flush =
+  DLS.new_key (fun () ->
+    let buf = Buffer.create pp_buffer_size in
+    let output' = Buffer.add_substring buf in
+    let flush' () =
+      output (Buffer.contents buf) 0 (Buffer.length buf);
+      Buffer.clear buf;
+      flush ()
+    in
+    make_formatter output' flush')
+
+let synchronized_formatter_of_out_channel oc =
+  make_synchronized_formatter (output_substring oc) (fun () -> flush oc)
 
 (*
   Symbolic pretty-printing
@@ -1104,83 +1167,83 @@ let formatter_of_symbolic_output_buffer sob =
 
 *)
 
-let open_hbox = pp_open_hbox std_formatter
-and open_vbox = pp_open_vbox std_formatter
-and open_hvbox = pp_open_hvbox std_formatter
-and open_hovbox = pp_open_hovbox std_formatter
-and open_box = pp_open_box std_formatter
-and close_box = pp_close_box std_formatter
-and open_tag = pp_open_tag std_formatter
-and close_tag = pp_close_tag std_formatter
-and open_stag = pp_open_stag std_formatter
-and close_stag = pp_close_stag std_formatter
-and print_as = pp_print_as std_formatter
-and print_string = pp_print_string std_formatter
-and print_bytes = pp_print_bytes std_formatter
-and print_int = pp_print_int std_formatter
-and print_float = pp_print_float std_formatter
-and print_char = pp_print_char std_formatter
-and print_bool = pp_print_bool std_formatter
-and print_break = pp_print_break std_formatter
-and print_cut = pp_print_cut std_formatter
-and print_space = pp_print_space std_formatter
-and force_newline = pp_force_newline std_formatter
-and print_flush = pp_print_flush std_formatter
-and print_newline = pp_print_newline std_formatter
-and print_if_newline = pp_print_if_newline std_formatter
+let open_hbox v = pp_open_hbox (DLS.get std_formatter_key) v
+and open_vbox v = pp_open_vbox (DLS.get std_formatter_key) v
+and open_hvbox v = pp_open_hvbox (DLS.get std_formatter_key) v
+and open_hovbox v = pp_open_hovbox (DLS.get std_formatter_key) v
+and open_box v = pp_open_box (DLS.get std_formatter_key) v
+and close_box v = pp_close_box (DLS.get std_formatter_key) v
+and open_stag v = pp_open_stag (DLS.get std_formatter_key) v
+and close_stag v = pp_close_stag (DLS.get std_formatter_key) v
+and print_as v w = pp_print_as (DLS.get std_formatter_key) v w
+and print_string v = pp_print_string (DLS.get std_formatter_key) v
+and print_bytes v = pp_print_bytes (DLS.get std_formatter_key) v
+and print_int v = pp_print_int (DLS.get std_formatter_key) v
+and print_float v = pp_print_float (DLS.get std_formatter_key) v
+and print_char v = pp_print_char (DLS.get std_formatter_key) v
+and print_bool v = pp_print_bool (DLS.get std_formatter_key) v
+and print_break v w = pp_print_break (DLS.get std_formatter_key) v w
+and print_cut v = pp_print_cut (DLS.get std_formatter_key) v
+and print_space v = pp_print_space (DLS.get std_formatter_key) v
+and force_newline v = pp_force_newline (DLS.get std_formatter_key) v
+and print_flush v = pp_print_flush (DLS.get std_formatter_key) v
+and print_newline v = pp_print_newline (DLS.get std_formatter_key) v
+and print_if_newline v = pp_print_if_newline (DLS.get std_formatter_key) v
 
-and open_tbox = pp_open_tbox std_formatter
-and close_tbox = pp_close_tbox std_formatter
-and print_tbreak = pp_print_tbreak std_formatter
+and open_tbox v = pp_open_tbox (DLS.get std_formatter_key) v
+and close_tbox v = pp_close_tbox (DLS.get std_formatter_key) v
+and print_tbreak v w = pp_print_tbreak (DLS.get std_formatter_key) v w
 
-and set_tab = pp_set_tab std_formatter
-and print_tab = pp_print_tab std_formatter
+and set_tab v = pp_set_tab (DLS.get std_formatter_key) v
+and print_tab v = pp_print_tab (DLS.get std_formatter_key) v
 
-and set_margin = pp_set_margin std_formatter
-and get_margin = pp_get_margin std_formatter
+and set_margin v = pp_set_margin (DLS.get std_formatter_key) v
+and get_margin v = pp_get_margin (DLS.get std_formatter_key) v
 
-and set_max_indent = pp_set_max_indent std_formatter
-and get_max_indent = pp_get_max_indent std_formatter
+and set_max_indent v = pp_set_max_indent (DLS.get std_formatter_key) v
+and get_max_indent v = pp_get_max_indent (DLS.get std_formatter_key) v
 
-and set_geometry = pp_set_geometry std_formatter
-and safe_set_geometry = pp_safe_set_geometry std_formatter
-and get_geometry = pp_get_geometry std_formatter
-and update_geometry = pp_update_geometry std_formatter
+and set_geometry ~max_indent ~margin =
+  pp_set_geometry (DLS.get std_formatter_key) ~max_indent ~margin
+and safe_set_geometry ~max_indent ~margin =
+  pp_safe_set_geometry (DLS.get std_formatter_key) ~max_indent ~margin
+and get_geometry v = pp_get_geometry (DLS.get std_formatter_key) v
+and update_geometry v = pp_update_geometry (DLS.get std_formatter_key) v
 
-and set_max_boxes = pp_set_max_boxes std_formatter
-and get_max_boxes = pp_get_max_boxes std_formatter
-and over_max_boxes = pp_over_max_boxes std_formatter
+and set_max_boxes v = pp_set_max_boxes (DLS.get std_formatter_key) v
+and get_max_boxes v = pp_get_max_boxes (DLS.get std_formatter_key) v
+and over_max_boxes v = pp_over_max_boxes (DLS.get std_formatter_key) v
 
-and set_ellipsis_text = pp_set_ellipsis_text std_formatter
-and get_ellipsis_text = pp_get_ellipsis_text std_formatter
+and set_ellipsis_text v = pp_set_ellipsis_text (DLS.get std_formatter_key) v
+and get_ellipsis_text v = pp_get_ellipsis_text (DLS.get std_formatter_key) v
 
-and set_formatter_out_channel =
-  pp_set_formatter_out_channel std_formatter
+and set_formatter_out_channel v =
+  pp_set_formatter_out_channel (DLS.get std_formatter_key) v
 
-and set_formatter_out_functions =
-  pp_set_formatter_out_functions std_formatter
-and get_formatter_out_functions =
-  pp_get_formatter_out_functions std_formatter
+and set_formatter_out_functions v =
+  pp_set_formatter_out_functions (DLS.get std_formatter_key) v
+and get_formatter_out_functions v =
+  pp_get_formatter_out_functions (DLS.get std_formatter_key) v
 
-and set_formatter_output_functions =
-  pp_set_formatter_output_functions std_formatter
-and get_formatter_output_functions =
-  pp_get_formatter_output_functions std_formatter
+and set_formatter_output_functions v w =
+  pp_set_formatter_output_functions (DLS.get std_formatter_key) v w
+and get_formatter_output_functions v =
+  pp_get_formatter_output_functions (DLS.get std_formatter_key) v
 
-and set_formatter_stag_functions =
-  pp_set_formatter_stag_functions std_formatter
-and get_formatter_stag_functions =
-  pp_get_formatter_stag_functions std_formatter
-and set_print_tags =
-  pp_set_print_tags std_formatter
-and get_print_tags =
-  pp_get_print_tags std_formatter
-and set_mark_tags =
-  pp_set_mark_tags std_formatter
-and get_mark_tags =
-  pp_get_mark_tags std_formatter
-and set_tags =
-  pp_set_tags std_formatter
+and set_formatter_stag_functions v =
+  pp_set_formatter_stag_functions (DLS.get std_formatter_key) v
+and get_formatter_stag_functions v =
+  pp_get_formatter_stag_functions (DLS.get std_formatter_key) v
+and set_print_tags v =
+  pp_set_print_tags (DLS.get std_formatter_key) v
+and get_print_tags v =
+  pp_get_print_tags (DLS.get std_formatter_key) v
+and set_mark_tags v =
+  pp_set_mark_tags (DLS.get std_formatter_key) v
+and get_mark_tags v =
+  pp_get_mark_tags (DLS.get std_formatter_key) v
+and set_tags v =
+  pp_set_tags (DLS.get std_formatter_key) v
 
 
 (* Convenience functions *)
@@ -1268,7 +1331,7 @@ open CamlinternalFormat
 (* Interpret a formatting entity on a formatter. *)
 let output_formatting_lit ppf fmting_lit = match fmting_lit with
   | Close_box                 -> pp_close_box ppf ()
-  | Close_tag                 -> pp_close_tag ppf ()
+  | Close_tag                 -> pp_close_stag ppf ()
   | Break (_, width, offset)  -> pp_print_break ppf width offset
   | FFlush                    -> pp_print_flush ppf ()
   | Force_newline             -> pp_force_newline ppf ()
@@ -1363,8 +1426,16 @@ let ifprintf _ppf (Format (fmt, _)) =
   make_iprintf ignore () fmt
 
 let fprintf ppf = kfprintf ignore ppf
-let printf fmt = fprintf std_formatter fmt
-let eprintf fmt = fprintf err_formatter fmt
+
+let printf (Format (fmt, _)) =
+  make_printf
+    (fun acc -> output_acc (DLS.get std_formatter_key) acc)
+    End_of_acc fmt
+
+let eprintf (Format (fmt, _)) =
+  make_printf
+    (fun acc -> output_acc (DLS.get err_formatter_key) acc)
+    End_of_acc fmt
 
 let kdprintf k (Format (fmt, _)) =
   make_printf
@@ -1398,89 +1469,22 @@ let asprintf fmt = kasprintf id fmt
 (* Flushing standard formatters at end of execution. *)
 
 let flush_standard_formatters () =
-  pp_print_flush std_formatter ();
-  pp_print_flush err_formatter ()
+  pp_print_flush (DLS.get std_formatter_key) ();
+  pp_print_flush (DLS.get err_formatter_key) ()
 
 let () = at_exit flush_standard_formatters
 
-(*
+let () = Domain.at_first_spawn (fun () ->
+  flush_standard_formatters ();
 
-  Deprecated stuff.
+  let fs = pp_get_formatter_out_functions std_formatter () in
+  pp_set_formatter_out_functions std_formatter
+    {fs with out_string = buffered_out_string std_buf_key;
+             out_flush = buffered_out_flush Stdlib.stdout std_buf_key};
 
-*)
+  let fs = pp_get_formatter_out_functions err_formatter () in
+  pp_set_formatter_out_functions err_formatter
+    {fs with out_string = buffered_out_string err_buf_key;
+             out_flush = buffered_out_flush Stdlib.stderr err_buf_key};
 
-(* Deprecated : subsumed by pp_set_formatter_out_functions *)
-let pp_set_all_formatter_output_functions state
-    ~out:f ~flush:g ~newline:h ~spaces:i =
-  pp_set_formatter_output_functions state f g;
-  state.pp_out_newline <- h;
-  state.pp_out_spaces <- i
-
-(* Deprecated : subsumed by pp_get_formatter_out_functions *)
-let pp_get_all_formatter_output_functions state () =
-  (state.pp_out_string, state.pp_out_flush,
-   state.pp_out_newline, state.pp_out_spaces)
-
-
-(* Deprecated : subsumed by set_formatter_out_functions *)
-let set_all_formatter_output_functions =
-  pp_set_all_formatter_output_functions std_formatter
-
-
-(* Deprecated : subsumed by get_formatter_out_functions *)
-let get_all_formatter_output_functions =
-  pp_get_all_formatter_output_functions std_formatter
-
-
-(* Deprecated : error prone function, do not use it.
-   This function is neither compositional nor incremental, since it flushes
-   the pretty-printer queue at each call.
-   To get the same functionality, define a formatter of your own writing to
-   the buffer argument, as in
-   let ppf = formatter_of_buffer b
-   then use {!fprintf ppf} as usual. *)
-let bprintf b (Format (fmt, _) : ('a, formatter, unit) format) =
-  let ppf = formatter_of_buffer b in
-  let k acc = output_acc ppf acc; pp_flush_queue ppf false in
-  make_printf k End_of_acc fmt
-
-
-(* Deprecated : alias for ksprintf. *)
-let kprintf = ksprintf
-
-
-
-(* Deprecated tag functions *)
-
-type formatter_tag_functions = {
-  mark_open_tag : tag -> string;
-  mark_close_tag : tag -> string;
-  print_open_tag : tag -> unit;
-  print_close_tag : tag -> unit;
-}
-
-
-let pp_set_formatter_tag_functions state {
-     mark_open_tag = mot;
-     mark_close_tag = mct;
-     print_open_tag = pot;
-     print_close_tag = pct;
-   } =
-  let stringify f e = function String_tag s -> f s | _ -> e in
-  state.pp_mark_open_tag <- stringify mot "";
-  state.pp_mark_close_tag <- stringify mct "";
-  state.pp_print_open_tag <- stringify pot ();
-  state.pp_print_close_tag <- stringify pct ()
-
-let pp_get_formatter_tag_functions fmt () =
-  let funs = pp_get_formatter_stag_functions fmt () in
-  let mark_open_tag s = funs.mark_open_stag (String_tag s) in
-  let mark_close_tag s = funs.mark_close_stag (String_tag s) in
-  let print_open_tag s = funs.print_open_stag (String_tag s) in
-  let print_close_tag s = funs.print_close_stag (String_tag s) in
-  {mark_open_tag; mark_close_tag; print_open_tag; print_close_tag}
-
-let set_formatter_tag_functions =
-  pp_set_formatter_tag_functions std_formatter
-and get_formatter_tag_functions =
-  pp_get_formatter_tag_functions std_formatter
+  Domain.at_exit flush_standard_formatters)

--- a/vendor/ocaml-4.13-upstream/format.mli
+++ b/vendor/ocaml-4.13-upstream/format.mli
@@ -30,15 +30,27 @@
    - {!std_formatter} outputs to {{!Stdlib.stdout}stdout}
    - {!err_formatter} outputs to {{!Stdlib.stderr}stderr}
 
-   Most functions in the {!Format} module come in two variants:
-   a short version that operates on {!std_formatter} and the
-   generic version prefixed by [pp_] that takes a formatter
-   as its first argument.
+   Most functions in the {!Format} module come in two variants: a short version
+   that operates on the current domain's standard formatter as obtained using
+   {!get_std_formatter} and the generic version prefixed by [pp_] that takes a
+   formatter as its first argument. For the version that operates on the
+   current domain's standard formatter, the call to {!get_std_formatter} is
+   delayed until the last argument is received.
 
    More formatters can be created with {!formatter_of_out_channel},
-   {!formatter_of_buffer}, {!formatter_of_symbolic_output_buffer}
-   or using {{!section:formatter}custom formatters}.
+   {!formatter_of_buffer}, {!formatter_of_symbolic_output_buffer} or using
+   {{!section:formatter}custom formatters}.
 
+   Warning: Since {{!section:formatter}formatters} contain mutable state, it is
+   not thread-safe to use the same formatter on multiple domains in parallel
+   without synchronization.
+
+   If multiple domains write to the same output channel using the
+   predefined formatters (as obtained by {!get_std_formatter} or
+   {!get_err_formatter}), the output from the domains will be interleaved with
+   each other at points where the formatters are flushed, such as with
+   {!print_flush}. This synchronization is not performed by formatters obtained
+   from {!formatter_of_out_channel} (on the standard out channels or others).
 *)
 
 (** {1 Introduction}
@@ -320,7 +332,7 @@ val pp_print_custom_break :
 
    The custom break is useful if you want to change which visible
    (non-whitespace) characters are printed in case of break or no break. For
-   example, when printing a list {[ [a; b; c] ]}, you might want to add a
+   example, when printing a list [ [a; b; c] ], you might want to add a
    trailing semicolon when it is printed vertically:
 
    {[
@@ -944,19 +956,41 @@ val get_formatter_stag_functions : unit -> formatter_stag_functions
 
 val formatter_of_out_channel : out_channel -> formatter
 (** [formatter_of_out_channel oc] returns a new formatter writing
-  to the corresponding output channel [oc].
+    to the corresponding output channel [oc].
 *)
 
+val synchronized_formatter_of_out_channel :
+  out_channel -> formatter Domain.DLS.key
+(** [synchronized_formatter_of_out_channel oc] returns the key to the
+    domain-local state that holds the domain-local formatter for writing to the
+    corresponding output channel [oc].
+
+    When the formatter is used with multiple domains, the output from the
+    domains will be interleaved with each other at points where the formatter
+    is flushed, such as with {!print_flush}.
+*)
+
+
 val std_formatter : formatter
-(** The standard formatter to write to standard output.
+(** The initial domain's standard formatter to write to standard output.
 
   It is defined as {!formatter_of_out_channel} {!Stdlib.stdout}.
 *)
 
+val get_std_formatter : unit -> formatter
+(** [get_std_formatter ()] returns the current domain's standard formatter used
+    to write to standard output.
+*)
+
 val err_formatter : formatter
-(** A formatter to write to standard error.
+(** The initial domain's formatter to write to standard error.
 
   It is defined as {!formatter_of_out_channel} {!Stdlib.stderr}.
+*)
+
+val get_err_formatter : unit -> formatter
+(* [get_err_formatter ()] returns the current domain's formatter used to write
+   to standard error.
 *)
 
 val formatter_of_buffer : Buffer.t -> formatter
@@ -967,17 +1001,26 @@ val formatter_of_buffer : Buffer.t -> formatter
 *)
 
 val stdbuf : Buffer.t
-(** The string buffer in which [str_formatter] writes. *)
+(** The initial domain's string buffer in which [str_formatter] writes. *)
+
+val get_stdbuf : unit -> Buffer.t
+(** [get_stdbuf ()] returns the current domain's string buffer in which the
+    current domain's string formatter writes. *)
 
 val str_formatter : formatter
-(** A formatter to output to the {!stdbuf} string buffer.
+(** The initial domain's formatter to output to the {!stdbuf} string buffer.
 
   [str_formatter] is defined as {!formatter_of_buffer} {!stdbuf}.
 *)
 
+val get_str_formatter : unit -> formatter
+(** The current domain's formatter to output to the current domains string
+    buffer.
+*)
+
 val flush_str_formatter : unit -> string
-(** Returns the material printed with [str_formatter], flushes
-  the formatter and resets the corresponding buffer.
+(** Returns the material printed with [str_formatter] of the current domain,
+    flushes the formatter and resets the corresponding buffer.
 *)
 
 val make_formatter :
@@ -985,11 +1028,24 @@ val make_formatter :
 (** [make_formatter out flush] returns a new formatter that outputs with
   function [out], and flushes with function [flush].
 
-  For instance, {[
+  For instance,
+  {[
     make_formatter
       (Stdlib.output oc)
-      (fun () -> Stdlib.flush oc) ]}
+      (fun () -> Stdlib.flush oc)
+  ]}
   returns a formatter to the {!Stdlib.out_channel} [oc].
+*)
+
+val make_synchronized_formatter :
+  (string -> int -> int -> unit) -> (unit -> unit) -> formatter Domain.DLS.key
+(** [make_synchronized_formatter out flush] returns the key to the domain-local
+    state that holds the domain-local formatter that outputs with function
+    [out], and flushes with function [flush].
+
+    When the formatter is used with multiple domains, the output from the
+    domains will be interleaved with each other at points where the formatter
+    is flushed, such as with {!print_flush}.
 *)
 
 val formatter_of_out_functions :
@@ -1002,6 +1058,8 @@ val formatter_of_out_functions :
 
   @since 4.06.0
 *)
+
+
 
 (** {2:symbolic Symbolic pretty-printing} *)
 
@@ -1237,10 +1295,24 @@ val fprintf : formatter -> ('a, formatter, unit) format -> 'a
 *)
 
 val printf : ('a, formatter, unit) format -> 'a
-(** Same as [fprintf] above, but output on [std_formatter]. *)
+(** Same as [fprintf] above, but output on [get_std_formatter ()].
+
+    It is defined similarly to [fun fmt -> fprintf (get_std_formatter ()) fmt]
+    but delays calling [get_std_formatter] until after the final argument
+    required by the [format] is received. When used with multiple domains, the
+    output from the domains will be interleaved with each other at points where
+    the formatter is flushed, such as with {!print_flush}.
+*)
 
 val eprintf : ('a, formatter, unit) format -> 'a
-(** Same as [fprintf] above, but output on [err_formatter]. *)
+(** Same as [fprintf] above, but output on [get_err_formatter ()].
+
+    It is defined similarly to [fun fmt -> fprintf (get_err_formatter ()) fmt]
+    but delays calling [get_err_formatter] until after the final argument
+    required by the [format] is received. When used with multiple domains, the
+    output from the domains will be interleaved with each other at points where
+    the formatter is flushed, such as with {!print_flush}.
+*)
 
 val sprintf : ('a, unit, string) format -> 'a
 (** Same as [printf] above, but instead of printing on a formatter,
@@ -1333,103 +1405,3 @@ val kasprintf : (string -> 'a) -> ('b, formatter, unit, 'a) format4 -> 'b
 
   @since 4.03
 *)
-
-(** {1 Deprecated} *)
-
-val bprintf : Buffer.t -> ('a, formatter, unit) format -> 'a
-  [@@ocaml.deprecated]
-(** @deprecated This function is error prone. Do not use it.
-  This function is neither compositional nor incremental, since it flushes
-  the pretty-printer queue at each call.
-
-  If you need to print to some buffer [b], you must first define a
-  formatter writing to [b], using [let to_b = formatter_of_buffer b]; then
-  use regular calls to [Format.fprintf] with formatter [to_b].
-*)
-
-val kprintf : (string -> 'a) -> ('b, unit, string, 'a) format4 -> 'b
-  [@@ocaml.deprecated "Use Format.ksprintf instead."]
-(** @deprecated An alias for [ksprintf]. *)
-
-val set_all_formatter_output_functions :
-  out:(string -> int -> int -> unit) ->
-  flush:(unit -> unit) ->
-  newline:(unit -> unit) ->
-  spaces:(int -> unit) ->
-  unit
-[@@ocaml.deprecated "Use Format.set_formatter_out_functions instead."]
-(** @deprecated Subsumed by [set_formatter_out_functions]. *)
-
-val get_all_formatter_output_functions :
-  unit ->
-  (string -> int -> int -> unit) *
-  (unit -> unit) *
-  (unit -> unit) *
-  (int -> unit)
-[@@ocaml.deprecated "Use Format.get_formatter_out_functions instead."]
-(** @deprecated Subsumed by [get_formatter_out_functions]. *)
-
-val pp_set_all_formatter_output_functions :
-  formatter -> out:(string -> int -> int -> unit) -> flush:(unit -> unit) ->
-  newline:(unit -> unit) -> spaces:(int -> unit) -> unit
-[@@ocaml.deprecated "Use Format.pp_set_formatter_out_functions instead."]
-(** @deprecated Subsumed by [pp_set_formatter_out_functions]. *)
-
-val pp_get_all_formatter_output_functions :
-  formatter -> unit ->
-  (string -> int -> int -> unit) * (unit -> unit) * (unit -> unit) *
-  (int -> unit)
-[@@ocaml.deprecated "Use Format.pp_get_formatter_out_functions instead."]
-(** @deprecated Subsumed by [pp_get_formatter_out_functions]. *)
-
-(** {2 String tags} *)
-
-val pp_open_tag : formatter -> tag -> unit
-[@@ocaml.deprecated "Use Format.pp_open_stag."]
-(** @deprecated Subsumed by {!pp_open_stag}. *)
-
-val open_tag : tag -> unit
-[@@ocaml.deprecated "Use Format.open_stag."]
-(** @deprecated Subsumed by {!open_stag}. *)
-
-val pp_close_tag : formatter -> unit -> unit
-[@@ocaml.deprecated "Use Format.pp_close_stag."]
-(** @deprecated Subsumed by {!pp_close_stag}. *)
-
-val close_tag : unit -> unit
-[@@ocaml.deprecated "Use Format.close_stag."]
-(** @deprecated Subsumed by {!close_stag}. *)
-
-type formatter_tag_functions = {
-  mark_open_tag : tag -> string;
-  mark_close_tag : tag -> string;
-  print_open_tag : tag -> unit;
-  print_close_tag : tag -> unit;
-}
-[@@ocaml.deprecated "Use formatter_stag_functions."]
-(** @deprecated Subsumed by {!formatter_stag_functions}. *)
-
-val pp_set_formatter_tag_functions :
-  formatter -> formatter_tag_functions -> unit
-[@@ocaml.deprecated
-  "This function will erase non-string tag formatting functions. \
-   Use Format.pp_set_formatter_stag_functions."]
-[@@warning "-3"]
-(** This function will erase non-string tag formatting functions.
-    @deprecated Subsumed by {!pp_set_formatter_stag_functions}. *)
-
-val set_formatter_tag_functions : formatter_tag_functions -> unit
-[@@ocaml.deprecated "Use Format.set_formatter_stag_functions."]
-[@@warning "-3"]
-(** @deprecated Subsumed by {!set_formatter_stag_functions}. *)
-
-val pp_get_formatter_tag_functions :
-  formatter -> unit -> formatter_tag_functions
-[@@ocaml.deprecated "Use Format.pp_get_formatter_stag_functions."]
-[@@warning "-3"]
-(** @deprecated Subsumed by {!pp_get_formatter_stag_functions}. *)
-
-val get_formatter_tag_functions : unit -> formatter_tag_functions
-[@@ocaml.deprecated "Use Format.get_formatter_stag_functions."]
-[@@warning "-3"]
-(** @deprecated Subsumed by {!get_formatter_stag_functions}. *)

--- a/vendor/ocaml-4.13-upstream/lexer.mll
+++ b/vendor/ocaml-4.13-upstream/lexer.mll
@@ -31,9 +31,8 @@ type error =
   | Keyword_as_label of string
   | Invalid_literal of string
   | Invalid_directive of string * string option
-;;
 
-exception Error of error * Location.t;;
+exception Error of error * Location.t
 
 (* The table of keywords *)
 
@@ -111,9 +110,9 @@ let store_string s = Buffer.add_string string_buffer s
 let store_lexeme lexbuf = store_string (Lexing.lexeme lexbuf)
 
 (* To store the position of the beginning of a string and comment *)
-let string_start_loc = ref Location.none;;
-let comment_start_loc = ref [];;
-let in_comment () = !comment_start_loc <> [];;
+let string_start_loc = ref Location.none
+let comment_start_loc = ref []
+let in_comment () = !comment_start_loc <> []
 let is_in_string = ref false
 let in_string () = !is_in_string
 let print_warnings = ref true
@@ -247,7 +246,6 @@ let update_loc lexbuf file line absolute chars =
     pos_lnum = if absolute then line else pos.pos_lnum + line;
     pos_bol = pos.pos_cnum - chars;
   }
-;;
 
 let preprocessor = ref None
 

--- a/vendor/ocaml-4.13-upstream/parser.mly
+++ b/vendor/ocaml-4.13-upstream/parser.mly
@@ -98,13 +98,13 @@ let push_loc x acc =
 
 let reloc_pat ~loc x =
   { x with ppat_loc = make_loc loc;
-           ppat_loc_stack = push_loc x.ppat_loc x.ppat_loc_stack };;
+           ppat_loc_stack = push_loc x.ppat_loc x.ppat_loc_stack }
 let reloc_exp ~loc x =
   { x with pexp_loc = make_loc loc;
-           pexp_loc_stack = push_loc x.pexp_loc x.pexp_loc_stack };;
+           pexp_loc_stack = push_loc x.pexp_loc x.pexp_loc_stack }
 let reloc_typ ~loc x =
   { x with ptyp_loc = make_loc loc;
-           ptyp_loc_stack = push_loc x.ptyp_loc x.ptyp_loc_stack };;
+           ptyp_loc_stack = push_loc x.ptyp_loc x.ptyp_loc_stack }
 
 let mkexpvar ~loc (name : string) =
   mkexp ~loc (Pexp_ident(mkrhs (Lident name) loc))

--- a/vendor/ocaml-4.13-upstream/parsetree.mli
+++ b/vendor/ocaml-4.13-upstream/parsetree.mli
@@ -804,6 +804,7 @@ and module_substitution =
      pms_attributes: attributes; (* ... [@@id1] [@@id2] *)
      pms_loc: Location.t;
     }
+(* S := M *)
 
 and module_type_declaration =
     {

--- a/vendor/ocaml-4.13-upstream/pprintast.ml
+++ b/vendor/ocaml-4.13-upstream/pprintast.ml
@@ -28,7 +28,7 @@ open Longident
 open Parsetree
 open Ast_helper
 
-let prefix_symbols  = [ '!'; '?'; '~' ] ;;
+let prefix_symbols  = [ '!'; '?'; '~' ]
 let infix_symbols = [ '='; '<'; '>'; '@'; '^'; '|'; '&'; '+'; '-'; '*'; '/';
                       '$'; '%'; '#' ]
 

--- a/vendor/ocaml-4.13-upstream/printast.ml
+++ b/vendor/ocaml-4.13-upstream/printast.ml
@@ -13,11 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Asttypes;;
-open Format;;
-open Lexing;;
-open Location;;
-open Parsetree;;
+open Asttypes
+open Format
+open Lexing
+open Location
+open Parsetree
 
 let fmt_position with_name f l =
   let fname = if with_name then l.pos_fname else "" in
@@ -25,7 +25,6 @@ let fmt_position with_name f l =
   then fprintf f "%s[%d]" fname l.pos_cnum
   else fprintf f "%s[%d,%d+%d]" fname l.pos_lnum l.pos_bol
                (l.pos_cnum - l.pos_bol)
-;;
 
 let fmt_location f loc =
   if not !Clflags.locations then ()
@@ -35,29 +34,24 @@ let fmt_location f loc =
                          (fmt_position p_2nd_name) loc.loc_end;
     if loc.loc_ghost then fprintf f " ghost";
   end
-;;
 
 let rec fmt_longident_aux f x =
   match x with
-  | Longident.Lident (s) -> fprintf f "%s" s;
-  | Longident.Ldot (y, s) -> fprintf f "%a.%s" fmt_longident_aux y s;
+  | Longident.Lident (s) -> fprintf f "%s" s
+  | Longident.Ldot (y, s) -> fprintf f "%a.%s" fmt_longident_aux y s
   | Longident.Lapply (y, z) ->
-      fprintf f "%a(%a)" fmt_longident_aux y fmt_longident_aux z;
-;;
+      fprintf f "%a(%a)" fmt_longident_aux y fmt_longident_aux z
 
-let fmt_longident f x = fprintf f "\"%a\"" fmt_longident_aux x;;
+let fmt_longident f x = fprintf f "\"%a\"" fmt_longident_aux x
 
 let fmt_longident_loc f (x : Longident.t loc) =
-  fprintf f "\"%a\" %a" fmt_longident_aux x.txt fmt_location x.loc;
-;;
+  fprintf f "\"%a\" %a" fmt_longident_aux x.txt fmt_location x.loc
 
 let fmt_string_loc f (x : string loc) =
-  fprintf f "\"%s\" %a" x.txt fmt_location x.loc;
-;;
+  fprintf f "\"%s\" %a" x.txt fmt_location x.loc
 
 let fmt_str_opt_loc f (x : string option loc) =
-  fprintf f "\"%s\" %a" (Option.value x.txt ~default:"_") fmt_location x.loc;
-;;
+  fprintf f "\"%s\" %a" (Option.value x.txt ~default:"_") fmt_location x.loc
 
 let fmt_char_option f = function
   | None -> fprintf f "None"
@@ -65,32 +59,28 @@ let fmt_char_option f = function
 
 let fmt_constant f x =
   match x with
-  | Pconst_integer (i,m) -> fprintf f "PConst_int (%s,%a)" i fmt_char_option m;
-  | Pconst_char (c) -> fprintf f "PConst_char %02x" (Char.code c);
+  | Pconst_integer (i,m) -> fprintf f "PConst_int (%s,%a)" i fmt_char_option m
+  | Pconst_char (c) -> fprintf f "PConst_char %02x" (Char.code c)
   | Pconst_string (s, strloc, None) ->
-      fprintf f "PConst_string(%S,%a,None)" s fmt_location strloc ;
+      fprintf f "PConst_string(%S,%a,None)" s fmt_location strloc
   | Pconst_string (s, strloc, Some delim) ->
-      fprintf f "PConst_string (%S,%a,Some %S)" s fmt_location strloc delim;
-  | Pconst_float (s,m) -> fprintf f "PConst_float (%s,%a)" s fmt_char_option m;
-;;
+      fprintf f "PConst_string (%S,%a,Some %S)" s fmt_location strloc delim
+  | Pconst_float (s,m) -> fprintf f "PConst_float (%s,%a)" s fmt_char_option m
 
 let fmt_mutable_flag f x =
   match x with
-  | Immutable -> fprintf f "Immutable";
-  | Mutable -> fprintf f "Mutable";
-;;
+  | Immutable -> fprintf f "Immutable"
+  | Mutable -> fprintf f "Mutable"
 
 let fmt_virtual_flag f x =
   match x with
-  | Virtual -> fprintf f "Virtual";
-  | Concrete -> fprintf f "Concrete";
-;;
+  | Virtual -> fprintf f "Virtual"
+  | Concrete -> fprintf f "Concrete"
 
 let fmt_override_flag f x =
   match x with
-  | Override -> fprintf f "Override";
-  | Fresh -> fprintf f "Fresh";
-;;
+  | Override -> fprintf f "Override"
+  | Fresh -> fprintf f "Fresh"
 
 let fmt_closed_flag f x =
   match x with
@@ -99,53 +89,46 @@ let fmt_closed_flag f x =
 
 let fmt_rec_flag f x =
   match x with
-  | Nonrecursive -> fprintf f "Nonrec";
-  | Recursive -> fprintf f "Rec";
-;;
+  | Nonrecursive -> fprintf f "Nonrec"
+  | Recursive -> fprintf f "Rec"
 
 let fmt_direction_flag f x =
   match x with
-  | Upto -> fprintf f "Up";
-  | Downto -> fprintf f "Down";
-;;
+  | Upto -> fprintf f "Up"
+  | Downto -> fprintf f "Down"
 
 let fmt_private_flag f x =
   match x with
-  | Public -> fprintf f "Public";
-  | Private -> fprintf f "Private";
-;;
+  | Public -> fprintf f "Public"
+  | Private -> fprintf f "Private"
 
 let line i f s (*...*) =
   fprintf f "%s" (String.make ((2*i) mod 72) ' ');
   fprintf f s (*...*)
-;;
 
 let list i f ppf l =
   match l with
-  | [] -> line i ppf "[]\n";
+  | [] -> line i ppf "[]\n"
   | _ :: _ ->
      line i ppf "[\n";
      List.iter (f (i+1) ppf) l;
-     line i ppf "]\n";
-;;
+     line i ppf "]\n"
 
 let option i f ppf x =
   match x with
-  | None -> line i ppf "None\n";
+  | None -> line i ppf "None\n"
   | Some x ->
       line i ppf "Some\n";
-      f (i+1) ppf x;
-;;
+      f (i+1) ppf x
 
-let longident_loc i ppf li = line i ppf "%a\n" fmt_longident_loc li;;
-let string i ppf s = line i ppf "\"%s\"\n" s;;
-let string_loc i ppf s = line i ppf "%a\n" fmt_string_loc s;;
-let str_opt_loc i ppf s = line i ppf "%a\n" fmt_str_opt_loc s;;
+let longident_loc i ppf li = line i ppf "%a\n" fmt_longident_loc li
+let string i ppf s = line i ppf "\"%s\"\n" s
+let string_loc i ppf s = line i ppf "%a\n" fmt_string_loc s
+let str_opt_loc i ppf s = line i ppf "%a\n" fmt_str_opt_loc s
 let arg_label i ppf = function
   | Nolabel -> line i ppf "Nolabel\n"
   | Optional s -> line i ppf "Optional \"%s\"\n" s
   | Labelled s -> line i ppf "Labelled \"%s\"\n" s
-;;
 
 let typevars ppf vs =
   List.iter (fun x -> fprintf ppf " %a" Pprintast.tyvar x.txt) vs
@@ -953,7 +936,6 @@ and label_x_bool_x_core_type_list i ppf x =
   | Rinherit (ct) ->
       line i ppf "Rinherit\n";
       core_type (i+1) ppf ct
-;;
 
 let rec toplevel_phrase i ppf x =
   match x with
@@ -968,15 +950,14 @@ let rec toplevel_phrase i ppf x =
 
 and directive_argument i ppf x =
   match x.pdira_desc with
-  | Pdir_string (s) -> line i ppf "Pdir_string \"%s\"\n" s;
-  | Pdir_int (n, None) -> line i ppf "Pdir_int %s\n" n;
-  | Pdir_int (n, Some m) -> line i ppf "Pdir_int %s%c\n" n m;
-  | Pdir_ident (li) -> line i ppf "Pdir_ident %a\n" fmt_longident li;
-  | Pdir_bool (b) -> line i ppf "Pdir_bool %s\n" (string_of_bool b);
-;;
+  | Pdir_string (s) -> line i ppf "Pdir_string \"%s\"\n" s
+  | Pdir_int (n, None) -> line i ppf "Pdir_int %s\n" n
+  | Pdir_int (n, Some m) -> line i ppf "Pdir_int %s%c\n" n m
+  | Pdir_ident (li) -> line i ppf "Pdir_ident %a\n" fmt_longident li
+  | Pdir_bool (b) -> line i ppf "Pdir_bool %s\n" (string_of_bool b)
 
-let interface ppf x = list 0 signature_item ppf x;;
+let interface ppf x = list 0 signature_item ppf x
 
-let implementation ppf x = list 0 structure_item ppf x;;
+let implementation ppf x = list 0 structure_item ppf x
 
-let top_phrase ppf x = toplevel_phrase 0 ppf x;;
+let top_phrase ppf x = toplevel_phrase 0 ppf x

--- a/vendor/ocaml-4.13-upstream/printast.mli
+++ b/vendor/ocaml-4.13-upstream/printast.mli
@@ -20,12 +20,12 @@
 
 *)
 
-open Parsetree;;
-open Format;;
+open Parsetree
+open Format
 
-val interface : formatter -> signature_item list -> unit;;
-val implementation : formatter -> structure_item list -> unit;;
-val top_phrase : formatter -> toplevel_phrase -> unit;;
+val interface : formatter -> signature_item list -> unit
+val implementation : formatter -> structure_item list -> unit
+val top_phrase : formatter -> toplevel_phrase -> unit
 
 val expression: int -> formatter -> expression -> unit
 val structure: int -> formatter -> structure -> unit

--- a/vendor/ocaml-4.13/ast_mapper.ml
+++ b/vendor/ocaml-4.13/ast_mapper.ml
@@ -864,7 +864,7 @@ module PpxContext = struct
         lid "principal", make_bool !Clflags.principal;
         lid "transparent_modules", make_bool !Clflags.transparent_modules;
         lid "unboxed_types", make_bool !Clflags.unboxed_types;
-        lid "unsafe_string", make_bool !Clflags.unsafe_string;
+        lid "unsafe_string", make_bool false; (* kept for compatibility *)
         get_cookies ()
       ]
     in
@@ -944,8 +944,6 @@ module PpxContext = struct
           Clflags.transparent_modules := get_bool payload
       | "unboxed_types" ->
           Clflags.unboxed_types := get_bool payload
-      | "unsafe_string" ->
-          Clflags.unsafe_string := get_bool payload
       | "cookies" ->
           let l = get_list (get_pair get_string (fun x -> x)) payload in
           cookies :=

--- a/vendor/ocaml-4.13/lexer.mll
+++ b/vendor/ocaml-4.13/lexer.mll
@@ -31,9 +31,8 @@ type error =
   | Keyword_as_label of string
   | Invalid_literal of string
   | Invalid_directive of string * string option
-;;
 
-exception Error of error * Location.t;;
+exception Error of error * Location.t
 
 (* The table of keywords *)
 
@@ -111,9 +110,9 @@ let store_string s = Buffer.add_string string_buffer s
 let store_lexeme lexbuf = store_string (Lexing.lexeme lexbuf)
 
 (* To store the position of the beginning of a string and comment *)
-let string_start_loc = ref Location.none;;
-let comment_start_loc = ref [];;
-let in_comment () = !comment_start_loc <> [];;
+let string_start_loc = ref Location.none
+let comment_start_loc = ref []
+let in_comment () = !comment_start_loc <> []
 let is_in_string = ref false
 let in_string () = !is_in_string
 let print_warnings = ref true
@@ -278,7 +277,6 @@ let update_loc lexbuf file line absolute chars =
     pos_lnum = if absolute then line else pos.pos_lnum + line;
     pos_bol = pos.pos_cnum - chars;
   }
-;;
 
 let preprocessor = ref None
 

--- a/vendor/ocaml-4.13/parser.mly
+++ b/vendor/ocaml-4.13/parser.mly
@@ -98,13 +98,13 @@ let push_loc x acc =
 
 let reloc_pat ~loc x =
   { x with ppat_loc = make_loc loc;
-           ppat_loc_stack = push_loc x.ppat_loc x.ppat_loc_stack };;
+           ppat_loc_stack = push_loc x.ppat_loc x.ppat_loc_stack }
 let reloc_exp ~loc x =
   { x with pexp_loc = make_loc loc;
-           pexp_loc_stack = push_loc x.pexp_loc x.pexp_loc_stack };;
+           pexp_loc_stack = push_loc x.pexp_loc x.pexp_loc_stack }
 let reloc_typ ~loc x =
   { x with ptyp_loc = make_loc loc;
-           ptyp_loc_stack = push_loc x.ptyp_loc x.ptyp_loc_stack };;
+           ptyp_loc_stack = push_loc x.ptyp_loc x.ptyp_loc_stack }
 
 let mkexpvar ~loc (name : string) =
   mkexp ~loc (Pexp_ident(mkrhs (Lident name) loc))

--- a/vendor/ocaml-4.13/parsetree.mli
+++ b/vendor/ocaml-4.13/parsetree.mli
@@ -806,6 +806,7 @@ and module_substitution =
      pms_attributes: attributes; (* ... [@@id1] [@@id2] *)
      pms_loc: Location.t;
     }
+(* S := M *)
 
 and module_type_declaration =
     {

--- a/vendor/ocaml-4.13/pprintast.ml
+++ b/vendor/ocaml-4.13/pprintast.ml
@@ -28,7 +28,7 @@ open Longident
 open Parsetree
 open Ast_helper
 
-let prefix_symbols  = [ '!'; '?'; '~' ] ;;
+let prefix_symbols  = [ '!'; '?'; '~' ]
 let infix_symbols = [ '='; '<'; '>'; '@'; '^'; '|'; '&'; '+'; '-'; '*'; '/';
                       '$'; '%'; '#' ]
 

--- a/vendor/ocaml-4.13/printast.ml
+++ b/vendor/ocaml-4.13/printast.ml
@@ -13,11 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Asttypes;;
-open Format;;
-open Lexing;;
-open Location;;
-open Parsetree;;
+open Asttypes
+open Format
+open Lexing
+open Location
+open Parsetree
 
 let fmt_position with_name f l =
   let fname = if with_name then l.pos_fname else "" in
@@ -25,7 +25,6 @@ let fmt_position with_name f l =
   then fprintf f "%s[%d]" fname l.pos_cnum
   else fprintf f "%s[%d,%d+%d]" fname l.pos_lnum l.pos_bol
                (l.pos_cnum - l.pos_bol)
-;;
 
 let fmt_location f loc =
   if not !Clflags.locations then ()
@@ -35,29 +34,24 @@ let fmt_location f loc =
                          (fmt_position p_2nd_name) loc.loc_end;
     if loc.loc_ghost then fprintf f " ghost";
   end
-;;
 
 let rec fmt_longident_aux f x =
   match x with
-  | Longident.Lident (s) -> fprintf f "%s" s;
-  | Longident.Ldot (y, s) -> fprintf f "%a.%s" fmt_longident_aux y s;
+  | Longident.Lident (s) -> fprintf f "%s" s
+  | Longident.Ldot (y, s) -> fprintf f "%a.%s" fmt_longident_aux y s
   | Longident.Lapply (y, z) ->
-      fprintf f "%a(%a)" fmt_longident_aux y fmt_longident_aux z;
-;;
+      fprintf f "%a(%a)" fmt_longident_aux y fmt_longident_aux z
 
-let fmt_longident f x = fprintf f "\"%a\"" fmt_longident_aux x;;
+let fmt_longident f x = fprintf f "\"%a\"" fmt_longident_aux x
 
 let fmt_longident_loc f (x : Longident.t loc) =
-  fprintf f "\"%a\" %a" fmt_longident_aux x.txt fmt_location x.loc;
-;;
+  fprintf f "\"%a\" %a" fmt_longident_aux x.txt fmt_location x.loc
 
 let fmt_string_loc f (x : string loc) =
-  fprintf f "\"%s\" %a" x.txt fmt_location x.loc;
-;;
+  fprintf f "\"%s\" %a" x.txt fmt_location x.loc
 
 let fmt_str_opt_loc f (x : string option loc) =
-  fprintf f "\"%s\" %a" (Option.value x.txt ~default:"_") fmt_location x.loc;
-;;
+  fprintf f "\"%s\" %a" (Option.value x.txt ~default:"_") fmt_location x.loc
 
 let fmt_char_option f = function
   | None -> fprintf f "None"
@@ -65,32 +59,28 @@ let fmt_char_option f = function
 
 let fmt_constant f x =
   match x with
-  | Pconst_integer (i,m) -> fprintf f "PConst_int (%s,%a)" i fmt_char_option m;
-  | Pconst_char (c) -> fprintf f "PConst_char %02x" (Char.code c);
+  | Pconst_integer (i,m) -> fprintf f "PConst_int (%s,%a)" i fmt_char_option m
+  | Pconst_char (c) -> fprintf f "PConst_char %02x" (Char.code c)
   | Pconst_string (s, strloc, None) ->
-      fprintf f "PConst_string(%S,%a,None)" s fmt_location strloc ;
+      fprintf f "PConst_string(%S,%a,None)" s fmt_location strloc
   | Pconst_string (s, strloc, Some delim) ->
-      fprintf f "PConst_string (%S,%a,Some %S)" s fmt_location strloc delim;
-  | Pconst_float (s,m) -> fprintf f "PConst_float (%s,%a)" s fmt_char_option m;
-;;
+      fprintf f "PConst_string (%S,%a,Some %S)" s fmt_location strloc delim
+  | Pconst_float (s,m) -> fprintf f "PConst_float (%s,%a)" s fmt_char_option m
 
 let fmt_mutable_flag f x =
   match x with
-  | Immutable -> fprintf f "Immutable";
-  | Mutable -> fprintf f "Mutable";
-;;
+  | Immutable -> fprintf f "Immutable"
+  | Mutable -> fprintf f "Mutable"
 
 let fmt_virtual_flag f x =
   match x with
-  | Virtual -> fprintf f "Virtual";
-  | Concrete -> fprintf f "Concrete";
-;;
+  | Virtual -> fprintf f "Virtual"
+  | Concrete -> fprintf f "Concrete"
 
 let fmt_override_flag f x =
   match x with
-  | Override -> fprintf f "Override";
-  | Fresh -> fprintf f "Fresh";
-;;
+  | Override -> fprintf f "Override"
+  | Fresh -> fprintf f "Fresh"
 
 let fmt_closed_flag f x =
   match x with
@@ -99,53 +89,46 @@ let fmt_closed_flag f x =
 
 let fmt_rec_flag f x =
   match x with
-  | Nonrecursive -> fprintf f "Nonrec";
-  | Recursive -> fprintf f "Rec";
-;;
+  | Nonrecursive -> fprintf f "Nonrec"
+  | Recursive -> fprintf f "Rec"
 
 let fmt_direction_flag f x =
   match x with
-  | Upto -> fprintf f "Up";
-  | Downto -> fprintf f "Down";
-;;
+  | Upto -> fprintf f "Up"
+  | Downto -> fprintf f "Down"
 
 let fmt_private_flag f x =
   match x with
-  | Public -> fprintf f "Public";
-  | Private -> fprintf f "Private";
-;;
+  | Public -> fprintf f "Public"
+  | Private -> fprintf f "Private"
 
 let line i f s (*...*) =
   fprintf f "%s" (String.make ((2*i) mod 72) ' ');
   fprintf f s (*...*)
-;;
 
 let list i f ppf l =
   match l with
-  | [] -> line i ppf "[]\n";
+  | [] -> line i ppf "[]\n"
   | _ :: _ ->
      line i ppf "[\n";
      List.iter (f (i+1) ppf) l;
-     line i ppf "]\n";
-;;
+     line i ppf "]\n"
 
 let option i f ppf x =
   match x with
-  | None -> line i ppf "None\n";
+  | None -> line i ppf "None\n"
   | Some x ->
       line i ppf "Some\n";
-      f (i+1) ppf x;
-;;
+      f (i+1) ppf x
 
-let longident_loc i ppf li = line i ppf "%a\n" fmt_longident_loc li;;
-let string i ppf s = line i ppf "\"%s\"\n" s;;
-let string_loc i ppf s = line i ppf "%a\n" fmt_string_loc s;;
-let str_opt_loc i ppf s = line i ppf "%a\n" fmt_str_opt_loc s;;
+let longident_loc i ppf li = line i ppf "%a\n" fmt_longident_loc li
+let string i ppf s = line i ppf "\"%s\"\n" s
+let string_loc i ppf s = line i ppf "%a\n" fmt_string_loc s
+let str_opt_loc i ppf s = line i ppf "%a\n" fmt_str_opt_loc s
 let arg_label i ppf = function
   | Nolabel -> line i ppf "Nolabel\n"
   | Optional s -> line i ppf "Optional \"%s\"\n" s
   | Labelled s -> line i ppf "Labelled \"%s\"\n" s
-;;
 
 let typevars ppf vs =
   List.iter (fun x -> fprintf ppf " %a" Pprintast.tyvar x.txt) vs
@@ -957,7 +940,6 @@ and label_x_bool_x_core_type_list i ppf x =
   | Rinherit (ct) ->
       line i ppf "Rinherit\n";
       core_type (i+1) ppf ct
-;;
 
 let rec toplevel_phrase i ppf x =
   match x with
@@ -972,15 +954,14 @@ let rec toplevel_phrase i ppf x =
 
 and directive_argument i ppf x =
   match x.pdira_desc with
-  | Pdir_string (s) -> line i ppf "Pdir_string \"%s\"\n" s;
-  | Pdir_int (n, None) -> line i ppf "Pdir_int %s\n" n;
-  | Pdir_int (n, Some m) -> line i ppf "Pdir_int %s%c\n" n m;
-  | Pdir_ident (li) -> line i ppf "Pdir_ident %a\n" fmt_longident li;
-  | Pdir_bool (b) -> line i ppf "Pdir_bool %s\n" (string_of_bool b);
-;;
+  | Pdir_string (s) -> line i ppf "Pdir_string \"%s\"\n" s
+  | Pdir_int (n, None) -> line i ppf "Pdir_int %s\n" n
+  | Pdir_int (n, Some m) -> line i ppf "Pdir_int %s%c\n" n m
+  | Pdir_ident (li) -> line i ppf "Pdir_ident %a\n" fmt_longident li
+  | Pdir_bool (b) -> line i ppf "Pdir_bool %s\n" (string_of_bool b)
 
-let interface ppf x = list 0 signature_item ppf x;;
+let interface ppf x = list 0 signature_item ppf x
 
-let implementation ppf x = list 0 structure_item ppf x;;
+let implementation ppf x = list 0 structure_item ppf x
 
-let top_phrase ppf x = toplevel_phrase 0 ppf x;;
+let top_phrase ppf x = toplevel_phrase 0 ppf x

--- a/vendor/ocaml-4.13/printast.mli
+++ b/vendor/ocaml-4.13/printast.mli
@@ -20,12 +20,12 @@
 
 *)
 
-open Parsetree;;
-open Format;;
+open Parsetree
+open Format
 
-val interface : formatter -> signature_item list -> unit;;
-val implementation : formatter -> structure_item list -> unit;;
-val top_phrase : formatter -> toplevel_phrase -> unit;;
+val interface : formatter -> signature_item list -> unit
+val implementation : formatter -> structure_item list -> unit
+val top_phrase : formatter -> toplevel_phrase -> unit
 
 val expression: int -> formatter -> expression -> unit
 val structure: int -> formatter -> structure -> unit

--- a/vendor/ocamlformat_support/dune
+++ b/vendor/ocamlformat_support/dune
@@ -2,5 +2,5 @@
  (name format_)
  (public_name ocamlformat.format_)
  (flags
-  (:standard -open Parser_shims))
- (libraries either parser_shims))
+  (:standard -open Parser_shims -open Ocaml_common))
+ (libraries either parser_shims ocaml_common))

--- a/vendor/ocamlformat_support/dune
+++ b/vendor/ocamlformat_support/dune
@@ -2,5 +2,5 @@
  (name format_)
  (public_name ocamlformat.format_)
  (flags
-  (:standard -open Parser_shims -open Ocaml_common))
- (libraries either parser_shims ocaml_common))
+  (:standard -open Parser_shims))
+ (libraries either parser_shims))

--- a/vendor/parse-wyc/lib/lexer.mll
+++ b/vendor/parse-wyc/lib/lexer.mll
@@ -31,9 +31,8 @@ type error =
   | Keyword_as_label of string
   | Invalid_literal of string
   | Invalid_directive of string * string option
-;;
 
-exception Error of error * Location.t;;
+exception Error of error * Location.t
 
 (* The table of keywords *)
 
@@ -111,9 +110,9 @@ let store_string s = Buffer.add_string string_buffer s
 let store_lexeme lexbuf = store_string (Lexing.lexeme lexbuf)
 
 (* To store the position of the beginning of a string and comment *)
-let string_start_loc = ref Location.none;;
-let comment_start_loc = ref [];;
-let in_comment () = !comment_start_loc <> [];;
+let string_start_loc = ref Location.none
+let comment_start_loc = ref []
+let in_comment () = !comment_start_loc <> []
 let is_in_string = ref false
 let in_string () = !is_in_string
 let print_warnings = ref true
@@ -247,7 +246,6 @@ let update_loc lexbuf file line absolute chars =
     pos_lnum = if absolute then line else pos.pos_lnum + line;
     pos_bol = pos.pos_cnum - chars;
   }
-;;
 
 let preprocessor = ref None
 

--- a/vendor/parse-wyc/lib/parser.mly
+++ b/vendor/parse-wyc/lib/parser.mly
@@ -106,13 +106,13 @@ let push_loc x acc =
 
 let reloc_pat ~loc x =
   { x with ppat_loc = make_loc loc;
-           ppat_loc_stack = push_loc x.ppat_loc x.ppat_loc_stack };;
+           ppat_loc_stack = push_loc x.ppat_loc x.ppat_loc_stack }
 let reloc_exp ~loc x =
   { x with pexp_loc = make_loc loc;
-           pexp_loc_stack = push_loc x.pexp_loc x.pexp_loc_stack };;
+           pexp_loc_stack = push_loc x.pexp_loc x.pexp_loc_stack }
 let reloc_typ ~loc x =
   { x with ptyp_loc = make_loc loc;
-           ptyp_loc_stack = push_loc x.ptyp_loc x.ptyp_loc_stack };;
+           ptyp_loc_stack = push_loc x.ptyp_loc x.ptyp_loc_stack }
 
 let mkexpvar ~loc (name : string) =
   mkexp ~loc (Pexp_ident(mkrhs (Lident name) loc))

--- a/vendor/parser-shims/parser_shims.ml
+++ b/vendor/parser-shims/parser_shims.ml
@@ -46,7 +46,6 @@ module Clflags = struct
   let for_package = ref (None: string option) (* -for-pack *)
   let transparent_modules = ref false     (* -trans-mod *)
   let locations = ref true                (* -d(no-)locations *)
-  let unsafe_string = ref false           (* -safe-string / -unsafe-string *)
   let color = ref None                    (* -color *)
   let error_style = ref None              (* -error-style *)
   let unboxed_types = ref false

--- a/vendor/parser-shims/parser_shims.mli
+++ b/vendor/parser-shims/parser_shims.mli
@@ -46,7 +46,6 @@ module Clflags : sig
   val for_package : string option ref
   val transparent_modules : bool ref
   val locations : bool ref
-  val unsafe_string : bool ref
   val color : Misc.Color.setting option ref
   val error_style : Misc.Error_style.setting option ref
   val unboxed_types : bool ref


### PR DESCRIPTION
Our customized copy of `Format` was not updated on purpose since the new version needs `Domain`, that needs `Atomic`, that needs C stubs. At some point I hope we will be bale to completely detach ourselves from the `Format` module.