### PR TITLE
Preserve normalization of cons-patterns into bracket lists

### DIFF
--- a/test/passing/tests/list_normalized.ml
+++ b/test/passing/tests/list_normalized.ml
@@ -8,3 +8,13 @@ let x = (* a *) 1 (* b *) :: (* c *) 2 :: 3 :: 4 (* d *) :: (* e *) ([][@attr]) 
 
 (* comments preserved when no normalization required *)
 let x = (* a *) [ (* b *) 1 (* c *) ; (* d *) 2 ; 3 ; 4 (* e *) ] (* f *)
+
+let x :: [] = e
+let x :: y = e
+let x :: y :: [] = e
+let x :: y :: ([][@attr]) = e
+let x :: (y[@attr]) :: [] = e
+let (*a*)x(*b*) :: (*c*)y(*d*) = e
+let (*a*)x(*b*) :: (*c*)y(*d*) :: (*e*)[](*f*) = e
+let (*a*)x(*b*) :: (*c*)y(*d*) :: (*e*)([][@attr])(*f*) = e
+let (*a*)x(*b*) :: (*c*)(y[@attr])(*d*) :: (*e*)[](*f*) = e

--- a/test/passing/tests/list_normalized.ml.ref
+++ b/test/passing/tests/list_normalized.ml.ref
@@ -19,3 +19,36 @@ let x =
 
 (* comments preserved when no normalization required *)
 let x = (* a *) [(* b *) 1 (* c *); (* d *) 2; 3; 4 (* e *)] (* f *)
+
+let (x :: []) = e
+
+let (x :: y) = e
+
+let [x; y] = e
+
+let (x :: y :: ([] [@attr])) = e
+
+let [x; (y [@attr])] = e
+
+let (*a*) (x (*b*) :: (*c*) y (*d*)) = e
+
+let
+    (*a*)
+    [ x (*b*)
+    ; (*c*)
+      y
+      (*d*)
+      (*e*) ] (*f*) =
+  e
+
+let (*a*) (x (*b*) :: (*c*) y (*d*) :: (*e*) ([] [@attr])) (*f*) = e
+
+let
+    (*a*)
+    [ x (*b*)
+    ; (*c*)
+      (y
+      [@attr] )
+      (*d*)
+      (*e*) ] (*f*) =
+  e


### PR DESCRIPTION
Fixing a small regression caused by #2113, all is good now.
Adding some tests.