### PR TITLE
Keep cons-patterns in the parsetree

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1044,17 +1044,9 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
            (wrap_k (char opn) (char cls)
               (Cmts.fmt_within c ~pro:(str " ") ~epi:(str " ") ppat_loc) ) )
   | Ppat_construct (lid, None) -> fmt_longident_loc c lid
-  | Ppat_construct
-      ( {txt= Lident "::"; loc= _}
-      , Some ([], {ppat_desc= Ppat_tuple [_; _]; ppat_attributes= []; _}) )
-    ->
-      let loc_args = Sugar.Pat.infix_cons c.cmts xpat in
+  | Ppat_cons lp ->
       Cmts.fmt c ppat_loc
-      @@ hvbox 0
-           (fmt_infix_op_args_pat c ~parens
-              (List.map loc_args ~f:(fun (loc, arg) ->
-                   let fmt_op = opt loc (fmt_longident_loc c) in
-                   (false, noop, noop, (fmt_op, [(Nolabel, arg)])) ) ) )
+        (hvbox 0 (fmt_pat_cons c ~parens (List.map lp ~f:(sub_pat ~ctx))))
   | Ppat_construct (lid, Some (exists, pat)) ->
       cbox 2
         (Params.parens_if parens c.conf
@@ -1440,20 +1432,6 @@ and fmt_label_arg ?(box = true) ?epi ?parens ?eol c
         $ cmts_after )
   | _ -> fmt_label lbl ":@," $ fmt_expression c ~box ?epi ?parens xarg
 
-and fmt_label_arg_pat ?(box = true) ?parens c (lbl, ({ast= arg; _} as xarg))
-    =
-  match (lbl, arg.ppat_desc) with
-  | (Labelled _ | Optional _), _ when Cmts.has_after c.cmts xarg.ast.ppat_loc
-    ->
-      let cmts_after = Cmts.fmt_after c xarg.ast.ppat_loc in
-      hvbox_if box 2
-        ( hvbox_if box 0
-            (fmt_pattern c
-               ~pro:(fmt_label lbl ":@;<0 2>")
-               ~box ?parens xarg )
-        $ cmts_after )
-  | _ -> fmt_label lbl ":@," $ fmt_pattern c ~box ?parens xarg
-
 and expression_width c xe =
   String.length
     (Cmts.preserve ~cache_key:(Expression xe.ast)
@@ -1612,35 +1590,23 @@ and fmt_infix_op_args c ~parens xexp op_args =
     ~parens_nested:(Ast.parenze_nested_exp xexp)
     (list_fl groups fmt_op_arg_group)
 
-and fmt_infix_op_args_pat c ~parens op_args =
+and fmt_pat_cons c ~parens args =
   let groups =
-    let not_simple (_, arg) = not (Pat.is_simple arg.ast) in
-    let exists_not_simple args = List.exists args ~f:not_simple in
-    let break (has_cmts, _, _, (_, args1)) (_, _, _, (_, args2)) =
-      has_cmts || exists_not_simple args1 || exists_not_simple args2
-    in
+    let not_simple arg = not (Pat.is_simple arg.ast) in
+    let break args1 args2 = not_simple args1 || not_simple args2 in
     match c.conf.fmt_opts.break_infix with
-    | `Wrap -> List.group op_args ~break
-    | `Fit_or_vertical -> List.map ~f:(fun x -> [x]) op_args
-  in
-  let fmt_arg _very_last ~first:_ ~last ((_, xarg) as lbl_xarg) =
-    let parens = parenze_pat xarg in
-    fmt_label_arg_pat c ~parens lbl_xarg $ fmt_if (not last) "@ "
+    | `Wrap -> List.group args ~break
+    | `Fit_or_vertical -> List.map ~f:(fun x -> [x]) args
   in
   let fmt_op_arg_group ~first:first_grp ~last:last_grp args =
     let indent = if first_grp && parens then -2 else 0 in
     hovbox indent
-      (list_fl args
-         (fun ~first ~last (_, cmts_before, cmts_after, (op, xargs)) ->
+      (list_fl args (fun ~first ~last xarg ->
            let very_first = first_grp && first in
            let very_last = last_grp && last in
-           cmts_before
-           $ hvbox 0
-               ( op
-               $ fmt_if (not very_first) " "
-               $ cmts_after
-               $ hovbox_if (not very_last) 2
-                   (list_fl xargs (fmt_arg very_last)) )
+           hvbox 0
+             ( fmt_if (not very_first) ":: "
+             $ hovbox_if (not very_last) 2 (fmt_pattern c ~box:true xarg) )
            $ fmt_if_k (not last) (break 1 0) ) )
     $ fmt_if_k (not last_grp) (break 1 0)
   in

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -164,39 +164,6 @@ module Exp = struct
     List.rev @@ infix_cons_ xexp []
 end
 
-module Pat = struct
-  let infix_cons cmts xpat =
-    let rec infix_cons_ ?cons_opt ({ast= pat; _} as xpat) acc =
-      let ctx = Pat pat in
-      let {ppat_desc; ppat_loc= l1; _} = pat in
-      match ppat_desc with
-      | Ppat_construct
-          ( ({txt= Lident "::"; _} as cons)
-          , Some
-              ( []
-              , { ppat_desc= Ppat_tuple [hd; tl]
-                ; ppat_loc= l3
-                ; ppat_attributes= []
-                ; _ } ) ) -> (
-          ( match acc with
-          | [] -> ()
-          | _ ->
-              Cmts.relocate cmts ~src:l1 ~before:hd.ppat_loc
-                ~after:tl.ppat_loc ) ;
-          Cmts.relocate cmts ~src:l3 ~before:hd.ppat_loc ~after:tl.ppat_loc ;
-          match tl.ppat_attributes with
-          | [] ->
-              infix_cons_ ~cons_opt:cons (sub_pat ~ctx tl)
-                ((cons_opt, sub_pat ~ctx hd) :: acc)
-          | _ ->
-              (Some cons, sub_pat ~ctx tl)
-              :: (cons_opt, sub_pat ~ctx hd)
-              :: acc )
-      | _ -> (cons_opt, xpat) :: acc
-    in
-    List.rev @@ infix_cons_ xpat []
-end
-
 let rec ite cmts ({ast= exp; _} as xexp) =
   let ctx = Exp exp in
   let {pexp_desc; pexp_loc; pexp_attributes; _} = exp in

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -60,15 +60,6 @@ module Exp : sig
       expression corresponding to a list ((::) application). *)
 end
 
-module Pat : sig
-  val infix_cons :
-       Cmts.t
-    -> pattern Ast.xt
-    -> (Longident.t loc option * pattern Ast.xt) list
-  (** [infix_cons pat] returns a list of patterns if [pat] is a pattern
-      corresponding to a list ((::) application). *)
-end
-
 val ite :
      Cmts.t
   -> expression Ast.xt

--- a/test/passing/tests/comments.ml.err
+++ b/test/passing/tests/comments.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/comments.ml:247 exceeds the margin
+Warning: tests/comments.ml:248 exceeds the margin

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -227,7 +227,8 @@ let rec fooooooooooo = function
   (* AA*)
   (*BB*)
   (* CC *)
-  | x (* DD *)
+  | x
+    (* DD *)
     (* XX *)
     :: (* YY *)
        (* EE *) t
@@ -238,8 +239,8 @@ let rec fooooooooooo = function
   (* AA *)
   (* BB *)
   | (module (* CC *)
-            (* DD *) F (* EE *) : (* FF *) M (* GG *) )
-    (* HH *) :: (* II *) t
+            (* DD *) F (* EE *) : (* FF *) M (* GG *) ) (* HH *)
+    :: (* II *) t
   (* JJ *)
   (* KK *) ->
       foo

--- a/vendor/diff-parsers-std-ext.patch
+++ b/vendor/diff-parsers-std-ext.patch
@@ -75,6 +75,15 @@
    let type_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_type a)
    let lazy_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_lazy a)
    let unpack ?loc ?attrs a = mk ?loc ?attrs (Ppat_unpack a)
+   let open_ ?loc ?attrs a b = mk ?loc ?attrs (Ppat_open (a, b))
+   let exception_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_exception a)
+   let extension ?loc ?attrs a = mk ?loc ?attrs (Ppat_extension a)
++  let cons ?loc ?attrs a = mk ?loc ?attrs (Ppat_cons a)
+ end
+ 
+ module Exp = struct
+   let mk ?(loc = !default_loc) ?(attrs = []) d =
+     {pexp_desc = d;
 @@@@
    let variant ?loc ?attrs a b = mk ?loc ?attrs (Pexp_variant (a, b))
    let record ?loc ?attrs a b = mk ?loc ?attrs (Pexp_record (a, b))
@@ -194,6 +203,15 @@
      val type_: ?loc:loc -> ?attrs:attrs -> lid -> pattern
      val lazy_: ?loc:loc -> ?attrs:attrs -> pattern -> pattern
      val unpack: ?loc:loc -> ?attrs:attrs -> str_opt -> pattern
+     val open_: ?loc:loc -> ?attrs:attrs  -> lid -> pattern -> pattern
+     val exception_: ?loc:loc -> ?attrs:attrs -> pattern -> pattern
+     val extension: ?loc:loc -> ?attrs:attrs -> extension -> pattern
++    val cons: ?loc:loc -> ?attrs:attrs -> pattern list -> pattern
+   end
+ 
+ (** Expressions *)
+ module Exp:
+   sig
 @@@@
                  -> expression option -> expression
      val field: ?loc:loc -> ?attrs:attrs -> expression -> lid -> expression
@@ -520,6 +538,16 @@
          constraint_ ~loc ~attrs (sub.pat sub p) (sub.typ sub t)
      | Ppat_type s -> type_ ~loc ~attrs (map_loc sub s)
      | Ppat_lazy p -> lazy_ ~loc ~attrs (sub.pat sub p)
+     | Ppat_unpack s -> unpack ~loc ~attrs (map_loc sub s)
+     | Ppat_open (lid,p) -> open_ ~loc ~attrs (map_loc sub lid) (sub.pat sub p)
+     | Ppat_exception p -> exception_ ~loc ~attrs (sub.pat sub p)
+     | Ppat_extension x -> extension ~loc ~attrs (sub.extension sub x)
++    | Ppat_cons pl -> cons ~loc ~attrs (List.map (sub.pat sub) pl)
+ end
+ 
+ module CE = struct
+   (* Value expressions for the class language *)
+ 
 @@@@
      let attrs = sub.attributes sub attrs in
      match desc with
@@ -1172,11 +1200,16 @@
  (* TODO define an abstraction boundary between locations-as-pairs
     and locations-as-Location.t; it should be clear when we move from
 @@@@
- let mkpat_cons_desc consloc args =
-   Ppat_construct(mkrhs (Lident "::") consloc, Some ([], args))
- let mkpat_cons ~loc consloc args =
-   mkpat ~loc (mkpat_cons_desc consloc args)
+ let mkexp_cons_desc consloc args =
+   Pexp_construct(mkrhs (Lident "::") consloc, Some args)
+ let mkexp_cons ~loc consloc args =
+   mkexp ~loc (mkexp_cons_desc consloc args)
  
+-let mkpat_cons_desc consloc args =
+-  Ppat_construct(mkrhs (Lident "::") consloc, Some ([], args))
+-let mkpat_cons ~loc consloc args =
+-  mkpat ~loc (mkpat_cons_desc consloc args)
+-
 -let ghexp_cons_desc consloc args =
 -  Pexp_construct(ghrhs (Lident "::") consloc, Some args)
 -let ghpat_cons_desc consloc args =
@@ -1375,6 +1408,23 @@
        { Pexp_open(od, mkexp ~loc:$loc($3) (Pexp_construct($3, None))) }
    | mod_longident DOT
      LBRACKET expr_semi_list error
+@@@@
+     pattern_(pattern_no_exn)
+       { $1 }
+ ;
+ 
+ %inline pattern_(self):
+-  | self COLONCOLON pattern
+-      { mkpat_cons ~loc:$sloc $loc($2) (ghpat ~loc:$sloc (Ppat_tuple[$1;$3])) }
++  | self COLONCOLON p = pattern
++      { match p.ppat_desc, p.ppat_attributes with
++        | Ppat_cons pl, [] -> Pat.cons ~loc:(make_loc $sloc) ($1 :: pl)
++        | _ -> Pat.cons ~loc:(make_loc $sloc) [$1; p] }
+   | self attribute
+       { Pat.attr $1 $2 }
+   | pattern_gen
+       { $1 }
+   | mkpat(
 @@@@
        { let (fields, closed) = $2 in
          Ppat_record(fields, closed) }
@@ -1722,6 +1772,18 @@
    | Ppat_type of Longident.t loc  (** Pattern [#tconst] *)
    | Ppat_lazy of pattern  (** Pattern [lazy P] *)
    | Ppat_unpack of string option loc
+@@@@
+            [Ppat_constraint(Ppat_unpack(Some "P"), Ptyp_package S)]
+          *)
+   | Ppat_exception of pattern  (** Pattern [exception P] *)
+   | Ppat_extension of extension  (** Pattern [[%id]] *)
+   | Ppat_open of Longident.t loc * pattern  (** Pattern [M.(P)] *)
++  | Ppat_cons of pattern list  (** Pattern [P1 :: ... :: Pn] *)
+ 
+ (** {2 Value expressions} *)
+ 
+ and expression =
+     {
 @@@@
           *)
    | Pexp_field of expression * Longident.t loc  (** [E.l] *)
@@ -2137,6 +2199,9 @@
 -      line i ppf "Ppat_extension \"%s\"\n" s.txt;
 +      line i ppf "Ppat_extension %a\n" fmt_string_loc s;
        payload i ppf arg
++  | Ppat_cons l ->
++      line i ppf "Ppat_cons\n";
++      list i pattern ppf l
  
  and expression i ppf x =
    line i ppf "expression %a\n" fmt_location x.pexp_loc;

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -173,6 +173,7 @@ module Pat = struct
   let open_ ?loc ?attrs a b = mk ?loc ?attrs (Ppat_open (a, b))
   let exception_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_exception a)
   let extension ?loc ?attrs a = mk ?loc ?attrs (Ppat_extension a)
+  let cons ?loc ?attrs a = mk ?loc ?attrs (Ppat_cons a)
 end
 
 module Exp = struct

--- a/vendor/parser-extended/ast_helper.mli
+++ b/vendor/parser-extended/ast_helper.mli
@@ -126,6 +126,7 @@ module Pat:
     val open_: ?loc:loc -> ?attrs:attrs  -> lid -> pattern -> pattern
     val exception_: ?loc:loc -> ?attrs:attrs -> pattern -> pattern
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> pattern
+    val cons: ?loc:loc -> ?attrs:attrs -> pattern list -> pattern
   end
 
 (** Expressions *)

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -562,6 +562,7 @@ module P = struct
     | Ppat_open (lid,p) -> open_ ~loc ~attrs (map_loc sub lid) (sub.pat sub p)
     | Ppat_exception p -> exception_ ~loc ~attrs (sub.pat sub p)
     | Ppat_extension x -> extension ~loc ~attrs (sub.extension sub x)
+    | Ppat_cons pl -> cons ~loc ~attrs (List.map (sub.pat sub) pl)
 end
 
 module CE = struct

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -284,6 +284,7 @@ and pattern_desc =
   | Ppat_exception of pattern  (** Pattern [exception P] *)
   | Ppat_extension of extension  (** Pattern [[%id]] *)
   | Ppat_open of Longident.t loc * pattern  (** Pattern [M.(P)] *)
+  | Ppat_cons of pattern list  (** Pattern [P1 :: ... :: Pn] *)
 
 (** {2 Value expressions} *)
 

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -311,6 +311,9 @@ and pattern i ppf x =
   | Ppat_extension (s, arg) ->
       line i ppf "Ppat_extension %a\n" fmt_string_loc s;
       payload i ppf arg
+  | Ppat_cons l ->
+      line i ppf "Ppat_cons\n";
+      list i pattern ppf l
 
 and expression i ppf x =
   line i ppf "expression %a\n" fmt_location x.pexp_loc;

--- a/vendor/parser-recovery/lib/parser.mly
+++ b/vendor/parser-recovery/lib/parser.mly
@@ -193,11 +193,6 @@ let mkexp_cons_desc consloc args =
 let mkexp_cons ~loc consloc args =
   mkexp ~loc (mkexp_cons_desc consloc args)
 
-let mkpat_cons_desc consloc args =
-  Ppat_construct(mkrhs (Lident "::") consloc, Some ([], args))
-let mkpat_cons ~loc consloc args =
-  mkpat ~loc (mkpat_cons_desc consloc args)
-
 let mkstrexp e attrs =
   { pstr_desc = Pstr_eval (e, attrs); pstr_loc = e.pexp_loc }
 
@@ -2722,8 +2717,10 @@ pattern_no_exn:
 ;
 
 %inline pattern_(self):
-  | self COLONCOLON pattern
-      { mkpat_cons ~loc:$sloc $loc($2) (ghpat ~loc:$sloc (Ppat_tuple[$1;$3])) }
+  | self COLONCOLON p = pattern
+      { match p.ppat_desc, p.ppat_attributes with
+        | Ppat_cons pl, [] -> Pat.cons ~loc:(make_loc $sloc) ($1 :: pl)
+        | _ -> Pat.cons ~loc:(make_loc $sloc) [$1; p] }
   | self attribute
       { Pat.attr $1 $2 }
   | pattern_gen


### PR DESCRIPTION
Extracted from ocamlformat-ng's concrete AST, again the idea is to make the parser do more work (more PRs doing this in the future) and cleanup the formatter, and also Sugar.ml.

No diff with test_branch.sh