### PR TITLE
Simplify representation and formatting of mod-unpack

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1058,21 +1058,9 @@ end = struct
         assert (loop ctx.pmty_desc)
     | Mod ctx -> (
       match ctx.pmod_desc with
-      | Pmod_unpack e1 -> (
-        match e1.pexp_desc with
-        | Pexp_constraint (_, ({ptyp_desc= Ptyp_package (_, it1N); _} as ty))
-          ->
-            assert (typ == ty || List.exists it1N ~f:snd_f)
-        | Pexp_constraint (_, t1)
-         |Pexp_coerce (_, None, t1)
-         |Pexp_poly (_, Some t1)
-         |Pexp_extension (_, PTyp t1) ->
-            assert (typ == t1)
-        | Pexp_coerce (_, Some t1, t2) -> assert (typ == t1 || typ == t2)
-        | Pexp_letexception (ext, _) -> assert (check_ext ext)
-        | Pexp_object {pcstr_fields; _} ->
-            assert (check_pcstr_fields pcstr_fields)
-        | _ -> assert false )
+      | Pmod_unpack (_, ty1, ty2) ->
+          let f (_, cstrs) = List.exists cstrs ~f:(fun (_, x) -> f x) in
+          assert (Option.exists ty1 ~f || Option.exists ty2 ~f)
       | _ -> assert false )
     | Sig ctx -> (
       match ctx.psig_desc with
@@ -1481,7 +1469,7 @@ end = struct
        |Pstr_class _ | Pstr_class_type _ | Pstr_include _ | Pstr_attribute _
         ->
           assert false )
-    | Mod {pmod_desc= Pmod_unpack e1; _} -> (
+    | Mod {pmod_desc= Pmod_unpack (e1, _, _); _} -> (
       match e1 with
       | { pexp_desc=
             Pexp_constraint

--- a/test/passing/tests/module.ml
+++ b/test/passing/tests/module.ml
@@ -98,3 +98,21 @@ module M =
       val y : t
     end)
     ( (* struct type z = K.y end *) )
+
+let _ =
+  let module M =
+    (val (* aa *) m (* bb *) : (* cc *) M (* dd *) :> (* ee *) N (* ff *))
+  in
+  let module M =
+    ( val m
+        : M with type t = k and type p = k
+        :> N with type t = t and type k = t )
+  in
+  let module M =
+    ( val (* aa *) m (* bb *)
+        : (* cc *)
+        M with type t = t (* dd *)
+        :> (* ee *)
+        N with type t = t (* ff *) )
+  in
+  ()

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -3384,10 +3384,8 @@ type ('k, 'd, 'm) map =
   (module MapT with type key = 'k and type data = 'd and type map = 'm)
 
 let add (type k d m) (m : (k, d, m) map) x y s =
-  let module M = ( val m : MapT
-                     with type key = k
-                      and type data = d
-                      and type map = m )
+  let module M =
+    (val m : MapT with type key = k and type data = d and type map = m)
   in
   M.of_t (M.add x y (M.to_t s))
 

--- a/vendor/diff-parsers-ext-parsewyc.patch
+++ b/vendor/diff-parsers-ext-parsewyc.patch
@@ -403,7 +403,8 @@
    | (* A core language expression that produces a first-class module.
         This expression can be annotated in various ways. *)
      LPAREN VAL attrs = attributes e = expr_colon_package_type RPAREN
-       { mkmod ~loc:$sloc ~attrs (Pmod_unpack e) }
+       { let (e, ty1, ty2) = e in
+         mkmod ~loc:$sloc ~attrs (Pmod_unpack (e, ty1, ty2)) }
 -  | LPAREN VAL attributes expr COLON error
 -      { unclosed "(" $loc($1) ")" $loc($6) }
 -  | LPAREN VAL attributes expr COLONGREATER error

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -206,7 +206,7 @@ let mk ?(loc = !default_loc) ?(attrs = []) d =
     mk ?loc ?attrs (Pmod_functor (arg, body))
   let apply ?loc ?attrs m1 m2 = mk ?loc ?attrs (Pmod_apply (m1, m2))
   let constraint_ ?loc ?attrs m mty = mk ?loc ?attrs (Pmod_constraint (m, mty))
-  let unpack ?loc ?attrs e = mk ?loc ?attrs (Pmod_unpack e)
+  let unpack ?loc ?attrs a b c = mk ?loc ?attrs (Pmod_unpack (a, b, c))
   let gen_apply ?loc ?attrs a b = mk ?loc ?attrs (Pmod_gen_apply (a, b))
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pmod_extension a)
   let hole ?loc ?attrs () = mk ?loc ?attrs Pmod_hole

--- a/vendor/parser-extended/ast_helper.mli
+++ b/vendor/parser-extended/ast_helper.mli
@@ -279,7 +279,8 @@ module Mod:
       module_expr
     val constraint_: ?loc:loc -> ?attrs:attrs -> module_expr -> module_type ->
       module_expr
-    val unpack: ?loc:loc -> ?attrs:attrs -> expression -> module_expr
+    val unpack: ?loc:loc -> ?attrs:attrs -> expression -> package_type option
+      -> package_type option -> module_expr
     val gen_apply: ?loc:loc -> ?attrs:attrs -> module_expr -> loc -> module_expr
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> module_expr
     val hole: ?loc:loc -> ?attrs:attrs -> unit -> module_expr

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -408,7 +408,11 @@ module M = struct
     | Pmod_constraint (m, mty) ->
         constraint_ ~loc ~attrs (sub.module_expr sub m)
                     (sub.module_type sub mty)
-    | Pmod_unpack e -> unpack ~loc ~attrs (sub.expr sub e)
+    | Pmod_unpack (e, ty1, ty2) ->
+        unpack ~loc ~attrs
+          (sub.expr sub e)
+          (map_opt (map_package_type sub) ty1)
+          (map_opt (map_package_type sub) ty2)
     | Pmod_gen_apply (me, lc) ->
         gen_apply ~loc ~attrs (sub.module_expr sub me) (sub.location sub lc)
     | Pmod_extension x -> extension ~loc ~attrs (sub.extension sub x)

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -1015,7 +1015,8 @@ and module_expr_desc =
       (** [functor(X : MT1) -> ME] *)
   | Pmod_apply of module_expr * module_expr  (** [ME1(ME2)] *)
   | Pmod_constraint of module_expr * module_type  (** [(ME : MT)] *)
-  | Pmod_unpack of expression  (** [(val E)] *)
+  | Pmod_unpack of expression * package_type option * package_type option
+      (** [(val E : M1 :> M2)] *)
   | Pmod_gen_apply of module_expr * Location.t  (** [ME()] *)
   | Pmod_extension of extension  (** [[%id]] *)
   | Pmod_hole  (** [_] *)

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -228,9 +228,9 @@ let rec core_type i ppf x =
   | Ptyp_poly (sl, ct) ->
       line i ppf "Ptyp_poly%a\n" typevars sl;
       core_type i ppf ct;
-  | Ptyp_package (s, l) ->
-      line i ppf "Ptyp_package %a\n" fmt_longident_loc s;
-      list i package_with ppf l;
+  | Ptyp_package pt ->
+      line i ppf "Ptyp_package\n";
+      package_type i ppf pt
   | Ptyp_extension (s, arg) ->
       line i ppf "Ptyp_extension %a\n" fmt_string_loc s;
       payload i ppf arg
@@ -255,6 +255,10 @@ and object_field i ppf x =
 and package_with i ppf (s, t) =
   line i ppf "with type %a\n" fmt_longident_loc s;
   core_type i ppf t
+
+and package_type i ppf (s, l) =
+  line i ppf "package_type %a\n" fmt_longident_loc s;
+  list i package_with ppf l
 
 and pattern i ppf x =
   line i ppf "pattern %a\n" fmt_location x.ppat_loc;
@@ -312,10 +316,7 @@ and pattern i ppf x =
       longident_loc i ppf li
   | Ppat_unpack (s, pt) ->
       line i ppf "Ppat_unpack %a\n" fmt_str_opt_loc s;
-      option i (fun i ppf (s, l) ->
-          line i ppf "package_type %a\n" fmt_longident_loc s;
-          list i package_with ppf l)
-        ppf pt
+      option i package_type ppf pt
   | Ppat_exception p ->
       line i ppf "Ppat_exception\n";
       pattern i ppf p
@@ -913,9 +914,11 @@ and module_expr i ppf x =
       line i ppf "Pmod_constraint\n";
       module_expr i ppf me;
       module_type i ppf mt;
-  | Pmod_unpack (e) ->
+  | Pmod_unpack (e, ty1, ty2) ->
       line i ppf "Pmod_unpack\n";
       expression i ppf e;
+      option i package_type ppf ty1;
+      option i package_type ppf ty2
   | Pmod_gen_apply (x, loc) ->
       line i ppf "Pmod_gen_apply\n";
       module_expr i ppf x;

--- a/vendor/parser-recovery/lib/parser.mly
+++ b/vendor/parser-recovery/lib/parser.mly
@@ -1182,20 +1182,21 @@ paren_module_expr:
   | (* A core language expression that produces a first-class module.
        This expression can be annotated in various ways. *)
     LPAREN VAL attrs = attributes e = expr_colon_package_type RPAREN
-      { mkmod ~loc:$sloc ~attrs (Pmod_unpack e) }
+      { let (e, ty1, ty2) = e in
+        mkmod ~loc:$sloc ~attrs (Pmod_unpack (e, ty1, ty2)) }
 ;
 
 (* The various ways of annotating a core language expression that
    produces a first-class module that we wish to unpack. *)
 %inline expr_colon_package_type:
     e = expr
-      { e }
-  | e = expr COLON ty = package_core_type
-      { ghexp ~loc:$loc (Pexp_constraint (e, ty)) }
-  | e = expr COLON ty1 = package_core_type COLONGREATER ty2 = package_core_type
-      { ghexp ~loc:$loc (Pexp_coerce (e, Some ty1, ty2)) }
-  | e = expr COLONGREATER ty2 = package_core_type
-      { ghexp ~loc:$loc (Pexp_coerce (e, None, ty2)) }
+      { e, None, None }
+  | e = expr COLON ty1 = package_type
+      { e, Some ty1, None }
+  | e = expr COLON ty1 = package_type COLONGREATER ty2 = package_type
+      { e, Some ty1, Some ty2 }
+  | e = expr COLONGREATER ty2 = package_type
+      { e, None, Some ty2 }
 ;
 
 (* A structure, which appears between STRUCT and END (among other places),
@@ -2547,8 +2548,7 @@ simple_pattern_not_ident:
   | LPAREN MODULE ext_attributes mkrhs(module_name) RPAREN
       { mkpat_attrs ~loc:$sloc (Ppat_unpack ($4, None)) $3 }
   | LPAREN MODULE ext_attributes mkrhs(module_name) COLON package_type RPAREN
-      { let (lid, cstrs, _attrs) = $6 in
-        mkpat_attrs ~loc:$sloc (Ppat_unpack ($4, Some (lid, cstrs))) $3 }
+      { mkpat_attrs ~loc:$sloc (Ppat_unpack ($4, Some $6)) $3 }
   | mkpat(simple_pattern_not_ident_)
       { $1 }
 ;
@@ -3192,7 +3192,8 @@ atomic_type:
         mktyp ~loc:$sloc ~attrs descr }
 ;
 %inline package_type: module_type
-      { package_type_of_module_type $1 }
+      { let (lid, cstrs, _attrs) = package_type_of_module_type $1 in
+        (lid, cstrs) }
 ;
 %inline row_field_list:
   separated_nonempty_llist(BAR, row_field)

--- a/vendor/parser-recovery/test/expect/structure/unclosed_mod_expr3.ml.ref
+++ b/vendor/parser-recovery/test/expect/structure/unclosed_mod_expr3.ml.ref
@@ -8,4 +8,6 @@
           Pexp_constant
           constant ([1,0+16]..[1,0+17])
             PConst_int (3,None)
+        None
+        None
 ]


### PR DESCRIPTION
Extracted from ocamlformat-ng's concrete AST in our long-running effort to make the AST closer to the original source.
Removing intermediate artificial expression and core_type nodes that complicate the comments and the pattern-matching.