### PR TITLE
Fix interpretation of glob patterns in .ocamlformat-ignore under Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 - Fix automated Windows build (#2205, @nojb)
 - Fix spacing between recursive module bindings and recursive module declarations (#2217, @gpetiot)
 - ocamlformat-rpc: use binary mode for stdin/stdout (#2218, @rgrinberg)
+- Fix interpretation of glob pattern in `.ocamlformat-ignore` under Windows (#2206, @nojb)
 
 ### Changes
 

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -400,9 +400,9 @@ let is_in_listing_file ~listings ~filename =
                           let f =
                             if Sys.win32 then
                               (* Use only forward slashes in the pattern as
-                                 these match match both forward and backward
+                                 these match both forward and backward
                                  slashes in ocaml-re when using the
-                                 "~match_backslashes" flag. *)
+                                 [match_backslashes] flag. *)
                               String.concat ~sep:"/"
                                 (String.split_on_chars f ~on:['\\'])
                             else f


### PR DESCRIPTION
Fixes #1773 

`ocaml-re` has a flag `~match_backslashes:true` which means that forward backslashes in the pattern will match both forward and backward backslashes in the matched filename. But it gets a bit tricky because _backward_ slashes in the pattern will still act as normal backslashes (escaping the following character), so we need to make sure there are no backward slashes in the pattern before building the regexp.

All in all, an ugly solution, but am not sure we can do much better with `ocaml-re`'s current API.