### PR TITLE
JaneStreet profile: align pattern-matching bar under keyword instead of parenthesis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 
 - `bench` binary renamed to `ocamlformat-bench` to avoid conflicts (#2101, @gpetiot)
 - JaneStreet profile: set `max-indent = 2` (#2099, @gpetiot)
+- JaneStreet profile: align pattern-matching bar `|` under keyword instead of parenthesis (#<PR_NUMBER>, @gpetiot)
 
 ### New features
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -12,7 +12,8 @@
 (** Configuration options *)
 
 type fmt_opts =
-  { assignment_operator: [`Begin_line | `End_line]
+  { align_pattern_matching_bar: [`Paren | `Keyword]
+  ; assignment_operator: [`Begin_line | `End_line]
   ; break_before_in: [`Fit_or_vertical | `Auto]
   ; break_cases: [`Fit | `Nested | `Toplevel | `Fit_or_vertical | `All]
   ; break_collection_expressions: [`Wrap | `Fit_or_vertical]
@@ -1428,7 +1429,8 @@ let ignore_invalid_options =
   mk ~default Arg.(value & flag & info ["ignore-invalid-option"] ~doc ~docs)
 
 let ocamlformat_profile =
-  { assignment_operator= `End_line
+  { align_pattern_matching_bar= `Paren
+  ; assignment_operator= `End_line
   ; break_before_in= `Fit_or_vertical
   ; break_cases= `Nested
   ; break_collection_expressions= `Fit_or_vertical
@@ -1489,7 +1491,8 @@ let ocamlformat_profile =
   ; wrap_fun_args= true }
 
 let conventional_profile =
-  { assignment_operator= C.default Formatting.assignment_operator
+  { align_pattern_matching_bar= `Paren
+  ; assignment_operator= C.default Formatting.assignment_operator
   ; break_before_in= C.default Formatting.break_before_in
   ; break_cases= C.default Formatting.break_cases
   ; break_collection_expressions=
@@ -1557,7 +1560,8 @@ let conventional_profile =
 let default_profile = conventional_profile
 
 let janestreet_profile =
-  { assignment_operator= `Begin_line
+  { align_pattern_matching_bar= `Keyword
+  ; assignment_operator= `Begin_line
   ; break_before_in= `Fit_or_vertical
   ; break_cases= `Fit_or_vertical
   ; break_collection_expressions=

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -13,7 +13,8 @@
 
 (** Formatting options *)
 type fmt_opts =
-  { assignment_operator: [`Begin_line | `End_line]
+  { align_pattern_matching_bar: [`Paren | `Keyword]
+  ; assignment_operator: [`Begin_line | `End_line]
   ; break_before_in: [`Fit_or_vertical | `Auto]
   ; break_cases: [`Fit | `Nested | `Toplevel | `Fit_or_vertical | `All]
   ; break_collection_expressions: [`Wrap | `Fit_or_vertical]

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -2,7 +2,6 @@ Warning: tests/js_source.ml:157 exceeds the margin
 Warning: tests/js_source.ml:3559 exceeds the margin
 Warning: tests/js_source.ml:9541 exceeds the margin
 Warning: tests/js_source.ml:9644 exceeds the margin
-Warning: tests/js_source.ml:9657 exceeds the margin
-Warning: tests/js_source.ml:9662 exceeds the margin
-Warning: tests/js_source.ml:9702 exceeds the margin
-Warning: tests/js_source.ml:9784 exceeds the margin
+Warning: tests/js_source.ml:9663 exceeds the margin
+Warning: tests/js_source.ml:9703 exceeds the margin
+Warning: tests/js_source.ml:9785 exceeds the margin

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9655,7 +9655,8 @@ let _ =
   match () with
   | _ ->
     (match () with
-     | _ -> long_function_name long_argument_name__________________________________________)
+     | _ ->
+       long_function_name long_argument_name__________________________________________)
 ;;
 
 let _ =
@@ -9793,7 +9794,8 @@ let[@a
   with
   | _
     when f
-        ~f:(function[@ocaml.warning (* ....................................... *) "-4"]
+        ~f:
+          (function[@ocaml.warning (* ....................................... *) "-4"]
             | _ -> .)
         ~f:
           (function[@ocaml.warning

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -1155,8 +1155,8 @@ let rec eq_sel : type a b c. (a, b) ty_sel -> (a, c) ty_sel -> (b, c) eq option 
   | Thd, Thd -> Some Eq
   | Ttl s1, Ttl s2 ->
     (match eq_sel s1 s2 with
-    | None -> None
-    | Some Eq -> Some Eq)
+     | None -> None
+     | Some Eq -> Some Eq)
   | _ -> None
 ;;
 
@@ -1169,12 +1169,12 @@ let rec get_case
   match cases with
   | (name, TCnoarg sel') :: rem ->
     (match eq_sel sel sel' with
-    | None -> get_case sel rem
-    | Some Eq -> name, None)
+     | None -> get_case sel rem
+     | Some Eq -> name, None)
   | (name, TCarg (sel', ty)) :: rem ->
     (match eq_sel sel sel' with
-    | None -> get_case sel rem
-    | Some Eq -> name, Some ty)
+     | None -> get_case sel rem
+     | Some Eq -> name, Some ty)
   | [] -> raise Not_found
 ;;
 
@@ -1204,10 +1204,10 @@ let rec variantize : type a e. e ty_env -> (a, e) ty -> a -> variant =
   | Rec t -> variantize (Econs (ty, e)) t v
   | Pop t ->
     (match e with
-    | Econs (_, e') -> variantize e' t v)
+     | Econs (_, e') -> variantize e' t v)
   | Var ->
     (match e with
-    | Econs (t, e') -> variantize e' t v)
+     | Econs (t, e') -> variantize e' t v)
   | Conv (s, proj, inj, t) -> VConv (s, variantize e t (proj v))
   | Sum ops ->
     let tag, arg = ops.sum_proj v in
@@ -1215,7 +1215,7 @@ let rec variantize : type a e. e ty_env -> (a, e) ty -> a -> variant =
       ( tag
       , may_map
           (function
-            | Tdyn (ty, arg) -> variantize e ty arg)
+           | Tdyn (ty, arg) -> variantize e ty arg)
           arg )
 ;;
 
@@ -1229,10 +1229,10 @@ let rec devariantize : type t e. e ty_env -> (t, e) ty -> variant -> t =
   | Rec t, _ -> devariantize (Econs (ty, e)) t v
   | Pop t, _ ->
     (match e with
-    | Econs (_, e') -> devariantize e' t v)
+     | Econs (_, e') -> devariantize e' t v)
   | Var, _ ->
     (match e with
-    | Econs (t, e') -> devariantize e' t v)
+     | Econs (t, e') -> devariantize e' t v)
   | Conv (s, proj, inj, t), VConv (s', v) when s = s' -> inj (devariantize e t v)
   | Sum ops, VSum (tag, a) ->
     (try
@@ -1241,7 +1241,7 @@ let rec devariantize : type t e. e ty_env -> (t, e) ty -> variant -> t =
        | TCnoarg sel, None -> ops.sum_inj (sel, Noarg)
        | _ -> raise VariantMismatch
      with
-    | Not_found -> raise VariantMismatch)
+     | Not_found -> raise VariantMismatch)
   | _ -> raise VariantMismatch
 ;;
 
@@ -1307,8 +1307,8 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
     (Sum
        { sum_proj =
            (function
-           | `Nil -> "Nil", None
-           | `Cons p -> "Cons", Some (Tdyn (tcons, p)))
+            | `Nil -> "Nil", None
+            | `Cons p -> "Cons", Some (Tdyn (tcons, p)))
        ; sum_cases = [ "Nil", TCnoarg Thd; "Cons", TCarg (Ttl Thd, tcons) ]
        ; sum_inj =
            (fun (type c) : ((noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist) ->
@@ -1343,9 +1343,9 @@ let ty_abc : ([ `A of int | `B of string | `C ], 'e) ty =
   (* Could also use [get_case] for proj, but direct definition is shorter *)
   Sum
     ( (function
-      | `A n -> "A", Some (Tdyn (Int, n))
-      | `B s -> "B", Some (Tdyn (String, s))
-      | `C -> "C", None)
+       | `A n -> "A", Some (Tdyn (Int, n))
+       | `B s -> "B", Some (Tdyn (String, s))
+       | `C -> "C", None)
     , function
       | "A", Some (Tdyn (Int, n)) -> `A n
       | "B", Some (Tdyn (String, s)) -> `B s
@@ -1360,8 +1360,8 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
   Rec
     (Sum
        ( (function
-         | `Nil -> "Nil", None
-         | `Cons p -> "Cons", Some (Tdyn (targ, p)))
+          | `Nil -> "Nil", None
+          | `Cons p -> "Cons", Some (Tdyn (targ, p)))
        , function
          | "Nil", None -> `Nil
          | "Cons", Some (Tdyn (Pair (_, Var), (p : a * a vlist))) -> `Cons p ))
@@ -1601,8 +1601,8 @@ let rec sameNat : type a b. a nat -> b nat -> (a, b) equal option =
   | NZ, NZ -> Some Eq
   | NS a', NS b' ->
     (match sameNat a' b' with
-    | Some Eq -> Some Eq
-    | None -> None)
+     | Some Eq -> Some Eq
+     | None -> None)
   | _ -> None
 ;;
 
@@ -1663,7 +1663,7 @@ let rec diff : type a b. (a, b) le -> a nat -> b nat -> (a, b) diff =
   | LeZ _, _, m -> Diff (m, PlusZ m)
   | LeS q, NS x, NS y ->
     (match diff q x y with
-    | Diff (m, p) -> Diff (m, PlusS p))
+     | Diff (m, p) -> Diff (m, PlusS p))
 ;;
 
 let rec diff : type a b. (a, b) le -> a nat -> b nat -> (a, b) diff =
@@ -1673,7 +1673,7 @@ let rec diff : type a b. (a, b) le -> a nat -> b nat -> (a, b) diff =
   | NZ, m, LeZ _ -> Diff (m, PlusZ m)
   | NS x, NS y, LeS q ->
     (match diff q x y with
-    | Diff (m, p) -> Diff (m, PlusS p))
+     | Diff (m, p) -> Diff (m, PlusS p))
   | _ -> .
 ;;
 
@@ -1683,7 +1683,7 @@ let rec diff : type a b. (a, b) le -> b nat -> (a, b) diff =
   | m, LeZ _ -> Diff (m, PlusZ m)
   | NS y, LeS q ->
     (match diff q y with
-    | Diff (m, p) -> Diff (m, PlusS p))
+     | Diff (m, p) -> Diff (m, PlusS p))
 ;;
 
 type (_, _) filter = Filter : ('m, 'n) le * ('a, 'm) seq -> ('a, 'n) filter
@@ -1699,8 +1699,8 @@ let rec filter : type a n. (a -> bool) -> (a, n) seq -> (a, n) filter =
   | Snil -> Filter (LeZ NZ, Snil)
   | Scons (a, l) ->
     (match filter f l with
-    | Filter (le, l') ->
-      if f a then Filter (LeS le, Scons (a, l')) else Filter (leS' le, l'))
+     | Filter (le, l') ->
+       if f a then Filter (LeS le, Scons (a, l')) else Filter (leS' le, l'))
 ;;
 
 (* 4.1 AVL trees *)
@@ -1768,17 +1768,17 @@ let rec ins : type n. int -> n avl -> (n avl, n succ avl) sum =
       | Inl a -> Inl (Node (bal, a, y, b))
       | Inr a ->
         (match bal with
-        | Less -> Inl (Node (Same, a, y, b))
-        | Same -> Inr (Node (More, a, y, b))
-        | More -> rotr a y b))
+         | Less -> Inl (Node (Same, a, y, b))
+         | Same -> Inr (Node (More, a, y, b))
+         | More -> rotr a y b))
     else (
       match ins x b with
       | Inl b -> Inl (Node (bal, a, y, b) : n avl)
       | Inr b ->
         (match bal with
-        | More -> Inl (Node (Same, a, y, b) : n avl)
-        | Same -> Inr (Node (Less, a, y, b) : n succ avl)
-        | Less -> rotl a y b))
+         | More -> Inl (Node (Same, a, y, b) : n avl)
+         | Same -> Inr (Node (Less, a, y, b) : n succ avl)
+         | Less -> rotl a y b))
 ;;
 
 let insert x (Avl t) =
@@ -1792,13 +1792,13 @@ let rec del_min : type n. n succ avl -> int * (n avl, n succ avl) sum = function
   | Node (Same, Leaf, x, r) -> x, Inl r
   | Node (bal, (Node _ as l), x, r) ->
     (match del_min l with
-    | y, Inr l -> y, Inr (Node (bal, l, x, r))
-    | y, Inl l ->
-      ( y
-      , (match bal with
-        | Same -> Inr (Node (Less, l, x, r))
-        | More -> Inl (Node (Same, l, x, r))
-        | Less -> rotl l x r) ))
+     | y, Inr l -> y, Inr (Node (bal, l, x, r))
+     | y, Inl l ->
+       ( y
+       , (match bal with
+          | Same -> Inr (Node (Less, l, x, r))
+          | More -> Inl (Node (Same, l, x, r))
+          | Less -> rotl l x r) ))
 ;;
 
 type _ avl_del =
@@ -1815,40 +1815,40 @@ let rec del : type n. int -> n avl -> n avl_del =
       match r with
       | Leaf ->
         (match bal with
-        | Same -> Ddecr (Eq, l)
-        | More -> Ddecr (Eq, l))
+         | Same -> Ddecr (Eq, l)
+         | More -> Ddecr (Eq, l))
       | Node _ ->
         (match bal, del_min r with
-        | _, (z, Inr r) -> Dsame (Node (bal, l, z, r))
-        | Same, (z, Inl r) -> Dsame (Node (More, l, z, r))
-        | Less, (z, Inl r) -> Ddecr (Eq, Node (Same, l, z, r))
-        | More, (z, Inl r) ->
-          (match rotr l z r with
-          | Inl t -> Ddecr (Eq, t)
-          | Inr t -> Dsame t)))
+         | _, (z, Inr r) -> Dsame (Node (bal, l, z, r))
+         | Same, (z, Inl r) -> Dsame (Node (More, l, z, r))
+         | Less, (z, Inl r) -> Ddecr (Eq, Node (Same, l, z, r))
+         | More, (z, Inl r) ->
+           (match rotr l z r with
+            | Inl t -> Ddecr (Eq, t)
+            | Inr t -> Dsame t)))
     else if y < x
     then (
       match del y l with
       | Dsame l -> Dsame (Node (bal, l, x, r))
       | Ddecr (Eq, l) ->
         (match bal with
-        | Same -> Dsame (Node (Less, l, x, r))
-        | More -> Ddecr (Eq, Node (Same, l, x, r))
-        | Less ->
-          (match rotl l x r with
-          | Inl t -> Ddecr (Eq, t)
-          | Inr t -> Dsame t)))
+         | Same -> Dsame (Node (Less, l, x, r))
+         | More -> Ddecr (Eq, Node (Same, l, x, r))
+         | Less ->
+           (match rotl l x r with
+            | Inl t -> Ddecr (Eq, t)
+            | Inr t -> Dsame t)))
     else (
       match del y r with
       | Dsame r -> Dsame (Node (bal, l, x, r))
       | Ddecr (Eq, r) ->
         (match bal with
-        | Same -> Dsame (Node (More, l, x, r))
-        | Less -> Ddecr (Eq, Node (Same, l, x, r))
-        | More ->
-          (match rotr l x r with
-          | Inl t -> Ddecr (Eq, t)
-          | Inr t -> Dsame t)))
+         | Same -> Dsame (Node (More, l, x, r))
+         | Less -> Ddecr (Eq, Node (Same, l, x, r))
+         | More ->
+           (match rotr l x r with
+            | Inl t -> Ddecr (Eq, t)
+            | Inr t -> Dsame t)))
 ;;
 
 let delete x (Avl t) =
@@ -1926,8 +1926,8 @@ let rec repair : type c n. (red, n) sub_tree -> (c, n) ctxt -> rb_tree =
   | CBlk (e, RightD, sib, c) -> fill c (Bnode (t, e, sib))
   | CRed (e, dir, sib, CBlk (e', dir', uncle, ct)) ->
     (match color uncle with
-    | Red -> repair (recolor dir e sib dir' e' (blacken uncle) t) ct
-    | Black -> fill ct (rotate dir e sib dir' e' uncle t))
+     | Red -> repair (recolor dir e sib dir' e' (blacken uncle) t) ct
+     | Black -> fill ct (rotate dir e sib dir' e' uncle t))
 ;;
 
 let rec ins : type c n. int -> (c, n) sub_tree -> (c, n) ctxt -> rb_tree =
@@ -1981,18 +1981,18 @@ let rec rep_equal : type a b. a rep -> b rep -> (a, b) equal option =
   | Rbool, Rbool -> Some Eq
   | Rpair (a1, a2), Rpair (b1, b2) ->
     (match rep_equal a1 b1 with
-    | None -> None
-    | Some Eq ->
-      (match rep_equal a2 b2 with
-      | None -> None
-      | Some Eq -> Some Eq))
+     | None -> None
+     | Some Eq ->
+       (match rep_equal a2 b2 with
+        | None -> None
+        | Some Eq -> Some Eq))
   | Rfun (a1, a2), Rfun (b1, b2) ->
     (match rep_equal a1 b1 with
-    | None -> None
-    | Some Eq ->
-      (match rep_equal a2 b2 with
-      | None -> None
-      | Some Eq -> Some Eq))
+     | None -> None
+     | Some Eq ->
+       (match rep_equal a2 b2 with
+        | None -> None
+        | Some Eq -> Some Eq))
   | _ -> None
 ;;
 
@@ -2099,11 +2099,11 @@ let rec compare : type a b. a rep -> b rep -> (string, (a, b) equal) sum =
   | I, I -> Inr Eq
   | Ar (x, y), Ar (s, t) ->
     (match compare x s with
-    | Inl _ as e -> e
-    | Inr Eq ->
-      (match compare y t with
-      | Inl _ as e -> e
-      | Inr Eq as e -> e))
+     | Inl _ as e -> e
+     | Inr Eq ->
+       (match compare y t with
+        | Inl _ as e -> e
+        | Inr Eq as e -> e))
   | I, Ar _ -> Inl "I <> Ar _"
   | Ar _, I -> Inl "Ar _ <> I"
 ;;
@@ -2141,21 +2141,21 @@ let rec tc : type n e. n nat -> e ctx -> term -> e checked =
   | V s -> lookup s ctx
   | Ap (f, x) ->
     (match tc n ctx f with
-    | Cerror _ as e -> e
-    | Cok (f', ft) ->
-      (match tc n ctx x with
-      | Cerror _ as e -> e
-      | Cok (x', xt) ->
-        (match ft with
-        | Ar (a, b) ->
-          (match compare a xt with
-          | Inl s -> Cerror s
-          | Inr Eq -> Cok (App (f', x'), b))
-        | _ -> Cerror "Non fun in Ap")))
+     | Cerror _ as e -> e
+     | Cok (f', ft) ->
+       (match tc n ctx x with
+        | Cerror _ as e -> e
+        | Cok (x', xt) ->
+          (match ft with
+           | Ar (a, b) ->
+             (match compare a xt with
+              | Inl s -> Cerror s
+              | Inr Eq -> Cok (App (f', x'), b))
+           | _ -> Cerror "Non fun in Ap")))
   | Ab (s, t, body) ->
     (match tc (NS n) (Ccons (n, s, t, ctx)) body with
-    | Cerror _ as e -> e
-    | Cok (body', et) -> Cok (Abs (n, body'), Ar (t, et)))
+     | Cerror _ as e -> e
+     | Cok (body', et) -> Cok (Abs (n, body'), Ar (t, et)))
   | C m -> Cok (Const m, I)
 ;;
 
@@ -2227,13 +2227,13 @@ let rec subst : type m1 r t s. (m1, r, t) lam -> (r, s) sub -> (s, t) lam' =
   | Shift e, Bind (_, _, r) -> subst e r
   | Shift e, Push sub ->
     (match subst e sub with
-    | Ex a -> Ex (Shift a))
+     | Ex a -> Ex (Shift a))
   | App (f, x), sub ->
     (match subst f sub, subst x sub with
-    | Ex g, Ex y -> Ex (App (g, y)))
+     | Ex g, Ex y -> Ex (App (g, y)))
   | Lam (v, x), sub ->
     (match subst x (Push sub) with
-    | Ex body -> Ex (Lam (v, body)))
+     | Ex body -> Ex (Lam (v, body)))
 ;;
 
 type closed = rnil
@@ -2246,10 +2246,10 @@ let rec rule
   match v1, v2 with
   | Lam (x, body), v ->
     (match subst body (Bind (x, v, Id)) with
-    | Ex term ->
-      (match mode term with
-      | Pexp -> Inl term
-      | Pval -> Inr term))
+     | Ex term ->
+       (match mode term with
+        | Pexp -> Inl term
+        | Pval -> Inr term))
   | Const (IntTo b, f), Const (IntR, x) -> Inr (Const (b, f x))
 ;;
 
@@ -2258,15 +2258,15 @@ let rec onestep : type m t. (m, closed, t) lam -> t rlam = function
   | Const (r, v) -> Inr (Const (r, v))
   | App (e1, e2) ->
     (match mode e1, mode e2 with
-    | Pexp, _ ->
-      (match onestep e1 with
-      | Inl e -> Inl (App (e, e2))
-      | Inr v -> Inl (App (v, e2)))
-    | Pval, Pexp ->
-      (match onestep e2 with
-      | Inl e -> Inl (App (e1, e))
-      | Inr v -> Inl (App (e1, v)))
-    | Pval, Pval -> rule e1 e2)
+     | Pexp, _ ->
+       (match onestep e1 with
+        | Inl e -> Inl (App (e, e2))
+        | Inr v -> Inl (App (v, e2)))
+     | Pval, Pexp ->
+       (match onestep e2 with
+        | Inl e -> Inl (App (e1, e))
+        | Inr v -> Inl (App (e1, v)))
+     | Pval, Pval -> rule e1 e2)
 ;;
 
 type ('env, 'a) var =
@@ -3589,7 +3589,7 @@ type var = [ `Var of string ]
 let subst_var ~subst : var -> _ = function
   | `Var s as x ->
     (try Subst.find s subst with
-    | Not_found -> x)
+     | Not_found -> x)
 ;;
 
 let free_var : var -> _ = function
@@ -4445,14 +4445,14 @@ let f (x : [ `A ]) =
 let f x =
   ignore
     (match x with
-    | #ab -> 1);
+     | #ab -> 1);
   ignore (x : [ `A ])
 ;;
 
 let f x =
   ignore
     (match x with
-    | `A | `B -> 1);
+     | `A | `B -> 1);
   ignore (x : [ `A ])
 ;;
 
@@ -9581,7 +9581,7 @@ let _ =
       match y with
       | e ->
         (match e with
-        | x -> x)]
+         | x -> x)]
 ;;
 
 let _ =
@@ -9655,7 +9655,8 @@ let _ =
   match () with
   | _ ->
     (match () with
-    | _ -> long_function_name long_argument_name__________________________________________)
+     | _ ->
+       long_function_name long_argument_name__________________________________________)
 ;;
 
 let _ =
@@ -9793,22 +9794,23 @@ let[@a
   with
   | _
     when f
-           ~f:(function[@ocaml.warning (* ....................................... *) "-4"]
-             | _ -> .)
+           ~f:
+             (function[@ocaml.warning (* ....................................... *) "-4"]
+              | _ -> .)
            ~f:
              (function[@ocaml.warning
                         (* ....................................... *)
                         (* ....................................... *)
                         "foooooooooooooooooooooooooooo \
                          fooooooooooooooooooooooooooooooooooooo"]
-             | _ -> .)
+              | _ -> .)
            ~f:
              (function[@ocaml.warning
                         (* ....................................... *)
                         let x = a
                         and y = b in
                         x + y]
-             | _ -> .) ->
+              | _ -> .) ->
     y [@attr
         (* ... *)
         (* ... *)


### PR DESCRIPTION
I isolated this change from #2094, @ceastlund is this PR alright for you?

I tried this PR on the list of 'base*` and `core*` projects we are monitoring and the diff looks good to me, but I would like to have your approval @ceastlund before merging this one.

This change can make an expression break after a label, the benefit is arguable but it looks like an improvement to me:
```diff
-           ~f:(function[@ocaml.warning (* ....................................... *) "-4"]
-             | _ -> .)
+           ~f:
+             (function[@ocaml.warning (* ....................................... *) "-4"]
+              | _ -> .)
```