### PR TITLE
[WIP] Replace AST with CST

### DIFF
--- a/vendor/parser-extended/asttypes.mli
+++ b/vendor/parser-extended/asttypes.mli
@@ -20,15 +20,6 @@
 
 *)
 
-type constant =
-    Const_int of int
-  | Const_char of char
-  | Const_string of string * Location.t * string option
-  | Const_float of string
-  | Const_int32 of int32
-  | Const_int64 of int64
-  | Const_nativeint of nativeint
-
 type rec_flag = Nonrecursive | Recursive
 
 type direction_flag = Upto | Downto
@@ -54,10 +45,15 @@ type obj_closed_flag =
 
 type label = string
 
+type label_info = {
+  name: string loc;
+  extra_info: [ `Single_token | `Previous_token of Location.t ];
+}
+
 type arg_label =
     Nolabel
-  | Labelled of string (** [label:T -> ...] *)
-  | Optional of string (** [?label:T -> ...] *)
+  | Labelled of label_info (*  label:T -> ... *)
+  | Optional of label_info (* ?label:T -> ... *)
 
 type 'a loc = 'a Location.loc = {
   txt : 'a;
@@ -70,3 +66,5 @@ type variance_and_injectivity = string loc list
 
 (* For Pexp_indexop_access *)
 type paren_kind = Paren | Brace | Bracket
+
+type and_or_with = And | With


### PR DESCRIPTION
Please don't merge this!
The purpose is to visualize the diff between the current state of the ast+parser of ocamlformat and the cst+parser of ocamlformat-ng prototype (https://github.com/tarides/ocamlformat-ng), the files in this branch have been made closer to the current main branch of ocamlformat, but this doesn't build.

To display the diff: `git diff main cst -- vendor/parser-extended/`

This is a suggestion of roadmap (non-exhaustive) of the changes left to report in ocamlformat, it should be easier to start with the type changes before working on the ext_attributes and the parentheses. Refer to parsetree.mli:

### 1. Enrich existing type constructors
- [x] `ptyp_alias` (#2239)
- [x] `pexp_pack` (#2234)
- [x] `pval_prim` (#2238)
- [x] `pcstr_record` (#2237)
- [x] `pcsig_self` (#2216)
- [x] `pcstr_self` (#2236)
- [x] new type `fun_param` (#2466)

### 2. Improve representation of poly/newtype
- [x] redesign the whole representation of `pexp_poly`, `pexp_newtype`, `ptyp_newtype_poly` (#2529)

### 3. Add location in Longident.t type
- [ ] replace occurrences of`Longident.t. loc` with `Longident.t`

### 4. Add extension and attributes
- [x] add fields `*_ext_attributes` (#2247), as these fields are kept together in the parser.

### 5. Preserve parentheses
- [ ] `Pexp_parens`
- [ ] `Ppat_parens`
- [ ] `Ptyp_parens`
- [ ] `Pcl_parens`
- [ ] `Pmty_parens`
- [ ] `Pmod_parens`

### Bonus
- [ ] types `module_expr` and `module_type` probably need to be reworked too
- [ ] undo the work made in `Sugar.ml` by reverting the normalization made in the parser

While reporting some of the changes into ocamlformat, if design choices make the files diverge from ocamlformat-ng please update the files in this branch.
Also don't forget to propagate the changes in `parser-recovery/lib/parser.mly` and run `dune build @all` to regenerate the diffs.