### PR TITLE
github actions:Do not apply 'dune subst' to override the version number of Windows binaries

### DIFF
--- a/tools/build-mingw64.sh
+++ b/tools/build-mingw64.sh
@@ -45,8 +45,6 @@ set +eu
 opam install -y --deps-only ./ocamlformat.opam
 set -eu
 
-dune subst
-
 dune build -p ocamlformat
 
 echo "Version check:"


### PR DESCRIPTION
Let's try this, and see if it's fixed after the next release, but I don't have a working Windows environment to check if it's fixed.

Please confirm me whether it is fixed (and only then I will close the issue #2068).