### PR TITLE
ocamlformat-rpc: use binary mode for stdin/stdout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - Fix alignment inconsistency of if-then-else in apply (#2203, @gpetiot)
 - Fix automated Windows build (#2205, @nojb)
 - Fix spacing between recursive module bindings and recursive module declarations (#2217, @gpetiot)
+- Fix ocamlformat-rpc on Windows (#2218, @rgrinberg)
 
 ### Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
 - Fix alignment inconsistency of if-then-else in apply (#2203, @gpetiot)
 - Fix automated Windows build (#2205, @nojb)
 - Fix spacing between recursive module bindings and recursive module declarations (#2217, @gpetiot)
-- Fix ocamlformat-rpc on Windows (#2218, @rgrinberg)
+- ocamlformat-rpc: use binary mode for stdin/stdout (#2218, @rgrinberg)
 
 ### Changes
 

--- a/lib-rpc-server/ocamlformat_rpc.ml
+++ b/lib-rpc-server/ocamlformat_rpc.ml
@@ -179,4 +179,7 @@ let rec rpc_main = function
           in
           rpc_main (Version_defined (v, conf)) ) )
 
-let run () = rpc_main Waiting_for_version
+let run () =
+  Stdio.In_channel.set_binary_mode stdin true;
+  Stdio.Out_channel.set_binary_mode stdout true;
+  rpc_main Waiting_for_version

--- a/lib-rpc-server/ocamlformat_rpc.ml
+++ b/lib-rpc-server/ocamlformat_rpc.ml
@@ -180,6 +180,6 @@ let rec rpc_main = function
           rpc_main (Version_defined (v, conf)) ) )
 
 let run () =
-  Stdio.In_channel.set_binary_mode stdin true;
-  Stdio.Out_channel.set_binary_mode stdout true;
+  Stdio.In_channel.set_binary_mode stdin true ;
+  Stdio.Out_channel.set_binary_mode stdout true ;
   rpc_main Waiting_for_version


### PR DESCRIPTION
Use stdin/stdout in binary mode. We don't wany any newline translation for Csexp packets.