### PR TITLE
ocamlformat 0.23.0 is not compatible with odoc-parser.2.0.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -63,7 +63,9 @@
     (= :version)))
   ocp-indent
   (odoc-parser
-   (>= 1.0.0))
+   (and
+    (>= 1.0.0)
+    (< 2.0.0)))
   (re
    (>= 1.7.2))
   stdio

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml-version" {>= "3.3.0"}
   "ocamlformat-rpc-lib" {with-test & post & = version}
   "ocp-indent"
-  "odoc-parser" {>= "1.0.0"}
+  "odoc-parser" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "stdio"
   "uuseg" {>= "10.0.0"}


### PR DESCRIPTION
Fix #2121 (also on opam-repo: https://github.com/ocaml/opam-repository/pull/21759)

I will make a new release to keep up with the last version of odoc-parser.