### PR TITLE
Distinguish option 'range' from 'numeric'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 - More comprehensible error message in case of version mismatch (#2042, @gpetiot)
 - The global configuration file (`$XDG_CONFIG_HOME` or `$HOME/.config`) is only applied when no project is detected, `--enable-outside-detected-project` is set, and no applicable `.ocamlformat` file has been found. Global and local configurations are no longer used at the same time. (#2039, @gpetiot)
 - Set `ocaml-version` to a fixed version (4.04.0) by default to avoid reproducibility issues and surprising behaviours (#2064, @kit-ty-kate)
+- Split option `--numeric=X-Y` into `--range=X-Y` and `--numeric` (flag). For now `--range` can only be used with `--numeric`. (#2073, @gpetiot)
 
 ### New features
 

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -52,6 +52,7 @@ let tests =
               (Translation_unit.parse_and_format kind ~input_name ~source
                  conf )
         | `Numeric range ->
+            let range = Range.make source ~range in
             ignore
               (Translation_unit.numeric kind ~input_name ~source ~range conf)
         ) )

--- a/bin/ocamlformat/main.ml
+++ b/bin/ocamlformat/main.ml
@@ -45,12 +45,6 @@ let print_error (conf : Conf.t) e =
   Translation_unit.Error.print Format.err_formatter
     ~debug:conf.opr_opts.debug ~quiet:conf.opr_opts.quiet e
 
-let check_range (conf : Conf.t) s =
-  let lines_nb = List.length @@ String.split_lines s in
-  match conf.opr_opts.range with
-  | Some (x, y) when 1 <= x && x <= y && y <= lines_nb -> (x, y)
-  | _ -> (1, lines_nb)
-
 let run_action action =
   match action with
   | Conf.Inplace inputs ->
@@ -91,14 +85,11 @@ let run_action action =
       Result.combine_errors_unit (List.map inputs ~f)
   | Print_config conf -> Conf.print_config conf ; Ok ()
   | Numeric {kind; file; name= input_name; conf} ->
+      let conf = {conf with opr_opts= {conf.opr_opts with quiet= true}} in
       let source = source_from_file file in
-      let range = check_range conf source in
-      let opr_opts = {conf.opr_opts with quiet= true; range= Some range} in
-      let conf = {conf with opr_opts} in
-      let indents =
-        Translation_unit.numeric kind ~input_name ~source ~range conf
-      in
-      List.iter indents ~f:(fun i -> Stdio.print_endline (Int.to_string i)) ;
+      let range = conf.opr_opts.range source in
+      Translation_unit.numeric kind ~input_name ~source ~range conf
+      |> List.iter ~f:(fun i -> Stdio.print_endline (Int.to_string i)) ;
       Ok ()
 ;;
 

--- a/bin/ocamlformat/main.ml
+++ b/bin/ocamlformat/main.ml
@@ -11,8 +11,7 @@
 
 (** OCamlFormat *)
 
-open Ocamlformat
-open Result.Monad_infix ;;
+open Ocamlformat ;;
 
 Caml.at_exit (Format.pp_print_flush Format.err_formatter) ;;
 
@@ -45,6 +44,12 @@ let source_from_file = function
 let print_error (conf : Conf.t) e =
   Translation_unit.Error.print Format.err_formatter
     ~debug:conf.opr_opts.debug ~quiet:conf.opr_opts.quiet e
+
+let check_range (conf : Conf.t) s =
+  let lines_nb = List.length @@ String.split_lines s in
+  match conf.opr_opts.range with
+  | Some (x, y) when 1 <= x && x <= y && y <= lines_nb -> (x, y)
+  | _ -> (1, lines_nb)
 
 let run_action action =
   match action with
@@ -85,12 +90,16 @@ let run_action action =
       in
       Result.combine_errors_unit (List.map inputs ~f)
   | Print_config conf -> Conf.print_config conf ; Ok ()
-  | Numeric ({kind; file; name= input_name; conf}, range) ->
-      let conf = {conf with opr_opts= {conf.opr_opts with quiet= true}} in
+  | Numeric {kind; file; name= input_name; conf} ->
       let source = source_from_file file in
-      Translation_unit.numeric kind ~input_name ~source ~range conf
-      |> Result.map_error ~f:(fun e -> [(fun () -> print_error conf e)])
-      >>| List.iter ~f:(fun i -> Stdio.print_endline (Int.to_string i))
+      let range = check_range conf source in
+      let opr_opts = {conf.opr_opts with quiet= true; range= Some range} in
+      let conf = {conf with opr_opts} in
+      let indents =
+        Translation_unit.numeric kind ~input_name ~source ~range conf
+      in
+      List.iter indents ~f:(fun i -> Stdio.print_endline (Int.to_string i)) ;
+      Ok ()
 ;;
 
 match Conf.action () with

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -80,7 +80,7 @@ type opr_opts =
   ; max_iters: int
   ; ocaml_version: Ocaml_version.t
   ; quiet: bool
-  ; range: (int * int) option }
+  ; range: string -> Range.t }
 
 type t = {fmt_opts: fmt_opts; opr_opts: opr_opts}
 
@@ -1179,11 +1179,9 @@ module Operational = struct
        whole input is considered. Warning: only supported in conbination \
        with `--numeric` for now."
     in
-    let default = None in
+    let default = Range.make ?range:None in
     let docv = "X-Y" in
-    C.any
-      Arg.(some (pair ~sep:'-' int int))
-      ~names:["range"] ~default ~doc ~docv ~kind
+    C.any Range.conv ~names:["range"] ~default ~doc ~docv ~kind
       (fun conf x -> update conf ~f:(fun f -> {f with range= x}))
       (fun conf -> conf.opr_opts.range)
 end

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -79,7 +79,8 @@ type opr_opts =
   ; margin_check: bool
   ; max_iters: int
   ; ocaml_version: Ocaml_version.t
-  ; quiet: bool }
+  ; quiet: bool
+  ; range: (int * int) option }
 
 type t = {fmt_opts: fmt_opts; opr_opts: opr_opts}
 
@@ -1170,6 +1171,21 @@ module Operational = struct
     C.flag ~default:false ~names:["q"; "quiet"] ~doc ~kind
       (fun conf x -> update conf ~f:(fun f -> {f with quiet= x}))
       (fun conf -> conf.opr_opts.quiet)
+
+  let range =
+    let doc =
+      "Apply the formatting to a range of lines. Must be included between 1 \
+       and the number of lines of the input. If a range is invalid the \
+       whole input is considered. Warning: only supported in conbination \
+       with `--numeric` for now."
+    in
+    let default = None in
+    let docv = "X-Y" in
+    C.any
+      Arg.(some (pair ~sep:'-' int int))
+      ~names:["range"] ~default ~doc ~docv ~kind
+      (fun conf x -> update conf ~f:(fun f -> {f with range= x}))
+      (fun conf -> conf.opr_opts.range)
 end
 
 let disable_conf_attrs =
@@ -1297,15 +1313,10 @@ let numeric =
   let doc =
     "Instead of re-formatting the file, output one integer per line \
      corresponding to the indentation value, printing as many values as \
-     lines in the range between lines X and Y (included)."
+     lines in the document."
   in
-  let default = None in
-  let docv = "X-Y" in
-  mk ~default
-    Arg.(
-      value
-      & opt (some (pair ~sep:'-' int int)) default
-      & info ["numeric"] ~doc ~docs ~docv)
+  let default = false in
+  mk ~default Arg.(value & flag & info ["numeric"] ~doc ~docs)
 
 let ocp_indent_options =
   let unsupported ocp_indent = (ocp_indent, ([], "")) in
@@ -1841,7 +1852,8 @@ let default =
       ; margin_check= C.default Operational.margin_check
       ; max_iters= C.default Operational.max_iters
       ; ocaml_version= C.default Operational.ocaml_version
-      ; quiet= C.default Operational.quiet } }
+      ; quiet= C.default Operational.quiet
+      ; range= C.default Operational.range } }
 
 let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
   let vfile = Fpath.v file in
@@ -1949,7 +1961,7 @@ let validate_action () =
       ; Option.some_if !inplace (`Inplace, "--inplace")
       ; Option.some_if !check (`Check, "--check")
       ; Option.some_if !print_config (`Print_config, "--print-config")
-      ; Option.map ~f:(fun r -> (`Numeric r, "--numeric")) !numeric ]
+      ; Option.some_if !numeric (`Numeric, "--numeric") ]
   with
   | [] -> Ok `No_action
   | [(action, _)] -> Ok action
@@ -1963,15 +1975,15 @@ type action =
   | Inplace of input list
   | Check of input list
   | Print_config of t
-  | Numeric of input * (int * int)
+  | Numeric of input
 
 let make_action ~enable_outside_detected_project ~root action inputs =
   let open Result in
-  let make_file ?(with_conf = fun c -> c) ?name kind file =
+  let make_file ?name kind file =
     let name = Option.value ~default:file name in
     build_config ~enable_outside_detected_project ~root ~file:name
       ~is_stdin:false
-    >>= fun conf -> Ok {kind; name; file= File file; conf= with_conf conf}
+    >>= fun conf -> Ok {kind; name; file= File file; conf}
   in
   let make_stdin ?(name = "<standard input>") kind =
     build_config ~enable_outside_detected_project ~root ~file:name
@@ -2003,9 +2015,9 @@ let make_action ~enable_outside_detected_project ~root action inputs =
       in
       build_config ~enable_outside_detected_project ~root ~file ~is_stdin
       >>= fun conf -> Ok (Print_config conf)
-  | (`No_action | `Output _ | `Inplace | `Check | `Numeric _), `No_input ->
+  | (`No_action | `Output _ | `Inplace | `Check | `Numeric), `No_input ->
       Error "Must specify at least one input file, or `-` for stdin"
-  | (`No_action | `Output _ | `Numeric _), `Several_files _ ->
+  | (`No_action | `Output _ | `Numeric), `Several_files _ ->
       Error
         "Must specify exactly one input file without --inplace or --check"
   | `Inplace, `Stdin _ ->
@@ -2018,8 +2030,8 @@ let make_action ~enable_outside_detected_project ~root action inputs =
       make_inputs inputs >>= fun inputs -> Ok (Inplace inputs)
   | `Check, ((`Single_file _ | `Several_files _ | `Stdin _) as inputs) ->
       make_inputs inputs >>= fun inputs -> Ok (Check inputs)
-  | `Numeric range, ((`Stdin _ | `Single_file _) as inp) ->
-      make_input inp >>= fun inp -> Ok (Numeric (inp, range))
+  | `Numeric, ((`Stdin _ | `Single_file _) as inp) ->
+      make_input inp >>= fun inp -> Ok (Numeric inp)
 
 let validate () =
   let root =

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -91,7 +91,7 @@ type opr_opts =
   ; ocaml_version: Ocaml_version.t
         (** Version of OCaml syntax of the output. *)
   ; quiet: bool
-  ; range: (int * int) option }
+  ; range: string -> Range.t }
 
 type t = {fmt_opts: fmt_opts; opr_opts: opr_opts}
 

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -90,7 +90,8 @@ type opr_opts =
             [max_iters] iterations. *)
   ; ocaml_version: Ocaml_version.t
         (** Version of OCaml syntax of the output. *)
-  ; quiet: bool }
+  ; quiet: bool
+  ; range: (int * int) option }
 
 type t = {fmt_opts: fmt_opts; opr_opts: opr_opts}
 
@@ -113,7 +114,7 @@ type action =
   | Check of input list
       (** Check whether the input files already are formatted. *)
   | Print_config of t  (** Print the configuration and exit. *)
-  | Numeric of input * (int * int)
+  | Numeric of input
 
 val action :
   unit -> (action Cmdliner.Cmd.eval_ok, Cmdliner.Cmd.eval_error) Result.t

--- a/lib/Indent.ml
+++ b/lib/Indent.ml
@@ -53,7 +53,8 @@ module Valid_ast = struct
         impossible "Cannot match pre-post formatting locations."
 
   let indent_range fragment ~unformatted:(ast, txt_src)
-      ~formatted:(fmted_ast, fmted_src) ~lines ~range:(low, high) =
+      ~formatted:(fmted_ast, fmted_src) ~lines ~range =
+    let low, high = Range.get range in
     let loctree, locs = Loc_tree.of_ast fragment ast in
     let _, locs' = Loc_tree.of_ast fragment fmted_ast in
     let indent_line i =
@@ -107,7 +108,8 @@ module Valid_ast = struct
 end
 
 module Partial_ast = struct
-  let indent_range ~source ~range:(low, high) =
+  let indent_range ~source ~range =
+    let low, high = Range.get range in
     List.rev
     @@ Ocp_indent.run ~source ~init:[]
          ~in_lines:(fun i -> low <= i && i <= high)

--- a/lib/Range.ml
+++ b/lib/Range.ml
@@ -17,12 +17,15 @@ let make ?range source =
   let lines_nb = List.length @@ String.split_lines source in
   match range with
   | Some (lower, upper)
-    when 1 <= lower && lower <= upper && upper <= lines_nb ->
-      let whole = lower = 1 && lower = lines_nb in
+    when 1 <= lower && lower <= upper && upper <= lines_nb + 1 ->
+      (* the last line of the buffer (lines_nb + 1) should be valid *)
+      let whole = lower = 1 && upper >= lines_nb in
       {lower; upper; whole}
   | _ -> {lower= 1; upper= lines_nb; whole= true}
 
 let get t = (t.lower, t.upper)
+
+let is_whole t = t.whole
 
 let conv =
   let open Cmdliner in

--- a/lib/Range.ml
+++ b/lib/Range.ml
@@ -1,0 +1,36 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                              OCamlFormat                               *)
+(*                                                                        *)
+(*            Copyright (c) Facebook, Inc. and its affiliates.            *)
+(*                                                                        *)
+(*      This source code is licensed under the MIT license found in       *)
+(*      the LICENSE file in the root directory of this source tree.       *)
+(*                                                                        *)
+(**************************************************************************)
+
+type t = {lower: int; upper: int; whole: bool}
+
+open Result.Monad_infix
+
+let make ?range source =
+  let lines_nb = List.length @@ String.split_lines source in
+  match range with
+  | Some (lower, upper)
+    when 1 <= lower && lower <= upper && upper <= lines_nb ->
+      let whole = lower = 1 && lower = lines_nb in
+      {lower; upper; whole}
+  | _ -> {lower= 1; upper= lines_nb; whole= true}
+
+let get t = (t.lower, t.upper)
+
+let conv =
+  let open Cmdliner in
+  let pair_conv = Arg.(pair ~sep:'-' int int) in
+  let parse x = Arg.conv_parser pair_conv x >>| fun range -> make ~range in
+  let pp fs x =
+    match x "" with
+    | {whole= true; _} -> Format.fprintf fs "<whole input>"
+    | {lower; upper; _} -> Arg.conv_printer pair_conv fs (lower, upper)
+  in
+  Arg.conv (parse, pp)

--- a/lib/Range.ml
+++ b/lib/Range.ml
@@ -29,7 +29,7 @@ let conv =
   let pair_conv = Arg.(pair ~sep:'-' int int) in
   let parse x = Arg.conv_parser pair_conv x >>| fun range -> make ~range in
   let pp fs x =
-    match x "" with
+    match x "this string is not important" with
     | {whole= true; _} -> Format.fprintf fs "<whole input>"
     | {lower; upper; _} -> Arg.conv_printer pair_conv fs (lower, upper)
   in

--- a/lib/Range.mli
+++ b/lib/Range.mli
@@ -9,16 +9,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Valid_ast : sig
-  val indent_range :
-       'a Extended_ast.t
-    -> unformatted:'a * string
-    -> formatted:'a * Source.t
-    -> lines:string list
-    -> range:Range.t
-    -> int list
-end
+type t
 
-module Partial_ast : sig
-  val indent_range : source:string -> range:Range.t -> int list
-end
+val make : ?range:int * int -> string -> t
+
+val get : t -> int * int
+
+val conv : (string -> t) Cmdliner.Arg.conv

--- a/lib/Range.mli
+++ b/lib/Range.mli
@@ -15,4 +15,6 @@ val make : ?range:int * int -> string -> t
 
 val get : t -> int * int
 
+val is_whole : t -> bool
+
 val conv : (string -> t) Cmdliner.Arg.conv

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -501,26 +501,9 @@ let parse_and_format = function
   | Syntax.Expression -> parse_and_format Expression Expression
   | Syntax.Repl_file -> parse_and_format Repl_file Repl_file
 
-let check_line nlines i =
-  (* the last line of the buffer (nlines + 1) should not raise an error *)
-  if 1 <= i && i <= nlines + 1 then Ok ()
-  else Error (Error.User_error (Format.sprintf "Invalid line number %i" i))
-
-let check_range nlines (low, high) =
-  check_line nlines low
-  >>= fun () ->
-  check_line nlines high
-  >>= fun () ->
-  if low <= high then Ok ()
-  else
-    Error (Error.User_error (Format.sprintf "Invalid range %i-%i" low high))
-
 let numeric (type a b) (fg : a list Extended_ast.t)
     (std_fg : b list Std_ast.t) ~input_name ~source ~range (conf : Conf.t) =
   let lines = String.split_lines source in
-  let nlines = List.length lines in
-  check_range nlines range
-  >>| fun () ->
   Location.input_name := input_name ;
   let preserve_beginend = Poly.(conf.fmt_opts.exp_grouping = `Preserve) in
   let parse_ast = Extended_ast.Parse.ast ~preserve_beginend in

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -34,8 +34,9 @@ val numeric :
   -> input_name:string
   -> source:string
   -> range:int * int
+       (** Values of [range] are checked in {!bin/ocamlformat/main.ml}. *)
   -> Conf.t
-  -> (int list, Error.t) Result.t
+  -> int list
 (** [numeric ~input_name ~source ~range conf opts] returns the indentation of
     the range of lines [range] (line numbers ranging from 1 to number of
     lines), where the line numbers are relative to [source] and the

--- a/lib/Translation_unit.mli
+++ b/lib/Translation_unit.mli
@@ -33,8 +33,7 @@ val numeric :
      Syntax.t
   -> input_name:string
   -> source:string
-  -> range:int * int
-       (** Values of [range] are checked in {!bin/ocamlformat/main.ml}. *)
+  -> range:Range.t
   -> Conf.t
   -> int list
 (** [numeric ~input_name ~source ~range conf opts] returns the indentation of

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -584,10 +584,10 @@ OPTIONS
            Do not check that the version matches the one specified in
            .ocamlformat.
 
-       --numeric=X-Y
+       --numeric
            Instead of re-formatting the file, output one integer per line
            corresponding to the indentation value, printing as many values as
-           lines in the range between lines X and Y (included).
+           lines in the document.
 
        -o DST, --output=DST
            Output file. Mutually exclusive with --inplace. Write to stdout if
@@ -616,6 +616,12 @@ OPTIONS
 
        -q, --quiet
            Quiet. May be set in .ocamlformat. The flag is unset by default.
+
+       --range=X-Y
+           Apply the formatting to a range of lines. Must be included between
+           1 and the number of lines of the input. If a range is invalid the
+           whole input is considered. Warning: only supported in conbination
+           with `--numeric` for now. The default value is none.
 
        --repl-file
            Parse input as toplevel phrases with their output.

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -621,7 +621,7 @@ OPTIONS
            Apply the formatting to a range of lines. Must be included between
            1 and the number of lines of the input. If a range is invalid the
            whole input is considered. Warning: only supported in conbination
-           with `--numeric` for now. The default value is none.
+           with `--numeric` for now. The default value is <whole input>.
 
        --repl-file
            Parse input as toplevel phrases with their output.

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1826,7 +1826,7 @@
  (action
   (with-stdout-to format_invalid_files-0.ml.stdout
    (with-stderr-to format_invalid_files-0.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --numeric=11-13 %{dep:tests/format_invalid_files.ml})))))
+     (run %{bin:ocamlformat} --margin-check --numeric --range=11-13 %{dep:tests/format_invalid_files.ml})))))
 
 (rule
  (alias runtest)
@@ -1844,7 +1844,7 @@
  (action
   (with-stdout-to format_invalid_files.ml.stdout
    (with-stderr-to format_invalid_files.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --numeric=7-8 %{dep:tests/format_invalid_files.ml})))))
+     (run %{bin:ocamlformat} --margin-check --numeric --range=7-8 %{dep:tests/format_invalid_files.ml})))))
 
 (rule
  (alias runtest)
@@ -1862,7 +1862,7 @@
  (action
   (with-stdout-to format_invalid_files_with_locations.ml.stdout
    (with-stderr-to format_invalid_files_with_locations.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --numeric=1-11 %{dep:tests/format_invalid_files_with_locations.ml})))))
+     (run %{bin:ocamlformat} --margin-check --numeric --range=1-11 %{dep:tests/format_invalid_files_with_locations.ml})))))
 
 (rule
  (alias runtest)
@@ -3964,7 +3964,7 @@
  (action
   (with-stdout-to partial.ml.stdout
    (with-stderr-to partial.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --numeric=2-14 %{dep:tests/partial.ml})))))
+     (run %{bin:ocamlformat} --margin-check --numeric --range=2-14 %{dep:tests/partial.ml})))))
 
 (rule
  (alias runtest)
@@ -3982,7 +3982,7 @@
  (action
   (with-stdout-to partial_double_quotes.ml.stdout
    (with-stderr-to partial_double_quotes.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --numeric=1-1 %{dep:tests/partial_double_quotes.ml})))))
+     (run %{bin:ocamlformat} --margin-check --numeric --range=1-1 %{dep:tests/partial_double_quotes.ml})))))
 
 (rule
  (alias runtest)

--- a/test/passing/tests/format_invalid_files-0.ml.opts
+++ b/test/passing/tests/format_invalid_files-0.ml.opts
@@ -1,1 +1,2 @@
---numeric=11-13
+--numeric
+--range=11-13

--- a/test/passing/tests/format_invalid_files.ml.opts
+++ b/test/passing/tests/format_invalid_files.ml.opts
@@ -1,1 +1,2 @@
---numeric=7-8
+--numeric
+--range=7-8

--- a/test/passing/tests/format_invalid_files_with_locations.ml.opts
+++ b/test/passing/tests/format_invalid_files_with_locations.ml.opts
@@ -1,1 +1,2 @@
---numeric=1-11
+--numeric
+--range=1-11

--- a/test/passing/tests/partial.ml.opts
+++ b/test/passing/tests/partial.ml.opts
@@ -1,1 +1,2 @@
---numeric=2-14
+--numeric
+--range=2-14

--- a/test/passing/tests/partial_double_quotes.ml.opts
+++ b/test/passing/tests/partial_double_quotes.ml.opts
@@ -1,1 +1,2 @@
---numeric=1-1
+--numeric
+--range=1-1

--- a/test/passing/tests/print_config.ml.err
+++ b/test/passing/tests/print_config.ml.err
@@ -1,5 +1,5 @@
 profile=ocamlformat (file tests/.ocamlformat:1)
-range= (profile ocamlformat (file tests/.ocamlformat:1))
+range=<whole input> (profile ocamlformat (file tests/.ocamlformat:1))
 quiet=false (profile ocamlformat (file tests/.ocamlformat:1))
 ocaml-version=4.13.0 (file tests/.ocamlformat:7)
 max-iters=2 (environment variable)

--- a/test/passing/tests/print_config.ml.err
+++ b/test/passing/tests/print_config.ml.err
@@ -1,4 +1,5 @@
 profile=ocamlformat (file tests/.ocamlformat:1)
+range= (profile ocamlformat (file tests/.ocamlformat:1))
 quiet=false (profile ocamlformat (file tests/.ocamlformat:1))
 ocaml-version=4.13.0 (file tests/.ocamlformat:7)
 max-iters=2 (environment variable)

--- a/test/passing/tests/verbose1.ml.err
+++ b/test/passing/tests/verbose1.ml.err
@@ -1,5 +1,5 @@
 profile=ocamlformat (file tests/.ocamlformat:1)
-range= (profile ocamlformat (file tests/.ocamlformat:1))
+range=<whole input> (profile ocamlformat (file tests/.ocamlformat:1))
 quiet=false (profile ocamlformat (file tests/.ocamlformat:1))
 ocaml-version=4.13.0 (file tests/.ocamlformat:7)
 max-iters=2 (file tests/.ocamlformat:6)

--- a/test/passing/tests/verbose1.ml.err
+++ b/test/passing/tests/verbose1.ml.err
@@ -1,4 +1,5 @@
 profile=ocamlformat (file tests/.ocamlformat:1)
+range= (profile ocamlformat (file tests/.ocamlformat:1))
 quiet=false (profile ocamlformat (file tests/.ocamlformat:1))
 ocaml-version=4.13.0 (file tests/.ocamlformat:7)
 max-iters=2 (file tests/.ocamlformat:6)

--- a/test/unit/test_indent.ml
+++ b/test/unit/test_indent.ml
@@ -11,6 +11,7 @@ module Partial_ast = struct
       ( test_name
       , `Quick
       , fun () ->
+          let range = Range.make ~range source in
           let indent = Indent.Partial_ast.indent_range ~source ~range in
           let output =
             Test_translation_unit.reindent ~source ~range indent

--- a/test/unit/test_range.ml
+++ b/test/unit/test_range.ml
@@ -1,4 +1,3 @@
-open Base
 open Ocamlformat
 
 let pp =
@@ -13,27 +12,35 @@ let tests_make =
     ( test_name
     , `Quick
     , fun () ->
-        let output = Range.(get @@ make source ?range) in
-        Alcotest.(check (pair int int)) test_name expected output )
+        let range = Range.make source ?range in
+        let l, h = Range.get range in
+        let output = (l, h, Range.is_whole range) in
+        Alcotest.(check (triple int int bool)) test_name expected output )
   in
-  [ test "" ~expected:(1, 0)
-  ; test "" ~range:(0, 0) ~expected:(1, 0)
-  ; test "" ~range:(1, 0) ~expected:(1, 0)
-  ; test "" ~range:(-1, -1) ~expected:(1, 0)
-  ; test "\n" ~expected:(1, 1)
-  ; test "\n" ~range:(0, 0) ~expected:(1, 1)
-  ; test "\n" ~range:(1, 0) ~expected:(1, 1)
-  ; test "\n" ~range:(-1, -1) ~expected:(1, 1)
-  ; test "\n" ~range:(1, 2) ~expected:(1, 1)
-  ; test "xxxx\nxxxxx" ~expected:(1, 2)
-  ; test "xxxx\nxxxxx" ~range:(1, 1000) ~expected:(1, 2)
-  ; test "xxxx\nxxxxx" ~range:(1, 2) ~expected:(1, 2)
-  ; test "\n\n" ~range:(0, 0) ~expected:(1, 2)
-  ; test "\n\n" ~range:(1, 2) ~expected:(1, 2)
-  ; test "xxx\nxxxx\nxxxx" ~expected:(1, 3)
-  ; test "xxx\nxxxx\nxxxx" ~range:(1, 3) ~expected:(1, 3)
-  ; test "xxx\nxxxx\nxxxx" ~range:(1, 1) ~expected:(1, 1)
-  ; test "xxx\nxxxx\nxxxx" ~range:(2, 3) ~expected:(2, 3)
-  ; test "xxx\nxxxx\nxxxx" ~range:(3, 3) ~expected:(3, 3) ]
+  [ test "" ~expected:(1, 0, true)
+  ; test "" ~range:(0, 0) ~expected:(1, 0, true)
+  ; test "" ~range:(1, 0) ~expected:(1, 0, true)
+  ; test "" ~range:(-1, -1) ~expected:(1, 0, true)
+  ; test "" ~range:(1, 1) ~expected:(1, 1, true)
+  ; test "\n" ~expected:(1, 1, true)
+  ; test "\n" ~range:(0, 0) ~expected:(1, 1, true)
+  ; test "\n" ~range:(1, 0) ~expected:(1, 1, true)
+  ; test "\n" ~range:(-1, -1) ~expected:(1, 1, true)
+  ; test "\n" ~range:(1, 2) ~expected:(1, 2, true)
+  ; test "xxxx\nxxxxx" ~expected:(1, 2, true)
+  ; test "xxxx\nxxxxx" ~range:(1, 1000) ~expected:(1, 2, true)
+  ; test "xxxx\nxxxxx" ~range:(1, 2) ~expected:(1, 2, true)
+  ; test "\n\n" ~expected:(1, 2, true)
+  ; test "\n\n" ~range:(0, 0) ~expected:(1, 2, true)
+  ; test "\n\n" ~range:(1, 2) ~expected:(1, 2, true)
+  ; test "\nxxxx\nxxxx" ~expected:(1, 3, true)
+  ; test "xxx\nxxxx\n" ~expected:(1, 2, true)
+  ; test "xxx\nxxxx\nxxxx" ~expected:(1, 3, true)
+  ; test "xxx\nxxxx\nxxxx" ~range:(1, 3) ~expected:(1, 3, true)
+  ; test "xxx\nxxxx\nxxxx" ~range:(1, 4) ~expected:(1, 4, true)
+  ; test "xxx\nxxxx\nxxxx" ~range:(1, 1) ~expected:(1, 1, false)
+  ; test "xxx\nxxxx\nxxxx" ~range:(2, 3) ~expected:(2, 3, false)
+  ; test "xxx\nxxxx\nxxxx" ~range:(3, 3) ~expected:(3, 3, false)
+  ; test "xxx\nxxxx\nxxxx" ~range:(4, 4) ~expected:(4, 4, false) ]
 
 let tests = tests_make

--- a/test/unit/test_range.ml
+++ b/test/unit/test_range.ml
@@ -8,7 +8,7 @@ let pp =
   pp_print_option ~none:pp_none (pp_pair pp_print_int)
 
 let tests_make =
-  let test ~source ?range ~expected =
+  let test ?range source ~expected =
     let test_name = Stdlib.Format.asprintf "make: %S %a" source pp range in
     ( test_name
     , `Quick
@@ -16,22 +16,24 @@ let tests_make =
         let output = Range.(get @@ make source ?range) in
         Alcotest.(check (pair int int)) test_name expected output )
   in
-  [ test ~source:"" ?range:None ~expected:(1, 0)
-  ; test ~source:"" ~range:(0, 0) ~expected:(1, 0)
-  ; test ~source:"" ~range:(1, 0) ~expected:(1, 0)
-  ; test ~source:"" ~range:(-1, -1) ~expected:(1, 0)
-  ; test ~source:"\n" ?range:None ~expected:(1, 1)
-  ; test ~source:"\n" ~range:(0, 0) ~expected:(1, 1)
-  ; test ~source:"\n" ~range:(1, 0) ~expected:(1, 1)
-  ; test ~source:"\n" ~range:(-1, -1) ~expected:(1, 1)
-  ; test ~source:"\n" ~range:(1, 2) ~expected:(1, 1)
-  ; test ~source:"xxxx\nxxxxx" ~range:(1, 1000) ~expected:(1, 2)
-  ; test ~source:"xxxx\nxxxxx" ~range:(1, 2) ~expected:(1, 2)
-  ; test ~source:"\n\n" ~range:(0, 0) ~expected:(1, 2)
-  ; test ~source:"\n\n" ~range:(1, 2) ~expected:(1, 2)
-  ; test ~source:"xxx\nxxxx\nxxxx" ~range:(1, 3) ~expected:(1, 3)
-  ; test ~source:"xxx\nxxxx\nxxxx" ~range:(1, 1) ~expected:(1, 1)
-  ; test ~source:"xxx\nxxxx\nxxxx" ~range:(2, 3) ~expected:(2, 3)
-  ; test ~source:"xxx\nxxxx\nxxxx" ~range:(3, 3) ~expected:(3, 3) ]
+  [ test "" ~expected:(1, 0)
+  ; test "" ~range:(0, 0) ~expected:(1, 0)
+  ; test "" ~range:(1, 0) ~expected:(1, 0)
+  ; test "" ~range:(-1, -1) ~expected:(1, 0)
+  ; test "\n" ~expected:(1, 1)
+  ; test "\n" ~range:(0, 0) ~expected:(1, 1)
+  ; test "\n" ~range:(1, 0) ~expected:(1, 1)
+  ; test "\n" ~range:(-1, -1) ~expected:(1, 1)
+  ; test "\n" ~range:(1, 2) ~expected:(1, 1)
+  ; test "xxxx\nxxxxx" ~expected:(1, 2)
+  ; test "xxxx\nxxxxx" ~range:(1, 1000) ~expected:(1, 2)
+  ; test "xxxx\nxxxxx" ~range:(1, 2) ~expected:(1, 2)
+  ; test "\n\n" ~range:(0, 0) ~expected:(1, 2)
+  ; test "\n\n" ~range:(1, 2) ~expected:(1, 2)
+  ; test "xxx\nxxxx\nxxxx" ~expected:(1, 3)
+  ; test "xxx\nxxxx\nxxxx" ~range:(1, 3) ~expected:(1, 3)
+  ; test "xxx\nxxxx\nxxxx" ~range:(1, 1) ~expected:(1, 1)
+  ; test "xxx\nxxxx\nxxxx" ~range:(2, 3) ~expected:(2, 3)
+  ; test "xxx\nxxxx\nxxxx" ~range:(3, 3) ~expected:(3, 3) ]
 
 let tests = tests_make

--- a/test/unit/test_range.ml
+++ b/test/unit/test_range.ml
@@ -1,0 +1,37 @@
+open Base
+open Ocamlformat
+
+let pp =
+  let open Stdlib.Format in
+  let pp_pair f fs (x, y) = fprintf fs "(%a, %a)" f x f y in
+  let pp_none fs () = Stdlib.Format.fprintf fs "None" in
+  pp_print_option ~none:pp_none (pp_pair pp_print_int)
+
+let tests_make =
+  let test ~source ?range ~expected =
+    let test_name = Stdlib.Format.asprintf "make: %S %a" source pp range in
+    ( test_name
+    , `Quick
+    , fun () ->
+        let output = Range.(get @@ make source ?range) in
+        Alcotest.(check (pair int int)) test_name expected output )
+  in
+  [ test ~source:"" ?range:None ~expected:(1, 0)
+  ; test ~source:"" ~range:(0, 0) ~expected:(1, 0)
+  ; test ~source:"" ~range:(1, 0) ~expected:(1, 0)
+  ; test ~source:"" ~range:(-1, -1) ~expected:(1, 0)
+  ; test ~source:"\n" ?range:None ~expected:(1, 1)
+  ; test ~source:"\n" ~range:(0, 0) ~expected:(1, 1)
+  ; test ~source:"\n" ~range:(1, 0) ~expected:(1, 1)
+  ; test ~source:"\n" ~range:(-1, -1) ~expected:(1, 1)
+  ; test ~source:"\n" ~range:(1, 2) ~expected:(1, 1)
+  ; test ~source:"xxxx\nxxxxx" ~range:(1, 1000) ~expected:(1, 2)
+  ; test ~source:"xxxx\nxxxxx" ~range:(1, 2) ~expected:(1, 2)
+  ; test ~source:"\n\n" ~range:(0, 0) ~expected:(1, 2)
+  ; test ~source:"\n\n" ~range:(1, 2) ~expected:(1, 2)
+  ; test ~source:"xxx\nxxxx\nxxxx" ~range:(1, 3) ~expected:(1, 3)
+  ; test ~source:"xxx\nxxxx\nxxxx" ~range:(1, 1) ~expected:(1, 1)
+  ; test ~source:"xxx\nxxxx\nxxxx" ~range:(2, 3) ~expected:(2, 3)
+  ; test ~source:"xxx\nxxxx\nxxxx" ~range:(3, 3) ~expected:(3, 3) ]
+
+let tests = tests_make

--- a/test/unit/test_range.mli
+++ b/test/unit/test_range.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test_case list

--- a/test/unit/test_translation_unit.ml
+++ b/test/unit/test_translation_unit.ml
@@ -114,7 +114,8 @@ let test_parse_and_format_expression =
   [ make_test "List.map" ~input:"List.map (fun x->\nx*x) [(1 + 9); 2;3] "
       ~expected:(Ok "List.map (fun x -> x * x) [ 1 + 9; 2; 3 ]\n") ]
 
-let reindent ~source ~range:(low, high) indents =
+let reindent ~source ~range indents =
+  let low, high = Range.get range in
   let lines = String.split_lines source in
   let low = low - 1 and high = high - 1 in
   String.concat ~sep:"\n"
@@ -133,6 +134,7 @@ let test_numeric =
     ( test_name
     , `Quick
     , fun () ->
+        let range = Range.make ~range source in
         let got =
           Translation_unit.numeric Use_file ~input_name:"_" ~source ~range
             Conf.default
@@ -319,6 +321,7 @@ let test_numeric_file =
     ( test_name
     , `Quick
     , fun () ->
+        let range = Range.make ~range source in
         let got =
           Translation_unit.numeric Use_file ~input_name:"_" ~source ~range
             Conf.default

--- a/test/unit/test_translation_unit.mli
+++ b/test/unit/test_translation_unit.mli
@@ -1,3 +1,4 @@
 val tests : unit Alcotest.test_case list
 
-val reindent : source:string -> range:int * int -> int list -> string
+val reindent :
+  source:string -> range:Ocamlformat.Range.t -> int list -> string

--- a/test/unit/test_unit.ml
+++ b/test/unit/test_unit.ml
@@ -117,6 +117,7 @@ let tests =
   ; ("Indent", Test_indent.tests)
   ; ("Literal_lexer", Test_literal_lexer.tests)
   ; ("Fmt", Test_fmt.tests)
+  ; ("Range", Test_range.tests)
   ; ("Translation_unit", Test_translation_unit.tests) ]
 
 let () = Alcotest.run "ocamlformat" tests


### PR DESCRIPTION
Some preliminary work before implementing `--range` option for the `format` feature (future work for vscode).