### PR TITLE
Improve formatting of odoc links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
   + Break sequences containing indexop-access assignments
   + Remove unnecessary parentheses around indices
 - Mute warnings for odoc code blocks whose syntax is not specified (#2151, @gpetiot)
+- Improve formatting of odoc links (#<PR_NUMBER>, @gpetiot)
 
 ### New features
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
   + Break sequences containing indexop-access assignments
   + Remove unnecessary parentheses around indices
 - Mute warnings for odoc code blocks whose syntax is not specified (#2151, @gpetiot)
-- Improve formatting of odoc links (#<PR_NUMBER>, @gpetiot)
+- Improve formatting of odoc links (#2152, @gpetiot)
 
 ### New features
 

--- a/lib-rpc/ocamlformat_rpc_lib.mli
+++ b/lib-rpc/ocamlformat_rpc_lib.mli
@@ -128,7 +128,7 @@ end
 
 (** For a basic working example, see:
     {{:https://github.com/ocaml-ppx/ocamlformat/blob/93a6b2f46cf31237c413c1d0ac604a8d69676297/test/rpc/rpc_test.ml}
-    test/rpc/rpc_test.ml}. *)
+      test/rpc/rpc_test.ml}. *)
 
 (** Disclaimer:
 

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -205,7 +205,7 @@ let rec fmt_inline_elements elements =
         wrap_elements "{" "}" ~always_wrap:false rf txt $ aux t
     | `Link (url, txt) :: t ->
         let url = wrap "{:" "}" (str_normalized url) in
-        wrap_elements "{" "}" ~always_wrap:false url txt $ aux t
+        hovbox 2 @@ wrap_elements "{" "}" ~always_wrap:false url txt $ aux t
   in
   aux (List.map elements ~f:(ign_loc ~f:Fn.id))
 


### PR DESCRIPTION
See https://github.com/ocaml-ppx/ocamlformat/pull/2008/files#r962587979