### PR TITLE
Closing parentheses of local open now comply with 'indicate-multiline-delimiters'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 
 - Preserve comments around object open/close flag (#2097, @trefis, @gpetiot)
 - Preserve comments around private/mutable/virtual keywords (#2098, @trefis, @gpetiot)
-- Closing parentheses of local open now comply with `indicate-multiline-delimiters` (#<PR_NUMBER>, @gpetiot)
+- Closing parentheses of local open now comply with `indicate-multiline-delimiters` (#2116, @gpetiot)
 
 ### Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 - Preserve comments around object open/close flag (#2097, @trefis, @gpetiot)
 - Preserve comments around private/mutable/virtual keywords (#2098, @trefis, @gpetiot)
+- Closing parentheses of local open now comply with `indicate-multiline-delimiters` (#<PR_NUMBER>, @gpetiot)
 
 ### Changes
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -350,7 +350,8 @@ module Exp = struct
       , (Match | Let_match | Non_apply) )
      |( { pexp_desc=
             ( Pexp_fun _ | Pexp_let _ | Pexp_letop _ | Pexp_letexception _
-            | Pexp_letmodule _ | Pexp_newtype _ | Pexp_open _ )
+            | Pexp_letmodule _ | Pexp_newtype _ | Pexp_open _
+            | Pexp_letopen _ )
         ; _ }
       , (Let_match | Non_apply) ) ->
         true
@@ -1388,7 +1389,7 @@ end = struct
        |Pexp_poly _ | Pexp_record _ | Pexp_send _ | Pexp_sequence _
        |Pexp_setfield _ | Pexp_setinstvar _ | Pexp_tuple _
        |Pexp_unreachable | Pexp_variant _ | Pexp_while _ | Pexp_hole
-       |Pexp_beginend _ | Pexp_cons _ ->
+       |Pexp_beginend _ | Pexp_cons _ | Pexp_letopen _ ->
           assert false
       | Pexp_extension (_, ext) -> assert (check_extensions ext)
       | Pexp_object {pcstr_self; pcstr_fields} ->
@@ -1538,6 +1539,7 @@ end = struct
          |Pexp_letmodule (_, _, e)
          |Pexp_newtype (_, e)
          |Pexp_open (_, e)
+         |Pexp_letopen (_, e)
          |Pexp_poly (e, _)
          |Pexp_send (e, _)
          |Pexp_setinstvar (_, e) ->
@@ -2103,6 +2105,7 @@ end = struct
          |Pexp_lazy e
          |Pexp_newtype (_, e)
          |Pexp_open (_, e)
+         |Pexp_letopen (_, e)
          |Pexp_sequence (_, e)
          |Pexp_setfield (_, _, e)
          |Pexp_setinstvar (_, e)
@@ -2177,6 +2180,7 @@ end = struct
        |Pexp_lazy e
        |Pexp_newtype (_, e)
        |Pexp_open (_, e)
+       |Pexp_letopen (_, e)
        |Pexp_fun (_, _, _, e)
        |Pexp_sequence (_, e)
        |Pexp_setfield (_, _, e)

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1260,7 +1260,7 @@ let config =
   let list_assoc = Arg.(list ~sep:',' assoc) in
   mk ~default
     Arg.(
-      value & opt list_assoc default & info ["c"; "config"] ~doc ~docs ~env)
+      value & opt list_assoc default & info ["c"; "config"] ~doc ~docs ~env )
 
 let inplace =
   let doc = "Format in-place, overwriting input file(s)." in
@@ -1378,7 +1378,7 @@ let output =
     Arg.(
       value
       & opt (some string) default
-      & info ["o"; "output"] ~doc ~docs ~docv)
+      & info ["o"; "output"] ~doc ~docs ~docv )
 
 let print_config =
   let doc =

--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -179,7 +179,7 @@ module Make (C : CONFIG) = struct
         value
         & vflag None
             [ (Some true, info names ~doc ~docs)
-            ; (Some false, info invert_names ~doc:invert_doc ~docs) ])
+            ; (Some false, info invert_names ~doc:invert_doc ~docs) ] )
     in
     let parse = Arg.conv_parser Arg.bool in
     let r = mk ~default:None term in

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2402,23 +2402,22 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       hovbox 0
         (Params.parens_if outer_parens c.conf
            ( hvbox 0
-               ( hvbox 0
-                   ( fmt_if inner_parens "("
-                   $ fmt_module_statement c ~attributes
-                       ~keyword:
-                         ( hvbox 0
-                             ( str "let" $ break 1 0
-                             $ Cmts.fmt_before c popen_loc
-                             $ fmt_or override "open!" "open"
-                             $ opt ext (fun _ -> fmt_if override " ")
-                             $ fmt_extension_suffix c ext )
-                         $ break 1 0 )
-                       (sub_mod ~ctx popen_expr)
-                   $ Cmts.fmt_after c popen_loc
-                   $ str " in" )
-               $ break 1000 0
-               $ fmt_expression c (sub_exp ~ctx e0)
-               $ fmt_if_k inner_parens (closing_paren c) )
+               (Params.parens_if inner_parens c.conf
+                  ( hvbox 0
+                      ( fmt_module_statement c ~attributes
+                          ~keyword:
+                            ( hvbox 0
+                                ( str "let" $ break 1 0
+                                $ Cmts.fmt_before c popen_loc
+                                $ fmt_or override "open!" "open"
+                                $ opt ext (fun _ -> fmt_if override " ")
+                                $ fmt_extension_suffix c ext )
+                            $ break 1 0 )
+                          (sub_mod ~ctx popen_expr)
+                      $ Cmts.fmt_after c popen_loc
+                      $ str " in" )
+                  $ break 1000 0
+                  $ fmt_expression c (sub_exp ~ctx e0) ) )
            $ fmt_atrs ) )
   | Pexp_try (e0, [{pc_lhs; pc_guard; pc_rhs}])
     when Poly.(

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1549,9 +1549,8 @@ and fmt_infix_op_args c ~parens xexp op_args =
     match exp.pexp_desc with
     | Pexp_ifthenelse _ | Pexp_let _ | Pexp_letexception _
      |Pexp_letmodule _ | Pexp_match _ | Pexp_newtype _ | Pexp_sequence _
-     |Pexp_try _ ->
+     |Pexp_try _ | Pexp_letopen _ ->
         true
-    | Pexp_open _ -> Source.is_long_pexp_open c.source exp
     | _ -> false
   in
   let fmt_arg very_last ~first:_ ~last ((_, xarg) as lbl_xarg) =
@@ -1603,9 +1602,8 @@ and fmt_exp_cons c ~parens xexp args =
     match exp.pexp_desc with
     | Pexp_ifthenelse _ | Pexp_let _ | Pexp_letexception _
      |Pexp_letmodule _ | Pexp_match _ | Pexp_newtype _ | Pexp_sequence _
-     |Pexp_try _ ->
+     |Pexp_try _ | Pexp_letopen _ ->
         true
-    | Pexp_open _ -> Source.is_long_pexp_open c.source exp
     | _ -> false
   in
   let fmt_arg very_last xarg =
@@ -2367,34 +2365,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             $ fmt "@;<1000 0>"
             $ fmt_expression c (sub_exp ~ctx exp) )
         $ fmt_atrs )
-  | Pexp_open
-      ( { popen_override= flag
-        ; popen_expr
-        ; popen_attributes= attributes
-        ; popen_loc }
-      , e0 ) ->
-      let override = is_override flag in
-      let long_syntax = Source.is_long_pexp_open c.source exp in
-      let force =
-        let maybe_break =
-          if long_syntax then Some Break
-          else
-            match e0.pexp_desc with
-            | Pexp_let _ | Pexp_extension _ | Pexp_letexception _
-             |Pexp_letmodule _ | Pexp_open _ ->
-                Some Break
-            | _ -> (
-              match popen_expr.pmod_desc with
-              | Pmod_ident _ -> Option.some_if override Break
-              | _ -> Some Break )
-        in
-        match (xexp.ctx, popen_expr.pmod_desc) with
-        | _, Pmod_ident _ when (not override) && not long_syntax -> Some Fit
-        | Exp {pexp_desc= Pexp_apply _ | Pexp_construct _; _}, _
-          when long_syntax ->
-            Some (Option.value maybe_break ~default:Fit)
-        | _ -> maybe_break
-      in
+  | Pexp_open (lid, e0) ->
       let can_skip_parens =
         (not (Cmts.has_before c.cmts e0.pexp_loc))
         && (not (Cmts.has_after c.cmts e0.pexp_loc))
@@ -2407,42 +2378,55 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         | Pexp_construct ({txt= Lident "[]"; _}, None) -> true
         | _ -> false
       in
-      let force_fit = match force with Some Fit -> true | _ -> false in
-      let opn, cls = if can_skip_parens then (".", "") else (".(", ")") in
-      let outer_parens, inner_parens =
-        if has_attr then (parens, true) else (false, parens)
-      in
-      let closing =
+      let outer_parens = has_attr && parens in
+      let inner_parens = not can_skip_parens in
+      let closing_break =
         match c.conf.fmt_opts.indicate_multiline_delimiters with
-        | `No | `Space ->
-            fits_breaks ?force cls ""
-            $ fits_breaks_if inner_parens ?force "" ")"
-        | `Closing_on_separate_line ->
-            fmt_if_k (force_fit && not can_skip_parens) (break 0 0)
-            $ fits_breaks ?force cls ""
-            $ fits_breaks_if inner_parens ?force "" ~hint:(1000, 0) ")"
+        | `No | `Space -> noop
+        | `Closing_on_separate_line -> fmt_if_k inner_parens (break 0 0)
       in
       hovbox 0
         (Params.parens_if outer_parens c.conf
            ( hvbox 0
                ( hvbox 0
-                   ( fits_breaks_if ?force ~level:1 inner_parens "" "("
+                   ( fmt_longident lid.txt $ Cmts.fmt_after c lid.loc
+                   $ str "." $ fmt_if inner_parens "(" )
+               $ fmt "@;<0 2>"
+               $ fmt_expression c (sub_exp ~ctx e0)
+               $ closing_break $ fmt_if inner_parens ")" )
+           $ fmt_atrs ) )
+  | Pexp_letopen
+      ( { popen_override= flag
+        ; popen_expr
+        ; popen_attributes= attributes
+        ; popen_loc }
+      , e0 ) ->
+      let override = is_override flag in
+      let outer_parens = has_attr && parens in
+      let inner_parens = has_attr || parens in
+      let closing =
+        match c.conf.fmt_opts.indicate_multiline_delimiters with
+        | `No | `Space -> fmt_if inner_parens ")"
+        | `Closing_on_separate_line -> fmt_if inner_parens "@;<1000 0>)"
+      in
+      hovbox 0
+        (Params.parens_if outer_parens c.conf
+           ( hvbox 0
+               ( hvbox 0
+                   ( fmt_if inner_parens "("
                    $ fmt_module_statement c ~attributes
                        ~keyword:
                          ( hvbox 0
-                             ( fits_breaks ?force ~level:4 "" "let"
-                             $ fits_breaks ?force ~level:4 "" ~hint:(1, 0) ""
+                             ( str "let" $ break 1 0
                              $ Cmts.fmt_before c popen_loc
-                             $ fits_breaks ?force ~level:4 ""
-                                 (if override then "open!" else "open")
+                             $ fmt_or override "open!" "open"
                              $ opt ext (fun _ -> fmt_if override " ")
                              $ fmt_extension_suffix c ext )
-                         $ fits_breaks ?force ~level:3 "" ~hint:(1, 0) "" )
+                         $ break 1 0 )
                        (sub_mod ~ctx popen_expr)
                    $ Cmts.fmt_after c popen_loc
-                   $ fits_breaks ~level:1 ?force opn " in" )
-               $ fmt_or_k force_fit (fmt "@;<0 2>")
-                   (fits_breaks ?force "" ~hint:(1000, 0) "")
+                   $ str " in" )
+               $ break 1000 0
                $ fmt_expression c (sub_exp ~ctx e0)
                $ closing )
            $ fmt_atrs ) )
@@ -2601,6 +2585,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                             | Pexp_function _ | Pexp_letexception _
                             | Pexp_open _ | Pexp_assert _ | Pexp_lazy _
                             | Pexp_pack _ | Pexp_fun _ | Pexp_beginend _
+                            | Pexp_letopen _
                             | Pexp_constraint
                                 ( { pexp_desc= Pexp_pack _
                                   ; pexp_attributes= []

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -104,18 +104,6 @@ let extend_loc_to_include_attributes (loc : Location.t) (l : attributes) =
   else
     {loc with loc_end= {loc.loc_end with pos_cnum= loc_end.loc_end.pos_cnum}}
 
-let contains_token_between t ~(from : Location.t) ~(upto : Location.t) tok =
-  let filter = Poly.( = ) tok in
-  let from = from.loc_start and upto = upto.loc_start in
-  Source_code_position.ascending from upto < 0
-  && not (List.is_empty (tokens_between t ~filter from upto))
-
-let is_long_pexp_open source {pexp_desc; _} =
-  match pexp_desc with
-  | Pexp_open ({popen_loc= from; _}, {pexp_loc= upto; _}) ->
-      contains_token_between source ~from ~upto Parser.IN
-  | _ -> false
-
 let is_long_functor_syntax (t : t) ~(from : Location.t) = function
   | Unit -> false
   | Named ({loc= _; _}, _) -> (

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -49,10 +49,6 @@ val string_literal : t -> [`Normalize | `Preserve] -> Location.t -> string
 
 val char_literal : t -> Location.t -> string
 
-val is_long_pexp_open : t -> expression -> bool
-(** [is_long_pexp_open source exp] holds if [exp] is a [Pexp_open] expression
-    that is expressed in long ('let open') form in source. *)
-
 val is_long_pmod_functor : t -> module_expr -> bool
 (** [is_long_pmod_functor source mod_exp] holds if [mod_exp] is a
     [Pmod_functor] expression that is expressed in long ('functor (M) ->')

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -16,7 +16,7 @@ let _ =
       (*comment*)
       (let open M in
       let x = x in
-      e)
+      e )
   in
   ()
 

--- a/test/passing/tests/let_in_constr.ml
+++ b/test/passing/tests/let_in_constr.ml
@@ -1,4 +1,4 @@
 let _ =
   Some
     (let open! List in
-    1)
+    1 )

--- a/test/passing/tests/open.ml.ref
+++ b/test/passing/tests/open.ml.ref
@@ -34,13 +34,13 @@ let () =
   ( (let open Term in
     term_result
       ( const Phases.phase1 $ arch $ hub_id $ build_dir $ logs_dir
-      $ setup_logs ))
+      $ setup_logs ) )
   , Term.info "phase1" ~doc ~sdocs:Manpage.s_common_options ~exits ~man )
 
 let () =
   (let open Arg in
   let doc = "Output all." in
-  value & flag & info ["all"] ~doc)
+  value & flag & info ["all"] ~doc )
   $
   let open Arg in
   let doc = "Commit to git." in
@@ -49,10 +49,10 @@ let () =
 let () =
   Arg.(
     let doc = "Output all." in
-    value & flag & info ["all"] ~doc)
+    value & flag & info ["all"] ~doc )
   $ Arg.(
       let doc = "Commit to git." in
-      value & flag & info ["commit"; "c"] ~doc)
+      value & flag & info ["commit"; "c"] ~doc )
 
 let () = X.(f y i)
 
@@ -285,7 +285,7 @@ open [%ext] [@@attr]
 let g =
   M.f
     ((let open M in
-     x) [@attr] )
+     x ) [@attr] )
 
 let _ = M.({f} [@warning "foo"])
 

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -101,7 +101,7 @@ let () =
     [@foo]] ;
   [%foo
     (let open M in
-    ()) [@foo]] ;
+    () ) [@foo]] ;
   [%foo fun [@foo] x -> ()] ;
   [%foo function[@foo] x -> ()] ;
   [%foo try[@foo] () with _ -> ()] ;

--- a/vendor/diff-parsers-std-ext.patch
+++ b/vendor/diff-parsers-std-ext.patch
@@ -97,6 +97,12 @@
    let for_ ?loc ?attrs a b c d e = mk ?loc ?attrs (Pexp_for (a, b, c, d, e))
    let constraint_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_constraint (a, b))
 @@@@
+   let poly ?loc ?attrs a b = mk ?loc ?attrs (Pexp_poly (a, b))
+   let object_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_object a)
+   let newtype ?loc ?attrs a b = mk ?loc ?attrs (Pexp_newtype (a, b))
+   let pack ?loc ?attrs a = mk ?loc ?attrs (Pexp_pack a)
+   let open_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_open (a, b))
++  let letopen ?loc ?attrs a b = mk ?loc ?attrs (Pexp_letopen (a, b))
    let letop ?loc ?attrs let_ ands body =
      mk ?loc ?attrs (Pexp_letop {let_; ands; body})
    let extension ?loc ?attrs a = mk ?loc ?attrs (Pexp_extension a)
@@ -226,6 +232,18 @@
                    -> expression
      val while_: ?loc:loc -> ?attrs:attrs -> expression -> expression
 @@@@
+     val poly: ?loc:loc -> ?attrs:attrs -> expression -> core_type option
+               -> expression
+     val object_: ?loc:loc -> ?attrs:attrs -> class_structure -> expression
+     val newtype: ?loc:loc -> ?attrs:attrs -> str -> expression -> expression
+     val pack: ?loc:loc -> ?attrs:attrs -> module_expr -> expression
+-    val open_: ?loc:loc -> ?attrs:attrs -> open_declaration -> expression
++    val open_: ?loc:loc -> ?attrs:attrs -> lid -> expression -> expression
++    val letopen: ?loc:loc -> ?attrs:attrs -> open_declaration -> expression
+                -> expression
+     val letop: ?loc:loc -> ?attrs:attrs -> binding_op
+                -> binding_op list -> expression -> expression
+     val extension: ?loc:loc -> ?attrs:attrs -> extension -> expression
      val unreachable: ?loc:loc -> ?attrs:attrs -> unit -> expression
  
      val case: pattern -> ?guard:expression -> expression -> case
@@ -513,6 +531,17 @@
      | Pexp_sequence (e1, e2) ->
          sequence ~loc ~attrs (sub.expr sub e1) (sub.expr sub e2)
 @@@@
+         poly ~loc ~attrs (sub.expr sub e) (map_opt (sub.typ sub) t)
+     | Pexp_object cls -> object_ ~loc ~attrs (sub.class_structure sub cls)
+     | Pexp_newtype (s, e) ->
+         newtype ~loc ~attrs (map_loc sub s) (sub.expr sub e)
+     | Pexp_pack me -> pack ~loc ~attrs (sub.module_expr sub me)
+-    | Pexp_open (o, e) ->
+-        open_ ~loc ~attrs (sub.open_declaration sub o) (sub.expr sub e)
++    | Pexp_open (o, e) -> open_ ~loc ~attrs (map_loc sub o) (sub.expr sub e)
++    | Pexp_letopen (o, e) ->
++        letopen ~loc ~attrs (sub.open_declaration sub o) (sub.expr sub e)
+     | Pexp_letop {let_; ands; body} ->
          letop ~loc ~attrs (sub.binding_op sub let_)
            (List.map (sub.binding_op sub) ands) (sub.expr sub body)
      | Pexp_extension x -> extension ~loc ~attrs (sub.extension sub x)
@@ -1272,6 +1301,21 @@
    tail = listx(delimiter, X, Y)
      { let xs, y = tail in
 @@@@
+     Opn.mk id ~override ~attrs ~loc ~docs, ext
+   }
+ ;
+ 
+ %inline open_dot_declaration: mkrhs(mod_longident)
+-  { let loc = make_loc $loc($1) in
+-    let me = Mod.ident ~loc $1 in
+-    Opn.mk ~loc me }
++  { $1 }
+ ;
+ 
+ (* -------------------------------------------------------------------------- *)
+ 
+ /* Module types */
+@@@@
      attrs = attributes
      mutable_ = virtual_with_mutable_flag
      label = mkrhs(label) COLON ty = core_type
@@ -1393,6 +1437,19 @@
    | simple_expr DOT mkrhs(label_longident) LESSMINUS expr
        { mkexp ~loc:$sloc (Pexp_setfield($1, $3, $5)) }
    | indexop_expr(DOT, seq_expr, LESSMINUS v=expr {Some v})
+@@@@
+   | LET EXCEPTION ext_attributes let_exception_declaration IN seq_expr
+       { Pexp_letexception($4, $6), $3 }
+   | LET OPEN override_flag ext_attributes module_expr IN seq_expr
+       { let open_loc = make_loc ($startpos($2), $endpos($5)) in
+         let od = Opn.mk $5 ~override:$3 ~loc:open_loc in
+-        Pexp_open(od, $7), $4 }
++        Pexp_letopen(od, $7), $4 }
+   | FUNCTION ext_attributes match_cases
+       { Pexp_function $3, $2 }
+   | FUN ext_attributes labeled_simple_pattern fun_def
+       { let (l,o,p) = $3 in
+         Pexp_fun(l, o, p, $4), $2 }
 @@@@
        mkexp_attrs ~loc:$sloc desc attrs }
    | mkexp(simple_expr_)
@@ -1818,6 +1875,20 @@
    | Pexp_while of expression * expression  (** [while E1 do E2 done] *)
    | Pexp_for of pattern * expression * expression * direction_flag * expression
 @@@@
+   | Pexp_pack of module_expr
+       (** [(module ME)].
+ 
+            [(module ME : S)] is represented as
+            [Pexp_constraint(Pexp_pack ME, Ptyp_package S)] *)
+-  | Pexp_open of open_declaration * expression
+-      (** - [M.(E)]
+-            - [let open M in E]
+-            - [let open! M in E] *)
++  | Pexp_open of Longident.t loc * expression  (** [M.(E)] *)
++  | Pexp_letopen of open_declaration * expression
++      (** - [let open M in E]
++          - [let open! M in E] *)
+   | Pexp_letop of letop
        (** - [let* P = E0 in E1]
              - [let* P0 = E00 and* P1 = E01 in E1] *)
    | Pexp_extension of extension  (** [[%id]] *)
@@ -2279,10 +2350,15 @@
    | Pexp_pack me ->
        line i ppf "Pexp_pack\n";
        module_expr i ppf me
-   | Pexp_open (o, e) ->
+-  | Pexp_open (o, e) ->
 -      line i ppf "Pexp_open %a\n" fmt_override_flag o.popen_override;
 -      module_expr i ppf o.popen_expr;
++  | Pexp_open (lid, e) ->
 +      line i ppf "Pexp_open\n";
++      longident_loc i ppf lid;
++      expression i ppf e
++  | Pexp_letopen (o, e) ->
++      line i ppf "Pexp_letopen\n";
 +      open_declaration i ppf o;
        expression i ppf e
    | Pexp_letop {let_; ands; body} ->

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -219,6 +219,7 @@ module Exp = struct
   let newtype ?loc ?attrs a b = mk ?loc ?attrs (Pexp_newtype (a, b))
   let pack ?loc ?attrs a = mk ?loc ?attrs (Pexp_pack a)
   let open_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_open (a, b))
+  let letopen ?loc ?attrs a b = mk ?loc ?attrs (Pexp_letopen (a, b))
   let letop ?loc ?attrs let_ ands body =
     mk ?loc ?attrs (Pexp_letop {let_; ands; body})
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pexp_extension a)

--- a/vendor/parser-extended/ast_helper.mli
+++ b/vendor/parser-extended/ast_helper.mli
@@ -188,7 +188,8 @@ module Exp:
     val object_: ?loc:loc -> ?attrs:attrs -> class_structure -> expression
     val newtype: ?loc:loc -> ?attrs:attrs -> str -> expression -> expression
     val pack: ?loc:loc -> ?attrs:attrs -> module_expr -> expression
-    val open_: ?loc:loc -> ?attrs:attrs -> open_declaration -> expression
+    val open_: ?loc:loc -> ?attrs:attrs -> lid -> expression -> expression
+    val letopen: ?loc:loc -> ?attrs:attrs -> open_declaration -> expression
                -> expression
     val letop: ?loc:loc -> ?attrs:attrs -> binding_op
                -> binding_op list -> expression -> expression

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -506,8 +506,9 @@ module E = struct
     | Pexp_newtype (s, e) ->
         newtype ~loc ~attrs (map_loc sub s) (sub.expr sub e)
     | Pexp_pack me -> pack ~loc ~attrs (sub.module_expr sub me)
-    | Pexp_open (o, e) ->
-        open_ ~loc ~attrs (sub.open_declaration sub o) (sub.expr sub e)
+    | Pexp_open (o, e) -> open_ ~loc ~attrs (map_loc sub o) (sub.expr sub e)
+    | Pexp_letopen (o, e) ->
+        letopen ~loc ~attrs (sub.open_declaration sub o) (sub.expr sub e)
     | Pexp_letop {let_; ands; body} ->
         letop ~loc ~attrs (sub.binding_op sub let_)
           (List.map (sub.binding_op sub) ands) (sub.expr sub body)

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -1564,9 +1564,7 @@ open_description:
 ;
 
 %inline open_dot_declaration: mkrhs(mod_longident)
-  { let loc = make_loc $loc($1) in
-    let me = Mod.ident ~loc $1 in
-    Opn.mk ~loc me }
+  { $1 }
 ;
 
 (* -------------------------------------------------------------------------- *)
@@ -2298,7 +2296,7 @@ expr:
   | LET OPEN override_flag ext_attributes module_expr IN seq_expr
       { let open_loc = make_loc ($startpos($2), $endpos($5)) in
         let od = Opn.mk $5 ~override:$3 ~loc:open_loc in
-        Pexp_open(od, $7), $4 }
+        Pexp_letopen(od, $7), $4 }
   | FUNCTION ext_attributes match_cases
       { Pexp_function $3, $2 }
   | FUN ext_attributes labeled_simple_pattern fun_def

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -422,10 +422,10 @@ and expression_desc =
 
            [(module ME : S)] is represented as
            [Pexp_constraint(Pexp_pack ME, Ptyp_package S)] *)
-  | Pexp_open of open_declaration * expression
-      (** - [M.(E)]
-            - [let open M in E]
-            - [let open! M in E] *)
+  | Pexp_open of Longident.t loc * expression  (** [M.(E)] *)
+  | Pexp_letopen of open_declaration * expression
+      (** - [let open M in E]
+          - [let open! M in E] *)
   | Pexp_letop of letop
       (** - [let* P = E0 in E1]
             - [let* P0 = E00 and* P1 = E01 in E1] *)

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -442,8 +442,12 @@ and expression i ppf x =
   | Pexp_pack me ->
       line i ppf "Pexp_pack\n";
       module_expr i ppf me
-  | Pexp_open (o, e) ->
+  | Pexp_open (lid, e) ->
       line i ppf "Pexp_open\n";
+      longident_loc i ppf lid;
+      expression i ppf e
+  | Pexp_letopen (o, e) ->
+      line i ppf "Pexp_letopen\n";
       open_declaration i ppf o;
       expression i ppf e
   | Pexp_letop {let_; ands; body} ->

--- a/vendor/parser-recovery/lib/parser.mly
+++ b/vendor/parser-recovery/lib/parser.mly
@@ -1565,9 +1565,7 @@ open_description:
 ;
 
 %inline open_dot_declaration: mkrhs(mod_longident)
-  { let loc = make_loc $loc($1) in
-    let me = Mod.ident ~loc $1 in
-    Opn.mk ~loc me }
+  { $1 }
 ;
 
 (* -------------------------------------------------------------------------- *)
@@ -2297,7 +2295,7 @@ expr [@recover.expr Annot.Exp.mk ()]:
   | LET OPEN override_flag ext_attributes module_expr IN seq_expr
       { let open_loc = make_loc ($startpos($2), $endpos($5)) in
         let od = Opn.mk $5 ~override:$3 ~loc:open_loc in
-        Pexp_open(od, $7), $4 }
+        Pexp_letopen(od, $7), $4 }
   | FUNCTION ext_attributes match_cases
       { Pexp_function $3, $2 }
   | FUN ext_attributes labeled_simple_pattern fun_def


### PR DESCRIPTION
Extracted from ocamlformat-ng's concrete AST, again the idea is to make the parser do more work (more PRs doing this in the future) and cleanup the formatter, and also Source.ml.

The goal of this change was splitting `Pexp_open` into `Pexp_letopen` and `Pexp_open`.
Rewriting the 2 cases made it easier to see that the `indicate-multiline-delimiters` option was not enforced here, it's fixed by calling the `Params.parens` like everywhere else.

The change only impacts the `ocamlformat` profile (`conventional` and `janestreet` don't have a space before the closing parenthesis).
