### PR TITLE
Fix parens around symbol identifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Remove abusive normalization in docstrings references (#2159, #2162, @EmileTrotignon)
 - Fix parentheses around symbols in if-then-else branches (#2169, @gpetiot)
 - Preserve position of comments around variant identifiers (#2179, @gpetiot)
+- Fix parentheses around symbol identifiers (#<PR_NUMBER>, @gpetiot)
 
 ### Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 - Remove abusive normalization in docstrings references (#2159, #2162, @EmileTrotignon)
 - Fix parentheses around symbols in if-then-else branches (#2169, @gpetiot)
 - Preserve position of comments around variant identifiers (#2179, @gpetiot)
-- Fix parentheses around symbol identifiers (#<PR_NUMBER>, @gpetiot)
+- Fix parentheses around symbol identifiers (#2185, @gpetiot)
 
 ### Changes
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2205,6 +2205,7 @@ end = struct
       , {pexp_attributes= _ :: _; _} )
       when Longident.is_infix id ->
         true
+    | Exp _, e when Exp.is_symbol e || Exp.is_monadic_binding e -> true
     | Exp {pexp_desc= Pexp_cons _; _}, {pexp_attributes= _ :: _; _} -> true
     | Exp {pexp_desc= Pexp_extension _; _}, {pexp_desc= Pexp_tuple _; _} ->
         false

--- a/test/passing/tests/symbol.ml
+++ b/test/passing/tests/symbol.ml
@@ -6,4 +6,18 @@ assert ( * ) ;;
 
 ( * ) [@a] ;;
 
-assert ( ( * ) [@a] )
+assert (( * ) [@a])
+
+module Array = struct
+  let ( .!() ) = Array.unsafe_get
+
+  let ( .!()<- ) = Array.unsafe_set
+end
+
+let ( .!() ), ( .!()<- ) = Array.((( .!() ) [@attr]), ( .!()<- ))
+
+let _ = ( let++ ) [@attr] ;;
+
+( let++ ) [@attr]
+
+let ( let++ ), (( and++ ) [@attr]) = X.((( let++ ) [@attr]), ( and++ ))


### PR DESCRIPTION
Fix #2184

The "parens before attributes" vs "parens around attributes" system could use a redesign