### PR TITLE
Update vendored parsers to restore OCaml 5.0 compat (9ef0373)

### DIFF
--- a/vendor/diff-stdlib-format.patch
+++ b/vendor/diff-stdlib-format.patch
@@ -538,7 +538,7 @@
  
  let () = at_exit flush_standard_formatters
  
--let () = Domain.at_first_spawn (fun () ->
+-let () = Domain.before_first_spawn (fun () ->
 -  flush_standard_formatters ();
 +(*
  
@@ -605,7 +605,7 @@
 -    {fs with out_string = buffered_out_string err_buf_key;
 -             out_flush = buffered_out_flush Stdlib.stderr err_buf_key};
  
--  Domain.at_exit flush_standard_formatters)
+-  Domain.at_each_spawn (fun _ -> Domain.at_exit flush_standard_formatters))
 +let pp_set_formatter_tag_functions state {
 +     mark_open_tag = mot;
 +     mark_close_tag = mct;

--- a/vendor/import-ocaml-upstream.sh
+++ b/vendor/import-ocaml-upstream.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-dune exec ../tools/diff-ocaml/diff_ocaml.exe -- import dd44a25 parser-upstream
+dune exec ../tools/diff-ocaml/diff_ocaml.exe -- import 9ef0373 parser-upstream

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -974,7 +974,7 @@ module PpxContext = struct
       | "include_dirs" ->
           Clflags.include_dirs := get_list get_string payload
       | "load_path" ->
-          Load_path.init (get_list get_string payload)
+          ()
       | "open_modules" ->
           Clflags.open_modules := get_list get_string payload
       | "for_package" ->

--- a/vendor/parser-standard/ast_mapper.ml
+++ b/vendor/parser-standard/ast_mapper.ml
@@ -924,7 +924,7 @@ module PpxContext = struct
       | "include_dirs" ->
           Clflags.include_dirs := get_list get_string payload
       | "load_path" ->
-          Load_path.init (get_list get_string payload)
+          ()
       | "open_modules" ->
           Clflags.open_modules := get_list get_string payload
       | "for_package" ->

--- a/vendor/parser-upstream/ast_mapper.ml
+++ b/vendor/parser-upstream/ast_mapper.ml
@@ -903,7 +903,16 @@ module PpxContext = struct
       | "include_dirs" ->
           Clflags.include_dirs := get_list get_string payload
       | "load_path" ->
-          Load_path.init (get_list get_string payload)
+          (* Duplicates Compmisc.auto_include, since we can't reference Compmisc
+             from this module. *)
+          let auto_include find_in_dir fn =
+            if !Clflags.no_std_include then
+              raise Not_found
+            else
+              let alert = Location.auto_include_alert in
+              Load_path.auto_include_otherlibs alert find_in_dir fn
+          in
+          Load_path.init ~auto_include (get_list get_string payload)
       | "open_modules" ->
           Clflags.open_modules := get_list get_string payload
       | "for_package" ->

--- a/vendor/parser-upstream/format.ml
+++ b/vendor/parser-upstream/format.ml
@@ -1474,7 +1474,7 @@ let flush_standard_formatters () =
 
 let () = at_exit flush_standard_formatters
 
-let () = Domain.at_first_spawn (fun () ->
+let () = Domain.before_first_spawn (fun () ->
   flush_standard_formatters ();
 
   let fs = pp_get_formatter_out_functions std_formatter () in
@@ -1487,4 +1487,4 @@ let () = Domain.at_first_spawn (fun () ->
     {fs with out_string = buffered_out_string err_buf_key;
              out_flush = buffered_out_flush Stdlib.stderr err_buf_key};
 
-  Domain.at_exit flush_standard_formatters)
+  Domain.at_each_spawn (fun _ -> Domain.at_exit flush_standard_formatters))


### PR DESCRIPTION
Fix #2105