### PR TITLE
Fix alignment inconsistency between let-binding and let-open

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 - Fix parentheses around symbols in if-then-else branches (#2169, @gpetiot)
 - Preserve position of comments around variant identifiers (#2179, @gpetiot)
 - Fix parentheses around symbol identifiers (#2185, @gpetiot)
-- Fix alignment inconsistency between let-binding and let-open (#<PR_NUMBER>, @gpetiot)
+- Fix alignment inconsistency between let-binding and let-open (#2187, @gpetiot)
 
 ### Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Fix parentheses around symbols in if-then-else branches (#2169, @gpetiot)
 - Preserve position of comments around variant identifiers (#2179, @gpetiot)
 - Fix parentheses around symbol identifiers (#2185, @gpetiot)
+- Fix alignment inconsistency between let-binding and let-open (#<PR_NUMBER>, @gpetiot)
 
 ### Changes
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2252,24 +2252,26 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let outer_parens = has_attr && parens in
       let inner_parens = has_attr || parens in
       hovbox 0
-        (Params.parens_if outer_parens c.conf
+        (Params.Exp.wrap c.conf ~parens:outer_parens ~fits_breaks:false
            ( hvbox 0
-               (Params.parens_if inner_parens c.conf
-                  ( hvbox 0
-                      ( fmt_module_statement c ~attributes
-                          ~keyword:
-                            ( hvbox 0
-                                ( str "let" $ break 1 0
-                                $ Cmts.fmt_before c popen_loc
-                                $ fmt_or override "open!" "open"
-                                $ opt ext (fun _ -> fmt_if override " ")
-                                $ fmt_extension_suffix c ext )
-                            $ break 1 0 )
-                          (sub_mod ~ctx popen_expr)
-                      $ Cmts.fmt_after c popen_loc
-                      $ str " in" )
-                  $ break 1000 0
-                  $ fmt_expression c (sub_exp ~ctx e0) ) )
+               (Params.Exp.wrap c.conf ~parens:inner_parens
+                  ~fits_breaks:false
+                  (vbox 0
+                     ( hvbox 0
+                         ( fmt_module_statement c ~attributes
+                             ~keyword:
+                               ( hvbox 0
+                                   ( str "let" $ break 1 0
+                                   $ Cmts.fmt_before c popen_loc
+                                   $ fmt_or override "open!" "open"
+                                   $ opt ext (fun _ -> fmt_if override " ")
+                                   $ fmt_extension_suffix c ext )
+                               $ break 1 0 )
+                             (sub_mod ~ctx popen_expr)
+                         $ Cmts.fmt_after c popen_loc
+                         $ str " in" )
+                     $ break 1000 0
+                     $ fmt_expression c (sub_exp ~ctx e0) ) ) )
            $ fmt_atrs ) )
   | Pexp_try (e0, [{pc_lhs; pc_guard; pc_rhs}])
     when Poly.(

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -15,8 +15,8 @@ let _ =
     f
       (*comment*)
       (let open M in
-      let x = x in
-      e )
+       let x = x in
+       e )
   in
   ()
 

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -87,7 +87,7 @@ let () =
     ()) [@foo]];
   [%foo
     (let open M in
-    ()) [@foo]];
+     ()) [@foo]];
   [%foo fun [@foo] x -> ()];
   [%foo
     function[@foo]

--- a/test/passing/tests/let_in_constr.ml
+++ b/test/passing/tests/let_in_constr.ml
@@ -1,4 +1,4 @@
 let _ =
   Some
     (let open! List in
-    1 )
+     1 )

--- a/test/passing/tests/open-closing-on-separate-line.ml.ref
+++ b/test/passing/tests/open-closing-on-separate-line.ml.ref
@@ -32,18 +32,18 @@ let _ =
 
 let () =
   ( (let open Term in
-    term_result
-      (const Phases.phase1 $ arch $ hub_id $ build_dir $ logs_dir
-     $ setup_logs
-      )
+     term_result
+       (const Phases.phase1 $ arch $ hub_id $ build_dir $ logs_dir
+      $ setup_logs
+       )
     )
   , Term.info "phase1" ~doc ~sdocs:Manpage.s_common_options ~exits ~man
   )
 
 let () =
   (let open Arg in
-  let doc = "Output all." in
-  value & flag & info ["all"] ~doc
+   let doc = "Output all." in
+   value & flag & info ["all"] ~doc
   )
   $
   let open Arg in
@@ -293,7 +293,7 @@ open [%ext] [@@attr]
 let g =
   M.f
     ((let open M in
-     x
+      x
      ) [@attr]
     )
 

--- a/test/passing/tests/open.ml.ref
+++ b/test/passing/tests/open.ml.ref
@@ -32,15 +32,15 @@ let _ =
 
 let () =
   ( (let open Term in
-    term_result
-      ( const Phases.phase1 $ arch $ hub_id $ build_dir $ logs_dir
-      $ setup_logs ) )
+     term_result
+       ( const Phases.phase1 $ arch $ hub_id $ build_dir $ logs_dir
+       $ setup_logs ) )
   , Term.info "phase1" ~doc ~sdocs:Manpage.s_common_options ~exits ~man )
 
 let () =
   (let open Arg in
-  let doc = "Output all." in
-  value & flag & info ["all"] ~doc )
+   let doc = "Output all." in
+   value & flag & info ["all"] ~doc )
   $
   let open Arg in
   let doc = "Commit to git." in
@@ -285,7 +285,7 @@ open [%ext] [@@attr]
 let g =
   M.f
     ((let open M in
-     x ) [@attr] )
+      x ) [@attr] )
 
 let _ = M.({f} [@warning "foo"])
 

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -101,7 +101,7 @@ let () =
     [@foo]] ;
   [%foo
     (let open M in
-    () ) [@foo]] ;
+     () ) [@foo]] ;
   [%foo fun [@foo] x -> ()] ;
   [%foo function[@foo] x -> ()] ;
   [%foo try[@foo] () with _ -> ()] ;


### PR DESCRIPTION
Fix #2186

What do you think @samoht (https://github.com/ocaml-ppx/ocamlformat/actions/runs/3267004322/jobs/5371567574), @jberdine (https://github.com/ocaml-ppx/ocamlformat/actions/runs/3267004322/jobs/5371567691), @ceastlund (https://github.com/ocaml-ppx/ocamlformat/actions/runs/3267004322/jobs/5371567786) ? The diff is quite large but it looks like the improvement is worth it.
(unfold the `Test [...] profile` task to see the diff)