### PR TITLE
Use the API of ocp-indent to parse the .ocp-indent files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 ### Changes
 
 - `bench` binary renamed to `ocamlformat-bench` to avoid conflicts (#2101, @gpetiot)
-- Use the API of ocp-indent to parse the `.ocp-indent` files (#<PR_NUMBER>, @gpetiot)
+- Use the API of ocp-indent to parse the `.ocp-indent` files (#2103, @gpetiot)
 - JaneStreet profile: set `max-indent = 2` (#2099, @gpetiot)
 
 ### New features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 ### Changes
 
 - `bench` binary renamed to `ocamlformat-bench` to avoid conflicts (#2101, @gpetiot)
+- Use the API of ocp-indent to parse the `.ocp-indent` files (#<PR_NUMBER>, @gpetiot)
 - JaneStreet profile: set `max-indent = 2` (#2099, @gpetiot)
 
 ### New features

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1780,7 +1780,6 @@ let failwith_user_errors ~from errors =
   raise (Conf_error msg)
 
 let read_config_file conf = function
-  | File_system.Ocp_indent _ when not !ocp_indent_config -> conf
   | File_system.Ocp_indent file | File_system.Ocamlformat file -> (
       let filename = Fpath.to_string file in
       try
@@ -1869,7 +1868,8 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
   let file_abs = Fpath.(vfile |> to_absolute |> normalize) in
   let fs =
     File_system.make ~enable_outside_detected_project
-      ~disable_conf_files:!disable_conf_files ~root ~file:file_abs
+      ~disable_conf_files:!disable_conf_files
+      ~ocp_indent_config:!ocp_indent_config ~root ~file:file_abs
   in
   let conf =
     List.fold fs.configuration_files ~init:default ~f:read_config_file

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1842,11 +1842,9 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
     List.fold fs.configuration_files ~init:default ~f:read_config_file
     |> update_using_env |> C.update_using_cmdline
   in
-  let no_ocamlformat_files =
-    List.for_all fs.configuration_files ~f:File_system.is_ocp_indent_file
-  in
   if
-    (not is_stdin) && no_ocamlformat_files
+    (not is_stdin)
+    && (not (File_system.has_ocamlformat_file fs))
     && not enable_outside_detected_project
   then (
     (let why =

--- a/lib/File_system.ml
+++ b/lib/File_system.ml
@@ -57,7 +57,8 @@ type t =
   ; configuration_files: configuration_file list
   ; project_root: Fpath.t option }
 
-let make ~enable_outside_detected_project ~disable_conf_files ~root ~file =
+let make ~enable_outside_detected_project ~disable_conf_files
+    ~ocp_indent_config ~root ~file =
   let dir = Fpath.(file |> split_base |> fst) in
   let volume, dir = Fpath.split_volume dir in
   let segs = Fpath.segs dir |> List.rev in
@@ -99,9 +100,10 @@ let make ~enable_outside_detected_project ~disable_conf_files ~root ~file =
                     Ocamlformat f_1 :: fs.configuration_files
                   else fs.configuration_files
                 in
-                let f_2 = Fpath.(dir / dot_ocp_indent) in
-                if Fpath.exists f_2 then Ocp_indent f_2 :: files else files
-              ) }
+                if ocp_indent_config then
+                  let f_2 = Fpath.(dir / dot_ocp_indent) in
+                  if Fpath.exists f_2 then Ocp_indent f_2 :: files else files
+                else files ) }
         in
         (* Inside a detected project, configs are applied in top-down
            starting from the project root (i.e. excluding the global config

--- a/lib/File_system.ml
+++ b/lib/File_system.ml
@@ -28,10 +28,6 @@ let dot_ocamlformat_enable = ".ocamlformat-enable"
 
 type configuration_file = Ocamlformat of Fpath.t | Ocp_indent of Fpath.t
 
-let is_ocp_indent_file = function
-  | Ocamlformat _ -> false
-  | Ocp_indent _ -> true
-
 let root_ocamlformat_file ~root =
   let root = Option.value root ~default:(Fpath.cwd ()) in
   Fpath.(root / dot_ocamlformat)
@@ -116,3 +112,8 @@ let make ~enable_outside_detected_project ~disable_conf_files
     ; enable_files= []
     ; configuration_files= []
     ; project_root= None }
+
+let has_ocamlformat_file fs =
+  List.exists fs.configuration_files ~f:(function
+    | Ocamlformat _ -> true
+    | Ocp_indent _ -> false )

--- a/lib/File_system.mli
+++ b/lib/File_system.mli
@@ -13,8 +13,6 @@ val project_root_witness : string list
 
 type configuration_file = Ocamlformat of Fpath.t | Ocp_indent of Fpath.t
 
-val is_ocp_indent_file : configuration_file -> bool
-
 val root_ocamlformat_file : root:Fpath.t option -> Fpath.t
 
 type t =
@@ -30,3 +28,5 @@ val make :
   -> root:Fpath.t option
   -> file:Fpath.t (** Absolute path of the file to format. *)
   -> t
+
+val has_ocamlformat_file : t -> bool

--- a/lib/File_system.mli
+++ b/lib/File_system.mli
@@ -26,6 +26,7 @@ type t =
 val make :
      enable_outside_detected_project:bool
   -> disable_conf_files:bool
+  -> ocp_indent_config:bool
   -> root:Fpath.t option
   -> file:Fpath.t (** Absolute path of the file to format. *)
   -> t


### PR DESCRIPTION
Also some cleaning of the parsing code, as for some weird reason ocp-indent options would get accepted almost everywhere, but they should only be accepted from `.ocp-indent` files, which simplifies the parsing a lot.