### PR TITLE
Fix parentheses around symbols in if-then-else branches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Fix dropped comment attached to the identifier of an open-expression (#2155, @gpetiot)
 - Correctly format chunks of file in presence of `enable`/`disable` floating attributes (#2156, @gpetiot)
 - Remove abusive normalization in docstrings references (#2159, #2162, @EmileTrotignon)
+- Fix parentheses around symbols in if-then-else branches (#<PR_NUMBER>, @gpetiot)
 
 ### Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 - Fix dropped comment attached to the identifier of an open-expression (#2155, @gpetiot)
 - Correctly format chunks of file in presence of `enable`/`disable` floating attributes (#2156, @gpetiot)
 - Remove abusive normalization in docstrings references (#2159, #2162, @EmileTrotignon)
-- Fix parentheses around symbols in if-then-else branches (#<PR_NUMBER>, @gpetiot)
+- Fix parentheses around symbols in if-then-else branches (#2169, @gpetiot)
 
 ### Changes
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2191,7 +2191,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         (Params.Exp.wrap c.conf ~parens
            (list_fl cnd_exps
               (fun ~first ~last (xcond, xbch, pexp_attributes) ->
-                let parens_bch = parenze_exp xbch in
+                let symbol_parens = Exp.is_symbol xbch.ast in
+                let parens_bch = parenze_exp xbch && not symbol_parens in
                 let p =
                   Params.get_if_then_else c.conf ~first ~last ~parens
                     ~parens_bch ~parens_prev_bch:!parens_prev_bch ~xcond
@@ -2203,17 +2204,13 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                       (fmt_attributes c ~pre:Blank pexp_attributes)
                     ~fmt_cond:(fmt_expression c)
                 in
-                let wrap_parens =
-                  if Exp.is_symbol xbch.ast then wrap "( " " )"
-                  else p.wrap_parens
-                in
                 parens_prev_bch := parens_bch ;
                 p.box_branch
                   ( p.cond
                   $ p.box_keyword_and_expr
                       ( p.branch_pro
-                      $ wrap_parens
-                          ( fmt_expression c ~box:false ~parens:false
+                      $ p.wrap_parens
+                          ( fmt_expression c ~box:false ~parens:symbol_parens
                               ?pro:p.expr_pro ?eol:p.expr_eol xbch
                           $ p.break_end_branch ) ) )
                 $ fmt_if_k (not last) p.space_between_branches ) ) )

--- a/test/passing/tests/ite-fit_or_vertical.ml.ref
+++ b/test/passing/tests/ite-fit_or_vertical.ml.ref
@@ -151,11 +151,11 @@ let foo =
     foo
 
 let _ =
-  if fooo then ( 
-    + )
-  else if bar then ( 
-    * )
-  else if foobar then ( 
-    / )
-  else ( 
-    - )
+  if fooo then
+    ( + )
+  else if bar then
+    ( * )
+  else if foobar then
+    ( / )
+  else
+    ( - )

--- a/test/passing/tests/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/tests/ite-fit_or_vertical_closing.ml.ref
@@ -163,8 +163,11 @@ let foo =
     foo
 
 let _ =
-  if fooo then ( 
-    + ) else if bar then ( 
-        * ) else if foobar then ( 
-            / ) else ( 
-                - )
+  if fooo then
+    ( + )
+  else if bar then
+    ( * )
+  else if foobar then
+    ( / )
+  else
+    ( - )

--- a/test/passing/tests/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/tests/ite-fit_or_vertical_no_indicate.ml.ref
@@ -151,11 +151,11 @@ let foo =
     foo
 
 let _ =
-  if fooo then ( 
-    + )
-  else if bar then ( 
-    * )
-  else if foobar then ( 
-    / )
-  else ( 
-    - )
+  if fooo then
+    ( + )
+  else if bar then
+    ( * )
+  else if foobar then
+    ( / )
+  else
+    ( - )

--- a/test/passing/tests/ite-kr.ml.ref
+++ b/test/passing/tests/ite-kr.ml.ref
@@ -185,8 +185,11 @@ let foo =
     foo
 
 let _ =
-  if fooo then ( +
-   ) else if bar then ( *
-   ) else if foobar then ( /
-   ) else ( -
-   )
+  if fooo then
+    ( + )
+  else if bar then
+    ( * )
+  else if foobar then
+    ( / )
+  else
+    ( - )

--- a/test/passing/tests/ite-kr_closing.ml.ref
+++ b/test/passing/tests/ite-kr_closing.ml.ref
@@ -195,8 +195,11 @@ let foo =
     foo
 
 let _ =
-  if fooo then ( +
-   ) else if bar then ( *
-   ) else if foobar then ( /
-   ) else ( -
-   )
+  if fooo then
+    ( + )
+  else if bar then
+    ( * )
+  else if foobar then
+    ( / )
+  else
+    ( - )


### PR DESCRIPTION
No diff found for this option with test_branch.sh, not used in the 3 preset profiles btw.