### PR TITLE
Create ocamlformat Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,28 @@ jobs:
 
       - name: Check help files
         run: opam exec -- dune build @help --auto-promote
+
+  docker:
+    runs-on: ubuntu-latest
+
+    env:
+      REGISTRY: ghcr.io
+      NAMESPACE: ${{ github.repository_owner }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: docker/setup-buildx-action@v2
+
+      - uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          pull: true
+          push: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,19 @@ jobs:
   docker:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        include:
+          - variant: debian
+            variant-version: 11
+            ocaml-version: 4.14
+          - variant: alpine
+            variant-version: 3.15
+            ocaml-version: 4.14
+
     env:
+      # Default variant that should also be tagged without extra suffix
+      VARIANT_DEFAULT: debian
       REGISTRY: ghcr.io
       NAMESPACE: ${{ github.repository_owner }}
 
@@ -55,9 +67,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build
-        uses: docker/build-push-action@v3
+      - uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/ocamlformat
+          tags: |
+            type=semver,pattern={{version}},suffix=-${{ matrix.variant }}
+            type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.variant }}
+            type=semver,pattern={{major}},suffix=-${{ matrix.variant }}
+
+            type=semver,pattern={{version}},enable=${{ matrix.variant == env.VARIANT_DEFAULT }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.variant == env.VARIANT_DEFAULT }}
+            type=semver,pattern={{major}},enable=${{ matrix.variant == env.VARIANT_DEFAULT }}
+
+      - uses: docker/build-push-action@v3
         with:
           context: .
-          pull: true
+          build-args: |
+            VARIANT=${{ matrix.variant }}
+            VARIANT_VERSION=${{ matrix.variant-version }}
+            OCAML_VERSION=${{ matrix.ocaml-version }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name == 'workflow_dispatch' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM ocaml/opam:alpine as builder
+ARG VARIANT=debian
+ARG VARIANT_VERSION=11
+ARG OCAML_VERION=4.14
+
+FROM ocaml/opam:${VARIANT}-${VARIANT_VERSION}-ocaml-${OCAML_VERION} as builder
 
 USER opam
 
@@ -12,7 +16,7 @@ ADD --chown=opam:opam . .
 RUN opam exec -- dune subst && \
     opam exec -- dune build @install
 
-FROM alpine
+FROM ${VARIANT}:${VARIANT_VERSION}
 
 COPY --from=builder --chown=root:root /src/_build/default/bin/ocamlformat/main.exe /usr/bin/ocamlformat
 ENTRYPOINT [ "/usr/bin/ocamlformat" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ocaml/opam:alpine as builder
+
+USER opam
+
+WORKDIR /src
+
+ADD --chown=opam:opam ocamlformat.opam .
+RUN opam pin add -yn ocamlformat . && \
+    opam install --deps-only ocamlformat
+
+ADD --chown=opam:opam . .
+RUN opam exec -- dune subst && \
+    opam exec -- dune build @install
+
+FROM alpine
+
+COPY --from=builder --chown=root:root /src/_build/default/bin/ocamlformat/main.exe /usr/bin/ocamlformat
+ENTRYPOINT [ "/usr/bin/ocamlformat" ]


### PR DESCRIPTION
Attempt to fix #1447

Adds a Dockerfile used to build from the source, using a multistage build and alpine base image to keep the final image size as small as possible.

A build job has also been added in the CI to test the build process, and maybe publish the image.

I am unsure about a few details:
- When should such image be published (on tags ? releases ?) ? And where should the image be published (for now I have set ghcr.io/ocaml-ppx/ocamlformat) ?
- Which version of ocaml and ocamlformat do you wish to build ? Maybe you have multiple development branches ?