### PR TITLE
Distribute the library in a separate ocamlformat-lib package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@
 - Remove unnecessary parentheses around partially applied infix operators with attributes (#2198, @gpetiot)
 - JaneStreet profile: doesn't align infix ops with open paren (#2204, @gpetiot)
 - Re-use the type let_binding from the parser instead of value_binding, improve the spacing of let-bindings regarding of having extension or comments (#2219, @gpetiot)
+- The `ocamlformat` package now only contains the binary, the library is available through the `ocamlformat-lib` package (#2230, @gpetiot)
 
 ### New features
 

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -11,7 +11,7 @@
 
 open Bechamel
 open Toolkit
-open Ocamlformat
+open Ocamlformat_lib
 
 type range = int * int
 

--- a/bench/dune
+++ b/bench/dune
@@ -11,7 +11,7 @@
 
 (executable
  (name bench)
- (libraries bechamel bechamel-js ocamlformat stdio yojson))
+ (libraries bechamel bechamel-js ocamlformat-lib stdio yojson))
 
 (rule
  (alias runbench)

--- a/bin/ocamlformat-rpc/main.ml
+++ b/bin/ocamlformat-rpc/main.ml
@@ -70,7 +70,8 @@ let info =
          as a reply of the same form."
     ; `P "Unknown commands are ignored." ]
   in
-  Cmd.info "ocamlformat-rpc" ~version:Ocamlformat.Version.current ~doc ~man
+  Cmd.info "ocamlformat-rpc" ~version:Ocamlformat_lib.Version.current ~doc
+    ~man
 
 let rpc_main_t = Term.(const Ocamlformat_rpc.run $ const ())
 

--- a/bin/ocamlformat/dune
+++ b/bin/ocamlformat/dune
@@ -18,7 +18,7 @@
   (:standard -open Ocamlformat_stdlib))
  (instrumentation
   (backend bisect_ppx))
- (libraries ocamlformat bin_conf))
+ (libraries ocamlformat-lib bin_conf))
 
 (rule
  (with-stdout-to

--- a/bin/ocamlformat/main.ml
+++ b/bin/ocamlformat/main.ml
@@ -11,7 +11,7 @@
 
 (** OCamlFormat *)
 
-open Ocamlformat ;;
+open Ocamlformat_lib ;;
 
 Caml.at_exit (Format.pp_print_flush Format.err_formatter) ;;
 

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@
  (github ocaml-ppx/ocamlformat))
 
 (package
- (name ocamlformat)
+ (name ocamlformat-lib)
  (synopsis "Auto-formatter for OCaml code")
  (description
   "OCamlFormat is a tool to automatically format OCaml code in a uniform style.")
@@ -40,8 +40,6 @@
     (>= 1.3.0)))
   (base
    (>= v0.12.0))
-  (cmdliner
-   (>= 1.1.0))
   dune
   dune-build-info
   either
@@ -61,8 +59,6 @@
     (= :version)))
   (ocp-indent
    (>= 1.8.0))
-  (re
-   (>= 1.10.3))
   stdio
   (uuseg
    (>= 10.0.0))
@@ -74,6 +70,22 @@
   astring
   result
   camlp-streams))
+
+(package
+ (name ocamlformat)
+ (synopsis "Auto-formatter for OCaml code")
+ (description
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style.")
+ (depends
+  (ocaml
+   (>= 4.08))
+  (cmdliner
+   (>= 1.1.0))
+  dune
+  (ocamlformat-lib
+   (= :version))
+  (re
+   (>= 1.10.3))))
 
 (package
  (name ocamlformat-bench)
@@ -91,7 +103,7 @@
    (>= 0.2.0))
   (bechamel-js
    (>= 0.2.0))
-  (ocamlformat
+  (ocamlformat-lib
    (= :version))
   stdio
   (yojson

--- a/lib-rpc-server/dune
+++ b/lib-rpc-server/dune
@@ -1,4 +1,7 @@
 (library
  (name ocamlformat_rpc)
  (public_name ocamlformat.rpc)
- (libraries ocamlformat ocamlformat.bin_conf ocamlformat.rpc_lib_protocol))
+ (libraries
+  ocamlformat-lib
+  ocamlformat.bin_conf
+  ocamlformat.rpc_lib_protocol))

--- a/lib-rpc-server/ocamlformat_rpc.ml
+++ b/lib-rpc-server/ocamlformat_rpc.ml
@@ -9,7 +9,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Ocamlformat
+open Ocamlformat_lib
 open Ocamlformat_stdlib
 
 module IO = struct

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -9,10 +9,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Ocamlformat
+open Ocamlformat_lib
 open Conf
 open Cmdliner
-module Decl = Ocamlformat.Conf_decl
+module Decl = Conf_decl
 
 type file = Stdin | File of string
 

--- a/lib/bin_conf/Bin_conf.mli
+++ b/lib/bin_conf/Bin_conf.mli
@@ -14,15 +14,15 @@ val build_config :
   -> root:Fpath.t option
   -> file:string
   -> is_stdin:bool
-  -> (Ocamlformat.Conf.t, string) Result.t
+  -> (Ocamlformat_lib.Conf.t, string) Result.t
 
 type file = Stdin | File of string
 
 type input =
-  { kind: Ocamlformat.Syntax.t
+  { kind: Ocamlformat_lib.Syntax.t
   ; name: string
   ; file: file
-  ; conf: Ocamlformat.Conf.t }
+  ; conf: Ocamlformat_lib.Conf.t }
 
 (** Formatting action: input type and source, and output destination. *)
 type action =
@@ -32,7 +32,7 @@ type action =
   | Inplace of input list  (** Format in-place, overwriting input file(s). *)
   | Check of input list
       (** Check whether the input files already are formatted. *)
-  | Print_config of Ocamlformat.Conf.t
+  | Print_config of Ocamlformat_lib.Conf.t
       (** Print the configuration and exit. *)
   | Numeric of input
 

--- a/lib/bin_conf/dune
+++ b/lib/bin_conf/dune
@@ -11,4 +11,4 @@
    Ocamlformat_result.Global_scope))
  (instrumentation
   (backend bisect_ppx))
- (libraries ocamlformat re))
+ (libraries ocamlformat-lib re))

--- a/lib/dune
+++ b/lib/dune
@@ -14,8 +14,8 @@
 (ocamllex Toplevel_lexer)
 
 (library
- (name ocamlformat)
- (public_name ocamlformat)
+ (name ocamlformat_lib)
+ (public_name ocamlformat-lib)
  (flags
   (:standard
    -open

--- a/ocamlformat-lib.opam
+++ b/ocamlformat-lib.opam
@@ -8,14 +8,27 @@ authors: ["Josh Berdine <jjb@fb.com>"]
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
   "alcotest" {with-test & >= "1.3.0"}
-  "bechamel" {>= "0.2.0"}
-  "bechamel-js" {>= "0.2.0"}
-  "ocamlformat-lib" {= version}
+  "base" {>= "v0.12.0"}
+  "dune" {>= "2.8"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.5.0"}
+  "ocamlformat-rpc-lib" {with-test & = version}
+  "ocp-indent" {>= "1.8.0"}
   "stdio"
-  "yojson" {>= "1.6.0"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "astring"
+  "result"
+  "camlp-streams"
   "odoc" {with-doc}
 ]
 build: [
@@ -33,3 +46,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"] # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license

--- a/ocamlformat-lib.opam.template
+++ b/ocamlformat-lib.opam.template
@@ -1,0 +1,1 @@
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"] # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -9,28 +9,10 @@ homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "alcotest" {with-test & >= "1.3.0"}
-  "base" {>= "v0.12.0"}
   "cmdliner" {>= "1.1.0"}
   "dune" {>= "2.8"}
-  "dune-build-info"
-  "either"
-  "fix"
-  "fpath"
-  "menhir" {>= "20201216"}
-  "menhirLib" {>= "20201216"}
-  "menhirSdk" {>= "20201216"}
-  "ocaml-version" {>= "3.5.0"}
-  "ocamlformat-rpc-lib" {with-test & = version}
-  "ocp-indent" {>= "1.8.0"}
+  "ocamlformat-lib" {= version}
   "re" {>= "1.10.3"}
-  "stdio"
-  "uuseg" {>= "10.0.0"}
-  "uutf" {>= "1.0.1"}
-  "csexp" {>= "1.4.0"}
-  "astring"
-  "result"
-  "camlp-streams"
   "odoc" {with-doc}
 ]
 build: [

--- a/test/unit/dune
+++ b/test/unit/dune
@@ -1,4 +1,4 @@
 (test
  (name test_unit)
- (package ocamlformat)
- (libraries alcotest base ocamlformat))
+ (package ocamlformat-lib)
+ (libraries alcotest base ocamlformat-lib))

--- a/test/unit/test_ast.ml
+++ b/test/unit/test_ast.ml
@@ -1,5 +1,5 @@
 open! Base
-open Ocamlformat
+open Ocamlformat_lib
 
 let test_string_id ~f name ~pass ~fail =
   let test symbol ~expected =

--- a/test/unit/test_conf.ml
+++ b/test/unit/test_conf.ml
@@ -1,4 +1,4 @@
-open Ocamlformat
+open Ocamlformat_lib
 
 let find name =
   List.find (fun Conf_decl.UI.{names; _} ->

--- a/test/unit/test_eol_compat.ml
+++ b/test/unit/test_eol_compat.ml
@@ -1,4 +1,4 @@
-open Ocamlformat
+open Ocamlformat_lib
 
 let normalize_eol_tests =
   let test name ~exclude_locs input ~lf ~crlf =

--- a/test/unit/test_fmt.ml
+++ b/test/unit/test_fmt.ml
@@ -1,5 +1,5 @@
 open Base
-open Ocamlformat
+open Ocamlformat_lib
 
 let eval_fmt term =
   let buffer = Buffer.create 0 in

--- a/test/unit/test_indent.ml
+++ b/test/unit/test_indent.ml
@@ -1,4 +1,4 @@
-open Ocamlformat
+open Ocamlformat_lib
 
 let read_file f = Stdio.In_channel.with_file f ~f:Stdio.In_channel.input_all
 

--- a/test/unit/test_literal_lexer.ml
+++ b/test/unit/test_literal_lexer.ml
@@ -1,5 +1,5 @@
 open Base
-open Ocamlformat
+open Ocamlformat_lib
 
 let single_quote = '\''
 

--- a/test/unit/test_range.ml
+++ b/test/unit/test_range.ml
@@ -1,4 +1,4 @@
-open Ocamlformat
+open Ocamlformat_lib
 
 let pp =
   let open Stdlib.Format in

--- a/test/unit/test_translation_unit.ml
+++ b/test/unit/test_translation_unit.ml
@@ -1,5 +1,5 @@
 open! Base
-open Ocamlformat
+open Ocamlformat_lib
 
 let normalize_eol = Eol_compat.normalize_eol ~line_endings:`Lf
 

--- a/test/unit/test_translation_unit.mli
+++ b/test/unit/test_translation_unit.mli
@@ -1,4 +1,4 @@
 val tests : unit Alcotest.test_case list
 
 val reindent :
-  source:string -> range:Ocamlformat.Range.t -> int list -> string
+  source:string -> range:Ocamlformat_lib.Range.t -> int list -> string

--- a/test/unit/test_unit.ml
+++ b/test/unit/test_unit.ml
@@ -1,5 +1,5 @@
 open Base
-open Ocamlformat
+open Ocamlformat_lib
 
 module Test_location = struct
   let test_compare_width_decreasing =

--- a/vendor/ocaml-common/dune
+++ b/vendor/ocaml-common/dune
@@ -1,6 +1,6 @@
 (library
  (name ocaml_common)
- (public_name ocamlformat.ocaml_common)
+ (public_name ocamlformat-lib.ocaml_common)
  (flags
   (:standard -w -9 -open Parser_shims))
  (libraries parser_shims))

--- a/vendor/ocamlformat-result/dune
+++ b/vendor/ocamlformat-result/dune
@@ -1,3 +1,3 @@
 (library
  (name ocamlformat_result)
- (public_name ocamlformat.result))
+ (public_name ocamlformat-lib.result))

--- a/vendor/ocamlformat-stdlib/dune
+++ b/vendor/ocamlformat-stdlib/dune
@@ -1,6 +1,6 @@
 (library
  (name ocamlformat_stdlib)
- (public_name ocamlformat.ocamlformat_stdlib)
+ (public_name ocamlformat-lib.ocamlformat_stdlib)
  (flags
   (:standard -open Ocaml_common))
  (libraries base cmdliner ocaml_common fpath stdio))

--- a/vendor/ocamlformat_support/dune
+++ b/vendor/ocamlformat_support/dune
@@ -1,6 +1,6 @@
 (library
  (name format_)
- (public_name ocamlformat.format_)
+ (public_name ocamlformat-lib.format_)
  (flags
   (:standard -open Parser_shims))
  (libraries either parser_shims))

--- a/vendor/odoc-parser/dune
+++ b/vendor/odoc-parser/dune
@@ -2,7 +2,7 @@
 
 (library
  (name odoc_parser)
- (public_name ocamlformat.odoc_parser)
+ (public_name ocamlformat-lib.odoc_parser)
  (instrumentation
   (backend bisect_ppx))
  (flags

--- a/vendor/parser-extended/dune
+++ b/vendor/parser-extended/dune
@@ -1,6 +1,6 @@
 (library
  (name parser_extended)
- (public_name ocamlformat.parser_extended)
+ (public_name ocamlformat-lib.parser_extended)
  (flags
   (:standard -w -9 -open Parser_shims -open Ocaml_common))
  (libraries compiler-libs.common menhirLib parser_shims ocaml_common))

--- a/vendor/parser-recovery/lib/dune
+++ b/vendor/parser-recovery/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name parser_recovery)
- (public_name ocamlformat.parser_recovery)
+ (public_name ocamlformat-lib.parser_recovery)
  (libraries menhirLib ocaml_common parser_extended)
  (flags
   (:standard -w -9 -open Ocaml_common -open Parser_extended)))

--- a/vendor/parser-shims/dune
+++ b/vendor/parser-shims/dune
@@ -1,4 +1,4 @@
 (library
  (name parser_shims)
- (public_name ocamlformat.parser_shims)
+ (public_name ocamlformat-lib.parser_shims)
  (libraries compiler-libs.common))

--- a/vendor/parser-standard/dune
+++ b/vendor/parser-standard/dune
@@ -1,6 +1,6 @@
 (library
  (name parser_standard)
- (public_name ocamlformat.parser_standard)
+ (public_name ocamlformat-lib.parser_standard)
  (flags
   (:standard -w -9 -open Parser_shims -open Ocaml_common))
  (libraries compiler-libs.common menhirLib parser_shims ocaml_common))


### PR DESCRIPTION
Split the current ocamlformat package in 2:
- ocamlformat-lib: the library
- ocamlformat: the binary

This can be useful for the ocaml platform, and maybe some users will prefer using the lib instead of the rpc (already possible but at least that won't add a dependance on the binary).

Closes #2190