### PR TITLE
Fix version check for 4.14.0 new syntax

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -51,7 +51,7 @@
   (menhirSdk
    (>= 20201216))
   (ocaml-version
-   (>= 3.3.0))
+   (>= 3.6.0))
   (ocamlformat-rpc-lib
    (and
     :with-test

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2131,7 +2131,7 @@ end = struct
     (* Object fields do not require parens, even with trailing attributes *)
     | Exp {pexp_desc= Pexp_object _; _}, _ -> false
     | _, {pexp_desc= Pexp_object _; pexp_attributes= []; _}
-      when Ocaml_version.(compare !ocaml_version Releases.v4_14 >= 0) ->
+      when Ocaml_version.(compare !ocaml_version Releases.v4_14_0 >= 0) ->
         false
     | ( Exp {pexp_desc= Pexp_construct ({txt= id; _}, _); _}
       , {pexp_attributes= _ :: _; _} )

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1348,7 +1348,7 @@ and fmt_label_arg ?(box = true) ?epi ?parens ?eol c
     when String.equal l i
          && List.is_empty arg.pexp_attributes
          && Ocaml_version.(
-              compare c.conf.opr_opts.ocaml_version.v Releases.v4_14 >= 0 )
+              compare c.conf.opr_opts.ocaml_version.v Releases.v4_14_0 >= 0 )
     ->
       let lbl =
         match lbl with

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -20,7 +20,7 @@ depends: [
   "menhir" {>= "20201216"}
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
-  "ocaml-version" {>= "3.3.0"}
+  "ocaml-version" {>= "3.6.0"}
   "ocamlformat-rpc-lib" {with-test & = version}
   "ocp-indent"
   "re" {>= "1.10.3"}


### PR DESCRIPTION
This fixes the CI.
Upgrade our dependencies: ocaml-version 3.6.0 should be used.