### PR TITLE
Keep cons-expressions in the parsetree

### DIFF
--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -132,36 +132,6 @@ module Exp = struct
       | _ -> [(xop, [xexp])]
     in
     infix_ None ~relocate:false (Nolabel, xexp)
-
-  let infix_cons cmts xexp =
-    let rec infix_cons_ ?cons_opt ({ast= exp; _} as xexp) acc =
-      let ctx = Exp exp in
-      let {pexp_desc; pexp_loc= l1; _} = exp in
-      match pexp_desc with
-      | Pexp_construct
-          ( ({txt= Lident "::"; _} as cons)
-          , Some
-              { pexp_desc= Pexp_tuple [hd; tl]
-              ; pexp_loc= l3
-              ; pexp_attributes= []
-              ; _ } ) -> (
-          ( match acc with
-          | [] -> ()
-          | _ ->
-              Cmts.relocate cmts ~src:l1 ~before:hd.pexp_loc
-                ~after:tl.pexp_loc ) ;
-          Cmts.relocate cmts ~src:l3 ~before:hd.pexp_loc ~after:tl.pexp_loc ;
-          match tl.pexp_attributes with
-          | [] ->
-              infix_cons_ ~cons_opt:cons (sub_exp ~ctx tl)
-                ((cons_opt, sub_exp ~ctx hd) :: acc)
-          | _ ->
-              (Some cons, sub_exp ~ctx tl)
-              :: (cons_opt, sub_exp ~ctx hd)
-              :: acc )
-      | _ -> (cons_opt, xexp) :: acc
-    in
-    List.rev @@ infix_cons_ xexp []
 end
 
 let rec ite cmts ({ast= exp; _} as xexp) =

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -51,13 +51,6 @@ module Exp : sig
   (** [infix cmts prec exp] returns the infix operator and the list of
       operands applied to this operator from expression [exp]. [prec] is the
       precedence of the infix operator. *)
-
-  val infix_cons :
-       Cmts.t
-    -> expression Ast.xt
-    -> (Longident.t loc option * expression Ast.xt) list
-  (** [infix_cons exp] returns a list of expressions if [exp] is an
-      expression corresponding to a list ((::) application). *)
 end
 
 val ite :

--- a/vendor/diff-parsers-std-ext.patch
+++ b/vendor/diff-parsers-std-ext.patch
@@ -103,6 +103,7 @@
    let unreachable ?loc ?attrs () = mk ?loc ?attrs Pexp_unreachable
    let hole  ?loc ?attrs () = mk ?loc ?attrs Pexp_hole
 +  let beginend ?loc ?attrs a = mk ?loc ?attrs (Pexp_beginend a)
++  let cons ?loc ?attrs a = mk ?loc ?attrs (Pexp_cons a)
  
    let case lhs ?guard rhs =
      {
@@ -231,6 +232,7 @@
      val binding_op: str -> pattern -> expression -> loc -> binding_op
      val hole: ?loc:loc -> ?attrs:attrs -> unit -> expression
 +    val beginend: ?loc:loc -> ?attrs:attrs -> expression -> expression
++    val cons: ?loc:loc -> ?attrs:attrs -> expression list -> expression
    end
  
  (** Value declarations *)
@@ -517,6 +519,7 @@
      | Pexp_unreachable -> unreachable ~loc ~attrs ()
      | Pexp_hole -> hole ~loc ~attrs ()
 +    | Pexp_beginend e -> beginend ~loc ~attrs (sub.expr sub e)
++    | Pexp_cons l -> cons ~loc ~attrs (List.map (sub.expr sub) l)
  
    let map_binding_op sub {pbop_op; pbop_pat; pbop_exp; pbop_loc} =
      let open Exp in
@@ -1199,12 +1202,13 @@
  
  (* TODO define an abstraction boundary between locations-as-pairs
     and locations-as-Location.t; it should be clear when we move from
-@@@@
- let mkexp_cons_desc consloc args =
-   Pexp_construct(mkrhs (Lident "::") consloc, Some args)
- let mkexp_cons ~loc consloc args =
-   mkexp ~loc (mkexp_cons_desc consloc args)
+    one world to the other *)
  
+-let mkexp_cons_desc consloc args =
+-  Pexp_construct(mkrhs (Lident "::") consloc, Some args)
+-let mkexp_cons ~loc consloc args =
+-  mkexp ~loc (mkexp_cons_desc consloc args)
+-
 -let mkpat_cons_desc consloc args =
 -  Ppat_construct(mkrhs (Lident "::") consloc, Some ([], args))
 -let mkpat_cons ~loc consloc args =
@@ -1372,6 +1376,23 @@
  %inline constrain:
      core_type EQUAL core_type
      { $1, $3, make_loc $sloc }
+@@@@
+       { let (pbop_pat, pbop_exp, rev_ands) = bindings in
+         let ands = List.rev rev_ands in
+         let pbop_loc = make_loc $sloc in
+         let let_ = {pbop_op; pbop_pat; pbop_exp; pbop_loc} in
+         mkexp ~loc:$sloc (Pexp_letop{ let_; ands; body}) }
+-  | expr COLONCOLON expr
+-      { mkexp_cons ~loc:$sloc $loc($2) (ghexp ~loc:$sloc (Pexp_tuple[$1;$3])) }
++  | expr COLONCOLON e = expr
++      { match e.pexp_desc, e.pexp_attributes with
++        | Pexp_cons l, [] -> Exp.cons ~loc:(make_loc $sloc) ($1 :: l)
++        | _ -> Exp.cons ~loc:(make_loc $sloc) [$1; e] }
+   | mkrhs(label) LESSMINUS expr
+       { mkexp ~loc:$sloc (Pexp_setinstvar($1, $3)) }
+   | simple_expr DOT mkrhs(label_longident) LESSMINUS expr
+       { mkexp ~loc:$sloc (Pexp_setfield($1, $3, $5)) }
+   | indexop_expr(DOT, seq_expr, LESSMINUS v=expr {Some v})
 @@@@
        mkexp_attrs ~loc:$sloc desc attrs }
    | mkexp(simple_expr_)
@@ -1803,6 +1824,7 @@
    | Pexp_unreachable  (** [.] *)
    | Pexp_hole  (** [_] *)
 +  | Pexp_beginend of expression  (** [begin E end] *)
++  | Pexp_cons of expression list  (** [E1 :: ... :: En] *)
  
  and case =
      {
@@ -2279,6 +2301,9 @@
 +  | Pexp_beginend e ->
 +      line i ppf "Pexp_beginend\n";
 +      expression i ppf e
++  | Pexp_cons l ->
++      line i ppf "Pexp_cons\n";
++      list i expression ppf l
  
  and value_description i ppf x =
    line i ppf "value_description %a %a\n" fmt_string_loc

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -225,6 +225,7 @@ module Exp = struct
   let unreachable ?loc ?attrs () = mk ?loc ?attrs Pexp_unreachable
   let hole  ?loc ?attrs () = mk ?loc ?attrs Pexp_hole
   let beginend ?loc ?attrs a = mk ?loc ?attrs (Pexp_beginend a)
+  let cons ?loc ?attrs a = mk ?loc ?attrs (Pexp_cons a)
 
   let case lhs ?guard rhs =
     {

--- a/vendor/parser-extended/ast_helper.mli
+++ b/vendor/parser-extended/ast_helper.mli
@@ -199,6 +199,7 @@ module Exp:
     val binding_op: str -> pattern -> expression -> loc -> binding_op
     val hole: ?loc:loc -> ?attrs:attrs -> unit -> expression
     val beginend: ?loc:loc -> ?attrs:attrs -> expression -> expression
+    val cons: ?loc:loc -> ?attrs:attrs -> expression list -> expression
   end
 
 (** Value declarations *)

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -515,6 +515,7 @@ module E = struct
     | Pexp_unreachable -> unreachable ~loc ~attrs ()
     | Pexp_hole -> hole ~loc ~attrs ()
     | Pexp_beginend e -> beginend ~loc ~attrs (sub.expr sub e)
+    | Pexp_cons l -> cons ~loc ~attrs (List.map (sub.expr sub) l)
 
   let map_binding_op sub {pbop_op; pbop_pat; pbop_exp; pbop_loc} =
     let open Exp in

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -180,11 +180,6 @@ let mkuplus ~oploc name arg =
    and locations-as-Location.t; it should be clear when we move from
    one world to the other *)
 
-let mkexp_cons_desc consloc args =
-  Pexp_construct(mkrhs (Lident "::") consloc, Some args)
-let mkexp_cons ~loc consloc args =
-  mkexp ~loc (mkexp_cons_desc consloc args)
-
 let mkstrexp e attrs =
   { pstr_desc = Pstr_eval (e, attrs); pstr_loc = e.pexp_loc }
 
@@ -2274,8 +2269,10 @@ expr:
         let pbop_loc = make_loc $sloc in
         let let_ = {pbop_op; pbop_pat; pbop_exp; pbop_loc} in
         mkexp ~loc:$sloc (Pexp_letop{ let_; ands; body}) }
-  | expr COLONCOLON expr
-      { mkexp_cons ~loc:$sloc $loc($2) (ghexp ~loc:$sloc (Pexp_tuple[$1;$3])) }
+  | expr COLONCOLON e = expr
+      { match e.pexp_desc, e.pexp_attributes with
+        | Pexp_cons l, [] -> Exp.cons ~loc:(make_loc $sloc) ($1 :: l)
+        | _ -> Exp.cons ~loc:(make_loc $sloc) [$1; e] }
   | mkrhs(label) LESSMINUS expr
       { mkexp ~loc:$sloc (Pexp_setinstvar($1, $3)) }
   | simple_expr DOT mkrhs(label_longident) LESSMINUS expr

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -433,6 +433,7 @@ and expression_desc =
   | Pexp_unreachable  (** [.] *)
   | Pexp_hole  (** [_] *)
   | Pexp_beginend of expression  (** [begin E end] *)
+  | Pexp_cons of expression list  (** [E1 :: ... :: En] *)
 
 and case =
     {

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -461,6 +461,9 @@ and expression i ppf x =
   | Pexp_beginend e ->
       line i ppf "Pexp_beginend\n";
       expression i ppf e
+  | Pexp_cons l ->
+      line i ppf "Pexp_cons\n";
+      list i expression ppf l
 
 and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_string_loc


### PR DESCRIPTION
Extracted from ocamlformat-ng's concrete AST, again the idea is to make the parser do more work (more PRs doing this in the future) and cleanup the formatter, and also Sugar.ml.

Same as #2113 and #2114 but for expressions.