### PR TITLE
Fix mingw64 build script, automate Windows release asset

### DIFF
--- a/.github/workflows/build-mingw64.yml
+++ b/.github/workflows/build-mingw64.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       ref:
         required: true
-        default: 'master'
+        default: 'main'
 
 env:
   CYGWINSETUP: setup-x86_64.exe
@@ -18,6 +18,9 @@ jobs:
     env:
       SHELLOPTS: igncr
     steps:
+      - name: Disable Git EOL Conversion
+        run: |
+          git config --global core.autocrlf false
       - name: Checkout Repository
         uses: actions/checkout@v1
         with:
@@ -33,6 +36,7 @@ jobs:
       - name: Run Build Script
         run: |
           cd '${{ github.workspace }}'
+          git config --global --add safe.directory "$(pwd)"
           bash tools/build-mingw64.sh
         shell: C:\cygwin64\bin\bash.exe --login --norc '{0}'
       - name: Upload Artifact

--- a/.github/workflows/build-mingw64.yml
+++ b/.github/workflows/build-mingw64.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           git config --global core.autocrlf false
       - name: Checkout Repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Download Cygwin Installer
@@ -40,7 +40,7 @@ jobs:
           bash tools/build-mingw64.sh
         shell: C:\cygwin64\bin\bash.exe --login --norc '{0}'
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ocamlformat-${{ github.event.inputs.ref }}.exe
           path: ${{ github.workspace }}\_build\install\default\bin\ocamlformat.exe

--- a/.github/workflows/build-mingw64.yml
+++ b/.github/workflows/build-mingw64.yml
@@ -48,24 +48,24 @@ jobs:
           cd '${{ github.workspace }}'
           git config --global --add safe.directory "$(pwd)"
           bash tools/build-mingw64.sh
-          echo "short_ref=$(basename ${{ env.build_ref }})" >> $GITHUB_ENV
+          echo "artifact_name=ocamlformat-$(basename ${{ env.build_ref }}).exe" >> $GITHUB_ENV
         shell: C:\cygwin64\bin\bash.exe --login --norc '{0}'
       - name: Rename Artifact
         run: |
-          Copy-Item ${{ github.workspace }}\_build\install\default\bin\ocamlformat.exe -Destination .\ocamlformat-${{ env.short_ref }}.exe
+          Copy-Item ${{ github.workspace }}\_build\install\default\bin\ocamlformat.exe -Destination .\${{ env.artifact_name }}
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ocamlformat-${{ env.short_ref }}.exe
-          path: ocamlformat-${{ env.short_ref }}.exe
+          name: ${{ env.artifact_name }}
+          path: ${{ env.artifact_name }}
           if-no-files-found: error
       - name: Upload Release Asset
         if: github.event_name == 'release'
         run: >
           curl.exe
-          --data-binary '@ocamlformat-${{ env.short_ref }}.exe'
+          --data-binary '@${{ env.artifact_name }}'
           -X POST
           -H "Content-Type: application/octet-stream"
           -H "Accept: application/vnd.github+json"
           -H "Authorization: Bearer ${{ github.token }}"
-          "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=ocamlformat-${{ env.short_ref }}.exe"
+          "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=${{ env.artifact_name }}"

--- a/.github/workflows/build-mingw64.yml
+++ b/.github/workflows/build-mingw64.yml
@@ -1,6 +1,8 @@
 name: Build mingw64 binary
 
 on:
+  release:
+    types: [released]
   workflow_dispatch:
     inputs:
       ref:
@@ -18,13 +20,21 @@ jobs:
     env:
       SHELLOPTS: igncr
     steps:
+      - name: Set Build Ref for Release Builds
+        if: github.event_name == 'release'
+        run: |
+          "build_ref=${{ github.ref }}" >> $env:GITHUB_ENV
+      - name: Set Build Ref for Manual Builds
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          "build_ref=${{ github.event.inputs.ref }}" >> $env:GITHUB_ENV
       - name: Disable Git EOL Conversion
         run: |
           git config --global core.autocrlf false
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ env.build_ref }}
       - name: Download Cygwin Installer
         run: |
           curl.exe -o C:\${{ env.CYGWINSETUP }} https://www.cygwin.com/${{ env.CYGWINSETUP }}
@@ -38,10 +48,24 @@ jobs:
           cd '${{ github.workspace }}'
           git config --global --add safe.directory "$(pwd)"
           bash tools/build-mingw64.sh
+          echo "short_ref=$(basename ${{ env.build_ref }})" >> $GITHUB_ENV
         shell: C:\cygwin64\bin\bash.exe --login --norc '{0}'
+      - name: Rename Artifact
+        run: |
+          Copy-Item ${{ github.workspace }}\_build\install\default\bin\ocamlformat.exe -Destination .\ocamlformat-${{ env.short_ref }}.exe
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ocamlformat-${{ github.event.inputs.ref }}.exe
-          path: ${{ github.workspace }}\_build\install\default\bin\ocamlformat.exe
+          name: ocamlformat-${{ env.short_ref }}.exe
+          path: ocamlformat-${{ env.short_ref }}.exe
           if-no-files-found: error
+      - name: Upload Release Asset
+        if: github.event_name == 'release'
+        run: >
+          curl.exe
+          --data-binary '@ocamlformat-${{ env.short_ref }}.exe'
+          -X POST
+          -H "Content-Type: application/octet-stream"
+          -H "Accept: application/vnd.github+json"
+          -H "Authorization: Bearer ${{ github.token }}"
+          "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=ocamlformat-${{ env.short_ref }}.exe"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Fix parentheses around symbol identifiers (#2185, @gpetiot)
 - Fix alignment inconsistency between let-binding and let-open (#2187, @gpetiot)
 - Fix reporting of operational settings origin in presence of profiles (#2188, @EmileTrotignon)
+- Fix automated Windows build (#2205, @nojb)
 
 ### Changes
 

--- a/tools/build-mingw64.sh
+++ b/tools/build-mingw64.sh
@@ -35,7 +35,7 @@ export PATH=$(pwd)/bin:${PATH}
 
 export OPAMROOT="$(cygpath -aml _opam)"
 
-opam init default "https://github.com/fdopen/opam-repository-mingw.git#opam2" -c "ocaml-variants.4.12.0+mingw64c" --disable-sandboxing --no-setup
+opam init default "https://github.com/fdopen/opam-repository-mingw.git#opam2" -c "ocaml-variants.4.14.0+mingw64c" --disable-sandboxing --no-setup
 
 eval $(opam env)
 

--- a/tools/build-mingw64.sh
+++ b/tools/build-mingw64.sh
@@ -35,6 +35,9 @@ export PATH=$(pwd)/bin:${PATH}
 
 export OPAMROOT="$(cygpath -aml _opam)"
 
+# If the following command fails with a curl error, make sure you have Cygwin's
+# curl in the PATH, and not a native Windows one.
+
 opam init default "https://github.com/fdopen/opam-repository-mingw.git#opam2" -c "ocaml-variants.4.14.0+mingw64c" --disable-sandboxing --no-setup
 
 eval $(opam env)

--- a/tools/build-mingw64.sh
+++ b/tools/build-mingw64.sh
@@ -50,7 +50,7 @@ set -eu
 
 dune subst
 
-dune build -p ocamlformat
+dune build -p ocamlformat @install
 
 echo "Version check:"
 


### PR DESCRIPTION
The first commit fixes a problem (#2068) wherein the Windows binary built in the GH action does not have the right `--version` string.

Moreover, I noticed that the Windows binary has not been uploaded for the last couple of releases. I propose to automate this part as well by hooking the GH action so that the Windows binary is automatically uploaded and recorded as an asset when a release happen.

An example of the machinery can be seen in my fork:

- the log of the GH action triggered by a release https://github.com/nojb/ocamlformat/actions/runs/3401060180/jobs/5655903936
- the release itself https://github.com/nojb/ocamlformat/releases/tag/bar, where you can see the asset `ocamlformat-bar.exe` that was built and uploaded automatically.

Fixes #2068 