### PR TITLE
Remove unnecessary parentheses around partially applied infix operators with attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 - Mute warnings for odoc code blocks whose syntax is not specified (#2151, @gpetiot)
 - Improve formatting of odoc links (#2152, @gpetiot)
 - Preserve sugared extension node attached to an `if` carrying attributes (#2167, @trefis, @gpetiot)
+- Remove unnecessary parentheses around partially applied infix operators with attributes (#<PR_NUMBER>, @gpetiot)
 
 ### New features
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@
 - Mute warnings for odoc code blocks whose syntax is not specified (#2151, @gpetiot)
 - Improve formatting of odoc links (#2152, @gpetiot)
 - Preserve sugared extension node attached to an `if` carrying attributes (#2167, @trefis, @gpetiot)
-- Remove unnecessary parentheses around partially applied infix operators with attributes (#<PR_NUMBER>, @gpetiot)
+- Remove unnecessary parentheses around partially applied infix operators with attributes (#2198, @gpetiot)
 
 ### New features
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -866,8 +866,6 @@ and Requires_sub_terms : sig
   val parenze_exp : expression In_ctx.xt -> bool
 
   val parenze_nested_exp : expression In_ctx.xt -> bool
-
-  val is_displaced_infix_op : expression In_ctx.xt -> bool
 end = struct
   open In_ctx
 
@@ -1968,19 +1966,6 @@ end = struct
           | _ -> false )
     | _ -> false
 
-  (** Check if an exp is a prefix op that is not fully applied *)
-  let is_displaced_prefix_op {ctx; ast= exp} =
-    match (ctx, exp.pexp_desc) with
-    | _, Pexp_ident {txt= i; _} when Longident.is_prefix i -> true
-    | _ -> false
-
-  (** Check if an exp is an infix op that is not fully applied *)
-  let is_displaced_infix_op {ctx; ast= exp} =
-    match (ctx, exp.pexp_desc) with
-    | _, Pexp_ident {txt= i; _} when Longident.is_infix i ->
-        List.is_empty exp.pexp_attributes
-    | _ -> false
-
   let marked_parenzed_inner_nested_match =
     let memo = Hashtbl.Poly.create () in
     register_reset (fun () -> Hashtbl.clear memo) ;
@@ -2177,10 +2162,8 @@ end = struct
       | _ -> failwith "exp must be lhs or rhs from the parent expression"
     in
     assert_check_exp xexp ;
-    is_displaced_prefix_op xexp
-    || is_displaced_infix_op xexp
-    || Hashtbl.find marked_parenzed_inner_nested_match exp
-       |> Option.value ~default:false
+    Hashtbl.find marked_parenzed_inner_nested_match exp
+    |> Option.value ~default:false
     ||
     match (ctx, exp) with
     | Str {pstr_desc= Pstr_eval _; _}, _ -> false

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -253,7 +253,3 @@ val parenze_mty : module_type xt -> bool
 val parenze_mod : module_expr xt -> bool
 (** [parenze_mod xmod] holds when module_expr-in-context [xmod] should be
     parenthesized. *)
-
-val is_displaced_infix_op : expression xt -> bool
-(** [is_displaced_infix_op xexp] holds if an expression-in-context [xexp] is
-    an infix op that is not fully applied. *)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2145,6 +2145,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                (fun ~first ~last (xcond, xbch, pexp_attributes) ->
                  let symbol_parens = Exp.is_symbol xbch.ast in
                  let parens_bch = parenze_exp xbch && not symbol_parens in
+                 let parens_exp = false in
                  let p =
                    Params.get_if_then_else c.conf ~first ~last ~parens
                      ~parens_bch ~parens_prev_bch:!parens_prev_bch ~xcond
@@ -2163,7 +2164,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                        ( p.branch_pro
                        $ p.wrap_parens
                            ( fmt_expression c ?box:p.box_expr
-                               ~parens:symbol_parens ?pro:p.expr_pro
+                               ~parens:parens_exp ?pro:p.expr_pro
                                ?eol:p.expr_eol xbch
                            $ p.break_end_branch ) ) )
                  $ fmt_if_k (not last) p.space_between_branches ) )
@@ -2986,11 +2987,11 @@ and fmt_case c ctx ~first ~last case =
     | (Pexp_match _ | Pexp_try _), `Align -> last
     | _ -> false
   in
+  let symbol_parens = Exp.is_symbol xrhs.ast in
   let parens_branch, parens_for_exp =
     if align_nested_match then (false, Some false)
     else if c.conf.fmt_opts.leading_nested_match_parens.v then (false, None)
-    else if is_displaced_infix_op xrhs then (false, None)
-    else (parenze_exp xrhs, Some false)
+    else (parenze_exp xrhs && not symbol_parens, Some false)
   in
   (* side effects of Cmts.fmt_before before [fmt_lhs] is important *)
   let leading_cmt = Cmts.fmt_before c pc_lhs.ppat_loc in

--- a/test/passing/tests/indicate_multiline_delimiters-cosl.ml.ref
+++ b/test/passing/tests/indicate_multiline_delimiters-cosl.ml.ref
@@ -1,7 +1,7 @@
 let compare = function
   | Eq -> ( = )
   | Neq -> ( <> )
-  | Lt -> ( < )
+  | Lt -> ( < ) [@attr]
   | Le -> ( <= )
   | Gt -> ( > )
   | Ge -> ( >= )

--- a/test/passing/tests/indicate_multiline_delimiters-space.ml.ref
+++ b/test/passing/tests/indicate_multiline_delimiters-space.ml.ref
@@ -1,7 +1,7 @@
 let compare = function
   | Eq -> ( = )
   | Neq -> ( <> )
-  | Lt -> ( < )
+  | Lt -> ( < ) [@attr]
   | Le -> ( <= )
   | Gt -> ( > )
   | Ge -> ( >= )

--- a/test/passing/tests/indicate_multiline_delimiters.ml
+++ b/test/passing/tests/indicate_multiline_delimiters.ml
@@ -1,7 +1,7 @@
 let compare = function
   | Eq -> ( = )
   | Neq -> ( <> )
-  | Lt -> ( < )
+  | Lt -> ( < ) [@attr]
   | Le -> ( <= )
   | Gt -> ( > )
   | Ge -> ( >= )

--- a/test/passing/tests/infix_bind-break.ml.ref
+++ b/test/passing/tests/infix_bind-break.ml.ref
@@ -238,3 +238,9 @@ let _ = f (( let* ) x (fun y -> z))
 let _ = f (( let* ) x (function y -> z))
 
 let _ = (x >>= fun () -> ()) [@a]
+
+let _ = ( >>= ) [@attr]
+
+let _ = f (( >>= ) [@attr]) ;;
+
+( >>= ) [@attr]

--- a/test/passing/tests/infix_bind-fit_or_vertical-break.ml.ref
+++ b/test/passing/tests/infix_bind-fit_or_vertical-break.ml.ref
@@ -244,3 +244,9 @@ let _ = f (( let* ) x (fun y -> z))
 let _ = f (( let* ) x (function y -> z))
 
 let _ = (x >>= fun () -> ()) [@a]
+
+let _ = ( >>= ) [@attr]
+
+let _ = f (( >>= ) [@attr]) ;;
+
+( >>= ) [@attr]

--- a/test/passing/tests/infix_bind-fit_or_vertical.ml.ref
+++ b/test/passing/tests/infix_bind-fit_or_vertical.ml.ref
@@ -234,3 +234,9 @@ let _ = f (( let* ) x (fun y -> z))
 let _ = f (( let* ) x (function y -> z))
 
 let _ = ((x >>= fun () -> ()) [@a])
+
+let _ = ( >>= ) [@attr]
+
+let _ = f (( >>= ) [@attr]) ;;
+
+( >>= ) [@attr]

--- a/test/passing/tests/infix_bind.ml
+++ b/test/passing/tests/infix_bind.ml
@@ -229,3 +229,9 @@ let _ = f (( let* ) x (fun y -> z))
 let _ = f (( let* ) x (function y -> z))
 
 let _ = ((x >>= fun () -> ()) [@a])
+
+let _ = ( >>= ) [@attr]
+
+let _ = f (( >>= ) [@attr]) ;;
+
+( >>= ) [@attr]

--- a/test/passing/tests/ite-compact.ml.ref
+++ b/test/passing/tests/ite-compact.ml.ref
@@ -127,7 +127,7 @@ let foo =
 
 let _ =
   if fooo then ( + )
-  else if bar then ( * )
+  else if bar then ( * ) [@attr]
   else if foobar then ( / )
   else ( - )
 

--- a/test/passing/tests/ite-compact_closing.ml.ref
+++ b/test/passing/tests/ite-compact_closing.ml.ref
@@ -142,7 +142,7 @@ let foo =
 
 let _ =
   if fooo then ( + )
-  else if bar then ( * )
+  else if bar then ( * ) [@attr]
   else if foobar then ( / )
   else ( - )
 

--- a/test/passing/tests/ite-fit_or_vertical.ml.ref
+++ b/test/passing/tests/ite-fit_or_vertical.ml.ref
@@ -154,7 +154,7 @@ let _ =
   if fooo then
     ( + )
   else if bar then
-    ( * )
+    ( * ) [@attr]
   else if foobar then
     ( / )
   else

--- a/test/passing/tests/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/tests/ite-fit_or_vertical_closing.ml.ref
@@ -166,7 +166,7 @@ let _ =
   if fooo then
     ( + )
   else if bar then
-    ( * )
+    ( * ) [@attr]
   else if foobar then
     ( / )
   else

--- a/test/passing/tests/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/tests/ite-fit_or_vertical_no_indicate.ml.ref
@@ -154,7 +154,7 @@ let _ =
   if fooo then
     ( + )
   else if bar then
-    ( * )
+    ( * ) [@attr]
   else if foobar then
     ( / )
   else

--- a/test/passing/tests/ite-kr.ml.ref
+++ b/test/passing/tests/ite-kr.ml.ref
@@ -189,6 +189,7 @@ let _ =
     ( + )
   else if bar then
     ( * )
+  [@attr]
   else if foobar then
     ( / )
   else

--- a/test/passing/tests/ite-kr_closing.ml.ref
+++ b/test/passing/tests/ite-kr_closing.ml.ref
@@ -199,6 +199,7 @@ let _ =
     ( + )
   else if bar then
     ( * )
+  [@attr]
   else if foobar then
     ( / )
   else

--- a/test/passing/tests/ite-kw_first.ml.ref
+++ b/test/passing/tests/ite-kw_first.ml.ref
@@ -147,7 +147,7 @@ let _ =
   if fooo
   then ( + )
   else if bar
-  then ( * )
+  then ( * ) [@attr]
   else if foobar
   then ( / )
   else ( - )

--- a/test/passing/tests/ite-kw_first_closing.ml.ref
+++ b/test/passing/tests/ite-kw_first_closing.ml.ref
@@ -162,7 +162,7 @@ let _ =
   if fooo
   then ( + )
   else if bar
-  then ( * )
+  then ( * ) [@attr]
   else if foobar
   then ( / )
   else ( - )

--- a/test/passing/tests/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/tests/ite-kw_first_no_indicate.ml.ref
@@ -146,7 +146,7 @@ let _ =
   if fooo
   then ( + )
   else if bar
-  then ( * )
+  then ( * ) [@attr]
   else if foobar
   then ( / )
   else ( - )

--- a/test/passing/tests/ite-no_indicate.ml.ref
+++ b/test/passing/tests/ite-no_indicate.ml.ref
@@ -126,7 +126,7 @@ let foo =
 
 let _ =
   if fooo then ( + )
-  else if bar then ( * )
+  else if bar then ( * ) [@attr]
   else if foobar then ( / )
   else ( - )
 

--- a/test/passing/tests/ite-vertical.ml.ref
+++ b/test/passing/tests/ite-vertical.ml.ref
@@ -185,6 +185,7 @@ let _ =
     ( + )
   else if bar then
     ( * )
+    [@attr]
   else if foobar then
     ( / )
   else

--- a/test/passing/tests/ite.ml
+++ b/test/passing/tests/ite.ml
@@ -128,7 +128,7 @@ let foo =
 
 let _ =
   if fooo then ( + )
-  else if bar then ( * )
+  else if bar then ( * ) [@attr]
   else if foobar then ( / )
   else ( - )
 

--- a/test/passing/tests/ite.ml.ref
+++ b/test/passing/tests/ite.ml.ref
@@ -127,7 +127,7 @@ let foo =
 
 let _ =
   if fooo then ( + )
-  else if bar then ( * )
+  else if bar then ( * ) [@attr]
   else if foobar then ( / )
   else ( - )
 

--- a/test/passing/tests/monadic_binding.ml
+++ b/test/passing/tests/monadic_binding.ml
@@ -21,3 +21,9 @@ let _ = ( let* ) x (function y -> z)
 let _ = f (( let* ) x (fun y -> z))
 
 let _ = f (( let* ) x (function y -> z))
+
+let _ = ( let+ ) [@attr]
+
+let _ = f (( let+ ) [@attr]) ;;
+
+( let+ ) [@attr]

--- a/test/passing/tests/prefix_infix.ml
+++ b/test/passing/tests/prefix_infix.ml
@@ -19,3 +19,9 @@ let z = (( ! ) [@attr]) 1 2 ~c:3
 let z = (( ! ) [@attr])
 
 let i x = (!r [@attr]) x
+
+let _ = ( * ) [@attr]
+
+let _ = f (( * ) [@attr]) ;;
+
+( * ) [@attr]


### PR DESCRIPTION
More consistency with how partially applied infix operators are handled, this change was already made for if-then-else