### PR TITLE
Desugar type constraints in record fields

### DIFF
--- a/test/passing/tests/js_syntax.ml.ref
+++ b/test/passing/tests/js_syntax.ml.ref
@@ -3,9 +3,9 @@
 let _ =
   [%raise_structural_sexp
     "feature's tip is already an ancestor of new base"
-      {feature_tip= (old_tip : Rev.t); new_base: Rev.t}]
+      {feature_tip= (old_tip : Rev.t); new_base= (new_base : Rev.t)}]
 
 let _ =
   [%raise_structural_sexp
     "feature's tip is already an ancestor of new base"
-      {feature_tip= (old_tip : Rev.t); new_base: Rev.t}]
+      {feature_tip= (old_tip : Rev.t); new_base= (new_base : Rev.t)}]

--- a/test/passing/tests/record-loose.ml.ref
+++ b/test/passing/tests/record-loose.ml.ref
@@ -120,3 +120,5 @@ let to_string {x; _ (* we should print y *)} = string_of_int x
 let {x (*b*) : z} = e
 
 let {(* a *) x (*b*) : (* c *) z (* d *)} = e
+
+let _ = {(*a*) x (*b*) : (*c*) t (*d*) :> (*e*) t (*f*) = (*g*) e (*h*)}

--- a/test/passing/tests/record-tight_decl.ml.ref
+++ b/test/passing/tests/record-tight_decl.ml.ref
@@ -120,3 +120,5 @@ let to_string {x; _ (* we should print y *)} = string_of_int x
 let {x (*b*) : z} = e
 
 let {(* a *) x (*b*) : (* c *) z (* d *)} = e
+
+let _ = {(*a*) x (*b*) : (*c*) t (*d*) :> (*e*) t (*f*) = (*g*) e (*h*)}

--- a/test/passing/tests/record.ml
+++ b/test/passing/tests/record.ml
@@ -125,3 +125,5 @@ let to_string {x; _ (* we should print y *)} = string_of_int x
 let { x (*b*) : z } = e
 
 let { (* a *) x (*b*) : (* c *) z (* d *) } = e
+
+let _ = { (*a*)x(*b*) : (*c*)t(*d*) :> (*e*)t(*f*) = (*g*)e(*h*) }

--- a/test/passing/tests/record.ml.ref
+++ b/test/passing/tests/record.ml.ref
@@ -120,3 +120,5 @@ let to_string {x; _ (* we should print y *)} = string_of_int x
 let {x (*b*): z} = e
 
 let {(* a *) x (*b*): (* c *) z (* d *)} = e
+
+let _ = {(*a*) x (*b*): (*c*) t (*d*) :> (*e*) t (*f*) = (*g*) e (*h*)}

--- a/vendor/diff-parsers-ext-parsewyc.patch
+++ b/vendor/diff-parsers-ext-parsewyc.patch
@@ -178,10 +178,10 @@
  
  let make_loc (startpos, endpos) = {
 @@@@
- 
- let mkpat_opt_constraint ~loc p = function
-   | None -> p
-   | Some typ -> mkpat ~loc (Ppat_constraint(p, typ))
+   match t1, t2 with
+   | Some t, None -> mkexp ~loc (Pexp_constraint(e, t))
+   | _, Some t -> mkexp ~loc (Pexp_coerce(e, t1, t))
+   | None, None -> assert false
  
 -let syntax_error () =
 -  raise Syntaxerr.Escape_error

--- a/vendor/parser-extended/ast_helper.mli
+++ b/vendor/parser-extended/ast_helper.mli
@@ -114,8 +114,9 @@ module Pat:
     val construct: ?loc:loc -> ?attrs:attrs ->
       lid -> (str list * pattern) option -> pattern
     val variant: ?loc:loc -> ?attrs:attrs -> label -> pattern option -> pattern
-    val record: ?loc:loc -> ?attrs:attrs -> (lid * pattern) list
-                -> obj_closed_flag -> pattern
+    val record: ?loc:loc -> ?attrs:attrs
+      -> (lid * core_type option * pattern option) list
+      -> obj_closed_flag -> pattern
     val array: ?loc:loc -> ?attrs:attrs -> pattern list -> pattern
     val list: ?loc:loc -> ?attrs:attrs -> pattern list -> pattern
     val or_: ?loc:loc -> ?attrs:attrs -> pattern -> pattern -> pattern
@@ -153,8 +154,9 @@ module Exp:
                    -> expression
     val variant: ?loc:loc -> ?attrs:attrs -> label -> expression option
                  -> expression
-    val record: ?loc:loc -> ?attrs:attrs -> (lid * expression) list
-                -> expression option -> expression
+    val record: ?loc:loc -> ?attrs:attrs
+      -> (lid * (core_type option * core_type option) * expression option) list
+      -> expression option -> expression
     val field: ?loc:loc -> ?attrs:attrs -> expression -> lid -> expression
     val setfield: ?loc:loc -> ?attrs:attrs -> expression -> lid -> expression
                   -> expression

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -464,8 +464,15 @@ module E = struct
     | Pexp_variant (lab, eo) ->
         variant ~loc ~attrs lab (map_opt (sub.expr sub) eo)
     | Pexp_record (l, eo) ->
-        record ~loc ~attrs (List.map (map_tuple (map_loc sub) (sub.expr sub)) l)
-          (map_opt (sub.expr sub) eo)
+        let fields =
+          List.map
+            (map_tuple3
+               (map_loc sub)
+               (map_tuple (map_opt (sub.typ sub)) (map_opt (sub.typ sub)))
+               (map_opt (sub.expr sub)))
+            l
+        in
+        record ~loc ~attrs fields (map_opt (sub.expr sub) eo)
     | Pexp_field (e, lid) ->
         field ~loc ~attrs (sub.expr sub e) (map_loc sub lid)
     | Pexp_setfield (e1, lid, e2) ->
@@ -564,9 +571,15 @@ module P = struct
              p)
     | Ppat_variant (l, p) -> variant ~loc ~attrs l (map_opt (sub.pat sub) p)
     | Ppat_record (lpl, cf) ->
-        record ~loc ~attrs
-               (List.map (map_tuple (map_loc sub) (sub.pat sub)) lpl)
-               (Flag.map_obj_closed sub cf)
+        let fields =
+          List.map
+            (map_tuple3
+               (map_loc sub)
+               (map_opt (sub.typ sub))
+               (map_opt (sub.pat sub)))
+            lpl
+        in
+        record ~loc ~attrs fields (Flag.map_obj_closed sub cf)
     | Ppat_array pl -> array ~loc ~attrs (List.map (sub.pat sub) pl)
     | Ppat_list pl -> list ~loc ~attrs (List.map (sub.pat sub) pl)
     | Ppat_or (p1, p2) -> or_ ~loc ~attrs (sub.pat sub p1) (sub.pat sub p2)

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -188,14 +188,6 @@ let mkexp_constraint ~loc e (t1, t2) =
   | _, Some t -> mkexp ~loc (Pexp_coerce(e, t1, t))
   | None, None -> assert false
 
-let mkexp_opt_constraint ~loc e = function
-  | None -> e
-  | Some constraint_ -> mkexp_constraint ~loc e constraint_
-
-let mkpat_opt_constraint ~loc p = function
-  | None -> p
-  | Some typ -> mkpat ~loc (Ppat_constraint(p, typ))
-
 let syntax_error () =
   raise Syntaxerr.Escape_error
 
@@ -259,15 +251,8 @@ let loc_last (id : Longident.t Location.loc) : string Location.loc =
 let loc_lident (id : string Location.loc) : Longident.t Location.loc =
   loc_map (fun x -> Lident x) id
 
-let exp_of_longident lid =
-  let lid = loc_map (fun id -> Lident (Longident.last id)) lid in
-  Exp.mk ~loc:lid.loc (Pexp_ident lid)
-
 let exp_of_label lbl =
   Exp.mk ~loc:lbl.loc (Pexp_ident (loc_lident lbl))
-
-let pat_of_label lbl =
-  Pat.mk ~loc:lbl.loc  (Ppat_var (loc_last lbl))
 
 let mk_newtypes ~loc newtypes exp =
   let mkexp = mkexp ~loc in
@@ -2531,15 +2516,8 @@ record_expr_content:
   | label = mkrhs(label_longident)
     c = type_constraint?
     eo = preceded(EQUAL, expr)?
-      { let constraint_loc, label, e =
-          match eo with
-          | None ->
-              (* No pattern; this is a pun. Desugar it. *)
-              $sloc, make_ghost label, exp_of_longident label
-          | Some e ->
-              ($startpos(c), $endpos), label, e
-        in
-        label, mkexp_opt_constraint ~loc:constraint_loc e c }
+      { let c = Option.value ~default:(None, None) c in
+        label, c, eo }
 ;
 %inline object_expr_content:
   xs = separated_or_terminated_nonempty_list(SEMI, object_expr_field)
@@ -2747,19 +2725,7 @@ pattern_comma_list(self):
   label = mkrhs(label_longident)
   octy = preceded(COLON, core_type)?
   opat = preceded(EQUAL, pattern)?
-    { let constraint_loc, label, pat =
-        match opat with
-        | None ->
-            (* No pattern; this is a pun. Desugar it.
-               But that the pattern was there and the label reconstructed (which
-               piece of AST is marked as ghost is important for warning
-               emission). *)
-            $sloc, make_ghost label, pat_of_label label
-        | Some pat ->
-            ($startpos(octy), $endpos), label, pat
-      in
-      label, mkpat_opt_constraint ~loc:constraint_loc pat octy
-    }
+    { label, octy, opat }
 ;
 
 /* Value descriptions */

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -258,7 +258,9 @@ and pattern_desc =
             - [`A]   when [pat] is [None],
             - [`A P] when [pat] is [Some P]
          *)
-  | Ppat_record of (Longident.t loc * pattern) list * obj_closed_flag
+  | Ppat_record of
+      (Longident.t loc * core_type option * pattern option) list
+      * obj_closed_flag
       (** [Ppat_record([(l1, P1) ; ... ; (ln, Pn)], flag)] represents:
             - [{ l1=P1; ...; ln=Pn }]
                  when [flag] is {{!Asttypes.closed_flag.Closed}[Closed]}
@@ -364,7 +366,12 @@ and expression_desc =
             - [`A]   when [exp] is [None]
             - [`A E] when [exp] is [Some E]
          *)
-  | Pexp_record of (Longident.t loc * expression) list * expression option
+  | Pexp_record of
+      ( Longident.t loc
+        * (core_type option * core_type option)
+        * expression option )
+        list
+      * expression option
       (** [Pexp_record([(l1,P1) ; ... ; (ln,Pn)], exp0)] represents
             - [{ l1=P1; ...; ln=Pn }]         when [exp0] is [None]
             - [{ E0 with l1=P1; ...; ln=Pn }] when [exp0] is [Some E0]

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -1005,9 +1005,10 @@ and label_decl i ppf {pld_name; pld_mutable; pld_type; pld_loc; pld_attributes}=
   line (i+1) ppf "%a" fmt_string_loc pld_name;
   core_type (i+1) ppf pld_type
 
-and longident_x_pattern i ppf (li, p) =
+and longident_x_pattern i ppf (li, t, p) =
   line i ppf "%a\n" fmt_longident_loc li;
-  pattern (i+1) ppf p;
+  option (i+1) core_type ppf t;
+  option (i+1) pattern ppf p;
 
 and case i ppf {pc_lhs; pc_guard; pc_rhs} =
   line i ppf "<case>\n";
@@ -1059,9 +1060,11 @@ and string_x_expression i ppf (s, e) =
   line i ppf "<override> %a\n" fmt_string_loc s;
   expression (i+1) ppf e;
 
-and longident_x_expression i ppf (li, e) =
+and longident_x_expression i ppf (li, (t1, t2), e) =
   line i ppf "%a\n" fmt_longident_loc li;
-  expression (i+1) ppf e;
+  option (i+1) core_type ppf t1;
+  option (i+1) core_type ppf t2;
+  option (i+1) expression ppf e;
 
 and label_x_expression i ppf (l,e) =
   line i ppf "<arg>\n";


### PR DESCRIPTION
Extracted from ocamlformat-ng's concrete AST in our long-running effort to make the AST closer to the original source.
This removes the sugaring of type constraints that the parser does for record fields that over-complicates the pattern matching in Fmt_ast.ml. The formatting is also simplified.


The diff of test_branch.sh is a fix:
```diff
diff --git a/core/src/univ_map.ml b/core/src/univ_map.ml
index 82193a7..18552b8 100644
--- a/core/src/univ_map.ml
+++ b/core/src/univ_map.ml
@@ -24,10 +24,9 @@ struct
       [%sexp
         { name= (Type_equal.Id.name type_id : string)
         ; uid=
-            (( if am_running_inline_test then Sexp.Atom "<uid>"
-             else Type_equal.Id.Uid.sexp_of_t (Type_equal.Id.uid type_id) ) : Sexp
-                                                                              .t)
-        }]
+            ( if am_running_inline_test then Sexp.Atom "<uid>"
+              else Type_equal.Id.Uid.sexp_of_t (Type_equal.Id.uid type_id)
+              : Sexp.t ) }]
```