### PR TITLE
Move option 'version-check' to record opr_opts

### DIFF
--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -96,7 +96,8 @@ type opr_opts =
         (** Version of OCaml syntax of the output. *)
   ; quiet: bool
   ; range: string -> Range.t
-  ; disable_conf_attrs: bool }
+  ; disable_conf_attrs: bool
+  ; version_check: bool }
 
 type t = {fmt_opts: fmt_opts; opr_opts: opr_opts}
 

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -595,8 +595,7 @@ OPTIONS
            Unset quiet.
 
        --no-version-check
-           Do not check that the version matches the one specified in
-           .ocamlformat.
+           Unset version-check.
 
        --numeric
            Instead of re-formatting the file, output one integer per line
@@ -647,6 +646,10 @@ OPTIONS
 
        --use-file
            Deprecated. Same as impl.
+
+       --version-check
+           Check that the version matches the one specified in .ocamlformat.
+           The flag is set by default.
 
        SRC Input files. At least one is required, and exactly one without
            --inplace. If - is passed, will read from stdin.

--- a/test/cli/print_config.t
+++ b/test/cli/print_config.t
@@ -6,6 +6,7 @@ No redundant values:
 
   $ ocamlformat empty.ml --print-config
   profile=default (file .ocamlformat:1)
+  version-check=true (profile default (file .ocamlformat:1))
   disable-conf-attrs=false (profile default (file .ocamlformat:1))
   range=<whole input> (profile default (file .ocamlformat:1))
   quiet=false (profile default (file .ocamlformat:1))
@@ -84,6 +85,7 @@ Redundant values from the conventional profile:
 
   $ ocamlformat empty.ml --print-config
   profile=default (file .ocamlformat:1)
+  version-check=true (profile default (file .ocamlformat:1))
   disable-conf-attrs=false (profile default (file .ocamlformat:1))
   range=<whole input> (profile default (file .ocamlformat:1))
   quiet=false (profile default (file .ocamlformat:1))
@@ -162,6 +164,7 @@ Redundant values from the ocamlformat profile:
 
   $ ocamlformat empty.ml --print-config
   profile=ocamlformat (file .ocamlformat:1)
+  version-check=true (profile ocamlformat (file .ocamlformat:1))
   disable-conf-attrs=false (profile ocamlformat (file .ocamlformat:1))
   range=<whole input> (profile ocamlformat (file .ocamlformat:1))
   quiet=false (profile ocamlformat (file .ocamlformat:1))

--- a/test/passing/tests/print_config.ml.err
+++ b/test/passing/tests/print_config.ml.err
@@ -1,4 +1,5 @@
 profile=ocamlformat (file tests/.ocamlformat:1)
+version-check=true (profile ocamlformat (file tests/.ocamlformat:1))
 disable-conf-attrs=false (profile ocamlformat (file tests/.ocamlformat:1))
 range=<whole input> (profile ocamlformat (file tests/.ocamlformat:1))
 quiet=false (profile ocamlformat (file tests/.ocamlformat:1))

--- a/test/passing/tests/verbose1.ml.err
+++ b/test/passing/tests/verbose1.ml.err
@@ -1,4 +1,5 @@
 profile=ocamlformat (file tests/.ocamlformat:1)
+version-check=true (profile ocamlformat (file tests/.ocamlformat:1))
 disable-conf-attrs=false (profile ocamlformat (file tests/.ocamlformat:1))
 range=<whole input> (profile ocamlformat (file tests/.ocamlformat:1))
 quiet=false (profile ocamlformat (file tests/.ocamlformat:1))


### PR DESCRIPTION
Reduce diff of #2175

The fix added in `build_config` doesn't need an entry in the changelog as the bug was masked in the `main` branch.