### PR TITLE
Remove upper-bound constraints for JS deps

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,9 +38,7 @@
     (< 4.15)))
   (alcotest :with-test)
   (base
-   (and
-    (>= v0.12.0)
-    (< v0.16)))
+   (>= v0.12.0))
   (cmdliner
    (>= 1.1.0))
   dune
@@ -65,8 +63,7 @@
    (>= 1.0.0))
   (re
    (>= 1.7.2))
-  (stdio
-   (< v0.16))
+  stdio
   (uuseg
    (>= 10.0.0))
   (uutf
@@ -91,8 +88,7 @@
    (>= 0.2.0))
   (ocamlformat
    (= :version))
-  (stdio
-   (< v0.16))
+  stdio
   yojson))
 
 (package

--- a/ocamlformat-bench.opam
+++ b/ocamlformat-bench.opam
@@ -14,7 +14,7 @@ depends: [
   "bechamel" {>= "0.2.0"}
   "bechamel-js" {>= "0.2.0"}
   "ocamlformat" {= version}
-  "stdio" {< "v0.16"}
+  "stdio"
   "yojson"
   "odoc" {with-doc}
 ]

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "ocaml" {>= "4.08" & < "4.15"}
   "alcotest" {with-test}
-  "base" {>= "v0.12.0" & < "v0.16"}
+  "base" {>= "v0.12.0"}
   "cmdliner" {>= "1.1.0"}
   "dune" {>= "2.8"}
   "dune" {with-test & < "3.0"}
@@ -25,7 +25,7 @@ depends: [
   "ocp-indent"
   "odoc-parser" {>= "1.0.0"}
   "re" {>= "1.7.2"}
-  "stdio" {< "v0.16"}
+  "stdio"
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
   "csexp" {>= "1.4.0"}


### PR DESCRIPTION
Following up the discussion of #2059 