### PR TITLE
Make ocamlformat-bench binary private

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Removed
 
-- `bench` binary is not distributed anymore to avoid name collisions (#<PR_NUMBER>, @gpetiot)
+- `bench` binary is not distributed anymore to avoid name collisions (#2104, @gpetiot)
 
 ### Deprecated
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Removed
 
+- `bench` binary is not distributed anymore to avoid name collisions (#<PR_NUMBER>, @gpetiot)
+
 ### Deprecated
 
 ### Bug fixes
@@ -11,7 +13,6 @@
 
 ### Changes
 
-- `bench` binary renamed to `ocamlformat-bench` to avoid conflicts (#2101, @gpetiot)
 - Use the API of ocp-indent to parse the `.ocp-indent` files (#2103, @gpetiot)
 - JaneStreet profile: set `max-indent = 2` (#2099, @gpetiot)
 

--- a/bench/dune
+++ b/bench/dune
@@ -11,13 +11,10 @@
 
 (executable
  (name bench)
- (public_name ocamlformat-bench)
- (package ocamlformat-bench)
  (libraries bechamel bechamel-js ocamlformat stdio yojson))
 
 (rule
  (alias runbench)
- (package ocamlformat-bench)
  (deps
   (source_tree test)
   %{bin:bench})


### PR DESCRIPTION
Follow-up on #2101 (better fix for #2100)