### PR TITLE
docs: update FAQ to use recursive glob for ignoring

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -1,3 +1,1 @@
-vendor/*/*
-vendor/*/*/*
-vendor/*/*/*/*
+vendor/**

--- a/doc/faq.mld
+++ b/doc/faq.mld
@@ -63,13 +63,10 @@ ml] and then running [ocamlformat] on this output.
 
 {1 How to ignore directories?}
 
-It is possible to disable OCamlFormat for the files of a directory by having an [.ocamlformat] file containing disable in this directory, or listing the files to ignore in an [.ocamlformat-ignore] file.
+It is possible to disable OCamlFormat for the files of a directory by having an [.ocamlformat] file containing disable in this directory, or listing the files to ignore in an [.ocamlformat-ignore] file:
 
-For now it is not possible to recursively ignore all subdirectories and files from a parent directory, you need to list all the descendants of the directory to ignore them, e.g.:
 {[
-dir/*
-dir/*/*
-dir/*/*/*
+dir/**
 ]}
 
 It is also possible to add an [.ocamlformat-ignore] file containing [*] in every directory that needs to be ignored.


### PR DESCRIPTION
Also updates the project's own `.ocamlformat-ignore` to use recursive glob. I have not tested this locally however, since I haven't been able to find instructions for how to build the project.