### PR TITLE
Apply 'if-then-else=vertical' to ocamlformat

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -4,3 +4,4 @@ margin = 77
 parse-docstrings = true
 wrap-comments = true
 line-endings = lf
+if-then-else = vertical

--- a/bin/ocamlformat/main.ml
+++ b/bin/ocamlformat/main.ml
@@ -18,7 +18,8 @@ Caml.at_exit (Format.pp_print_flush Format.err_formatter) ;;
 Caml.at_exit (Format_.pp_print_flush Format_.err_formatter)
 
 let format ?output_file ~kind ~input_name ~source (conf : Conf.t) =
-  if conf.opr_opts.disable.v then Ok source
+  if conf.opr_opts.disable.v then
+    Ok source
   else
     Translation_unit.parse_and_format kind ?output_file ~input_name ~source
       conf

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -118,7 +118,8 @@ module String_id = struct
          (String.lfindi s ~pos:3 ~f:(fun _ c -> not (Char_id.is_kwdop c)))
 
   let is_infix i =
-    if Char_id.is_infixop i.[0] then true
+    if Char_id.is_infixop i.[0] then
+      true
     else
       match i with
       | "!=" | "land" | "lor" | "lxor" | "mod" | "::" | ":=" | "asr"
@@ -1602,8 +1603,10 @@ end = struct
       match ptyp_desc with
       | Ptyp_arrow (t, _) ->
           let assoc =
-            if List.exists t ~f:(fun x -> x.pap_type == typ) then Left
-            else Right
+            if List.exists t ~f:(fun x -> x.pap_type == typ) then
+              Left
+            else
+              Right
           in
           Some (MinusGreater, assoc)
       | Ptyp_tuple _ -> Some (InfixOp3, Non)
@@ -1618,24 +1621,41 @@ end = struct
       | Pcty_constr (_, _ :: _ :: _) -> Some (Comma, Non)
       | Pcty_arrow (t, _) ->
           let assoc =
-            if List.exists t ~f:(fun x -> x.pap_type == typ) then Left
-            else Right
+            if List.exists t ~f:(fun x -> x.pap_type == typ) then
+              Left
+            else
+              Right
           in
           Some (MinusGreater, assoc)
       | _ -> None )
     | {ctx= Cty {pcty_desc; _}; ast= Cty typ; _} -> (
       match pcty_desc with
       | Pcty_arrow (_, t2) ->
-          Some (MinusGreater, if t2 == typ then Right else Left)
+          Some
+            ( MinusGreater
+            , if t2 == typ then
+                Right
+              else
+                Left )
       | _ -> None )
     | {ast= Cty _; _} -> None
     | {ast= Typ _; _} -> None
     | {ctx= Exp {pexp_desc; _}; ast= Exp exp} -> (
       match pexp_desc with
       | Pexp_tuple (e0 :: _) ->
-          Some (Comma, if exp == e0 then Left else Right)
+          Some
+            ( Comma
+            , if exp == e0 then
+                Left
+              else
+                Right )
       | Pexp_cons l ->
-          Some (ColonColon, if exp == List.last_exn l then Right else Left)
+          Some
+            ( ColonColon
+            , if exp == List.last_exn l then
+                Right
+              else
+                Left )
       | Pexp_construct
           ({txt= Lident "[]"; _}, Some {pexp_desc= Pexp_tuple [_; _]; _}) ->
           Some (Semi, Non)
@@ -1645,7 +1665,8 @@ end = struct
        |Pexp_variant (_, Some _) ->
           Some (Apply, Non)
       | Pexp_indexop_access {pia_lhs= lhs; pia_rhs= rhs; _} -> (
-          if lhs == exp then Some (Dot, Left)
+          if lhs == exp then
+            Some (Dot, Left)
           else
             match rhs with
             | Some e when e == exp -> Some (LessMinus, Right)
@@ -1656,14 +1677,21 @@ end = struct
             if
               loc.loc_end.pos_cnum - loc.loc_start.pos_cnum
               = String.length i - 1
-            then Some (UMinus, Non)
-            else Some (High, Non)
+            then
+              Some (UMinus, Non)
+            else
+              Some (High, Non)
         | _ -> (
           match i.[0] with
           | '!' | '?' | '~' -> Some (High, Non)
           | _ -> Some (Apply, Non) ) )
       | Pexp_infix ({txt= i; _}, e1, _) -> (
-          let child = if e1 == exp then Left else Right in
+          let child =
+            if e1 == exp then
+              Left
+            else
+              Right
+          in
           match (i.[0], i) with
           | _, ":=" -> Some (ColonEqual, child)
           | _, ("or" | "||") -> Some (BarBar, child)
@@ -1744,8 +1772,10 @@ end = struct
             if
               loc.loc_end.pos_cnum - loc.loc_start.pos_cnum
               = String.length i - 1
-            then Some UMinus
-            else Some High
+            then
+              Some UMinus
+            else
+              Some High
         | "!=" -> Some Apply
         | _ -> (
           match i.[0] with '!' | '?' | '~' -> Some High | _ -> Some Apply ) )
@@ -1806,7 +1836,10 @@ end = struct
             (* add parens only when the context has a higher prec than ast *)
             | cmp -> cmp >= 0
           in
-          if ambiguous then `Ambiguous else `Non_ambiguous
+          if ambiguous then
+            `Ambiguous
+          else
+            `Non_ambiguous
       | None -> `No_prec_ast )
     | None -> `No_prec_ctx
 
@@ -2133,8 +2166,10 @@ end = struct
       | _ -> (
         match ctx with
         | Exp {pexp_desc; _} ->
-            if is_right_infix_arg pexp_desc exp then Exp.is_sequence exp
-            else exposed_right_exp Non_apply exp
+            if is_right_infix_arg pexp_desc exp then
+              Exp.is_sequence exp
+            else
+              exposed_right_exp Non_apply exp
         | _ -> exposed_right_exp Non_apply exp )
     in
     let rec ifthenelse pexp_desc =

--- a/lib/Chunk.ml
+++ b/lib/Chunk.ml
@@ -59,8 +59,10 @@ let split fg c l =
           match acc with
           | [] ->
               let chunk =
-                if c.opr_opts.disable.v then (Disable init_loc, [x])
-                else (Enable, [x])
+                if c.opr_opts.disable.v then
+                  (Disable init_loc, [x])
+                else
+                  (Enable, [x])
               in
               (chunk :: acc, c)
           | (st, h) :: t -> ((st, x :: h) :: t, c) ) ) )

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -215,8 +215,10 @@ end = struct
                 if
                   Location.compare_start_col (List.last_exn cmtl).loc next
                   <= 0
-                then `Before_next
-                else `After_prev
+                then
+                  `Before_next
+                else
+                  `After_prev
             | 1, y when y > 1 && Source.empty_line_after src loc ->
                 `After_prev
             | _, y
@@ -237,7 +239,8 @@ end = struct
                     | `Before_next -> true )
               in
               (prev, next)
-            else ([], cmtl)
+            else
+              ([], cmtl)
           in
           (of_list prev, of_list next)
       | after :: befores -> (of_list after, of_list (List.concat befores))
@@ -255,8 +258,10 @@ let add_cmts t position loc ?deep_loc cmts =
           if
             is_adjacent t.source deep_loc cmt.loc
             && not (Source.begins_line ~ignore_spaces:true t.source cmt.loc)
-          then deep_loc
-          else loc
+          then
+            deep_loc
+          else
+            loc
       | None -> loc
     in
     update_cmts t position ~f:(Map.add_exn ~key ~data:cmtl)
@@ -440,7 +445,8 @@ let preserve ~cache_key f t =
       preserve_nomemo f t )
 
 let pop_if_debug t loc =
-  if t.debug then update_remaining t ~f:(fun s -> Set.remove s loc)
+  if t.debug then
+    update_remaining t ~f:(fun s -> Set.remove s loc)
 
 let find_cmts ?(filter = Fn.const true) t pos loc =
   pop_if_debug t loc ;
@@ -480,12 +486,14 @@ module Asterisk_prefixed = struct
       | _ ->
           let drop = function ' ' | '\t' -> true | _ -> false in
           let line = String.rstrip ~drop (String.drop_prefix txt pos) in
-          if String.is_empty line then [" "]
+          if String.is_empty line then
+            [" "]
           else if Char.equal line.[String.length line - 1] '\n' then
             [String.drop_suffix line 1; ""]
           else if Char.is_whitespace txt.[String.length txt - 1] then
             [line ^ " "]
-          else [line]
+          else
+            [line]
     in
     split_ 0
 
@@ -527,8 +535,10 @@ module Unwrapped = struct
     let unindented = unindent_lines ~opn_pos first_line tl_lines in
     let fmt_line ~first ~last:_ s =
       let sep, sp =
-        if is_white_line s then (str "\n", noop)
-        else (fmt "@;<1000 0>", fmt_if starts_with_sp " ")
+        if is_white_line s then
+          (str "\n", noop)
+        else
+          (fmt "@;<1000 0>", fmt_if starts_with_sp " ")
       in
       fmt_if_k (not first) sep $ sp $ str (String.rstrip s)
     in
@@ -580,8 +590,20 @@ let fmt_cmt (cmt : Cmt.t) ~wrap:wrap_comments ~ocp_indent_compat ~fmt_code
         `Verbatim str
     | str when Char.equal str.[0] '$' -> (
         let dollar_suf = Char.equal str.[String.length str - 1] '$' in
-        let cls : Fmt.s = if dollar_suf then "$*)" else "*)" in
-        let len = String.length str - if dollar_suf then 2 else 1 in
+        let cls : Fmt.s =
+          if dollar_suf then
+            "$*)"
+          else
+            "*)"
+        in
+        let len =
+          String.length str
+          -
+          if dollar_suf then
+            2
+          else
+            1
+        in
         let source = String.sub ~pos:1 ~len str in
         match fmt_code source with
         | Ok formatted -> `Code (formatted, cls)
@@ -679,7 +701,8 @@ module Toplevel = struct
                 fmt_or
                   (Source.empty_line_before t.source first_loc)
                   "\n@;<1000 0>" "@\n"
-              else break 1 0
+              else
+                break 1 0
         in
         let epi =
           let ({loc= last_loc; _} : Cmt.t) = List.last_exn cmts in
@@ -689,7 +712,8 @@ module Toplevel = struct
                 fmt_or
                   (Source.empty_line_after t.source last_loc)
                   "\n@;<1000 0>" "@\n"
-              else break 1 0
+              else
+                break 1 0
           | After -> noop
         in
         pro $ fmt_cmts_aux t conf cmts ~fmt_code pos $ epi

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -20,8 +20,10 @@ let warn_raw, collect_warnings =
   let delay_warning = ref false in
   let delayed_warning_list = ref [] in
   let warn_ s =
-    if !delay_warning then delayed_warning_list := s :: !delayed_warning_list
-    else Format.eprintf "%s%!" s
+    if !delay_warning then
+      delayed_warning_list := s :: !delayed_warning_list
+    else
+      Format.eprintf "%s%!" s
   in
   let collect_warnings f =
     let old_flag, old_list = (!delay_warning, !delayed_warning_list) in
@@ -312,8 +314,10 @@ module Formatting = struct
         )
       (fun conf ->
         let elt = conf.fmt_opts.break_struct in
-        if elt.v then Elt.make `Force elt.from
-        else Elt.make `Natural elt.from )
+        if elt.v then
+          Elt.make `Force elt.from
+        else
+          Elt.make `Natural elt.from )
 
   let cases_exp_indent =
     let docv = "COLS" in

--- a/lib/Config_option.ml
+++ b/lib/Config_option.ml
@@ -79,7 +79,12 @@ let update_from_elt ~redundant elt updated_from =
   let from =
     match from with
     | `Profile _ ->
-        `Updated (updated_from, if redundant then Some from else None)
+        `Updated
+          ( updated_from
+          , if redundant then
+              Some from
+            else
+              None )
     | _ -> `Updated (updated_from, None)
   in
   let v = Conf_t.Elt.v elt in
@@ -127,7 +132,11 @@ let removed ~since:rversion rmsg = {rmsg; rversion}
 
 let in_attributes cond = function
   | Operational -> ""
-  | Formatting -> if cond then "" else " Cannot be set in attributes."
+  | Formatting ->
+      if cond then
+        ""
+      else
+        " Cannot be set in attributes."
 
 let maybe_empty = function "" -> "" | x -> " " ^ x
 
@@ -176,7 +185,12 @@ let status_doc ppf = function
   | `Removed _ -> ()
 
 let generated_flag_doc ~allow_inline ~doc ~kind ~default ~status =
-  let default = if default then "set" else "unset" in
+  let default =
+    if default then
+      "set"
+    else
+      "unset"
+  in
   Format.asprintf "%s The flag is $(b,%s) by default.%s%a" doc default
     (in_attributes allow_inline kind)
     status_doc status
@@ -184,7 +198,10 @@ let generated_flag_doc ~allow_inline ~doc ~kind ~default ~status =
 let generated_doc conv ~allow_inline ~doc ~kind ~default ~status =
   let default_doc = Format.asprintf "%a" (Arg.conv_printer conv) default in
   let default =
-    if String.is_empty default_doc then "none" else default_doc
+    if String.is_empty default_doc then
+      "none"
+    else
+      default_doc
   in
   Format.asprintf "%s The default value is $(b,%s).%s%a" doc default
     (in_attributes allow_inline kind)
@@ -214,7 +231,10 @@ let flag ~default ~names ~doc ~kind
   let open Cmdliner in
   let invert_names =
     List.filter_map names ~f:(fun n ->
-        if String.length n = 1 then None else Some ("no-" ^ n) )
+        if String.length n = 1 then
+          None
+        else
+          Some ("no-" ^ n) )
   in
   let doc = generated_flag_doc ~allow_inline ~doc ~kind ~default ~status in
   let invert_doc = "Unset $(b," ^ List.last_exn names ^ ")." in

--- a/lib/Docstring.ml
+++ b/lib/Docstring.ml
@@ -152,7 +152,8 @@ let odoc_block_element c fmt = function
 let odoc_docs c fmt elems = list (ign_loc (odoc_block_element c)) fmt elems
 
 let normalize ~parse_docstrings ~normalize_code text =
-  if not parse_docstrings then normalize_text text
+  if not parse_docstrings then
+    normalize_text text
   else
     let location = Lexing.dummy_pos in
     let parsed = Odoc_parser.parse_comment ~location ~text in

--- a/lib/Eol_compat.ml
+++ b/lib/Eol_compat.ml
@@ -13,7 +13,8 @@ let normalize_eol ?(exclude_locs = []) ~line_endings s =
   let buf = Buffer.create (String.length s) in
   let add_cr n = Buffer.add_string buf (String.make n '\r') in
   let rec normalize_segment ~seen_cr i stop =
-    if i = stop then add_cr seen_cr
+    if i = stop then
+      add_cr seen_cr
     else
       match s.[i] with
       | '\r' -> normalize_segment ~seen_cr:(seen_cr + 1) (i + 1) stop

--- a/lib/Extended_ast.ml
+++ b/lib/Extended_ast.ml
@@ -111,7 +111,10 @@ module Parse = struct
 
   let normalize fg ~preserve_beginend x =
     map fg fix_letop_locs @@ map fg normalize_lists
-    @@ (if preserve_beginend then Fn.id else map fg remove_beginend_nodes)
+    @@ ( if preserve_beginend then
+         Fn.id
+       else
+         map fg remove_beginend_nodes )
     @@ x
 
   let ast (type a) (fg : a t) ~preserve_beginend ~input_name str : a =

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -123,7 +123,11 @@ let utf8_length s =
 
 let str_as n s = with_pp (fun fs -> Format.pp_print_as fs n s)
 
-let str s = if String.is_empty s then noop else str_as (utf8_length s) s
+let str s =
+  if String.is_empty s then
+    noop
+  else
+    str_as (utf8_length s) s
 
 let sp = function
   | Blank -> char ' '
@@ -158,17 +162,31 @@ let list_fl xs pp =
       pp ~first:(Option.is_none prev) ~last:(Option.is_none next) x )
 
 let list_k l sep f =
-  list_fl l (fun ~first:_ ~last x -> f x $ if last then noop else sep)
+  list_fl l (fun ~first:_ ~last x ->
+      f x
+      $
+      if last then
+        noop
+      else
+        sep )
 
 let list xs sep pp = list_k xs (fmt sep) pp
 
 (** Conditional formatting ----------------------------------------------*)
 
-let fmt_if_k cnd x = if cnd then x else noop
+let fmt_if_k cnd x =
+  if cnd then
+    x
+  else
+    noop
 
 let fmt_if cnd f = fmt_if_k cnd (fmt f)
 
-let fmt_or_k cnd t f = if cnd then t else f
+let fmt_or_k cnd t f =
+  if cnd then
+    t
+  else
+    f
 
 let fmt_or cnd t f = fmt_or_k cnd (fmt t) (fmt f)
 
@@ -211,8 +229,10 @@ let wrap_if cnd pre suf = wrap_if_k cnd (fmt pre) (fmt suf)
 and wrap pre suf = wrap_k (fmt pre) (fmt suf)
 
 let wrap_if_fits_or cnd pre suf k =
-  if cnd then wrap_k (str pre) (str suf) k
-  else fits_breaks pre "" $ k $ fits_breaks suf ""
+  if cnd then
+    wrap_k (str pre) (str suf) k
+  else
+    fits_breaks pre "" $ k $ fits_breaks suf ""
 
 let wrap_fits_breaks_if ?(space = true) (c : Conf.t) cnd pre suf k =
   match (c.fmt_opts.indicate_multiline_delimiters.v, space) with
@@ -254,7 +274,12 @@ let debug_box_open ?name box_kind n fs =
       | Some s -> Format.sprintf "%s:%s" box_kind s
       | None -> box_kind
     in
-    let openning = if n = 0 then name else Format.sprintf "%s<%d" name n in
+    let openning =
+      if n = 0 then
+        name
+      else
+        Format.sprintf "%s<%d" name n
+    in
     pp_color_k (box_depth_color ())
       (fun fs -> Format.fprintf fs "@<0>[@<0>%s@<0>>" openning)
       fs ;
@@ -335,11 +360,17 @@ let fill_text ?(epi = "") text =
       ~equal:(fun x y -> String.is_empty x && String.is_empty y)
       (String.split (String.rstrip text) ~on:'\n')
   in
-  let pro = if String.starts_with_whitespace text then " " else "" in
+  let pro =
+    if String.starts_with_whitespace text then
+      " "
+    else
+      ""
+  in
   let epi =
     if String.length text > 1 && String.ends_with_whitespace text then
       " " ^ epi
-    else epi
+    else
+      epi
   in
   str pro
   $ hvbox 0

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -167,7 +167,8 @@ let closing_paren ?force ?(offset = 0) c =
   | `Closing_on_separate_line -> fits_breaks ")" ")" ~hint:(1000, offset)
 
 let maybe_disabled_k c (loc : Location.t) (l : attributes) f k =
-  if not c.conf.opr_opts.disable.v then f c
+  if not c.conf.opr_opts.disable.v then
+    f c
   else
     let loc = Source.extend_loc_to_include_attributes loc l in
     Cmts.drop_inside c.cmts loc ;
@@ -285,7 +286,8 @@ let fmt_constant c ?epi {pconst_desc; pconst_loc= loc} =
             List.for_all delim ~f:not_suffix || not break_on_newlines
           in
           let fmt_next next =
-            if String.is_empty next then fmt_if_k print_ln (str "\\n")
+            if String.is_empty next then
+              fmt_if_k print_ln (str "\\n")
             else if Char.equal next.[0] ' ' then
               fmt_if_k print_ln (str "\\n")
               $ cbreak ~fits:("", 0, "") ~breaks:("\\", -1, "\\")
@@ -298,7 +300,8 @@ let fmt_constant c ?epi {pconst_desc; pconst_loc= loc} =
         in
         let lines = String.split ~on:'\n' s in
         let lines =
-          if break_on_newlines then lines
+          if break_on_newlines then
+            lines
           else
             let n_lines = List.length lines in
             (* linebreaks are merged with the preceding line when possible
@@ -402,7 +405,12 @@ let fmt_parsed_docstring c ~loc ?pro ~epi str_cmt parsed =
   @@ vbox_if (Option.is_none pro) 0 (fmt_opt pro $ wrap "(**" "*)" doc $ epi)
 
 let docstring_epi ~standalone ~next ~epi ~floating =
-  let epi = if Option.is_some next then fmt "@\n" else fmt_opt epi in
+  let epi =
+    if Option.is_some next then
+      fmt "@\n"
+    else
+      fmt_opt epi
+  in
   match next with
   | (None | Some (_, false)) when floating && not standalone ->
       str "\n" $ epi
@@ -440,11 +448,13 @@ let fmt_docstring_around_item' ?(is_val = false) ?(force_before = false)
         |> List.partition_tf ~f:(fun (_, (_, floating)) -> floating)
       in
       let placement =
-        if force_before then `Before
+        if force_before then
+          `Before
         else if
           Poly.( = ) c.conf.fmt_opts.doc_comments_tag_only.v `Fit
           && fit && is_tag_only doc
-        then `Fit
+        then
+          `Fit
         else
           let ((`Before | `After) as conf) =
             match c.conf.fmt_opts.doc_comments.v with
@@ -489,7 +499,11 @@ let fmt_assign_arrow c =
 
 let arrow_sep c ~parens : Fmt.s =
   match c.conf.fmt_opts.break_separators.v with
-  | `Before -> if parens then "@;<1 1>-> " else "@ -> "
+  | `Before ->
+      if parens then
+        "@;<1 1>-> "
+      else
+        "@ -> "
   | `After -> " ->@;<1 0>"
 
 let fmt_docstring_padded c doc =
@@ -514,8 +528,10 @@ let fmt_quoted_string key ext s = function
   | None -> wrap_k (str (Format.sprintf "{%s%s|" key ext)) (str "|}") (str s)
   | Some delim ->
       let ext_and_delim =
-        if String.is_empty delim then ext
-        else Format.sprintf "%s %s" ext delim
+        if String.is_empty delim then
+          ext
+        else
+          Format.sprintf "%s %s" ext delim
       in
       wrap_k
         (str (Format.sprintf "{%s%s|" key ext_and_delim))
@@ -756,9 +772,12 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
   let doc, atrs = doc_atrs ptyp_attributes in
   Cmts.fmt c ptyp_loc
   @@ (fun k -> k $ fmt_docstring c ~pro:(fmt "@ ") doc)
-  @@ ( if List.is_empty atrs then Fn.id
-     else fun k ->
-       hvbox 0 (Params.parens c.conf (k $ fmt_attributes c ~pre:Cut atrs)) )
+  @@ ( if List.is_empty atrs then
+       Fn.id
+     else
+       fun k ->
+         hvbox 0 (Params.parens c.conf (k $ fmt_attributes c ~pre:Cut atrs))
+     )
   @@
   let parens = parenze_typ xtyp in
   hvbox_if box 0
@@ -786,7 +805,10 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
       let ct2 = {pap_label= Nolabel; pap_loc= ct2.ptyp_loc; pap_type= ct2} in
       let xt1N = List.rev (ct2 :: List.rev ctl) in
       let indent =
-        if Poly.(c.conf.fmt_opts.break_separators.v = `Before) then 2 else 0
+        if Poly.(c.conf.fmt_opts.break_separators.v = `Before) then
+          2
+        else
+          0
       in
       ( match pro with
       | Some pro when c.conf.fmt_opts.ocp_indent_compat.v ->
@@ -835,8 +857,10 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
               ( if
                 in_type_declaration
                 && Poly.(c.conf.fmt_opts.type_decl.v = `Sparse)
-              then "@;<1000 0>| "
-              else "@ | " )
+              then
+                "@;<1000 0>| "
+              else
+                "@ | " )
               (fmt_row_field c ctx)
       in
       let protect_token = Exposed.Right.(list ~elt:row_field) rfs in
@@ -848,10 +872,18 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
           | `Sparse -> Option.some_if space_around Break
           | `Compact -> None
         in
-        let nspaces = if empty then 0 else 1 in
+        let nspaces =
+          if empty then
+            0
+          else
+            1
+        in
         let space = (protect_token || space_around) && not empty in
         fits_breaks
-          (if space && not empty then " ]" else "]")
+          ( if space && not empty then
+            " ]"
+          else
+            "]" )
           ~hint:(nspaces, 0) "]" ?force
       in
       hvbox 0
@@ -859,7 +891,12 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
         | Closed, None, [{prf_desc= Rinherit _; _}] ->
             str "[ | " $ row_fields rfs $ closing
         | Closed, None, _ ->
-            let opening = if space_around then "[ " else "[" in
+            let opening =
+              if space_around then
+                "[ "
+              else
+                "["
+            in
             fits_breaks opening "[ " $ row_fields rfs $ closing
         | Open, None, _ -> str "[> " $ row_fields rfs $ closing
         | Closed, Some [], _ -> str "[< " $ row_fields rfs $ closing
@@ -1108,8 +1145,10 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
                   let cmts_before = Cmts.has_before c.cmts loc in
                   let leading_cmt =
                     let pro, adj =
-                      if first_grp && first then (noop, fmt "@ ")
-                      else (fmt "@ ", noop)
+                      if first_grp && first then
+                        (noop, fmt "@ ")
+                      else
+                        (fmt "@ ", noop)
                     in
                     Cmts.fmt_before ~pro c loc ~adj ~eol:noop
                   in
@@ -1117,8 +1156,14 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
                     if first_grp && first then
                       fmt_opt pro
                       $ fits_breaks
-                          (if parens then "(" else "")
-                          (if nested then "" else "( ")
+                          ( if parens then
+                            "("
+                          else
+                            "" )
+                          ( if nested then
+                            ""
+                          else
+                            "( " )
                       $ open_box (-2)
                     else if first then
                       Params.get_or_pattern_sep c.conf ~ctx:ctx0 ~cmts_before
@@ -1130,8 +1175,18 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
                   leading_cmt $ fmt_pattern c ~box:true ~pro xpat )
               $ close_box )
         $ fmt_or_k nested
-            (fits_breaks (if parens then ")" else "") "")
-            (fits_breaks (if parens then ")" else "") ~hint:(1, 2) ")") )
+            (fits_breaks
+               ( if parens then
+                 ")"
+               else
+                 "" )
+               "" )
+            (fits_breaks
+               ( if parens then
+                 ")"
+               else
+                 "" )
+               ~hint:(1, 2) ")" ) )
   | Ppat_constraint (pat, typ) ->
       hvbox 2
         (Params.parens_if parens c.conf
@@ -1191,7 +1246,12 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
         | Ppat_construct ({txt= Lident "[]"; _}, None) -> true
         | _ -> false
       in
-      let opn, cls = if can_skip_parens then (".", "") else (".(", ")") in
+      let opn, cls =
+        if can_skip_parens then
+          (".", "")
+        else
+          (".(", ")")
+      in
       cbox 0
         ( fmt_longident_loc c lid
         $ wrap_k (str opn) (str cls)
@@ -1386,7 +1446,10 @@ and fmt_args_grouped ?epi:(global_epi = noop) c ctx args =
   in
   let fmt_args ~first ~last args =
     hovbox
-      (if first then 2 else 0)
+      ( if first then
+        2
+      else
+        0 )
       (list_fl args (fmt_arg c) $ fmt_if_k last global_epi)
     $ fmt_if_k (not last) (break 1 0)
   in
@@ -1407,8 +1470,10 @@ and fmt_args_grouped ?epi:(global_epi = noop) c ctx args =
     Cmts.has_after c.cmts (snd x).pexp_loc || not (is_simple x && is_simple y)
   in
   let groups =
-    if c.conf.fmt_opts.wrap_fun_args.v then List.group args ~break
-    else List.map args ~f:(fun x -> [x])
+    if c.conf.fmt_opts.wrap_fun_args.v then
+      List.group args ~break
+    else
+      List.map args ~f:(fun x -> [x])
   in
   list_fl groups fmt_args
 
@@ -1416,12 +1481,15 @@ and fmt_sequence c ?ext ~has_attr parens width xexp fmt_atrs =
   let fmt_sep c ?(force_break = false) xe1 ext xe2 =
     let break =
       let l1 = xe1.ast.pexp_loc and l2 = xe2.ast.pexp_loc in
-      if sequence_blank_line c l1 l2 then fmt "\n@;<1000 0>"
+      if sequence_blank_line c l1 l2 then
+        fmt "\n@;<1000 0>"
       else if c.conf.fmt_opts.break_sequences.v || force_break then
         fmt "@;<1000 0>"
       else if parens && Poly.(c.conf.fmt_opts.sequence_style.v = `Before)
-      then fmt "@;<1 -2>"
-      else fmt "@;<1 0>"
+      then
+        fmt "@;<1 -2>"
+      else
+        fmt "@;<1 0>"
     in
     match c.conf.fmt_opts.sequence_style.v with
     | `Before ->
@@ -1484,8 +1552,10 @@ and fmt_infix_op_args c ~parens xexp op_args =
                   | Some p when Prec.compare p Apply <= 0 -> true
                   | Some _ -> false
                   | None -> false )
-            then `Fit_or_vertical
-            else `Wrap
+            then
+              `Fit_or_vertical
+            else
+              `Wrap
         | None -> impossible "Pexp_apply expressions always have a prec" )
     in
     match break_infix with
@@ -1513,7 +1583,12 @@ and fmt_infix_op_args c ~parens xexp op_args =
     fmt_expression c ?box ~parens xarg
   in
   let fmt_op_arg_group ~first:first_grp ~last:last_grp args =
-    let indent = if first_grp && parens then -2 else 0 in
+    let indent =
+      if first_grp && parens then
+        -2
+      else
+        0
+    in
     hovbox indent
       (list_fl args
          (fun ~first ~last (_, cmts_before, cmts_after, (op, xarg)) ->
@@ -1546,7 +1621,12 @@ and fmt_pat_cons c ~parens args =
     | `Fit_or_vertical | `Wrap_or_vertical -> List.map ~f:(fun x -> [x]) args
   in
   let fmt_op_arg_group ~first:first_grp ~last:last_grp args =
-    let indent = if first_grp && parens then -2 else 0 in
+    let indent =
+      if first_grp && parens then
+        -2
+      else
+        0
+    in
     hovbox indent
       (list_fl args (fun ~first ~last xarg ->
            let very_first = first_grp && first in
@@ -1687,7 +1767,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let op =
         if Location.width loc = String.length op - 1 then
           String.sub op ~pos:1 ~len:(String.length op - 1)
-        else op
+        else
+          op
       in
       let spc = fmt_if (Exp.exposed_left e1) "@ " in
       Params.parens_if parens c.conf
@@ -1710,7 +1791,12 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let parens_r = parenze_exp xr in
       let xargs, xbody = Sugar.fun_ c.cmts xr in
       let fmt_cstr, xbody = type_constr_and_body c xbody in
-      let indent_wrap = if parens then -2 else 0 in
+      let indent_wrap =
+        if parens then
+          -2
+        else
+          0
+      in
       let pre_body, body = fmt_body c ?ext xbody in
       let followed_by_infix_op =
         match xbody.ast.pexp_desc with
@@ -1816,7 +1902,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
            $ fmt_atrs ) )
   | Pexp_apply (e0, e1N1) -> (
       let wrap =
-        if c.conf.fmt_opts.wrap_fun_args.v then Fn.id else hvbox 2
+        if c.conf.fmt_opts.wrap_fun_args.v then
+          Fn.id
+        else
+          hvbox 2
       in
       match List.rev e1N1 with
       | (lbl, ({pexp_desc= Pexp_fun _; pexp_loc; _} as eN1)) :: rev_e1N
@@ -1836,7 +1925,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
           let force =
             if Location.is_single_line pexp_loc c.conf.fmt_opts.margin.v then
               Fit
-            else Break
+            else
+              Break
           in
           hvbox 0
             (Params.parens_if parens c.conf
@@ -1877,7 +1967,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
           let force =
             if Location.is_single_line pexp_loc c.conf.fmt_opts.margin.v then
               Fit
-            else Break
+            else
+              Break
           in
           let e1N = List.rev rev_e1N in
           let ctx = Exp eN in
@@ -1907,7 +1998,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
           let e1N = List.rev rev_e1N in
           let ctx'' = Exp eN in
           let default_indent =
-            if c.conf.fmt_opts.wrap_fun_args.v then 2 else 4
+            if c.conf.fmt_opts.wrap_fun_args.v then
+              2
+            else
+              4
           in
           let indent =
             Params.function_indent c.conf ~ctx ~default:default_indent
@@ -1929,7 +2023,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
           let force =
             if Location.is_single_line pexp_loc c.conf.fmt_opts.margin.v then
               Fit
-            else Break
+            else
+              Break
           in
           fmt_if parens "("
           $ hvbox 2
@@ -1950,7 +2045,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
   | Pexp_list e1N ->
       let p = Params.get_list_expr c.conf in
       let offset =
-        if c.conf.fmt_opts.dock_collection_brackets.v then 0 else 2
+        if c.conf.fmt_opts.dock_collection_brackets.v then
+          0
+        else
+          2
       in
       let cmt_break = break 1 offset in
       hvbox_if has_attr 0
@@ -1966,7 +2064,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let paren_body =
         if Exp.is_symbol e0 || Exp.is_monadic_binding e0 then
           not (List.is_empty e0.pexp_attributes)
-        else parenze_exp (sub_exp ~ctx e0)
+        else
+          parenze_exp (sub_exp ~ctx e0)
       in
       hovbox 0
         (Params.parens_if parens c.conf
@@ -2072,7 +2171,12 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         match xbody.ast.pexp_desc with Pexp_function _ -> true | _ -> false
       in
       let pre_body, body = fmt_body c ?ext xbody in
-      let default_indent = if Option.is_none eol then 2 else 1 in
+      let default_indent =
+        if Option.is_none eol then
+          2
+        else
+          1
+      in
       let indent =
         Params.function_indent c.conf ~ctx ~default:default_indent
       in
@@ -2290,8 +2394,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let xpc_rhs = sub_exp ~ctx pc_rhs in
       let leading_cmt = Cmts.fmt_before c pc_lhs.ppat_loc in
       let parens_here, parens_for_exp =
-        if c.conf.fmt_opts.leading_nested_match_parens.v then (false, None)
-        else (parenze_exp xpc_rhs, Some false)
+        if c.conf.fmt_opts.leading_nested_match_parens.v then
+          (false, None)
+        else
+          (parenze_exp xpc_rhs, Some false)
       in
       Params.Exp.wrap c.conf ~parens ~disambiguate:true
         (hvbox 2
@@ -2754,7 +2860,10 @@ and fmt_class_expr c ?eol ({ast= exp; _} as xexp) =
   | Pcl_fun _ ->
       let xargs, xbody = Sugar.cl_fun c.cmts xexp in
       hvbox
-        (if Option.is_none eol then 2 else 1)
+        ( if Option.is_none eol then
+          2
+        else
+          1 )
         (Params.parens_if parens c.conf
            ( hovbox 2
                ( box_fun_decl_args c 0
@@ -2989,9 +3098,12 @@ and fmt_case c ctx ~first ~last case =
   in
   let symbol_parens = Exp.is_symbol xrhs.ast in
   let parens_branch, parens_for_exp =
-    if align_nested_match then (false, Some false)
-    else if c.conf.fmt_opts.leading_nested_match_parens.v then (false, None)
-    else (parenze_exp xrhs && not symbol_parens, Some false)
+    if align_nested_match then
+      (false, Some false)
+    else if c.conf.fmt_opts.leading_nested_match_parens.v then
+      (false, None)
+    else
+      (parenze_exp xrhs && not symbol_parens, Some false)
   in
   (* side effects of Cmts.fmt_before before [fmt_lhs] is important *)
   let leading_cmt = Cmts.fmt_before c pc_lhs.ppat_loc in
@@ -3006,7 +3118,12 @@ and fmt_case c ctx ~first ~last case =
       (Cmts.has_before c.cmts pc_rhs.pexp_loc)
       (fmt "@;<1000 0>")
   in
-  let indent = if align_nested_match then 0 else indent in
+  let indent =
+    if align_nested_match then
+      0
+    else
+      indent
+  in
   let p = Params.get_cases c.conf ~first ~indent ~parens_branch ~xbch:xrhs in
   p.leading_space $ leading_cmt
   $ p.box_all
@@ -3030,14 +3147,20 @@ and fmt_value_description ?ext c ctx vd =
   in
   update_config_maybe_disabled c pval_loc pval_attributes
   @@ fun c ->
-  let pre = if List.is_empty pval_prim then "val" else "external" in
+  let pre =
+    if List.is_empty pval_prim then
+      "val"
+    else
+      "external"
+  in
   let doc_before, doc_after, atrs =
     fmt_docstring_around_item ~is_val:true c pval_attributes
   in
   let fmt_val_prim s =
     if String.exists s ~f:(function ' ' | '\n' -> true | _ -> false) then
       wrap "{|" "|}" (str s)
-    else wrap "\"" "\"" (str (String.escaped s))
+    else
+      wrap "\"" "\"" (str (String.escaped s))
   in
   hvbox 0
     ( doc_before
@@ -3300,7 +3423,12 @@ and fmt_type_extension ?ext c ctx
            $ str " +="
            $ fmt_private_flag c ptyext_private
            $ list_fl ptyext_constructors (fun ~first ~last:_ x ->
-                 let bar_fits = if first then "" else "| " in
+                 let bar_fits =
+                   if first then
+                     ""
+                   else
+                     "| "
+                 in
                  cbreak ~fits:("", 1, bar_fits) ~breaks:("", 0, "| ")
                  $ fmt_ctor x ) )
        $ fmt_item_attributes c ~pre:(Break (1, 0)) atrs )
@@ -3402,7 +3530,12 @@ and fmt_module_type c ({ast= mty; _} as xmty) =
   | Pmty_with _ ->
       let wcs, mt = Sugar.mod_with (sub_mty ~ctx mty) in
       let fmt_cstr ~first ~last:_ wc =
-        let pre = if first then "with" else " and" in
+        let pre =
+          if first then
+            "with"
+          else
+            " and"
+        in
         fmt_or first "@ " "@," $ fmt_with_constraint c ctx ~pre wc
       in
       let fmt_cstrs ~first:_ ~last:_ (wcs_and, loc, attr) =
@@ -3549,7 +3682,11 @@ and fmt_class_types ?ext c ctx ~pre ~sep cls =
       let class_types =
         hovbox 2
           ( hvbox 2
-              ( str (if first then pre else "and")
+              ( str
+                  ( if first then
+                    pre
+                  else
+                    "and" )
               $ fmt_if_k first (fmt_extension_suffix c ext)
               $ fmt_virtual_flag c cl.pci_virt
               $ fmt "@ "
@@ -3589,7 +3726,11 @@ and fmt_class_exprs ?ext c ctx cls =
              ( hovbox 2
                  ( box_fun_decl_args c 2
                      ( hovbox 2
-                         ( str (if first then "class" else "and")
+                         ( str
+                             ( if first then
+                               "class"
+                             else
+                               "and" )
                          $ fmt_if_k first (fmt_extension_suffix c ext)
                          $ fmt_virtual_flag c cl.pci_virt
                          $ fmt "@ "
@@ -3668,10 +3809,16 @@ and fmt_module c ?ext ?epi ?(can_sparse = false) keyword ?(eqty = "=") name
       attributes
   in
   hvbox
-    (if compact then 0 else 2)
+    ( if compact then
+      0
+    else
+      2 )
     ( doc_before
     $ box_b
-        ( (if Option.is_some blk_t.epi then hovbox else hvbox)
+        ( ( if Option.is_some blk_t.epi then
+            hovbox
+          else
+            hvbox )
             0
             ( box_t
                 ( hvbox_if
@@ -3712,11 +3859,23 @@ and fmt_module_declaration ?ext c ctx ~rec_flag ~first pmd =
   let {pmd_name; pmd_type; pmd_attributes; pmd_loc} = pmd in
   update_config_maybe_disabled c pmd_loc pmd_attributes
   @@ fun c ->
-  let ext = if first then ext else None in
-  let keyword = if first then "module" else "and" in
+  let ext =
+    if first then
+      ext
+    else
+      None
+  in
+  let keyword =
+    if first then
+      "module"
+    else
+      "and"
+  in
   let xargs, xmty =
-    if rec_flag then ([], sub_mty ~ctx pmd_type)
-    else sugar_pmty_functor c ~for_functor_kw:false (sub_mty ~ctx pmd_type)
+    if rec_flag then
+      ([], sub_mty ~ctx pmd_type)
+    else
+      sugar_pmty_functor c ~for_functor_kw:false (sub_mty ~ctx pmd_type)
   in
   let eqty =
     match xmty.ast.pmty_desc with Pmty_alias _ -> None | _ -> Some ":"
@@ -3835,7 +3994,12 @@ and fmt_mod_apply c ctx loc attrs ~parens ~dock_struct me_f arg =
             && not arg_is_simple
           in
           compose_module (fmt_module_expr c (sub_mod ~ctx me_f)) ~f:Fn.id
-          $ break (if break_struct then 1000 else 1) 0
+          $ break
+              ( if break_struct then
+                1000
+              else
+                1 )
+              0
           $ str "("
         in
         let epi =
@@ -4025,9 +4189,20 @@ and fmt_type c ?ext ?eq rec_flag decls ctx =
   let fmt_decl c ctx ~prev ~next:_ decl =
     let first = Option.is_none prev in
     let pre =
-      if first then if is_rec then "type" else "type nonrec" else "and"
+      if first then
+        if is_rec then
+          "type"
+        else
+          "type nonrec"
+      else
+        "and"
     in
-    let ext = if first then ext else None in
+    let ext =
+      if first then
+        ext
+      else
+        None
+    in
     fmt_type_declaration c ~pre ?eq ?ext ctx decl
   in
   let ast x = Td x in
@@ -4099,7 +4274,12 @@ and fmt_structure_item c ~last:last_item ?ext ~semisemi
                 (fits_breaks "" ~hint:(1000, -2) ";;")
         in
         let rec_flag = first && Asttypes.is_recursive rec_flag in
-        let ext = if first then ext else None in
+        let ext =
+          if first then
+            ext
+          else
+            None
+        in
         fmt_value_binding c ~rec_flag ?ext ctx ?epi b
       in
       fmt_item_list c ctx update_config ast fmt_item bindings
@@ -4129,7 +4309,12 @@ and fmt_let c ctx ~ext ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr
     | `Auto -> fits_breaks " in" ~hint:(1, -indent) "in"
   in
   let fmt_binding ~first ~last binding =
-    let ext = if first then ext else None in
+    let ext =
+      if first then
+        ext
+      else
+        None
+    in
     let in_ indent = fmt_if_k last (fmt_in indent) in
     let rec_flag = first && Asttypes.is_recursive rec_flag in
     fmt_value_binding c ~rec_flag ?ext ctx ~in_ binding
@@ -4145,8 +4330,10 @@ and fmt_let c ctx ~ext ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr
   Params.Exp.wrap c.conf ~parens:(parens || has_attr) ~fits_breaks:false
     (vbox 0
        ( hvbox 0 (list_fl bindings fmt_binding)
-       $ ( if blank_line_after_in then fmt "\n@,"
-         else break 1000 indent_after_in )
+       $ ( if blank_line_after_in then
+           fmt "\n@,"
+         else
+           break 1000 indent_after_in )
        $ hvbox 0 fmt_expr ) )
   $ fmt_atrs
 
@@ -4246,8 +4433,18 @@ and fmt_value_binding c ~rec_flag ?ext ?in_ ?epi ctx
 and fmt_module_binding ?ext c ctx ~rec_flag ~first pmb =
   update_config_maybe_disabled c pmb.pmb_loc pmb.pmb_attributes
   @@ fun c ->
-  let ext = if first then ext else None in
-  let keyword = if first then "module" else "and" in
+  let ext =
+    if first then
+      ext
+    else
+      None
+  in
+  let keyword =
+    if first then
+      "module"
+    else
+      "and"
+  in
   let xargs, xbody =
     sugar_pmod_functor c ~for_functor_kw:false (sub_mod ~ctx pmb.pmb_expr)
   in

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -62,8 +62,10 @@ let fmt_verbatim_block s =
   let force_break = String.contains s '\n' in
   let content =
     (* Literal newline to avoid indentation *)
-    if force_break then wrap "\n" "@\n" (str s)
-    else fits_breaks " " "\n" $ str s $ fits_breaks " " ~hint:(0, 0) ""
+    if force_break then
+      wrap "\n" "@\n" (str s)
+    else
+      fits_breaks " " "\n" $ str s $ fits_breaks " " ~hint:(0, 0) ""
   in
   hvbox 0 (wrap "{v" "v}" content)
 
@@ -77,9 +79,12 @@ let fmt_code_block conf s1 s2 =
   in
   let fmt_line ~first ~last:_ l =
     let l = String.rstrip l in
-    if first then str l
-    else if String.length l = 0 then str "\n"
-    else fmt "@," $ str l
+    if first then
+      str l
+    else if String.length l = 0 then
+      str "\n"
+    else
+      fmt "@," $ str l
   in
   let fmt_no_code s =
     let lines = String.split_lines s in
@@ -115,9 +120,12 @@ let fmt_math_block s =
     @@ String.split_lines s
   in
   let fmt ~first ~last:_ line =
-    if first then str line
-    else if String.is_empty line then str "\n"
-    else fmt "@;<1000 0>" $ str line
+    if first then
+      str line
+    else if String.is_empty line then
+      str "\n"
+    else
+      fmt "@;<1000 0>" $ str line
   in
   hvbox 2 (wrap "{math@;" "@;<0 -2>}" (list_fl lines fmt))
 
@@ -172,7 +180,8 @@ let rec fmt_inline_elements elements =
         let escape =
           if String.length w > 0 && Char.(w.[0] = '+' || w.[0] = '-') then
             "\\"
-          else ""
+          else
+            ""
         in
         cbreak ~fits:("", 1, "") ~breaks:("", 0, escape)
         $ str_normalized w $ aux t
@@ -284,7 +293,10 @@ let fmt_block_element c = function
         | None -> noop
       in
       let elems =
-        if List.is_empty elems then elems else space_elt :: elems
+        if List.is_empty elems then
+          elems
+        else
+          space_elt :: elems
       in
       hovbox 0 (wrap "{" "}" (str lvl $ lbl $ fmt_inline_elements elems))
   | #nestable_block_element as elm ->

--- a/lib/Indent.ml
+++ b/lib/Indent.ml
@@ -31,13 +31,15 @@ module Valid_ast = struct
     let rec aux = function
       | [] -> None
       | (h : Location.t) :: t ->
-          if h.loc_start.pos_lnum = line then Some h
+          if h.loc_start.pos_lnum = line then
+            Some h
           else if h.loc_start.pos_lnum <= line && line <= h.loc_end.pos_lnum
           then
             match Loc_tree.children loctree h with
             | [] -> Some h
             | children -> Some (Option.value (aux children) ~default:h)
-          else aux t
+          else
+            aux t
     in
     aux locs
 
@@ -68,7 +70,8 @@ module Valid_ast = struct
       | None -> None
     in
     let rec aux ?prev acc idx_ocpi i =
-      if i > high then (List.rev acc, idx_ocpi)
+      if i > high then
+        (List.rev acc, idx_ocpi)
       else
         match
           match List.nth lines (i - 1) with
@@ -95,7 +98,13 @@ module Valid_ast = struct
       match aux_ret with
       | [] -> impossible "list expected to contain at least a `Maybe item"
       | `Ok x :: t -> on_indent i (t, x :: res)
-      | `Maybe x :: t -> (t, (if i = 0 then x else i) :: res)
+      | `Maybe x :: t ->
+          ( t
+          , ( if i = 0 then
+              x
+            else
+              i )
+            :: res )
     in
     let aux_ret, ret =
       Ocp_indent.run ~source:txt_src ~init:(aux_ret, []) ~on_indent

--- a/lib/Loc_tree.ml
+++ b/lib/Loc_tree.ml
@@ -17,8 +17,10 @@ include Non_overlapping_interval_tree.Make (Location)
 let of_ast fragment ast =
   let attribute (m : Ast_mapper.mapper) attr =
     (* ignore location of docstrings *)
-    if Ast.Attr.is_doc attr then attr
-    else Ast_mapper.default_mapper.attribute m attr
+    if Ast.Attr.is_doc attr then
+      attr
+    else
+      Ast_mapper.default_mapper.attribute m attr
   in
   let locs = ref [] in
   let location _ loc =

--- a/lib/Migrate_ast.ml
+++ b/lib/Migrate_ast.ml
@@ -29,8 +29,10 @@ module Position = struct
   let column {pos_bol; pos_cnum; _} = pos_cnum - pos_bol
 
   let fmt fs {pos_lnum; pos_bol; pos_cnum; pos_fname= _} =
-    if pos_lnum = -1 then Format.fprintf fs "[%d]" pos_cnum
-    else Format.fprintf fs "[%d,%d+%d]" pos_lnum pos_bol (pos_cnum - pos_bol)
+    if pos_lnum = -1 then
+      Format.fprintf fs "[%d]" pos_cnum
+    else
+      Format.fprintf fs "[%d,%d+%d]" pos_lnum pos_bol (pos_cnum - pos_bol)
 
   let to_string x = Format.asprintf "%a" fmt x
 
@@ -39,7 +41,10 @@ module Position = struct
   let compare_col p1 p2 = Int.compare (column p1) (column p2)
 
   let compare p1 p2 =
-    if phys_equal p1 p2 then 0 else Int.compare p1.pos_cnum p2.pos_cnum
+    if phys_equal p1 p2 then
+      0
+    else
+      Int.compare p1.pos_cnum p2.pos_cnum
 
   include (val Comparator.make ~compare ~sexp_of_t)
 
@@ -52,7 +57,10 @@ module Location = struct
   let fmt fs {loc_start; loc_end; loc_ghost} =
     Format.fprintf fs "(%a..%a)%s" Position.fmt loc_start Position.fmt
       loc_end
-      (if loc_ghost then " ghost" else "")
+      ( if loc_ghost then
+        " ghost"
+      else
+        "" )
 
   let to_string x = Format.asprintf "%a" fmt x
 
@@ -103,7 +111,12 @@ module Location = struct
     width x <= margin + 1 && x.loc_start.pos_lnum = x.loc_end.pos_lnum
 
   let smallest loc stack =
-    let min a b = if width a < width b then a else b in
+    let min a b =
+      if width a < width b then
+        a
+      else
+        b
+    in
     List.reduce_exn (loc :: stack) ~f:min
 
   let of_lexbuf (lexbuf : Lexing.lexbuf) =

--- a/lib/Non_overlapping_interval_tree.ml
+++ b/lib/Non_overlapping_interval_tree.ml
@@ -58,7 +58,8 @@ module Make (Itv : IN) = struct
              | Some children -> parents map children ~ancestors elt
              | None -> ancestors )
              |> Option.some
-           else None ) )
+           else
+             None ) )
 
   let add_root t root = {t with roots= root :: t.roots}
 

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -110,7 +110,8 @@ let make_mapper conf ~ignore_doc_comments =
     let atrs =
       if ignore_doc_comments then
         List.filter atrs ~f:(fun a -> not (Ast.Attr.is_doc a))
-      else atrs
+      else
+        atrs
     in
     Ast_mapper.default_mapper.attributes m (sort_attributes atrs)
   in
@@ -195,12 +196,16 @@ let diff_cmts (conf : Conf.t) x y =
       | str ->
           if Char.equal str.[0] '$' then
             let chars_removed =
-              if Char.equal str.[String.length str - 1] '$' then 2 else 1
+              if Char.equal str.[String.length str - 1] '$' then
+                2
+              else
+                1
             in
             let len = String.length str - chars_removed in
             let source = String.sub ~pos:1 ~len str in
             normalize_code source
-          else norm_non_code z
+          else
+            norm_non_code z
     in
     Set.of_list (module String) (List.map ~f z)
   in

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -103,7 +103,8 @@ let make_mapper conf ~ignore_doc_comments =
     let atrs =
       if ignore_doc_comments then
         List.filter atrs ~f:(fun a -> not (is_doc a))
-      else atrs
+      else
+        atrs
     in
     Ast_mapper.default_mapper.attributes m (sort_attributes atrs)
   in

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -17,7 +17,8 @@ open Fmt
 let parens_if parens (c : Conf.t) ?(disambiguate = false) k =
   if disambiguate && c.fmt_opts.disambiguate_non_breaking_match.v then
     wrap_if_fits_or parens "(" ")" k
-  else if not parens then k
+  else if not parens then
+    k
   else
     match c.fmt_opts.indicate_multiline_delimiters.v with
     | `Space ->
@@ -38,20 +39,24 @@ module Exp = struct
             | `Space -> ("( ", Some (1, 0), ")")
             | `No -> ("(", Some (0, 0), ")")
             | `Closing_on_separate_line -> ("(", Some (1000, 0), ")")
-          else ("", None, "")
+          else
+            ("", None, "")
         in
         wrap_if_k (parens || parens_nested) (Fmt.fits_breaks "(" opn)
           (Fmt.fits_breaks ")" ?hint cls)
           k
-      else k
+      else
+        k
   end
 
   let wrap (c : Conf.t) ?(disambiguate = false) ?(fits_breaks = true)
       ?(offset_closing_paren = 0) ~parens k =
     if disambiguate && c.fmt_opts.disambiguate_non_breaking_match.v then
       wrap_if_fits_or parens "(" ")" k
-    else if not parens then k
-    else if fits_breaks then wrap_fits_breaks ~space:false c "(" ")" k
+    else if not parens then
+      k
+    else if fits_breaks then
+      wrap_fits_breaks ~space:false c "(" ")" k
     else
       match c.fmt_opts.indicate_multiline_delimiters.v with
       | `Space ->
@@ -64,7 +69,12 @@ end
 
 let get_or_pattern_sep ?(cmts_before = false) ?(space = false) (c : Conf.t)
     ~ctx =
-  let nspaces = if cmts_before then 1000 else 1 in
+  let nspaces =
+    if cmts_before then
+      1000
+    else
+      1
+  in
   match ctx with
   | Ast.Exp {pexp_desc= Pexp_function _ | Pexp_match _ | Pexp_try _; _} -> (
     match c.fmt_opts.break_cases.v with
@@ -78,7 +88,13 @@ let get_or_pattern_sep ?(cmts_before = false) ?(space = false) (c : Conf.t)
         match c.fmt_opts.indicate_nested_or_patterns.v with
         | `Space ->
             cbreak ~fits:("", nspaces, "| ")
-              ~breaks:("", 0, if space then " | " else " |")
+              ~breaks:
+                ( ""
+                , 0
+                , if space then
+                    " | "
+                  else
+                    " |" )
         | `Unsafe_no -> break nspaces 0 $ str "| " ) )
   | _ -> break nspaces 0 $ str "| "
 
@@ -100,7 +116,10 @@ let get_cases (c : Conf.t) ~first ~indent ~parens_branch ~xbch =
     | _ -> false
   in
   let open_paren_branch =
-    if beginend then fmt "@;<1 0>begin" else fmt_if parens_branch " ("
+    if beginend then
+      fmt "@;<1 0>begin"
+    else
+      fmt_if parens_branch " ("
   in
   let close_paren_branch =
     if beginend then
@@ -168,16 +187,21 @@ let get_cases (c : Conf.t) ~first ~indent ~parens_branch ~xbch =
       ; close_paren_branch }
 
 let wrap_collec c ~space_around opn cls =
-  if space_around then wrap_k (str opn $ char ' ') (break 1 0 $ str cls)
-  else wrap_fits_breaks c opn cls
+  if space_around then
+    wrap_k (str opn $ char ' ') (break 1 0 $ str cls)
+  else
+    wrap_fits_breaks c opn cls
 
 let wrap_record (c : Conf.t) =
   wrap_collec c ~space_around:c.fmt_opts.space_around_records.v "{" "}"
 
 let wrap_tuple (c : Conf.t) ~parens ~no_parens_if_break =
-  if parens then wrap_fits_breaks c "(" ")"
-  else if no_parens_if_break then Fn.id
-  else wrap_k (fits_breaks "" "( ") (fits_breaks "" ~hint:(1, 0) ")")
+  if parens then
+    wrap_fits_breaks c "(" ")"
+  else if no_parens_if_break then
+    Fn.id
+  else
+    wrap_k (fits_breaks "" "( ") (fits_breaks "" ~hint:(1, 0) ")")
 
 type record_type =
   { docked_before: Fmt.t
@@ -191,7 +215,12 @@ type record_type =
 
 let get_record_type (c : Conf.t) =
   let sparse_type_decl = Poly.(c.fmt_opts.type_decl.v = `Sparse) in
-  let space = if c.fmt_opts.space_around_records.v then 1 else 0 in
+  let space =
+    if c.fmt_opts.space_around_records.v then
+      1
+    else
+      0
+  in
   let dock = c.fmt_opts.dock_collection_brackets.v in
   let break_before, sep_before, sep_after =
     match c.fmt_opts.break_separators.v with
@@ -208,7 +237,12 @@ let get_record_type (c : Conf.t) =
   in
   { docked_before= fmt_if dock " {"
   ; break_before
-  ; box_record= (fun k -> if dock then k else hvbox 0 (wrap_record c k))
+  ; box_record=
+      (fun k ->
+        if dock then
+          k
+        else
+          hvbox 0 (wrap_record c k) )
   ; box_spaced= c.fmt_opts.space_around_records.v
   ; sep_before
   ; sep_after
@@ -226,11 +260,18 @@ type elements_collection_record_expr = {break_after_with: Fmt.t}
 type elements_collection_record_pat = {wildcard: Fmt.t}
 
 let get_record_expr (c : Conf.t) =
-  let space = if c.fmt_opts.space_around_records.v then 1 else 0 in
+  let space =
+    if c.fmt_opts.space_around_records.v then
+      1
+    else
+      0
+  in
   let dock = c.fmt_opts.dock_collection_brackets.v in
   let box k =
-    if dock then hvbox 0 (wrap "{" "}" (break space 2 $ k $ break space 0))
-    else hvbox 0 (wrap_record c k)
+    if dock then
+      hvbox 0 (wrap "{" "}" (break space 2 $ k $ break space 0))
+    else
+      hvbox 0 (wrap_record c k)
   in
   ( ( match c.fmt_opts.break_separators.v with
     | `Before ->
@@ -251,9 +292,19 @@ let box_collec (c : Conf.t) =
   | `Fit_or_vertical -> hvbox
 
 let collection_expr (c : Conf.t) ~space_around opn cls =
-  let space = if space_around then 1 else 0 in
+  let space =
+    if space_around then
+      1
+    else
+      0
+  in
   let dock = c.fmt_opts.dock_collection_brackets.v in
-  let offset = if dock then -2 else String.length opn - 1 in
+  let offset =
+    if dock then
+      -2
+    else
+      String.length opn - 1
+  in
   match c.fmt_opts.break_separators.v with
   | `Before ->
       { box=
@@ -263,7 +314,8 @@ let collection_expr (c : Conf.t) ~space_around opn cls =
                 (wrap_k (str opn) (str cls)
                    ( break space (String.length opn + 1)
                    $ box_collec c 0 k $ break space 0 ) )
-            else box_collec c 0 (wrap_collec c ~space_around opn cls k) )
+            else
+              box_collec c 0 (wrap_collec c ~space_around opn cls k) )
       ; sep_before= break 0 offset $ str "; "
       ; sep_after_non_final= noop
       ; sep_after_final= noop }
@@ -274,7 +326,8 @@ let collection_expr (c : Conf.t) ~space_around opn cls =
               hvbox 0
                 (wrap_k (str opn) (str cls)
                    (break space 2 $ box_collec c 0 k $ break space 0) )
-            else box_collec c 0 (wrap_collec c ~space_around opn cls k) )
+            else
+              box_collec c 0 (wrap_collec c ~space_around opn cls k) )
       ; sep_before= noop
       ; sep_after_non_final=
           fmt_or_k dock (fmt ";@;<1 0>")
@@ -288,7 +341,12 @@ let get_array_expr (c : Conf.t) =
   collection_expr c ~space_around:c.fmt_opts.space_around_arrays.v "[|" "|]"
 
 let box_pattern_docked (c : Conf.t) ~ctx ~space_around opn cls k =
-  let space = if space_around then 1 else 0 in
+  let space =
+    if space_around then
+      1
+    else
+      0
+  in
   let indent_opn, indent_cls =
     match (ctx, c.fmt_opts.break_separators.v) with
     | Ast.Exp {pexp_desc= Pexp_match _ | Pexp_try _; _}, `Before ->
@@ -306,7 +364,8 @@ let get_record_pat (c : Conf.t) ~ctx =
     if c.fmt_opts.dock_collection_brackets.v then
       box_pattern_docked c ~ctx
         ~space_around:c.fmt_opts.space_around_records.v "{" "}"
-    else params.box
+    else
+      params.box
   in
   ( {params with box}
   , {wildcard= params.sep_before $ str "_" $ params.sep_after_final} )
@@ -316,7 +375,8 @@ let collection_pat (c : Conf.t) ~ctx ~space_around opn cls =
   let box =
     if c.fmt_opts.dock_collection_brackets.v then
       box_collec c 0 >> box_pattern_docked c ~ctx ~space_around opn cls
-    else params.box
+    else
+      params.box
   in
   {params with box}
 
@@ -349,9 +409,12 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
     | _ -> false
   in
   let wrap_parens ~wrap_breaks k =
-    if beginend then wrap "begin" "end" (wrap_breaks k)
-    else if parens_bch then wrap "(" ")" (wrap_breaks k)
-    else k
+    if beginend then
+      wrap "begin" "end" (wrap_breaks k)
+    else if parens_bch then
+      wrap "(" ")" (wrap_breaks k)
+    else
+      k
   in
   let get_parens_breaks ~opn_hint:(oh_space, oh_other)
       ~cls_hint:(ch_sp, ch_sl) =
@@ -374,7 +437,10 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
           | true, `No -> -1
           | true, (`Space | `Closing_on_separate_line) -> -2 )
           ( hvbox
-              (if parens then 0 else 2)
+              ( if parens then
+                0
+              else
+                2 )
               ( fmt_if (not first) "else "
               $ str "if"
               $ fmt_if_k first (fmt_opt fmt_extension_suffix)
@@ -386,7 +452,10 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens ~parens_bch
   match c.fmt_opts.if_then_else.v with
   | `Compact ->
       let box_branch =
-        if first && parens && not beginend then hovbox 0 else hovbox 2
+        if first && parens && not beginend then
+          hovbox 0
+        else
+          hovbox 2
       in
       { box_branch
       ; cond= cond ()

--- a/lib/Parse_with_comments.ml
+++ b/lib/Parse_with_comments.ml
@@ -64,9 +64,17 @@ let split_hash_bang source =
 let parse ?(disable_w50 = false) parse fragment (conf : Conf.t) ~input_name
     ~source =
   let warnings =
-    if conf.opr_opts.quiet.v then List.map ~f:W.disable W.in_lexer else []
+    if conf.opr_opts.quiet.v then
+      List.map ~f:W.disable W.in_lexer
+    else
+      []
   in
-  let warnings = if disable_w50 then warnings else W.enable 50 :: warnings in
+  let warnings =
+    if disable_w50 then
+      warnings
+    else
+      W.enable 50 :: warnings
+  in
   ignore @@ Warnings.parse_options false (W.to_string warnings) ;
   let w50 = ref [] in
   let t =
@@ -79,7 +87,8 @@ let parse ?(disable_w50 = false) parse fragment (conf : Conf.t) ~input_name
         then (
           w50 := (loc, warn) :: !w50 ;
           false )
-        else not conf.opr_opts.quiet.v )
+        else
+          not conf.opr_opts.quiet.v )
       ~f:(fun () ->
         let ast = parse fragment ~input_name source in
         Warnings.check_fatal () ;
@@ -116,4 +125,5 @@ let parse_toplevel ?disable_w50 (conf : Conf.t) ~input_name ~source =
   if is_repl_block source && conf.fmt_opts.parse_toplevel_phrases.v then
     Either.Second
       (parse ?disable_w50 parse_ast Repl_file conf ~input_name ~source)
-  else First (parse ?disable_w50 parse_ast Use_file conf ~input_name ~source)
+  else
+    First (parse ?disable_w50 parse_ast Use_file conf ~input_name ~source)

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -47,13 +47,19 @@ let tokens_between (t : t) ~filter loc_start loc_end =
   | None -> []
   | Some i ->
       let rec loop i acc =
-        if i >= Array.length t.tokens then List.rev acc
+        if i >= Array.length t.tokens then
+          List.rev acc
         else
           let ((tok, tok_loc) as x) = t.tokens.(i) in
           if Position.compare tok_loc.Location.loc_end loc_end > 0 then
             List.rev acc
           else
-            let acc = if filter tok then x :: acc else acc in
+            let acc =
+              if filter tok then
+                x :: acc
+              else
+                acc
+            in
             loop (i + 1) acc
       in
       loop i []
@@ -76,10 +82,14 @@ let find_token_before t ~filter pos =
   | None -> None
   | Some i ->
       let rec loop i =
-        if i < 0 then None
+        if i < 0 then
+          None
         else
           let ((tok, _) as elt) = t.tokens.(i) in
-          if filter tok then Some elt else loop (i - 1)
+          if filter tok then
+            Some elt
+          else
+            loop (i - 1)
       in
       loop i
 
@@ -88,19 +98,27 @@ let find_token_after t ~filter pos =
   | None -> None
   | Some i ->
       let rec loop i =
-        if i >= Array.length t.tokens then None
+        if i >= Array.length t.tokens then
+          None
         else
           let ((tok, _) as elt) = t.tokens.(i) in
-          if filter tok then Some elt else loop (i + 1)
+          if filter tok then
+            Some elt
+          else
+            loop (i + 1)
       in
       loop i
 
 let extend_loc_to_include_attributes (loc : Location.t) (l : attributes) =
   let loc_end =
     List.fold l ~init:loc ~f:(fun acc ({attr_loc; _} : attribute) ->
-        if Location.compare_end attr_loc acc <= 0 then acc else attr_loc )
+        if Location.compare_end attr_loc acc <= 0 then
+          acc
+        else
+          attr_loc )
   in
-  if phys_equal loc_end loc then loc
+  if phys_equal loc_end loc then
+    loc
   else
     {loc with loc_end= {loc.loc_end with pos_cnum= loc_end.loc_end.pos_cnum}}
 
@@ -136,7 +154,8 @@ let char_literal t loc =
     (Literal_lexer.char (string_at t loc))
 
 let begins_line ?(ignore_spaces = true) t (l : Location.t) =
-  if not ignore_spaces then Position.column l.loc_start = 0
+  if not ignore_spaces then
+    Position.column l.loc_start = 0
   else
     match find_token_before t ~filter:(fun _ -> true) l.loc_start with
     | None -> true

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -61,7 +61,8 @@ let fun_ cmts ?(will_keep_first_ast_node = true) xexp =
           in
           (xargs, xbody)
       | _ -> ([], xexp)
-    else ([], xexp)
+    else
+      ([], xexp)
   in
   fun_ ~will_keep_first_ast_node xexp
 
@@ -83,7 +84,8 @@ let cl_fun ?(will_keep_first_ast_node = true) cmts xexp =
             :: xargs
           , xbody )
       | _ -> ([], xexp)
-    else ([], xexp)
+    else
+      ([], xexp)
   in
   fun_ ~will_keep_first_ast_node xexp
 
@@ -104,7 +106,8 @@ module Exp = struct
             | (None, {ast= {pexp_loc; _}; _}) :: _ -> pexp_loc
             | _ -> loc
           in
-          if relocate then Cmts.relocate cmts ~src ~before ~after:e2.pexp_loc ;
+          if relocate then
+            Cmts.relocate cmts ~src ~before ~after:e2.pexp_loc ;
           op_args1 @ [(Some {txt= op; loc}, sub_exp ~ctx e2)]
       | ( Right
         , {pexp_desc= Pexp_infix ({txt= op; loc}, e1, e2); pexp_loc= src; _}
@@ -119,7 +122,8 @@ module Exp = struct
             | Some (_, {ast= {pexp_loc; _}; _}) -> pexp_loc
             | None -> e1.pexp_loc
           in
-          if relocate then Cmts.relocate cmts ~src ~before ~after ;
+          if relocate then
+            Cmts.relocate cmts ~src ~before ~after ;
           (xop, sub_exp ~ctx e1) :: op_args2
       | _ -> [(xop, xexp)]
     in
@@ -145,7 +149,8 @@ let sequence cmts xexp =
            && Source.extension_using_sugar ~name:ext ~payload:e1.pexp_loc ->
         let ctx = Exp exp in
         if (not allow_attribute) && not (List.is_empty exp.pexp_attributes)
-        then [(None, xexp)]
+        then
+          [(None, xexp)]
         else (
           Cmts.relocate cmts ~src:pstr_loc ~before:e1.pexp_loc
             ~after:e2.pexp_loc ;
@@ -163,7 +168,8 @@ let sequence cmts xexp =
             List.append l1 l2 )
     | Pexp_sequence (e1, e2) ->
         if (not allow_attribute) && not (List.is_empty exp.pexp_attributes)
-        then [(None, xexp)]
+        then
+          [(None, xexp)]
         else (
           Cmts.relocate cmts ~src:pexp_loc ~before:e1.pexp_loc
             ~after:e2.pexp_loc ;
@@ -315,7 +321,8 @@ module Let_binding = struct
     let ({ast= body; _} as xbody) = sub_exp ~ctx lb_exp in
     if
       (not (List.is_empty xbody.ast.pexp_attributes)) || pat_is_extension pat
-    then (xpat, `None [], xbody)
+    then
+      (xpat, `None [], xbody)
     else
       match polynewtype cmts pat body with
       | Some (xpat, pvars, xtyp, xbody) ->
@@ -370,7 +377,14 @@ module Let_binding = struct
 
   let of_value_binding cmts ~ctx ~first vb =
     let pat, typ, exp = type_cstr cmts ~ctx vb.pvb_pat vb.pvb_expr in
-    { lb_op= Location.{txt= (if first then "let" else "and"); loc= none}
+    { lb_op=
+        Location.
+          { txt=
+              ( if first then
+                "let"
+              else
+                "and" )
+          ; loc= none }
     ; lb_pat= pat
     ; lb_typ= typ
     ; lb_exp= exp

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -87,7 +87,8 @@ module Error = struct
                %!"
         | exn -> Format.fprintf fmt "%s\n%!" (Exn.to_string exn) )
     | Unstable {iteration; prev; next; input_name} ->
-        if debug then print_diff input_name ~prev ~next ;
+        if debug then
+          print_diff input_name ~prev ~next ;
         if iteration <= 1 then
           Format.fprintf fmt
             "%s: %S was not already formatted. ([max-iters = 1])\n%!" exe
@@ -181,7 +182,8 @@ module Error = struct
                        %!"
                       Location.print_loc loc msg )
             | `Cannot_parse ((Syntaxerr.Error _ | Lexer.Error _) as exn) ->
-                if debug then Location.report_exception fmt exn
+                if debug then
+                  Location.report_exception fmt exn
             | `Warning50 l ->
                 if debug then
                   List.iter l ~f:(fun (l, w) -> Warning.print_warning l w)
@@ -192,7 +194,8 @@ module Error = struct
         | exn ->
             Format.fprintf fmt
               "  BUG: unhandled exception. Use [--debug] for details.\n%!" ;
-            if debug then Format.fprintf fmt "%s\n%!" (Exn.to_string exn) )
+            if debug then
+              Format.fprintf fmt "%s\n%!" (Exn.to_string exn) )
 end
 
 let with_file input_name output_file suf ext f =
@@ -232,14 +235,18 @@ let check_margin (conf : Conf.t) ~filename ~fmted =
           "Warning: %s:%i exceeds the margin\n%!" filename i )
 
 let with_optional_box_debug ~box_debug k =
-  if box_debug then Fmt.with_box_debug k else k
+  if box_debug then
+    Fmt.with_box_debug k
+  else
+    k
 
 let with_buffer_formatter ~buffer_size k =
   let buffer = Buffer.create buffer_size in
   let fs = Format_.formatter_of_buffer buffer in
   Fmt.eval fs k ;
   Format_.pp_print_flush fs () ;
-  if Buffer.length buffer > 0 then Format_.pp_print_newline fs () ;
+  if Buffer.length buffer > 0 then
+    Format_.pp_print_newline fs () ;
   Buffer.contents buffer
 
 let recover (type a) (fg : a Extended_ast.t) ~input_name str : a =
@@ -281,12 +288,14 @@ let format (type a b) (fg : a Extended_ast.t) (std_fg : b Std_ast.t)
       Some
         (dump_ast ~input_name ?output_file ~suffix (fun fmt ->
              Std_ast.Printast.ast fg fmt ast ) )
-    else None
+    else
+      None
   in
   let dump_formatted ~suffix fmted =
     if conf.opr_opts.debug.v then
       Some (dump_formatted ~input_name ?output_file ~suffix fmted)
-    else None
+    else
+      None
   in
   Location.input_name := input_name ;
   (* iterate until formatting stabilizes *)
@@ -316,7 +325,8 @@ let format (type a b) (fg : a Extended_ast.t) (std_fg : b Std_ast.t)
       |> (ignore : string option -> unit) ;
     let fmted, cmts_t = format ~box_debug:false in
     let conf =
-      if conf.opr_opts.debug.v then conf
+      if conf.opr_opts.debug.v then
+        conf
       else
         { conf with
           opr_opts=
@@ -410,8 +420,10 @@ let format (type a b) (fg : a Extended_ast.t) (std_fg : b Std_ast.t)
                  should be dropped. *)
               let txt = String.drop_prefix txt 1 in
               let cmt = Cmt.create txt loc in
-              if conf.fmt_opts.parse_docstrings.v then Either.First cmt
-              else Either.Second cmt
+              if conf.fmt_opts.parse_docstrings.v then
+                Either.First cmt
+              else
+                Either.Second cmt
           | _ -> Either.Second cmt
         in
         let old_docstrings, old_comments =

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -390,7 +390,8 @@ let is_in_listing_file ~listings ~filename =
                 match Fpath.of_string line with
                 | Ok file_on_current_line -> (
                     let f = Fpath.(dir // file_on_current_line) in
-                    if Fpath.equal filename f then Some loc
+                    if Fpath.equal filename f then
+                      Some loc
                     else
                       try
                         let filename = Fpath.to_string filename in
@@ -471,12 +472,18 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
         {f with disable= {f.disable with v= true}} ) )
   else
     let listings =
-      if conf.opr_opts.disable.v then fs.enable_files else fs.ignore_files
+      if conf.opr_opts.disable.v then
+        fs.enable_files
+      else
+        fs.ignore_files
     in
     match is_in_listing_file ~listings ~filename:file_abs with
     | Some loc ->
         let status =
-          if conf.opr_opts.disable.v then "enabled" else "ignored"
+          if conf.opr_opts.disable.v then
+            "enabled"
+          else
+            "ignored"
         in
         if conf.opr_opts.debug.v then
           warn ~loc "%a is %s." Fpath.pp file_abs status ;
@@ -490,7 +497,8 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
       collect_warnings (fun () ->
           build_config ~enable_outside_detected_project ~root ~file ~is_stdin )
     in
-    if not conf.opr_opts.quiet.v then warn_now () ;
+    if not conf.opr_opts.quiet.v then
+      warn_now () ;
     Ok conf
   with Conf_error msg -> Error msg
 

--- a/lib/bin_conf/File_system.ml
+++ b/lib/bin_conf/File_system.ml
@@ -44,7 +44,10 @@ let xdg_config () =
   match xdg_config_home with
   | Some xdg_config_home ->
       let filename = Fpath.(xdg_config_home / "ocamlformat") in
-      if Fpath.exists filename then Some filename else None
+      if Fpath.exists filename then
+        Some filename
+      else
+        None
   | None -> None
 
 type t =
@@ -72,7 +75,8 @@ let make ~enable_outside_detected_project ~disable_conf_files
           match xdg_config () with
           | Some xdg -> {fs with configuration_files= [Ocamlformat xdg]}
           | None -> fs
-        else fs
+        else
+          fs
     | "" :: upper_segs -> aux fs ~segs:upper_segs
     | _ :: upper_segs ->
         let sep = Fpath.dir_sep in
@@ -81,31 +85,43 @@ let make ~enable_outside_detected_project ~disable_conf_files
           { fs with
             ignore_files=
               (let filename = Fpath.(dir / dot_ocamlformat_ignore) in
-               if Fpath.exists filename then filename :: fs.ignore_files
-               else fs.ignore_files )
+               if Fpath.exists filename then
+                 filename :: fs.ignore_files
+               else
+                 fs.ignore_files )
           ; enable_files=
               (let filename = Fpath.(dir / dot_ocamlformat_enable) in
-               if Fpath.exists filename then filename :: fs.enable_files
-               else fs.enable_files )
+               if Fpath.exists filename then
+                 filename :: fs.enable_files
+               else
+                 fs.enable_files )
           ; configuration_files=
-              ( if disable_conf_files then []
+              ( if disable_conf_files then
+                []
               else
                 let f_1 = Fpath.(dir / dot_ocamlformat) in
                 let files =
                   if Fpath.exists f_1 then
                     Ocamlformat f_1 :: fs.configuration_files
-                  else fs.configuration_files
+                  else
+                    fs.configuration_files
                 in
                 if ocp_indent_config then
                   let f_2 = Fpath.(dir / dot_ocp_indent) in
-                  if Fpath.exists f_2 then Ocp_indent f_2 :: files else files
-                else files ) }
+                  if Fpath.exists f_2 then
+                    Ocp_indent f_2 :: files
+                  else
+                    files
+                else
+                  files ) }
         in
         (* Inside a detected project, configs are applied in top-down
            starting from the project root (i.e. excluding the global config
            file). *)
-        if is_project_root ~root dir then {fs with project_root= Some dir}
-        else aux fs ~segs:upper_segs
+        if is_project_root ~root dir then
+          {fs with project_root= Some dir}
+        else
+          aux fs ~segs:upper_segs
   in
   aux ~segs
     { ignore_files= []

--- a/test/failing/gen/gen.ml
+++ b/test/failing/gen/gen.ml
@@ -83,10 +83,16 @@ let emit_test test_name setup =
   let opts =
     if setup.has_opts then
       read_lines (Printf.sprintf "tests/%s.opts" test_name)
-    else []
+    else
+      []
   in
   let ref_name =
-    "tests/" ^ if setup.has_ref then test_name ^ ".broken-ref" else test_name
+    "tests/"
+    ^
+    if setup.has_ref then
+      test_name ^ ".broken-ref"
+    else
+      test_name
   in
   let base_test_name =
     "tests/" ^ match setup.base_file with Some n -> n | None -> test_name

--- a/test/passing/gen/gen.ml
+++ b/test/passing/gen/gen.ml
@@ -86,7 +86,8 @@ let cmd should_fail args =
       {|(with-accepted-exit-codes 1
        (run %s))|}
       cmd_string
-  else Printf.sprintf {|(run %s)|} cmd_string
+  else
+    Printf.sprintf {|(run %s)|} cmd_string
 
 let emit_test test_name setup =
   let opts =
@@ -94,10 +95,16 @@ let emit_test test_name setup =
     ::
     ( if setup.has_opts then
       read_lines (Printf.sprintf "tests/%s.opts" test_name)
-    else [] )
+    else
+      [] )
   in
   let ref_name =
-    "tests/" ^ if setup.has_ref then test_name ^ ".ref" else test_name
+    "tests/"
+    ^
+    if setup.has_ref then
+      test_name ^ ".ref"
+    else
+      test_name
   in
   let err_name = "tests/" ^ test_name ^ ".err" in
   let base_test_name =

--- a/test/rpc/rpc_test.ml
+++ b/test/rpc/rpc_test.ml
@@ -88,7 +88,10 @@ let get_client ?versions () =
   | Uninitialized -> start ?versions ()
   | Running (cl, _) ->
       let i, _ = Unix.waitpid [WNOHANG] (Ocf.pid cl) in
-      if i = 0 then Ok cl else start ?versions ()
+      if i = 0 then
+        Ok cl
+      else
+        start ?versions ()
   | Errored -> Error `No_process
 
 let close_client () =
@@ -96,7 +99,10 @@ let close_client () =
   | Uninitialized -> ()
   | Running (cl, close) ->
       let i, _ = Unix.waitpid [WNOHANG] (Ocf.pid cl) in
-      if i = 0 then close () else ()
+      if i = 0 then
+        close ()
+      else
+        ()
   | Errored -> ()
 
 let config c =

--- a/test/rpc/rpc_test_fail.ml
+++ b/test/rpc/rpc_test_fail.ml
@@ -86,7 +86,10 @@ let get_client () =
   | Uninitialized -> start ()
   | Running (cl, _) ->
       let i, _ = Unix.waitpid [WNOHANG] (Ocf.pid cl) in
-      if i = 0 then Ok cl else start ()
+      if i = 0 then
+        Ok cl
+      else
+        start ()
   | Errored -> Error `No_process
 
 let close_client () =
@@ -94,7 +97,10 @@ let close_client () =
   | Uninitialized -> ()
   | Running (cl, close) ->
       let i, _ = Unix.waitpid [WNOHANG] (Ocf.pid cl) in
-      if i = 0 then close () else ()
+      if i = 0 then
+        close ()
+      else
+        ()
   | Errored -> ()
 
 let config c =

--- a/test/unit/test_translation_unit.ml
+++ b/test/unit/test_translation_unit.ml
@@ -123,13 +123,15 @@ let reindent ~source ~range indents =
   let low = low - 1 and high = high - 1 in
   String.concat ~sep:"\n"
   @@ List.mapi lines ~f:(fun i line ->
-         if i < low then line
+         if i < low then
+           line
          else if low <= i && i <= high then
            let indent = List.nth_exn indents (i - low) in
            let line = String.lstrip line in
            let spaces = String.make indent ' ' in
            spaces ^ line
-         else line )
+         else
+           line )
 
 let test_numeric =
   let make_test name ~source ~range expected =

--- a/tools/diff-ocaml/diff_ocaml.ml
+++ b/tools/diff-ocaml/diff_ocaml.ml
@@ -28,7 +28,8 @@ let diff d1 d2 f =
       (Printf.sprintf
          {|diff -U 5 -L %s %s -L %s %s | sed 's/^@@ .* @@$/@@@@/g'|} f1 f1 f2
          f2 )
-  else 0
+  else
+    0
 
 let import ~org ~prj ~version ~src ~dst f =
   Sys.command


### PR DESCRIPTION
ocamlformat will become the first project to adopt the future diff-friendly profile (#2020) before it's made available to other projects. Let's switch one option at a time to reduce the future diff.