### PR TITLE
Add missing parens around immediate objects having attributes attached in 4.14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Fix indentation when ocamlformat is disabled on an expression (#2129, @gpetiot)
 - Reset max-indent when the `max-indent` option is not set (#2131, @hhugo, @gpetiot)
+- Add missing parentheses around immediate objects having attributes attached in 4.14 (#<PR_NUMBER>, @gpetiot)
 
 ## 0.24.1 (2022-07-18)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 - Fix indentation when ocamlformat is disabled on an expression (#2129, @gpetiot)
 - Reset max-indent when the `max-indent` option is not set (#2131, @hhugo, @gpetiot)
-- Add missing parentheses around immediate objects having attributes attached in 4.14 (#<PR_NUMBER>, @gpetiot)
+- Add missing parentheses around immediate objects having attributes attached in 4.14 (#2144, @gpetiot)
 
 ## 0.24.1 (2022-07-18)
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2303,7 +2303,7 @@ end = struct
         false
     (* Object fields do not require parens, even with trailing attributes *)
     | Exp {pexp_desc= Pexp_object _; _}, _ -> false
-    | _, {pexp_desc= Pexp_object _; _}
+    | _, {pexp_desc= Pexp_object _; pexp_attributes= []; _}
       when Ocaml_version.(compare !ocaml_version Releases.v4_14 >= 0) ->
         false
     | ( Exp {pexp_desc= Pexp_construct ({txt= id; _}, _); _}

--- a/test/passing/tests/object_expr-414.ml.ref
+++ b/test/passing/tests/object_expr-414.ml.ref
@@ -14,3 +14,10 @@ ignore
   object
     method one = 1
   end
+
+let () =
+  f
+    (object
+       method m x = x
+    end
+    [@xxx] )

--- a/test/passing/tests/object_expr.ml
+++ b/test/passing/tests/object_expr.ml
@@ -1,3 +1,5 @@
 object method one = 1 end # one;;
 Some object method one = 1 end;;
 ignore object method one = 1 end;;
+
+let () = f (object method m x = x end [@xxx])

--- a/test/passing/tests/object_expr.ml.ref
+++ b/test/passing/tests/object_expr.ml.ref
@@ -14,3 +14,10 @@ ignore
   (object
      method one = 1
   end )
+
+let () =
+  f
+    (object
+       method m x = x
+    end
+    [@xxx] )


### PR DESCRIPTION
Fix #2142 