### PR TITLE
Bump JS dependencies to include 0.15

### DIFF
--- a/ocamlformat-bench.opam
+++ b/ocamlformat-bench.opam
@@ -14,7 +14,7 @@ depends: [
   "bechamel" {>= "0.2.0"}
   "bechamel-js" {>= "0.2.0"}
   "ocamlformat" {= version}
-  "stdio" {< "v0.15"}
+  "stdio" {< "v0.16"}
   "yojson"
   "odoc" {with-doc}
 ]

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "ocaml" {>= "4.08" & < "4.15"}
   "alcotest" {with-test}
-  "base" {>= "v0.12.0" & < "v0.15"}
+  "base" {>= "v0.12.0" & < "v0.16"}
   "cmdliner" {>= "1.1.0"}
   "dune" {>= "2.8"}
   "dune" {with-test & < "3.0"}
@@ -25,7 +25,7 @@ depends: [
   "ocp-indent"
   "odoc-parser" {>= "1.0.0"}
   "re" {>= "1.7.2"}
-  "stdio" {< "v0.15"}
+  "stdio" {< "v0.16"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
   "csexp" {>= "1.4.0"}


### PR DESCRIPTION
As far as I can tell, ocamlformat works fine with the latest
(and recently released) Jane Street libraries, 0.15. This PR
bumps ocamlformat's dependencies to include that latest release.

I'd like to push for releasing this change into opam sooner rather
than later. Is there a process for that?