### PR TITLE
Fix indentation when ocamlformat is disabled on an expression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-- Preserve linebreaks when ocamlformat is disabled (#2129, @gpetiot)
+- Fix indentation when ocamlformat is disabled on an expression (#2129, @gpetiot)
 
 ## 0.24.1 (2022-07-18)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-- Preserve linebreaks when ocamlformat is disabled (#<PR_NUMBER>, @gpetiot)
+- Preserve linebreaks when ocamlformat is disabled (#2129, @gpetiot)
 
 ## 0.24.1 (2022-07-18)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## (unreleased)
+
+### Bug fixes
+
+- Preserve linebreaks when ocamlformat is disabled (#<PR_NUMBER>, @gpetiot)
+
 ## 0.24.1 (2022-07-18)
 
 ### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -166,29 +166,13 @@ let closing_paren ?force ?(offset = 0) c =
   | `Space -> fits_breaks ")" " )" ?force
   | `Closing_on_separate_line -> fits_breaks ")" ")" ~hint:(1000, offset)
 
-let drop_while ~f s =
-  let i = ref 0 in
-  while !i < String.length s && f !i s.[!i] do
-    Int.incr i
-  done ;
-  String.sub s ~pos:!i ~len:(String.length s - !i)
-
 let maybe_disabled_k c (loc : Location.t) (l : attributes) f k =
   if not c.conf.opr_opts.disable then f c
   else
     let loc = Source.extend_loc_to_include_attributes loc l in
     Cmts.drop_inside c.cmts loc ;
     let s = Source.string_at c.source loc in
-    let indent_of_first_line = Position.column loc.loc_start in
-    let l = String.split ~on:'\n' s in
-    let l =
-      List.mapi l ~f:(fun i s ->
-          if i = 0 then s
-          else
-            drop_while s ~f:(fun i c ->
-                Char.is_whitespace c && i < indent_of_first_line ) )
-    in
-    k (Cmts.fmt c loc (list l "@\n" str))
+    k (Cmts.fmt c loc (str s))
 
 let maybe_disabled c loc l f = maybe_disabled_k c loc l f Fn.id
 

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1245,6 +1245,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to disabled_attr.ml.stdout
+   (with-stderr-to disabled_attr.ml.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/disabled_attr.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/disabled_attr.ml disabled_attr.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/disabled_attr.ml.err disabled_attr.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to disambiguate.ml.stdout
    (with-stderr-to disambiguate.ml.stderr
      (run %{bin:ocamlformat} --margin-check %{dep:tests/disambiguate.ml})))))

--- a/test/passing/tests/disabled_attr.ml
+++ b/test/passing/tests/disabled_attr.ml
@@ -1,0 +1,21 @@
+let _ =
+  let disabled = {|
+  |}[@ocamlformat "disable"] in
+  ()
+
+let _ =
+  let disabled = "
+  "[@ocamlformat "disable"] in
+  ()
+
+let _ =
+  let disabled =
+    begin
+      (* xxx
+
+         xxx *)
+
+      y
+    end[@ocamlformat "disable"]
+  in
+  ()


### PR DESCRIPTION
Fix #2128 

The code I removed originated from https://github.com/ocaml-ppx/ocamlformat/commit/b86d6b78b2cb22127cee75b69ddea26de6dfb74d but the test introduced back then (test/passing/tests/skip.ml) is still passing.