### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Preserve comments around object open/close flag (#2097, @trefis, @gpetiot)
 - Preserve comments around private/mutable/virtual keywords (#2098, @trefis, @gpetiot)
 - Closing parentheses of local open now comply with `indicate-multiline-delimiters` (#2116, @gpetiot)
+- emacs: fix byte-compile warnings (#2119, @syohex)
 
 ### Changes
 

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -47,7 +47,7 @@
 (require 'vc)
 
 (defcustom ocamlformat-command "ocamlformat"
-  "The 'ocamlformat' command."
+  "The `ocamlformat' command."
   :type 'string
   :group 'ocamlformat)
 
@@ -84,11 +84,11 @@ echo output if used from inside a `before-save-hook'."
 (defcustom ocamlformat-file-kind nil
   "Add a parse argument to ocamlformat if using an unrecognized extension.
 
-It can either be set to 'implementation, 'interface or
+It can either be set to \\='implementation, \\='interface or
 nil (default)."
   :type '(choice
-          (const :tag "implementation" 'implementation)
-          (const :tag "interface" 'interface)
+          (const :tag "implementation" implementation)
+          (const :tag "interface" interface)
           (const :tag "none" nil))
   :group 'ocamlformat)
 
@@ -96,7 +96,7 @@ nil (default)."
 (defun ocamlformat-before-save ()
   "Add this to .emacs to run ocamlformat on the current buffer when saving:
 
-\(add-hook 'before-save-hook 'ocamlformat-before-save)."
+\(add-hook \\='before-save-hook \\='ocamlformat-before-save)."
   (interactive)
   (when (eq major-mode 'tuareg-mode) (ocamlformat)))
 


### PR DESCRIPTION
- Use `...' instead of '...'
- Remove needless quotes from choice values
- Escape single quote in docstring

```
ocamlformat.el:49:2: Warning: custom-declare-variable `ocamlformat-command'
    docstring has wrong usage of unescaped single quotes (use \= or different
    quoting)
ocamlformat.el:84:2: Warning: custom-declare-variable `ocamlformat-file-kind'
    docstring has wrong usage of unescaped single quotes (use \= or different
    quoting)
ocamlformat.el:84:12: Warning: defcustom for ‘ocamlformat-file-kind’ has
    syntactically odd type ‘'(choice (const :tag implementation
    'implementation) (const :tag interface 'interface) (const :tag none nil))’

In ocamlformat-before-save:
ocamlformat.el:96:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)
```