### PR TITLE
Tests: reset .ocamlformat using profile=default

### DIFF
--- a/test/cli/bad_kind.t
+++ b/test/cli/bad_kind.t
@@ -1,4 +1,4 @@
-  $ touch .ocamlformat
+  $ echo profile=default > .ocamlformat
 
   $ echo 'module X : S' > a.mli
 

--- a/test/cli/check.t
+++ b/test/cli/check.t
@@ -1,4 +1,4 @@
-  $ touch .ocamlformat
+  $ echo profile=default > .ocamlformat
 
   $ echo 'let x = 1' > a.ml
   $ ocamlformat --check a.ml

--- a/test/cli/debug.t
+++ b/test/cli/debug.t
@@ -1,4 +1,4 @@
-  $ touch .ocamlformat
+  $ echo profile=default > .ocamlformat
 
   $ cat > a.ml << EOF
   > (* Intentionally not formatted *)

--- a/test/cli/deprecated_option.t
+++ b/test/cli/deprecated_option.t
@@ -1,4 +1,4 @@
-  $ touch .ocamlformat
+  $ echo profile=default > .ocamlformat
 
   $ echo 'let x = y' > a.ml
 

--- a/test/cli/large_string.t
+++ b/test/cli/large_string.t
@@ -1,4 +1,4 @@
-  $ touch .ocamlformat
+  $ echo profile=default > .ocamlformat
 
   $ echo "let _ = \"$(printf '%*s' 300000 | sed 's/ /_ _/g')\"" > a.ml
 

--- a/test/cli/max_iters.t
+++ b/test/cli/max_iters.t
@@ -1,4 +1,4 @@
-  $ touch .ocamlformat
+  $ echo profile=default > .ocamlformat
 
   $ echo 'let x = 1' > a.ml
   $ ocamlformat --max-iters=1 a.ml

--- a/test/cli/name.t
+++ b/test/cli/name.t
@@ -1,4 +1,4 @@
-  $ touch .ocamlformat
+  $ echo profile=default > .ocamlformat
 
   $ echo 'let x =     1' > a.ml
   $ ocamlformat --name a.cpp a.ml

--- a/test/cli/repl_file_errors.t/run.t
+++ b/test/cli/repl_file_errors.t/run.t
@@ -1,4 +1,4 @@
-  $ touch .ocamlformat
+  $ echo profile=default > .ocamlformat
 
 Make sure the locations of errors in repl files are right.
 
@@ -27,5 +27,5 @@ Make sure the locations of errors in repl files are right.
   [1]
 
   $ ocamlformat --repl-file empty_line_begin.repl
-  # foo bar ;;
+  # foo bar;;
   - : 0

--- a/test/cli/stdin.t
+++ b/test/cli/stdin.t
@@ -1,4 +1,4 @@
-  $ touch .ocamlformat
+  $ echo profile=default > .ocamlformat
 
 One of '--impl', '--intf' or '--name' is required when the input is read from stdin:
 


### PR DESCRIPTION
Dune 2 and dune 3 implement cram tests slightly differently. In dune 3, a `.git` directory is added so that executables that rely on git work properly.

Without this (in dune 2), ocamlformat walks up the directory structure and applies 2 files: the `.ocamlformat` file at the project root (the one used for ocamlformat itself) and the empty ones that are touched in each cram test. Merging this is equivalent to the exterior one.

In dune 3, only the empty one is used. This makes a difference in the `repl_file_errors.t` test.

The dune 3 behavior is the intended one. This commit fixes the "reset" strategy to use instead `profile=default` (which will properly override the external file) and makes the test suite compatible with dune 2 and dune 3.
