### PR TITLE
JaneStreet profile: doesn't align infix ops with open paren

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,7 @@
 - Improve formatting of odoc links (#2152, @gpetiot)
 - Preserve sugared extension node attached to an `if` carrying attributes (#2167, @trefis, @gpetiot)
 - Remove unnecessary parentheses around partially applied infix operators with attributes (#2198, @gpetiot)
-- JaneStreet profile: doesn't align infix ops with open paren (#<PR_NUMBER>, @gpetiot)
+- JaneStreet profile: doesn't align infix ops with open paren (#2204, @gpetiot)
 
 ### New features
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 - Improve formatting of odoc links (#2152, @gpetiot)
 - Preserve sugared extension node attached to an `if` carrying attributes (#2167, @trefis, @gpetiot)
 - Remove unnecessary parentheses around partially applied infix operators with attributes (#2198, @gpetiot)
+- JaneStreet profile: doesn't align infix ops with open paren (#<PR_NUMBER>, @gpetiot)
 
 ### New features
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1113,7 +1113,7 @@ let ( (* disable_outside_detected_project *) ) =
 
 let ocamlformat_profile from =
   let elt content = Elt.make content from in
-  { align_pattern_matching_bar= elt `Paren
+  { align_symbol_open_paren= elt true
   ; assignment_operator= elt `End_line
   ; break_before_in= elt `Fit_or_vertical
   ; break_cases= elt `Nested
@@ -1178,7 +1178,7 @@ let ocamlformat_profile from =
 let conventional_profile from =
   let elt content = Elt.make content from in
   let default_elt opt = elt @@ C.default opt in
-  { align_pattern_matching_bar= elt `Paren
+  { align_symbol_open_paren= elt true
   ; assignment_operator= default_elt Formatting.assignment_operator
   ; break_before_in= default_elt Formatting.break_before_in
   ; break_cases= default_elt Formatting.break_cases
@@ -1250,7 +1250,7 @@ let default_profile = conventional_profile
 
 let janestreet_profile from =
   let elt content = Elt.make content from in
-  { align_pattern_matching_bar= elt `Keyword
+  { align_symbol_open_paren= elt false
   ; assignment_operator= elt `Begin_line
   ; break_before_in= elt `Fit_or_vertical
   ; break_cases= elt `Fit_or_vertical

--- a/lib/Conf_t.ml
+++ b/lib/Conf_t.ml
@@ -22,7 +22,7 @@ end
 type 'a elt = 'a Elt.t
 
 type fmt_opts =
-  { align_pattern_matching_bar: [`Paren | `Keyword] elt
+  { align_symbol_open_paren: bool elt
   ; assignment_operator: [`Begin_line | `End_line] elt
   ; break_before_in: [`Fit_or_vertical | `Auto] elt
   ; break_cases:

--- a/lib/Conf_t.mli
+++ b/lib/Conf_t.mli
@@ -26,7 +26,7 @@ type 'a elt = 'a Elt.t
 
 (** Formatting options *)
 type fmt_opts =
-  { align_pattern_matching_bar: [`Paren | `Keyword] elt
+  { align_symbol_open_paren: bool elt
   ; assignment_operator: [`Begin_line | `End_line] elt
   ; break_before_in: [`Fit_or_vertical | `Auto] elt
   ; break_cases:

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1530,9 +1530,10 @@ and fmt_infix_op_args c ~parens xexp op_args =
            $ fmt_if_k (not last) (break 1 0) ) )
     $ fmt_if_k (not last_grp) (break 1 0)
   in
+  let align = not c.conf.fmt_opts.align_symbol_open_paren.v in
   Params.Exp.Infix_op_arg.wrap c.conf ~parens
     ~parens_nested:(Ast.parenze_nested_exp xexp)
-    (list_fl groups fmt_op_arg_group)
+    (hvbox_if align 0 (list_fl groups fmt_op_arg_group))
 
 and fmt_pat_cons c ~parens args =
   let groups =
@@ -1562,9 +1563,7 @@ and fmt_pat_cons c ~parens args =
 
 and fmt_match c ~parens ?ext ctx xexp cs e0 keyword =
   let indent = Params.match_indent c.conf ~ctx:xexp.ctx in
-  let align =
-    Poly.(c.conf.fmt_opts.align_pattern_matching_bar.v = `Keyword)
-  in
+  let align = not c.conf.fmt_opts.align_symbol_open_paren.v in
   hvbox indent
     ( Params.Exp.wrap c.conf ~parens ~disambiguate:true
     @@ hvbox_if align 0
@@ -2099,9 +2098,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             {pexp_desc= Pexp_infix (_, _, {pexp_desc= Pexp_function _; _}); _}
           ->
             false
-        | _ ->
-            parens
-            && Poly.(c.conf.fmt_opts.align_pattern_matching_bar.v = `Keyword)
+        | _ -> parens && not c.conf.fmt_opts.align_symbol_open_paren.v
       in
       Params.Exp.wrap c.conf ~parens ~disambiguate:true ~fits_breaks:false
       @@ hvbox_if align 0

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7617,3 +7617,10 @@ let x =
     ~f:(fun thing ->
       something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
 ;;
+
+let x =
+  f
+    ("A string _____________________"
+    ^ "Another string _____________"
+    ^ "Yet another string _________")
+;;

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9842,3 +9842,10 @@ let x =
   foo [ [ A ]; B ] ~f:(fun thing ->
       something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
 ;;
+
+let x =
+  f
+    ("A string _____________________"
+     ^ "Another string _____________"
+     ^ "Yet another string _________")
+;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9842,3 +9842,10 @@ let x =
   foo [ [ A ]; B ] ~f:(fun thing ->
     something that reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally needs wrapping)
 ;;
+
+let x =
+  f
+    ("A string _____________________"
+     ^ "Another string _____________"
+     ^ "Yet another string _________")
+;;


### PR DESCRIPTION
Second half of #2202

Re-using the hidden option that was used for aligning the `|` with the beginning of the pattern matching instead of the opening paren. Difference with #2203 is that here we don't want to apply this change everywhere but only with the janestreet profile.