### PR TITLE
Replace `_ ref` by `() -> _` to access Cmdliner options in conf

### DIFF
--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -222,7 +222,7 @@ module Make (C : CONFIG) = struct
     let parse = Arg.conv_parser Arg.bool in
     let r = mk ~default:None term in
     let to_string = Bool.to_string in
-    let cmdline_get () = !r in
+    let cmdline_get = r in
     let opt =
       { names
       ; values= Bool
@@ -254,7 +254,7 @@ module Make (C : CONFIG) = struct
     let parse = Arg.conv_parser converter in
     let r = mk ~default:None term in
     let to_string = Format.asprintf "%a%!" (Arg.conv_printer converter) in
-    let cmdline_get () = !r in
+    let cmdline_get = r in
     let opt =
       { names
       ; values
@@ -379,7 +379,7 @@ module Make (C : CONFIG) = struct
     in
     let r = mk ~default:None term in
     let to_string _ = "" in
-    let cmdline_get () = !r in
+    let cmdline_get = r in
     let opt =
       { names
       ; values= Choice []

--- a/vendor/ocamlformat-stdlib/cmdliner_ext.ml
+++ b/vendor/ocamlformat-stdlib/cmdliner_ext.ml
@@ -22,7 +22,7 @@ let mk ~default arg =
   let var = ref default in
   let set x = var := x in
   args := Arg (arg, set) :: !args ;
-  var
+  (fun () -> !var)
 
 let parse info validate =
   Cmd.eval_value (Cmd.v info (Term.(ret (const validate $ tuple !args))))

--- a/vendor/ocamlformat-stdlib/cmdliner_ext.mli
+++ b/vendor/ocamlformat-stdlib/cmdliner_ext.mli
@@ -2,7 +2,7 @@
 
 include module type of struct include Cmdliner end
 
-val mk : default:'a -> 'a Term.t -> 'a ref
+val mk : default:'a -> 'a Term.t -> (unit -> 'a)
 (** [mk ~default term] is a ref which, after [parse] is called, contains
     the value of the command line option specified by [term]. *)
 


### PR DESCRIPTION
Remove export of references by the `mk` function. Now you get a `unit -> 'a` that can be viewed as a read-only reference. A reference is still used internally.