### PR TITLE
Set ocaml-version to a fixed version by default to avoid reproducibility issues and surprising behaviours

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Doc-comments code blocks with a language other than 'ocaml' (set in metadata) are not parsed as OCaml (#2037, @gpetiot)
 - More comprehensible error message in case of version mismatch (#2042, @gpetiot)
 - The global configuration file (`$XDG_CONFIG_HOME` or `$HOME/.config`) is only applied when no project is detected, `--enable-outside-detected-project` is set, and no applicable `.ocamlformat` file has been found. Global and local configurations are no longer used at the same time. (#2039, @gpetiot)
+- Set `ocaml-version` to a fixed version (4.04.0) by default to avoid reproducibility issues and surprising behaviours (#2064, @kit-ty-kate)
 
 ### New features
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1190,9 +1190,8 @@ module Operational = struct
     let docv = "V" in
     let doc = "Version of OCaml syntax of the output." in
     let default = Ocaml_version.Releases.v4_04_0 in
-    let default_doc = "4.04.0" in
-    C.any ocaml_version_conv ~names:["ocaml-version"] ~default ~default_doc
-      ~doc ~docv ~kind
+    C.any ocaml_version_conv ~names:["ocaml-version"] ~default ~doc ~docv
+      ~kind
       (fun conf x -> update conf ~f:(fun f -> {f with ocaml_version= x}))
       (fun conf -> conf.opr_opts.ocaml_version)
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1189,8 +1189,8 @@ module Operational = struct
   let ocaml_version =
     let docv = "V" in
     let doc = "Version of OCaml syntax of the output." in
-    let default = Ocaml_version.sys_version in
-    let default_doc = "the version of OCaml used to build OCamlFormat" in
+    let default = Ocaml_version.Releases.v4_04_0 in
+    let default_doc = "4.04.0" in
     C.any ocaml_version_conv ~names:["ocaml-version"] ~default ~default_doc
       ~doc ~docv ~kind
       (fun conf x -> update conf ~f:(fun f -> {f with ocaml_version= x}))

--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -112,13 +112,8 @@ module Make (C : CONFIG) = struct
       (in_attributes allow_inline kind)
       status_doc status
 
-  let generated_doc ?default_doc conv ~allow_inline ~doc ~kind ~default
-      ~status =
-    let default_doc =
-      match default_doc with
-      | Some x -> x
-      | None -> Format.asprintf "%a" (Arg.conv_printer conv) default
-    in
+  let generated_doc conv ~allow_inline ~doc ~kind ~default ~status =
+    let default_doc = Format.asprintf "%a" (Arg.conv_printer conv) default in
     let default =
       if String.is_empty default_doc then "none" else default_doc
     in
@@ -183,13 +178,12 @@ module Make (C : CONFIG) = struct
     store := Pack opt :: !store ;
     opt
 
-  let any ?default_doc converter ~default ~docv ~names ~doc ~kind
+  let any converter ~default ~docv ~names ~doc ~kind
       ?(allow_inline = Poly.(kind = Formatting)) ?(status = `Valid) update
       get_value =
     let open Cmdliner in
     let doc =
-      generated_doc converter ?default_doc ~allow_inline ~doc ~kind ~default
-        ~status
+      generated_doc converter ~allow_inline ~doc ~kind ~default ~status
     in
     let docs = section_name kind status in
     let term =

--- a/lib/Config_option.mli
+++ b/lib/Config_option.mli
@@ -91,11 +91,7 @@ module Make (C : CONFIG) : sig
   val flag : default:bool -> bool option_decl
 
   val any :
-       ?default_doc:string
-    -> 'a Cmdliner.Arg.conv
-    -> default:'a
-    -> docv:string
-    -> 'a option_decl
+    'a Cmdliner.Arg.conv -> default:'a -> docv:string -> 'a option_decl
 
   val removed_option :
     names:string list -> since:Version.t -> msg:string -> unit

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -655,8 +655,8 @@ OPTIONS
            omitted.
 
        --ocaml-version=V
-           Version of OCaml syntax of the output. The default value is the
-           version of OCaml used to build OCamlFormat.
+           Version of OCaml syntax of the output. The default value is
+           4.04.0.
 
        --ocp-indent-config
            Read .ocp-indent configuration files. base is an alias for

--- a/ocamlformat-rpc-help.txt
+++ b/ocamlformat-rpc-help.txt
@@ -3,7 +3,7 @@ NAME
        code.
 
 SYNOPSIS
-       ocamlformat-rpc [OPTION]… 
+       ocamlformat-rpc [OPTION]…
 
 DESCRIPTION
        ocamlformat-rpc listens to RPC requests, provided on the standard


### PR DESCRIPTION
See for example https://github.com/ocaml/opam-repository/pull/21236#discussion_r853088590

To me, ocamlformat should always aim to give a reproducible output regardless of the version of the compiler you currently have. To this end I’m setting the default value of `ocaml-version` to the oldest version of the compiler to ever be compatible with ocamlformat.