### PR TITLE
Preserve syntax of generative modules '(struct end)' vs '()'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 ### Changes
 
 - Indent 2 columns after `initializer` keyword (#2145, @gpetiot)
-- Preserve syntax of generative  modules (`(struct end)` vs `()`) and preserve comments position inside `()` (#PR_NUMBER, @gpetiot)
+- Preserve syntax of generative modules (`(struct end)` vs `()`) and preserve comments position inside the `()` argument (#2135, @trefis, @gpetiot)
 
 ## 0.24.1 (2022-07-18)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ### Changes
 
 - Indent 2 columns after `initializer` keyword (#2145, @gpetiot)
+- Preserve syntax of generative  modules (`(struct end)` vs `()`) and preserve comments position inside `()` (#PR_NUMBER, @gpetiot)
 
 ## 0.24.1 (2022-07-18)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 ### Changes
 
 - Indent 2 columns after `initializer` keyword (#2145, @gpetiot)
-- Preserve syntax of generative modules (`(struct end)` vs `()`) and preserve comments position inside the `()` argument (#2135, @trefis, @gpetiot)
+- Preserve syntax of generative modules (`(struct end)` vs `()`) (#2135, @trefis, @gpetiot)
 
 ## 0.24.1 (2022-07-18)
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -436,6 +436,7 @@ and mod_is_simple x =
   | Pmod_structure (_ :: _) | Pmod_extension _ | Pmod_functor (_, _) -> false
   | Pmod_constraint (e, t) -> mod_is_simple e && mty_is_simple t
   | Pmod_apply (a, b) -> mod_is_simple a && mod_is_simple b
+  | Pmod_gen_apply (a, _) -> mod_is_simple a
 
 module Mty = struct
   let is_simple = mty_is_simple
@@ -528,7 +529,8 @@ module Structure_item = struct
           let rec is_simple_mod me =
             match me.pmod_desc with
             | Pmod_apply (me1, me2) -> is_simple_mod me1 && is_simple_mod me2
-            | Pmod_functor (_, me) -> is_simple_mod me
+            | Pmod_functor (_, me) | Pmod_gen_apply (me, _) ->
+                is_simple_mod me
             | Pmod_ident i -> Longident.is_simple c i.txt
             | _ -> false
           in
@@ -1965,6 +1967,7 @@ end = struct
     | Mod {pmod_desc= Pmod_apply (_, x); _}, Pmod_functor _ when m == x ->
         false
     | Mod {pmod_desc= Pmod_apply _; _}, Pmod_functor _ -> true
+    | Mod {pmod_desc= Pmod_gen_apply _; _}, Pmod_functor _ -> true
     | _ -> false
 
   (** [parenze_pat {ctx; ast}] holds when pattern [ast] should be

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3898,52 +3898,50 @@ and fmt_with_constraint c ctx ~pre = function
       $ fmt_module c ~eqty:":=" "module type" m1 [] None ~rec_flag:false m2
           []
 
-and fmt_mod_apply c ctx loc attrs ~parens ~can_break_before_struct me_f arg =
-  match (me_f.pmod_desc, arg) with
-  | Pmod_ident _, `Unit x ->
-      { empty with
-        bdy=
-          Cmts.fmt c loc
-            ( hvbox 2
-                ( compose_module
-                    (fmt_module_expr c (sub_mod ~ctx me_f))
-                    ~f:Fn.id
-                $ break 1 0 $ x )
-            $ fmt_attributes_and_docstrings c attrs ) }
-  | Pmod_ident _, `Block (blk_a, arg_is_simple) ->
-      let fmt_rator =
-        let break_struct =
-          c.conf.fmt_opts.break_struct && can_break_before_struct
-          && not arg_is_simple
+and fmt_mod_apply c ctx loc attrs ~parens ~dock_struct me_f arg =
+  match me_f.pmod_desc with
+  | Pmod_ident _ -> (
+    match arg with
+    | `Unit x ->
+        { empty with
+          bdy=
+            Cmts.fmt c loc
+              ( hvbox 2
+                  ( compose_module
+                      (fmt_module_expr c (sub_mod ~ctx me_f))
+                      ~f:Fn.id
+                  $ break 1 0 $ x )
+              $ fmt_attributes_and_docstrings c attrs ) }
+    | `Block (blk_a, arg_is_simple) ->
+        let fmt_rator =
+          let break_struct =
+            c.conf.fmt_opts.break_struct && (not dock_struct)
+            && not arg_is_simple
+          in
+          compose_module (fmt_module_expr c (sub_mod ~ctx me_f)) ~f:Fn.id
+          $ break (if break_struct then 1000 else 1) 0
+          $ str "("
         in
-        compose_module (fmt_module_expr c (sub_mod ~ctx me_f)) ~f:Fn.id
-        $ break (if break_struct then 1000 else 1) 0
-        $ str "("
-      in
-      let epi =
-        fmt_opt blk_a.epi $ str ")"
-        $ fmt_attributes_and_docstrings c attrs
-        $ Cmts.fmt_after c loc
-      in
-      if Option.is_some blk_a.pro then
-        { blk_a with
-          pro=
-            Some
-              (Cmts.fmt_before c loc $ hvbox 2 fmt_rator $ fmt_opt blk_a.pro)
-        ; epi= Some epi }
-      else
-        { blk_a with
-          opn= open_hvbox 2 $ blk_a.opn
-        ; bdy= Cmts.fmt_before c loc $ open_hvbox 2 $ fmt_rator $ blk_a.bdy
-        ; cls= close_box $ blk_a.cls $ close_box
-        ; epi= Some epi }
+        let epi =
+          fmt_opt blk_a.epi $ str ")"
+          $ fmt_attributes_and_docstrings c attrs
+          $ Cmts.fmt_after c loc
+        in
+        if Option.is_some blk_a.pro then
+          { blk_a with
+            pro=
+              Some
+                ( Cmts.fmt_before c loc $ hvbox 2 fmt_rator
+                $ fmt_opt blk_a.pro )
+          ; epi= Some epi }
+        else
+          { blk_a with
+            opn= open_hvbox 2 $ blk_a.opn
+          ; bdy= Cmts.fmt_before c loc $ open_hvbox 2 $ fmt_rator $ blk_a.bdy
+          ; cls= close_box $ blk_a.cls $ close_box
+          ; epi= Some epi } )
   | _ ->
-      let can_break_before_struct =
-        match me_f.pmod_desc with Pmod_apply _ -> true | _ -> false
-      in
-      let blk_f =
-        fmt_module_expr ~can_break_before_struct c (sub_mod ~ctx me_f)
-      in
+      let blk_f = fmt_module_expr ~dock_struct:false c (sub_mod ~ctx me_f) in
       let has_epi = Cmts.has_after c.cmts loc || not (List.is_empty attrs) in
       { empty with
         opn= blk_f.opn $ open_hvbox 2
@@ -3962,8 +3960,7 @@ and fmt_mod_apply c ctx loc attrs ~parens ~can_break_before_struct me_f arg =
           Option.some_if has_epi
             (Cmts.fmt_after c loc $ fmt_attributes_and_docstrings c attrs) }
 
-and fmt_module_expr ?(can_break_before_struct = false) c ({ast= m; _} as xmod)
-    =
+and fmt_module_expr ?(dock_struct = true) c ({ast= m; _} as xmod) =
   let ctx = Mod m in
   let {pmod_desc; pmod_loc; pmod_attributes} = m in
   update_config_maybe_disabled_block c pmod_loc pmod_attributes
@@ -3972,18 +3969,17 @@ and fmt_module_expr ?(can_break_before_struct = false) c ({ast= m; _} as xmod)
   match pmod_desc with
   | Pmod_gen_apply (me, loc) ->
       let arg = Cmts.fmt c loc @@ wrap "(" ")" @@ Cmts.fmt_within c loc in
-      fmt_mod_apply c ctx ~parens ~can_break_before_struct pmod_loc
-        pmod_attributes me (`Unit arg)
+      fmt_mod_apply c ctx ~parens ~dock_struct pmod_loc pmod_attributes me
+        (`Unit arg)
   | Pmod_apply (me_f, me_a) ->
-      let can_break_before_struct =
+      let dock_struct =
         match me_f.pmod_desc with
-        | Pmod_apply _ -> true
-        | Pmod_ident _ -> can_break_before_struct
-        | _ -> false
+        | Pmod_apply _ -> false
+        | Pmod_ident _ -> dock_struct
+        | _ -> true
       in
       let blk_a = fmt_module_expr c (sub_mod ~ctx me_a) in
-      fmt_mod_apply c ctx ~parens ~can_break_before_struct pmod_loc
-        pmod_attributes me_f
+      fmt_mod_apply c ctx ~parens ~dock_struct pmod_loc pmod_attributes me_f
         (`Block (blk_a, Mod.is_simple me_a))
   | Pmod_constraint (me, mt) ->
       let blk_e = fmt_module_expr c (sub_mod ~ctx me) in

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2289,7 +2289,9 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         | _ -> (xbody, None)
       in
       let can_sparse =
-        match xbody.ast.pmod_desc with Pmod_apply _ -> true | _ -> false
+        match xbody.ast.pmod_desc with
+        | Pmod_apply _ | Pmod_gen_apply _ -> true
+        | _ -> false
       in
       hvbox 0
         ( Params.parens_if

--- a/test/passing/tests/generative.ml
+++ b/test/passing/tests/generative.ml
@@ -1,5 +1,4 @@
 module Generative () = struct end
 
 module M = Generative ()
-
 module M = String_id (M) ()

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -5343,7 +5343,7 @@ let g x =
 ;;
 
 module F (X : sig end) = Char
-module C4 = F ();;
+module C4 = F (struct end);;
 
 C4.chr 66
 
@@ -5352,7 +5352,7 @@ module G (X : sig end) = struct
 end
 
 (* does not alias X *)
-module M = G ()
+module M = G (struct end)
 
 module M' = struct
   module N = struct
@@ -5430,7 +5430,7 @@ module G : functor (X : sig end) -> sig
 end =
   F
 
-module M5 = G ();;
+module M5 = G (struct end);;
 
 M5.N'.x
 
@@ -5982,7 +5982,7 @@ module H () = F ()
 
 (* Alias *)
 module U = struct end
-module M = F ()
+module M = F (struct end)
 
 (* ok *)
 module M = F (U)
@@ -6534,7 +6534,7 @@ module Make (Unit : sig end) : Priv = struct
   type t = int
 end
 
-module A = Make ()
+module A = Make (struct end)
 
 module type Priv' = sig
   type t = private [> `A ]
@@ -6544,7 +6544,7 @@ module Make' (Unit : sig end) : Priv' = struct
   type t = [ `A ]
 end
 
-module A' = Make' ()
+module A' = Make' (struct end)
 (* PR5057 *)
 
 module TT = struct
@@ -9325,7 +9325,7 @@ type foo += private A of int
 let f : 'a 'b 'c. < .. > = assert false
 
 let () =
-  let module M = (functor (T : sig end) -> struct end) () in
+  let module M = (functor (T : sig end) -> struct end) (struct end) in
   ()
 ;;
 

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -5343,7 +5343,7 @@ let g x =
 ;;
 
 module F (X : sig end) = Char
-module C4 = F ();;
+module C4 = F (struct end);;
 
 C4.chr 66
 
@@ -5352,7 +5352,7 @@ module G (X : sig end) = struct
 end
 
 (* does not alias X *)
-module M = G ()
+module M = G (struct end)
 
 module M' = struct
   module N = struct
@@ -5430,7 +5430,7 @@ module G : functor (X : sig end) -> sig
 end =
   F
 
-module M5 = G ();;
+module M5 = G (struct end);;
 
 M5.N'.x
 
@@ -5982,7 +5982,7 @@ module H () = F ()
 
 (* Alias *)
 module U = struct end
-module M = F ()
+module M = F (struct end)
 
 (* ok *)
 module M = F (U)
@@ -6534,7 +6534,7 @@ module Make (Unit : sig end) : Priv = struct
   type t = int
 end
 
-module A = Make ()
+module A = Make (struct end)
 
 module type Priv' = sig
   type t = private [> `A ]
@@ -6544,7 +6544,7 @@ module Make' (Unit : sig end) : Priv' = struct
   type t = [ `A ]
 end
 
-module A' = Make' ()
+module A' = Make' (struct end)
 (* PR5057 *)
 
 module TT = struct
@@ -9325,7 +9325,7 @@ type foo += private A of int
 let f : 'a 'b 'c. < .. > = assert false
 
 let () =
-  let module M = (functor (T : sig end) -> struct end) () in
+  let module M = (functor (T : sig end) -> struct end) (struct end) in
   ()
 ;;
 

--- a/test/passing/tests/module.ml
+++ b/test/passing/tests/module.ml
@@ -77,3 +77,24 @@ module GZ : functor (X : sig end) () (Z : sig end) -> sig end =
 
 module GZZZZZZZZZZZZZZ : functor (X : sig end) () (Z : sig end) -> sig end =
   _
+
+module M = struct end
+
+module M = F ()
+module M = F (* xxx *) ( (* xxx *) ) (* xxx *)
+
+module M = F (struct end)
+
+module M = F (G) ()
+module M = F (G) ( (* xxx *) )
+
+module M = F (G) (struct end)
+
+module M =
+  F
+    (struct
+      val x : t
+
+      val y : t
+    end)
+    ()

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -5095,7 +5095,7 @@ let g x =
 
 module F (X : sig end) = Char
 
-module C4 = F () ;;
+module C4 = F (struct end) ;;
 
 C4.chr 66
 
@@ -5104,7 +5104,7 @@ module G (X : sig end) = struct
 end
 
 (* does not alias X *)
-module M = G ()
+module M = G (struct end)
 
 module M' = struct
   module N = struct
@@ -5182,7 +5182,7 @@ module G : functor (X : sig end) -> sig
 end =
   F
 
-module M5 = G () ;;
+module M5 = G (struct end) ;;
 
 M5.N'.x
 
@@ -5743,7 +5743,7 @@ module H () = F ()
 (* Alias *)
 module U = struct end
 
-module M = F ()
+module M = F (struct end)
 
 (* ok *)
 module M = F (U)
@@ -6325,7 +6325,7 @@ module Make (Unit : sig end) : Priv = struct
   type t = int
 end
 
-module A = Make ()
+module A = Make (struct end)
 
 module type Priv' = sig
   type t = private [> `A]
@@ -6335,7 +6335,7 @@ module Make' (Unit : sig end) : Priv' = struct
   type t = [`A]
 end
 
-module A' = Make' ()
+module A' = Make' (struct end)
 (* PR5057 *)
 
 module TT = struct
@@ -8942,7 +8942,7 @@ type foo += private A of int
 let f : 'a 'b 'c. < .. > = assert false
 
 let () =
-  let module M = (functor (T : sig end) -> struct end) () in
+  let module M = (functor (T : sig end) -> struct end) (struct end) in
   ()
 
 class c =

--- a/vendor/diff-parsers-std-ext.patch
+++ b/vendor/diff-parsers-std-ext.patch
@@ -116,6 +116,18 @@
       pc_lhs = lhs;
       pc_guard = guard;
 @@@@
+   let functor_ ?loc ?attrs arg body =
+     mk ?loc ?attrs (Pmod_functor (arg, body))
+   let apply ?loc ?attrs m1 m2 = mk ?loc ?attrs (Pmod_apply (m1, m2))
+   let constraint_ ?loc ?attrs m mty = mk ?loc ?attrs (Pmod_constraint (m, mty))
+   let unpack ?loc ?attrs e = mk ?loc ?attrs (Pmod_unpack e)
++  let gen_apply ?loc ?attrs a b = mk ?loc ?attrs (Pmod_gen_apply (a, b))
+   let extension ?loc ?attrs a = mk ?loc ?attrs (Pmod_extension a)
+   let hole ?loc ?attrs () = mk ?loc ?attrs Pmod_hole
+ end
+ 
+ module Sig = struct
+@@@@
      }
    let attr d a = {d with pcty_attributes = d.pcty_attributes @ [a]}
  
@@ -282,6 +294,18 @@
      val mk_exception: ?loc:loc -> ?attrs:attrs -> ?docs:docs ->
        extension_constructor -> type_exception
  
+@@@@
+     val apply: ?loc:loc -> ?attrs:attrs -> module_expr -> module_expr ->
+       module_expr
+     val constraint_: ?loc:loc -> ?attrs:attrs -> module_expr -> module_type ->
+       module_expr
+     val unpack: ?loc:loc -> ?attrs:attrs -> expression -> module_expr
++    val gen_apply: ?loc:loc -> ?attrs:attrs -> module_expr -> loc -> module_expr
+     val extension: ?loc:loc -> ?attrs:attrs -> extension -> module_expr
+     val hole: ?loc:loc -> ?attrs:attrs -> unit -> module_expr
+   end
+ 
+ (** Signature items *)
 @@@@
      val mk: ?loc:loc -> ?attrs:attrs -> class_type_desc -> class_type
      val attr: class_type -> attribute -> class_type
@@ -518,6 +542,19 @@
      | Pctf_attribute x -> attribute ~loc (sub.attribute sub x)
      | Pctf_extension x -> extension ~loc ~attrs (sub.extension sub x)
  
+@@@@
+         apply ~loc ~attrs (sub.module_expr sub m1) (sub.module_expr sub m2)
+     | Pmod_constraint (m, mty) ->
+         constraint_ ~loc ~attrs (sub.module_expr sub m)
+                     (sub.module_type sub mty)
+     | Pmod_unpack e -> unpack ~loc ~attrs (sub.expr sub e)
++    | Pmod_gen_apply (me, lc) ->
++        gen_apply ~loc ~attrs (sub.module_expr sub me) (sub.location sub lc)
+     | Pmod_extension x -> extension ~loc ~attrs (sub.extension sub x)
+     | Pmod_hole -> hole ~loc ~attrs ()
+ 
+   let map_structure_item sub {pstr_loc = loc; pstr_desc = desc} =
+     let open Str in
 @@@@
          field ~loc ~attrs (sub.expr sub e) (map_loc sub lid)
      | Pexp_setfield (e1, lid, e2) ->
@@ -1301,6 +1338,23 @@
    tail = listx(delimiter, X, Y)
      { let xs, y = tail in
 @@@@
+       x = mkrhs(mod_longident)
+         { Pmod_ident x }
+     | (* In a functor application, the actual argument must be parenthesized. *)
+       me1 = module_expr me2 = paren_module_expr
+         { Pmod_apply(me1, me2) }
+-    | (* Application to unit is sugar for application to an empty structure. *)
+-      me1 = module_expr LPAREN RPAREN
+-        { (* TODO review mkmod location *)
+-          Pmod_apply(me1, mkmod ~loc:$sloc (Pmod_structure [])) }
++    | me = module_expr LPAREN RPAREN
++        { Pmod_gen_apply (me, make_loc ($startpos($2), $endpos($3))) }
+     | (* An extension. *)
+       ex = extension
+         { Pmod_extension ex }
+     | (* A hole. *)
+       UNDERSCORE
+@@@@
      Opn.mk id ~override ~attrs ~loc ~docs, ext
    }
  ;
@@ -1996,6 +2050,18 @@
                          ([T] can be a {{!core_type_desc.Ptyp_poly}[Ptyp_poly]})
    *)
 @@@@
+   | Pmod_functor of functor_parameter * module_expr
+       (** [functor(X : MT1) -> ME] *)
+   | Pmod_apply of module_expr * module_expr  (** [ME1(ME2)] *)
+   | Pmod_constraint of module_expr * module_type  (** [(ME : MT)] *)
+   | Pmod_unpack of expression  (** [(val E)] *)
++  | Pmod_gen_apply of module_expr * Location.t  (** [ME()] *)
+   | Pmod_extension of extension  (** [[%id]] *)
+   | Pmod_hole  (** [_] *)
+ 
+ and structure = structure_item list
+ 
+@@@@
  and directive_argument_desc =
    | Pdir_string of string
    | Pdir_int of string * char option
@@ -2625,10 +2691,15 @@
        attribute i ppf "Psig_attribute" a
  
 @@@@
+       module_expr i ppf me;
        module_type i ppf mt;
    | Pmod_unpack (e) ->
        line i ppf "Pmod_unpack\n";
        expression i ppf e;
++  | Pmod_gen_apply (x, loc) ->
++      line i ppf "Pmod_gen_apply\n";
++      module_expr i ppf x;
++      line (i+1) ppf "() %a" fmt_location loc
    | Pmod_extension (s, arg) ->
 -      line i ppf "Pmod_extension \"%s\"\n" s.txt;
 +      line i ppf "Pmod_extension %a\n" fmt_string_loc s;

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -270,6 +270,7 @@ let mk ?(loc = !default_loc) ?(attrs = []) d =
   let apply ?loc ?attrs m1 m2 = mk ?loc ?attrs (Pmod_apply (m1, m2))
   let constraint_ ?loc ?attrs m mty = mk ?loc ?attrs (Pmod_constraint (m, mty))
   let unpack ?loc ?attrs e = mk ?loc ?attrs (Pmod_unpack e)
+  let gen_apply ?loc ?attrs a b = mk ?loc ?attrs (Pmod_gen_apply (a, b))
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pmod_extension a)
   let hole ?loc ?attrs () = mk ?loc ?attrs Pmod_hole
 end

--- a/vendor/parser-extended/ast_helper.mli
+++ b/vendor/parser-extended/ast_helper.mli
@@ -282,6 +282,7 @@ module Mod:
     val constraint_: ?loc:loc -> ?attrs:attrs -> module_expr -> module_type ->
       module_expr
     val unpack: ?loc:loc -> ?attrs:attrs -> expression -> module_expr
+    val gen_apply: ?loc:loc -> ?attrs:attrs -> module_expr -> loc -> module_expr
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> module_expr
     val hole: ?loc:loc -> ?attrs:attrs -> unit -> module_expr
   end

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -402,6 +402,8 @@ module M = struct
         constraint_ ~loc ~attrs (sub.module_expr sub m)
                     (sub.module_type sub mty)
     | Pmod_unpack e -> unpack ~loc ~attrs (sub.expr sub e)
+    | Pmod_gen_apply (me, lc) ->
+        gen_apply ~loc ~attrs (sub.module_expr sub me) (sub.location sub lc)
     | Pmod_extension x -> extension ~loc ~attrs (sub.extension sub x)
     | Pmod_hole -> hole ~loc ~attrs ()
 

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -1299,10 +1299,8 @@ module_expr:
     | (* In a functor application, the actual argument must be parenthesized. *)
       me1 = module_expr me2 = paren_module_expr
         { Pmod_apply(me1, me2) }
-    | (* Application to unit is sugar for application to an empty structure. *)
-      me1 = module_expr LPAREN RPAREN
-        { (* TODO review mkmod location *)
-          Pmod_apply(me1, mkmod ~loc:$sloc (Pmod_structure [])) }
+    | me = module_expr LPAREN RPAREN
+        { Pmod_gen_apply (me, make_loc ($startpos($2), $endpos($3))) }
     | (* An extension. *)
       ex = extension
         { Pmod_extension ex }

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -981,6 +981,7 @@ and module_expr_desc =
   | Pmod_apply of module_expr * module_expr  (** [ME1(ME2)] *)
   | Pmod_constraint of module_expr * module_type  (** [(ME : MT)] *)
   | Pmod_unpack of expression  (** [(val E)] *)
+  | Pmod_gen_apply of module_expr * Location.t  (** [ME()] *)
   | Pmod_extension of extension  (** [[%id]] *)
   | Pmod_hole  (** [_] *)
 

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -876,6 +876,10 @@ and module_expr i ppf x =
   | Pmod_unpack (e) ->
       line i ppf "Pmod_unpack\n";
       expression i ppf e;
+  | Pmod_gen_apply (x, loc) ->
+      line i ppf "Pmod_gen_apply\n";
+      module_expr i ppf x;
+      line (i+1) ppf "() %a" fmt_location loc
   | Pmod_extension (s, arg) ->
       line i ppf "Pmod_extension %a\n" fmt_string_loc s;
       payload i ppf arg

--- a/vendor/parser-recovery/lib/parser.mly
+++ b/vendor/parser-recovery/lib/parser.mly
@@ -1284,10 +1284,8 @@ module_expr [@recover.expr Annot.Mod.mk ()]:
     | (* In a functor application, the actual argument must be parenthesized. *)
       me1 = module_expr me2 = paren_module_expr
         { Pmod_apply(me1, me2) }
-    | (* Application to unit is sugar for application to an empty structure. *)
-      me1 = module_expr LPAREN RPAREN
-        { (* TODO review mkmod location *)
-          Pmod_apply(me1, mkmod ~loc:$sloc (Pmod_structure [])) }
+    | me = module_expr LPAREN RPAREN
+        { Pmod_gen_apply (me, make_loc ($startpos($2), $endpos($3))) }
     | (* An extension. *)
       ex = extension
         { Pmod_extension ex }


### PR DESCRIPTION
Extracted from ocamlformat-ng's concrete AST

PS: preserving this syntax (and not removing/adding keywords) makes the formatting of comments easier.