### PR TITLE
Build parser-recovery tests only for ocamlformat package

### DIFF
--- a/vendor/parser-recovery/test/expect/gen/dune
+++ b/vendor/parser-recovery/test/expect/gen/dune
@@ -1,8 +1,12 @@
 (executable
  (name gen)
+ (public_name ocamlformat.parser_recovery.test_gen)
+ (package ocamlformat)
  (modules gen))
 
 (executable
  (name driver)
+ (public_name ocamlformat.parser_recovery.test_driver)
+ (package ocamlformat)
  (modules driver)
  (libraries parser_recovery))


### PR DESCRIPTION
Should fix the first issue of https://github.com/ocaml/opam-repository/pull/21421#issuecomment-1136866049