### PR TITLE
Dissociate prefix and infix applications from general applications in the AST

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1671,11 +1671,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         $ hvbox 0 (fmt_str_loc c op)
         $ fmt_expression c (sub_exp ~ctx r) )
   | Pexp_infix
-      ( ({txt= id; loc= _} as op)
-      , l
-      , ({pexp_desc= Pexp_fun _; pexp_loc; pexp_attributes; _} as r) )
-    when (not (String_id.is_monadic_binding id))
-         && not c.conf.fmt_opts.break_infix_before_func ->
+      (op, l, ({pexp_desc= Pexp_fun _; pexp_loc; pexp_attributes; _} as r))
+    when not c.conf.fmt_opts.break_infix_before_func ->
       (* side effects of Cmts.fmt c.cmts before Sugar.fun_ is important *)
       let cmts_before = Cmts.fmt_before c pexp_loc in
       let cmts_after = Cmts.fmt_after c pexp_loc in
@@ -1713,11 +1710,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                $ body $ fmt_if parens_r ")" $ cmts_after ) )
         $ fmt_atrs )
   | Pexp_infix
-      ( ({txt= id; loc= _} as op)
+      ( op
       , l
       , ({pexp_desc= Pexp_function cs; pexp_loc; pexp_attributes; _} as r) )
-    when (not (String_id.is_monadic_binding id))
-         && not c.conf.fmt_opts.break_infix_before_func ->
+    when not c.conf.fmt_opts.break_infix_before_func ->
       let cmts_before = Cmts.fmt_before c pexp_loc in
       let cmts_after = Cmts.fmt_after c pexp_loc in
       let xr = sub_exp ~ctx r in
@@ -2068,11 +2064,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let align =
         match ctx0 with
         | Exp
-            { pexp_desc=
-                Pexp_infix
-                  ({txt= id; loc= _}, _, {pexp_desc= Pexp_function _; _})
-            ; _ }
-          when not (String_id.is_monadic_binding id) ->
+            {pexp_desc= Pexp_infix (_, _, {pexp_desc= Pexp_function _; _}); _}
+          ->
             false
         | _ ->
             parens
@@ -2430,13 +2423,11 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       , PStr
           [ ( { pstr_desc=
                   Pstr_eval
-                    ( ( { pexp_desc= Pexp_infix ({txt= id; loc= _}, _, _)
-                        ; pexp_attributes= []
-                        ; _ } as e1 )
+                    ( ( {pexp_desc= Pexp_infix _; pexp_attributes= []; _} as
+                      e1 )
                     , _ )
               ; pstr_loc= _ } as str ) ] )
-    when (not (String_id.is_monadic_binding id))
-         && List.is_empty pexp_attributes
+    when List.is_empty pexp_attributes
          && Source.extension_using_sugar ~name:ext ~payload:e1.pexp_loc ->
       hvbox 0
         ( fmt_expression c ~box ?eol ~parens ~ext (sub_exp ~ctx:(Str str) e1)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1604,21 +1604,17 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                   $ fmt "@ " $ fmt_expression c xbody ) )
            $ fmt "@ ;@ "
            $ list grps " ;@;<1000 0>" fmt_grp ) )
-  | Pexp_apply
-      ( { pexp_desc= Pexp_ident {txt= Lident "|>"; loc}
-        ; pexp_attributes= []
-        ; _ }
-      , [ (Nolabel, e0)
-        ; ( Nolabel
-          , { pexp_desc=
-                Pexp_extension
-                  ( name
-                  , PStr
-                      [ ( { pstr_desc=
-                              Pstr_eval
-                                (({pexp_desc= Pexp_fun _; _} as retn), [])
-                          ; pstr_loc= _ } as pld ) ] )
-            ; _ } ) ] ) ->
+  | Pexp_infix
+      ( {txt= "|>"; loc}
+      , e0
+      , { pexp_desc=
+            Pexp_extension
+              ( name
+              , PStr
+                  [ ( { pstr_desc=
+                          Pstr_eval (({pexp_desc= Pexp_fun _; _} as retn), [])
+                      ; pstr_loc= _ } as pld ) ] )
+        ; _ } ) ->
       let xargs, xbody = Sugar.fun_ c.cmts (sub_exp ~ctx:(Str pld) retn) in
       let fmt_cstr, xbody = type_constr_and_body c xbody in
       hvbox 0
@@ -1635,14 +1631,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                       $ fmt_fun_args c xargs $ fmt_opt fmt_cstr $ fmt "@ ->"
                       )
                   $ fmt "@ " $ fmt_expression c xbody ) ) ) )
-  | Pexp_apply
-      ( { pexp_desc= Pexp_ident {txt= Lident ":="; loc}
-        ; pexp_attributes= []
-        ; pexp_loc
-        ; _ }
-      , [(Nolabel, r); (Nolabel, v)] )
+  | Pexp_infix ({txt= ":="; loc}, r, v)
     when is_simple c.conf (expression_width c) (sub_exp ~ctx r) ->
-      Cmts.relocate c.cmts ~src:pexp_loc ~before:loc ~after:loc ;
       let cmts_before =
         let adj =
           fmt_if Poly.(c.conf.fmt_opts.assignment_operator = `End_line) "@,"
@@ -1663,14 +1653,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                  $ str " :=" )
                $ fmt "@;<1 2>" $ cmts_after
                $ hvbox 2 (fmt_expression c (sub_exp ~ctx v)) ) )
-  | Pexp_apply
-      ( { pexp_desc=
-            Pexp_ident
-              {txt= Lident (("~-" | "~-." | "~+" | "~+.") as op); loc}
-        ; pexp_loc
-        ; pexp_attributes= []
-        ; _ }
-      , [(Nolabel, e1)] ) ->
+  | Pexp_prefix ({txt= ("~-" | "~-." | "~+" | "~+.") as op; loc}, e1) ->
       let op =
         if Location.width loc = String.length op - 1 then
           String.sub op ~pos:1 ~len:(String.length op - 1)
@@ -1681,29 +1664,17 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         ( Cmts.fmt c pexp_loc
           @@ hvbox 2 (str op $ spc $ fmt_expression c (sub_exp ~ctx e1))
         $ fmt_atrs )
-  | Pexp_apply
-      ( ( { pexp_desc= Pexp_ident {txt= id; loc}
-          ; pexp_attributes= []
-          ; pexp_loc
-          ; _ } as op )
-      , [(Nolabel, l); (Nolabel, ({pexp_desc= Pexp_ident _; _} as r))] )
-    when Longident.is_hash_getter id ->
-      Cmts.relocate c.cmts ~src:pexp_loc ~before:loc ~after:loc ;
+  | Pexp_infix (({txt= id; _} as op), l, ({pexp_desc= Pexp_ident _; _} as r))
+    when String_id.is_hash_getter id ->
       Params.parens_if parens c.conf
         ( fmt_expression c (sub_exp ~ctx l)
-        $ fmt_expression c (sub_exp ~ctx op)
+        $ hvbox 0 (fmt_str_loc c op)
         $ fmt_expression c (sub_exp ~ctx r) )
-  | Pexp_apply
-      ( ( { pexp_desc= Pexp_ident {txt= id; loc= _}
-          ; pexp_attributes= []
-          ; pexp_loc= _
-          ; _ } as op )
-      , [ (Nolabel, l)
-        ; ( Nolabel
-          , ({pexp_desc= Pexp_fun _; pexp_loc; pexp_attributes; _} as r) ) ]
-      )
-    when Longident.is_infix id
-         && (not (Longident.is_monadic_binding id))
+  | Pexp_infix
+      ( ({txt= id; loc= _} as op)
+      , l
+      , ({pexp_desc= Pexp_fun _; pexp_loc; pexp_attributes; _} as r) )
+    when (not (String_id.is_monadic_binding id))
          && not c.conf.fmt_opts.break_infix_before_func ->
       (* side effects of Cmts.fmt c.cmts before Sugar.fun_ is important *)
       let cmts_before = Cmts.fmt_before c pexp_loc in
@@ -1716,13 +1687,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let pre_body, body = fmt_body c ?ext xbody in
       let followed_by_infix_op =
         match xbody.ast.pexp_desc with
-        | Pexp_apply
-            ( { pexp_desc= Pexp_ident {txt= id; loc= _}
-              ; pexp_attributes= []
-              ; _ }
-            , [ (Nolabel, _)
-              ; (Nolabel, {pexp_desc= Pexp_fun _ | Pexp_function _; _}) ] )
-          when Longident.is_infix id ->
+        | Pexp_infix (_, _, {pexp_desc= Pexp_fun _ | Pexp_function _; _}) ->
             true
         | _ -> false
       in
@@ -1735,9 +1700,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                        $ fmt "@;"
                        $ hovbox 2
                            ( hvbox 0
-                               ( fmt_expression c (sub_exp ~ctx op)
-                               $ fmt "@ " $ cmts_before $ fmt_if parens_r "("
-                               $ str "fun " )
+                               ( fmt_str_loc c op $ fmt "@ " $ cmts_before
+                               $ fmt_if parens_r "(" $ str "fun " )
                            $ fmt_attributes c pexp_attributes ~suf:" "
                            $ hvbox_if
                                (not c.conf.fmt_opts.wrap_fun_args)
@@ -1748,15 +1712,11 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                $ fmt_or followed_by_infix_op "@;<1000 0>" "@ "
                $ body $ fmt_if parens_r ")" $ cmts_after ) )
         $ fmt_atrs )
-  | Pexp_apply
-      ( ( {pexp_desc= Pexp_ident {txt= id; loc= _}; pexp_attributes= []; _}
-        as op )
-      , [ (Nolabel, l)
-        ; ( Nolabel
-          , ({pexp_desc= Pexp_function cs; pexp_loc; pexp_attributes; _} as r)
-          ) ] )
-    when Longident.is_infix id
-         && (not (Longident.is_monadic_binding id))
+  | Pexp_infix
+      ( ({txt= id; loc= _} as op)
+      , l
+      , ({pexp_desc= Pexp_function cs; pexp_loc; pexp_attributes; _} as r) )
+    when (not (String_id.is_monadic_binding id))
          && not c.conf.fmt_opts.break_infix_before_func ->
       let cmts_before = Cmts.fmt_before c pexp_loc in
       let cmts_after = Cmts.fmt_after c pexp_loc in
@@ -1770,20 +1730,13 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                $ fmt "@;"
                $ hovbox 2
                    ( hvbox 0
-                       ( fmt_expression c (sub_exp ~ctx op)
-                       $ fmt "@ " $ cmts_before $ fmt_if parens_r "( "
-                       $ str "function"
+                       ( fmt_str_loc c op $ fmt "@ " $ cmts_before
+                       $ fmt_if parens_r "( " $ str "function"
                        $ fmt_extension_suffix c ext )
                    $ fmt_attributes c pexp_attributes ) )
            $ fmt "@ " $ fmt_cases c (Exp r) cs $ fmt_if parens_r " )"
            $ cmts_after ) )
-  | Pexp_apply
-      ( { pexp_desc= Pexp_ident {txt= id; loc= _}
-        ; pexp_attributes= []
-        ; pexp_loc= _
-        ; _ }
-      , [(Nolabel, _); (Nolabel, _)] )
-    when Longident.is_infix id && not (Longident.is_monadic_binding id) ->
+  | Pexp_infix _ ->
       let op_args = Sugar.Exp.infix c.cmts (prec_ast (Exp exp)) xexp in
       let inner_wrap = parens || has_attr in
       let outer_wrap =
@@ -1828,13 +1781,12 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
            (hvbox indent_wrap
               ( fmt_infix_op_args ~parens:inner_wrap c xexp infix_op_args
               $ fmt_atrs ) ) )
-  | Pexp_apply (e0, [(Nolabel, e1)]) when Exp.is_prefix e0 ->
-      let has_cmts = Cmts.has_before c.cmts e1.pexp_loc in
+  | Pexp_prefix (op, e) ->
+      let has_cmts = Cmts.has_before c.cmts e.pexp_loc in
       hvbox 2
         (Params.Exp.wrap c.conf ~parens
-           ( fmt_expression c ~box (sub_exp ~ctx e0)
-           $ fmt_if has_cmts "@,"
-           $ fmt_expression c ~box (sub_exp ~ctx e1)
+           ( fmt_str_loc c op $ fmt_if has_cmts "@,"
+           $ fmt_expression c ~box (sub_exp ~ctx e)
            $ fmt_atrs ) )
   | Pexp_apply (e0, e1N1) -> (
       let wrap = if c.conf.fmt_opts.wrap_fun_args then Fn.id else hvbox 2 in
@@ -2117,15 +2069,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         match ctx0 with
         | Exp
             { pexp_desc=
-                Pexp_apply
-                  ( { pexp_desc= Pexp_ident {txt= id; loc= _}
-                    ; pexp_attributes= []
-                    ; _ }
-                  , [(Nolabel, _); (Nolabel, {pexp_desc= Pexp_function _; _})]
-                  )
+                Pexp_infix
+                  ({txt= id; loc= _}, _, {pexp_desc= Pexp_function _; _})
             ; _ }
-          when Longident.is_infix id && not (Longident.is_monadic_binding id)
-          ->
+          when not (String_id.is_monadic_binding id) ->
             false
         | _ ->
             parens
@@ -2483,19 +2430,12 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       , PStr
           [ ( { pstr_desc=
                   Pstr_eval
-                    ( ( { pexp_desc=
-                            Pexp_apply
-                              ( { pexp_desc= Pexp_ident {txt= id; loc= _}
-                                ; pexp_attributes= []
-                                ; pexp_loc= _
-                                ; _ }
-                              , [(Nolabel, _); (Nolabel, _)] )
+                    ( ( { pexp_desc= Pexp_infix ({txt= id; loc= _}, _, _)
                         ; pexp_attributes= []
                         ; _ } as e1 )
                     , _ )
               ; pstr_loc= _ } as str ) ] )
-    when Longident.is_infix id
-         && (not (Longident.is_monadic_binding id))
+    when (not (String_id.is_monadic_binding id))
          && List.is_empty pexp_attributes
          && Source.extension_using_sugar ~name:ext ~payload:e1.pexp_loc ->
       hvbox 0

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -94,13 +94,8 @@ module Exp = struct
       let ctx = Exp xexp.ast in
       match (assoc, xexp.ast) with
       | ( Left
-        , { pexp_desc=
-              ( Pexp_apply
-                  ( {pexp_desc= Pexp_ident {txt= Lident op; loc}; _}
-                  , [(_, e1); (_, e2)] )
-              | Pexp_infix ({txt= op; loc}, e1, e2) )
-          ; pexp_loc= src
-          ; _ } )
+        , {pexp_desc= Pexp_infix ({txt= op; loc}, e1, e2); pexp_loc= src; _}
+        )
         when Option.equal Prec.equal prec (prec_ast ctx) ->
           let op_args1 = infix_ None (sub_exp ~ctx e1) in
           let before =
@@ -112,13 +107,8 @@ module Exp = struct
           if relocate then Cmts.relocate cmts ~src ~before ~after:e2.pexp_loc ;
           op_args1 @ [(Some {txt= op; loc}, sub_exp ~ctx e2)]
       | ( Right
-        , { pexp_desc=
-              ( Pexp_apply
-                  ( {pexp_desc= Pexp_ident {txt= Lident op; loc}; _}
-                  , [(_, e1); (_, e2)] )
-              | Pexp_infix ({txt= op; loc}, e1, e2) )
-          ; pexp_loc= src
-          ; _ } )
+        , {pexp_desc= Pexp_infix ({txt= op; loc}, e1, e2); pexp_loc= src; _}
+        )
         when Option.equal Prec.equal prec (prec_ast ctx) ->
           let op_args2 = infix_ (Some {txt= op; loc}) (sub_exp ~ctx e2) in
           let before =

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -95,9 +95,10 @@ module Exp = struct
       match (assoc, xexp.ast) with
       | ( Left
         , { pexp_desc=
-              Pexp_apply
-                ( {pexp_desc= Pexp_ident {txt= Lident op; loc}; _}
-                , [(_, e1); (_, e2)] )
+              ( Pexp_apply
+                  ( {pexp_desc= Pexp_ident {txt= Lident op; loc}; _}
+                  , [(_, e1); (_, e2)] )
+              | Pexp_infix ({txt= op; loc}, e1, e2) )
           ; pexp_loc= src
           ; _ } )
         when Option.equal Prec.equal prec (prec_ast ctx) ->
@@ -112,9 +113,10 @@ module Exp = struct
           op_args1 @ [(Some {txt= op; loc}, sub_exp ~ctx e2)]
       | ( Right
         , { pexp_desc=
-              Pexp_apply
-                ( {pexp_desc= Pexp_ident {txt= Lident op; loc}; _}
-                , [(_, e1); (_, e2)] )
+              ( Pexp_apply
+                  ( {pexp_desc= Pexp_ident {txt= Lident op; loc}; _}
+                  , [(_, e1); (_, e2)] )
+              | Pexp_infix ({txt= op; loc}, e1, e2) )
           ; pexp_loc= src
           ; _ } )
         when Option.equal Prec.equal prec (prec_ast ctx) ->

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9463,7 +9463,7 @@ let tail2 = 0 :: ([ 1; 2 ] [@hello])
 let tail3 = 0 :: ([] [@hello])
 let f ~l:(l [@foo]) = l
 let test x y = (( + ) [@foo]) x y
-let test x = (( ~- ) [@foo])x
+let test x = (( ~- ) [@foo]) x
 let test contents = { contents = contents [@foo] }
 
 class type t = object (_[@foo]) end

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9463,7 +9463,7 @@ let tail2 = 0 :: ([ 1; 2 ] [@hello])
 let tail3 = 0 :: ([] [@hello])
 let f ~l:(l [@foo]) = l
 let test x y = (( + ) [@foo]) x y
-let test x = (( ~- ) [@foo])x
+let test x = (( ~- ) [@foo]) x
 let test contents = { contents = contents [@foo] }
 
 class type t = object (_[@foo]) end

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -9075,7 +9075,7 @@ let f ~l:(l [@foo]) = l
 
 let test x y = (( + ) [@foo]) x y
 
-let test x = (( ~- ) [@foo])x
+let test x = (( ~- ) [@foo]) x
 
 let test contents = {contents= contents [@foo]}
 

--- a/vendor/diff-parsers-ext-parsewyc.patch
+++ b/vendor/diff-parsers-ext-parsewyc.patch
@@ -603,9 +603,9 @@
        { Pexp_ident ($1) }
    | constant
 @@@@
-       { Pexp_apply($1, [Nolabel,$2]) }
+       { Pexp_prefix($1, $2) }
    | op(BANG {"!"}) simple_expr
-       { Pexp_apply($1, [Nolabel,$2]) }
+       { Pexp_prefix($1, $2) }
    | LBRACELESS object_expr_content GREATERRBRACE
        { Pexp_override $2 }
 -  | LBRACELESS object_expr_content error

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -229,6 +229,8 @@ module Exp = struct
   let hole  ?loc ?attrs () = mk ?loc ?attrs Pexp_hole
   let beginend ?loc ?attrs a = mk ?loc ?attrs (Pexp_beginend a)
   let cons ?loc ?attrs a = mk ?loc ?attrs (Pexp_cons a)
+  let prefix ?loc ?attrs a b = mk ?loc ?attrs (Pexp_prefix (a, b))
+  let infix ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_infix (a, b, c))
 
   let case lhs ?guard rhs =
     {

--- a/vendor/parser-extended/ast_helper.mli
+++ b/vendor/parser-extended/ast_helper.mli
@@ -207,6 +207,9 @@ module Exp:
     val hole: ?loc:loc -> ?attrs:attrs -> unit -> expression
     val beginend: ?loc:loc -> ?attrs:attrs -> expression -> expression
     val cons: ?loc:loc -> ?attrs:attrs -> expression list -> expression
+    val prefix: ?loc:loc -> ?attrs:attrs -> str -> expression -> expression
+    val infix:
+      ?loc:loc -> ?attrs:attrs -> str -> expression -> expression -> expression
   end
 
 (** Value declarations *)

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -544,6 +544,10 @@ module E = struct
     | Pexp_hole -> hole ~loc ~attrs ()
     | Pexp_beginend e -> beginend ~loc ~attrs (sub.expr sub e)
     | Pexp_cons l -> cons ~loc ~attrs (List.map (sub.expr sub) l)
+    | Pexp_prefix (op, e) ->
+        prefix ~loc ~attrs (map_loc sub op) (sub.expr sub e)
+    | Pexp_infix (op, e1, e2) ->
+        infix ~loc ~attrs (map_loc sub op) (sub.expr sub e1) (sub.expr sub e2)
 
   let map_binding_op sub {pbop_op; pbop_pat; pbop_exp; pbop_loc} =
     let open Exp in

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -121,8 +121,8 @@ let reloc_typ ~loc x =
 let mkexpvar ~loc (name : string) =
   mkexp ~loc (Pexp_ident(mkrhs (Lident name) loc))
 
-let mkoperator =
-  mkexpvar
+let mkoperator ~loc (name : string) =
+  mkrhs name loc
 
 let mkpatvar ~loc name =
   mkpat ~loc (Ppat_var (mkrhs name loc))
@@ -151,7 +151,7 @@ let ghstr ~loc d = Str.mk ~loc:(ghost_loc loc) d
 let ghsig ~loc d = Sig.mk ~loc:(ghost_loc loc) d
 
 let mkinfix arg1 op arg2 =
-  Pexp_apply(op, [Nolabel, arg1; Nolabel, arg2])
+  Pexp_infix(op, arg1, arg2)
 
 let neg_string f =
   if String.length f > 0 && f.[0] = '-'
@@ -165,7 +165,7 @@ let mkuminus ~oploc name arg =
   | ("-" | "-."), Pexp_constant({pconst_desc= Pconst_float (f, m); _} as c) ->
       Pexp_constant({c with pconst_desc= Pconst_float(neg_string f, m)})
   | _ ->
-      Pexp_apply(mkoperator ~loc:oploc ("~" ^ name), [Nolabel, arg])
+      Pexp_prefix(mkoperator ~loc:oploc ("~" ^ name), arg)
 
 let mkuplus ~oploc name arg =
   let desc = arg.pexp_desc in
@@ -173,7 +173,7 @@ let mkuplus ~oploc name arg =
   | "+", Pexp_constant({pconst_desc= Pconst_integer _; _})
   | ("+" | "+."), Pexp_constant({pconst_desc= Pconst_float _; _}) -> desc
   | _ ->
-      Pexp_apply(mkoperator ~loc:oploc ("~" ^ name), [Nolabel, arg])
+      Pexp_prefix(mkoperator ~loc:oploc ("~" ^ name), arg)
 
 (* TODO define an abstraction boundary between locations-as-pairs
    and locations-as-Location.t; it should be clear when we move from
@@ -2275,9 +2275,9 @@ simple_expr:
   | name_tag %prec prec_constant_constructor
       { Pexp_variant($1, None) }
   | op(PREFIXOP) simple_expr
-      { Pexp_apply($1, [Nolabel,$2]) }
+      { Pexp_prefix($1, $2) }
   | op(BANG {"!"}) simple_expr
-      { Pexp_apply($1, [Nolabel,$2]) }
+      { Pexp_prefix($1, $2) }
   | LBRACELESS object_expr_content GREATERRBRACE
       { Pexp_override $2 }
   | LBRACELESS object_expr_content error

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -441,6 +441,8 @@ and expression_desc =
   | Pexp_beginend of expression  (** [begin E end] *)
   | Pexp_cons of expression list  (** [E1 :: ... :: En] *)
   | Pexp_indexop_access of indexop_access
+  | Pexp_prefix of string loc * expression  (** [op E] *)
+  | Pexp_infix of string loc * expression * expression  (** [E1 op E2] *)
 
 and indexop_access =
   {

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -490,6 +490,13 @@ and expression i ppf x =
       end;
       paren_kind i ppf pia_paren;
       option i expression ppf pia_rhs
+  | Pexp_prefix (op, e) ->
+      line i ppf "Pexp_prefix %a\n" fmt_string_loc op;
+      expression i ppf e
+  | Pexp_infix (op, e1, e2) ->
+      line i ppf "Pexp_infix %a\n" fmt_string_loc op;
+      expression i ppf e1;
+      expression i ppf e2
 
 and if_branch i ppf { if_cond; if_body } =
   line i ppf "if_branch\n";

--- a/vendor/parser-recovery/test/expect/structure/binop.ml.ref
+++ b/vendor/parser-recovery/test/expect/structure/binop.ml.ref
@@ -2,18 +2,10 @@
   structure_item ([1,0+0]..[1,0+3])
     Pstr_eval
     expression ([1,0+0]..[1,0+3])
-      Pexp_apply
-      expression ([1,0+2]..[1,0+3])
-        Pexp_ident "+" ([1,0+2]..[1,0+3])
-      [
-        <arg>
-        Nolabel
-          expression ([1,0+0]..[1,0+1])
-            Pexp_ident "x" ([1,0+0]..[1,0+1])
-        <arg>
-        Nolabel
-          expression (_none_[0,0+-1]..[0,0+-1]) ghost
-            Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
-            []
-      ]
+      Pexp_infix "+" ([1,0+2]..[1,0+3])
+      expression ([1,0+0]..[1,0+1])
+        Pexp_ident "x" ([1,0+0]..[1,0+1])
+      expression (_none_[0,0+-1]..[0,0+-1]) ghost
+        Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
+        []
 ]

--- a/vendor/parser-recovery/test/expect/structure/many_unclosed.ml.ref
+++ b/vendor/parser-recovery/test/expect/structure/many_unclosed.ml.ref
@@ -6,112 +6,88 @@
         pattern ([1,0+4]..[1,0+11])
           Ppat_var "foooooo" ([1,0+4]..[1,0+11])
         expression ([1,0+13]..[1,0+143])
-          Pexp_apply
-          expression ([1,0+64]..[1,0+65])
-            Pexp_ident "=" ([1,0+64]..[1,0+65])
-          [
-            <arg>
-            Nolabel
-              expression ([1,0+13]..[1,0+63])
-                Pexp_apply
-                expression ([1,0+36]..[1,0+37])
-                  Pexp_ident "=" ([1,0+36]..[1,0+37])
-                [
-                  <arg>
-                  Nolabel
-                    expression ([1,0+13]..[1,0+36])
-                      Pexp_apply
-                      expression ([1,0+13]..[1,0+26])
-                        Pexp_ident "fooooooooolet" ([1,0+13]..[1,0+26])
-                      [
-                        <arg>
-                        Nolabel
-                          expression ([1,0+27]..[1,0+36])
-                            Pexp_ident "foooooooo" ([1,0+27]..[1,0+36])
-                      ]
-                  <arg>
-                  Nolabel
-                    expression ([1,0+38]..[1,0+63])
-                      Pexp_apply
-                      expression ([1,0+38]..[1,0+41])
-                        Pexp_ident "bar" ([1,0+38]..[1,0+41])
-                      [
-                        <arg>
-                        Nolabel
-                          expression ([1,0+42]..[1,0+49])
-                            Pexp_ident "baaaaar" ([1,0+42]..[1,0+49])
-                        <arg>
-                        Nolabel
-                          expression ([1,0+50]..[1,0+61])
-                            Pexp_ident "barrrmodule" ([1,0+50]..[1,0+61])
-                        <arg>
-                        Nolabel
-                          expression ([1,0+62]..[1,0+63])
-                            Pexp_construct "K" ([1,0+62]..[1,0+63])
-                            None
-                      ]
-                ]
-            <arg>
-            Nolabel
-              expression ([1,0+74]..[1,0+143])
+          Pexp_infix "=" ([1,0+64]..[1,0+65])
+          expression ([1,0+13]..[1,0+63])
+            Pexp_infix "=" ([1,0+36]..[1,0+37])
+            expression ([1,0+13]..[1,0+36])
+              Pexp_apply
+              expression ([1,0+13]..[1,0+26])
+                Pexp_ident "fooooooooolet" ([1,0+13]..[1,0+26])
+              [
+                <arg>
+                Nolabel
+                  expression ([1,0+27]..[1,0+36])
+                    Pexp_ident "foooooooo" ([1,0+27]..[1,0+36])
+              ]
+            expression ([1,0+38]..[1,0+63])
+              Pexp_apply
+              expression ([1,0+38]..[1,0+41])
+                Pexp_ident "bar" ([1,0+38]..[1,0+41])
+              [
+                <arg>
+                Nolabel
+                  expression ([1,0+42]..[1,0+49])
+                    Pexp_ident "baaaaar" ([1,0+42]..[1,0+49])
+                <arg>
+                Nolabel
+                  expression ([1,0+50]..[1,0+61])
+                    Pexp_ident "barrrmodule" ([1,0+50]..[1,0+61])
+                <arg>
+                Nolabel
+                  expression ([1,0+62]..[1,0+63])
+                    Pexp_construct "K" ([1,0+62]..[1,0+63])
+                    None
+              ]
+          expression ([1,0+74]..[1,0+143])
+            Pexp_let Nonrec
+            [
+              <def> ([1,0+74]..[1,0+79])
+                pattern ([1,0+78]..[1,0+79])
+                  Ppat_var "k" ([1,0+78]..[1,0+79])
+                expression (_none_[0,0+-1]..[0,0+-1]) ghost
+                  Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
+                  []
+            ]
+            expression ([1,0+81]..[1,0+143])
+              Pexp_beginend
+              expression ([1,0+88]..[1,0+143])
                 Pexp_let Nonrec
                 [
-                  <def> ([1,0+74]..[1,0+79])
-                    pattern ([1,0+78]..[1,0+79])
-                      Ppat_var "k" ([1,0+78]..[1,0+79])
-                    expression (_none_[0,0+-1]..[0,0+-1]) ghost
-                      Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
-                      []
+                  <def> ([1,0+88]..[1,0+102])
+                    pattern ([1,0+92]..[1,0+93])
+                      Ppat_var "x" ([1,0+92]..[1,0+93])
+                    expression ([1,0+100]..[1,0+102])
+                      Pexp_construct "()" ([1,0+100]..[1,0+102])
+                      None
                 ]
-                expression ([1,0+81]..[1,0+143])
-                  Pexp_beginend
-                  expression ([1,0+88]..[1,0+143])
-                    Pexp_let Nonrec
-                    [
-                      <def> ([1,0+88]..[1,0+102])
-                        pattern ([1,0+92]..[1,0+93])
-                          Ppat_var "x" ([1,0+92]..[1,0+93])
-                        expression ([1,0+100]..[1,0+102])
-                          Pexp_construct "()" ([1,0+100]..[1,0+102])
-                          None
-                    ]
-                    expression ([1,0+104]..[1,0+143])
-                      Pexp_let Nonrec
-                      [
-                        <def> ([1,0+104]..[1,0+143])
-                          pattern ([1,0+108]..[1,0+115])
-                            Ppat_var "foooooo" ([1,0+108]..[1,0+115])
-                          expression ([1,0+119]..[1,0+143])
-                            Pexp_apply
-                            expression ([1,0+142]..[1,0+143])
-                              Pexp_ident "=" ([1,0+142]..[1,0+143])
-                            [
-                              <arg>
-                              Nolabel
-                                expression ([1,0+119]..[1,0+141])
-                                  Pexp_apply
-                                  expression ([1,0+119]..[1,0+125])
-                                    Pexp_ident "fooooo" ([1,0+119]..[1,0+125])
-                                  [
-                                    <arg>
-                                    Nolabel
-                                      expression ([1,0+127]..[1,0+139])
-                                        Pexp_ident "foooooooolet" ([1,0+127]..[1,0+139])
-                                    <arg>
-                                    Nolabel
-                                      expression ([1,0+140]..[1,0+141])
-                                        Pexp_ident "k" ([1,0+140]..[1,0+141])
-                                  ]
-                              <arg>
-                              Nolabel
-                                expression (_none_[0,0+-1]..[0,0+-1]) ghost
-                                  Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
-                                  []
-                            ]
-                      ]
-                      expression (_none_[0,0+-1]..[0,0+-1]) ghost
-                        Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
-                        []
-          ]
+                expression ([1,0+104]..[1,0+143])
+                  Pexp_let Nonrec
+                  [
+                    <def> ([1,0+104]..[1,0+143])
+                      pattern ([1,0+108]..[1,0+115])
+                        Ppat_var "foooooo" ([1,0+108]..[1,0+115])
+                      expression ([1,0+119]..[1,0+143])
+                        Pexp_infix "=" ([1,0+142]..[1,0+143])
+                        expression ([1,0+119]..[1,0+141])
+                          Pexp_apply
+                          expression ([1,0+119]..[1,0+125])
+                            Pexp_ident "fooooo" ([1,0+119]..[1,0+125])
+                          [
+                            <arg>
+                            Nolabel
+                              expression ([1,0+127]..[1,0+139])
+                                Pexp_ident "foooooooolet" ([1,0+127]..[1,0+139])
+                            <arg>
+                            Nolabel
+                              expression ([1,0+140]..[1,0+141])
+                                Pexp_ident "k" ([1,0+140]..[1,0+141])
+                          ]
+                        expression (_none_[0,0+-1]..[0,0+-1]) ghost
+                          Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
+                          []
+                  ]
+                  expression (_none_[0,0+-1]..[0,0+-1]) ghost
+                    Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
+                    []
     ]
 ]

--- a/vendor/parser-recovery/test/expect/use_file/many_unclosed.mlt.ref
+++ b/vendor/parser-recovery/test/expect/use_file/many_unclosed.mlt.ref
@@ -10,112 +10,88 @@ Ptop_def
           pattern ([1,0+4]..[1,0+11])
             Ppat_var "foooooo" ([1,0+4]..[1,0+11])
           expression ([1,0+13]..[1,0+143])
-            Pexp_apply
-            expression ([1,0+64]..[1,0+65])
-              Pexp_ident "=" ([1,0+64]..[1,0+65])
-            [
-              <arg>
-              Nolabel
-                expression ([1,0+13]..[1,0+63])
-                  Pexp_apply
-                  expression ([1,0+36]..[1,0+37])
-                    Pexp_ident "=" ([1,0+36]..[1,0+37])
-                  [
-                    <arg>
-                    Nolabel
-                      expression ([1,0+13]..[1,0+36])
-                        Pexp_apply
-                        expression ([1,0+13]..[1,0+26])
-                          Pexp_ident "fooooooooolet" ([1,0+13]..[1,0+26])
-                        [
-                          <arg>
-                          Nolabel
-                            expression ([1,0+27]..[1,0+36])
-                              Pexp_ident "foooooooo" ([1,0+27]..[1,0+36])
-                        ]
-                    <arg>
-                    Nolabel
-                      expression ([1,0+38]..[1,0+63])
-                        Pexp_apply
-                        expression ([1,0+38]..[1,0+41])
-                          Pexp_ident "bar" ([1,0+38]..[1,0+41])
-                        [
-                          <arg>
-                          Nolabel
-                            expression ([1,0+42]..[1,0+49])
-                              Pexp_ident "baaaaar" ([1,0+42]..[1,0+49])
-                          <arg>
-                          Nolabel
-                            expression ([1,0+50]..[1,0+61])
-                              Pexp_ident "barrrmodule" ([1,0+50]..[1,0+61])
-                          <arg>
-                          Nolabel
-                            expression ([1,0+62]..[1,0+63])
-                              Pexp_construct "K" ([1,0+62]..[1,0+63])
-                              None
-                        ]
-                  ]
-              <arg>
-              Nolabel
-                expression ([1,0+74]..[1,0+143])
+            Pexp_infix "=" ([1,0+64]..[1,0+65])
+            expression ([1,0+13]..[1,0+63])
+              Pexp_infix "=" ([1,0+36]..[1,0+37])
+              expression ([1,0+13]..[1,0+36])
+                Pexp_apply
+                expression ([1,0+13]..[1,0+26])
+                  Pexp_ident "fooooooooolet" ([1,0+13]..[1,0+26])
+                [
+                  <arg>
+                  Nolabel
+                    expression ([1,0+27]..[1,0+36])
+                      Pexp_ident "foooooooo" ([1,0+27]..[1,0+36])
+                ]
+              expression ([1,0+38]..[1,0+63])
+                Pexp_apply
+                expression ([1,0+38]..[1,0+41])
+                  Pexp_ident "bar" ([1,0+38]..[1,0+41])
+                [
+                  <arg>
+                  Nolabel
+                    expression ([1,0+42]..[1,0+49])
+                      Pexp_ident "baaaaar" ([1,0+42]..[1,0+49])
+                  <arg>
+                  Nolabel
+                    expression ([1,0+50]..[1,0+61])
+                      Pexp_ident "barrrmodule" ([1,0+50]..[1,0+61])
+                  <arg>
+                  Nolabel
+                    expression ([1,0+62]..[1,0+63])
+                      Pexp_construct "K" ([1,0+62]..[1,0+63])
+                      None
+                ]
+            expression ([1,0+74]..[1,0+143])
+              Pexp_let Nonrec
+              [
+                <def> ([1,0+74]..[1,0+79])
+                  pattern ([1,0+78]..[1,0+79])
+                    Ppat_var "k" ([1,0+78]..[1,0+79])
+                  expression (_none_[0,0+-1]..[0,0+-1]) ghost
+                    Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
+                    []
+              ]
+              expression ([1,0+81]..[1,0+143])
+                Pexp_beginend
+                expression ([1,0+88]..[1,0+143])
                   Pexp_let Nonrec
                   [
-                    <def> ([1,0+74]..[1,0+79])
-                      pattern ([1,0+78]..[1,0+79])
-                        Ppat_var "k" ([1,0+78]..[1,0+79])
-                      expression (_none_[0,0+-1]..[0,0+-1]) ghost
-                        Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
-                        []
+                    <def> ([1,0+88]..[1,0+102])
+                      pattern ([1,0+92]..[1,0+93])
+                        Ppat_var "x" ([1,0+92]..[1,0+93])
+                      expression ([1,0+100]..[1,0+102])
+                        Pexp_construct "()" ([1,0+100]..[1,0+102])
+                        None
                   ]
-                  expression ([1,0+81]..[1,0+143])
-                    Pexp_beginend
-                    expression ([1,0+88]..[1,0+143])
-                      Pexp_let Nonrec
-                      [
-                        <def> ([1,0+88]..[1,0+102])
-                          pattern ([1,0+92]..[1,0+93])
-                            Ppat_var "x" ([1,0+92]..[1,0+93])
-                          expression ([1,0+100]..[1,0+102])
-                            Pexp_construct "()" ([1,0+100]..[1,0+102])
-                            None
-                      ]
-                      expression ([1,0+104]..[1,0+143])
-                        Pexp_let Nonrec
-                        [
-                          <def> ([1,0+104]..[1,0+143])
-                            pattern ([1,0+108]..[1,0+115])
-                              Ppat_var "foooooo" ([1,0+108]..[1,0+115])
-                            expression ([1,0+119]..[1,0+143])
-                              Pexp_apply
-                              expression ([1,0+142]..[1,0+143])
-                                Pexp_ident "=" ([1,0+142]..[1,0+143])
-                              [
-                                <arg>
-                                Nolabel
-                                  expression ([1,0+119]..[1,0+141])
-                                    Pexp_apply
-                                    expression ([1,0+119]..[1,0+125])
-                                      Pexp_ident "fooooo" ([1,0+119]..[1,0+125])
-                                    [
-                                      <arg>
-                                      Nolabel
-                                        expression ([1,0+127]..[1,0+139])
-                                          Pexp_ident "foooooooolet" ([1,0+127]..[1,0+139])
-                                      <arg>
-                                      Nolabel
-                                        expression ([1,0+140]..[1,0+141])
-                                          Pexp_ident "k" ([1,0+140]..[1,0+141])
-                                    ]
-                                <arg>
-                                Nolabel
-                                  expression (_none_[0,0+-1]..[0,0+-1]) ghost
-                                    Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
-                                    []
-                              ]
-                        ]
-                        expression (_none_[0,0+-1]..[0,0+-1]) ghost
-                          Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
-                          []
-            ]
+                  expression ([1,0+104]..[1,0+143])
+                    Pexp_let Nonrec
+                    [
+                      <def> ([1,0+104]..[1,0+143])
+                        pattern ([1,0+108]..[1,0+115])
+                          Ppat_var "foooooo" ([1,0+108]..[1,0+115])
+                        expression ([1,0+119]..[1,0+143])
+                          Pexp_infix "=" ([1,0+142]..[1,0+143])
+                          expression ([1,0+119]..[1,0+141])
+                            Pexp_apply
+                            expression ([1,0+119]..[1,0+125])
+                              Pexp_ident "fooooo" ([1,0+119]..[1,0+125])
+                            [
+                              <arg>
+                              Nolabel
+                                expression ([1,0+127]..[1,0+139])
+                                  Pexp_ident "foooooooolet" ([1,0+127]..[1,0+139])
+                              <arg>
+                              Nolabel
+                                expression ([1,0+140]..[1,0+141])
+                                  Pexp_ident "k" ([1,0+140]..[1,0+141])
+                            ]
+                          expression (_none_[0,0+-1]..[0,0+-1]) ghost
+                            Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
+                            []
+                    ]
+                    expression (_none_[0,0+-1]..[0,0+-1]) ghost
+                      Pexp_extension "merlin.hole" (_none_[0,0+-1]..[0,0+-1]) ghost
+                      []
       ]
   ]


### PR DESCRIPTION
Extracted from ocamlformat-ng's concrete AST in our long-running effort to make the AST closer to the original source.

In this one, we create dedicated types for prefix and infix op applications, instead of testing the kind of operators used in a generic `Pexp_apply`, remove impossible cases (no labels, operator is an identifier).

No diff on the janestreet, ocamlformat and conventional profiles.