### PR TITLE
Moves module attributes after the module keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,9 @@ profile. This started with version 0.26.0.
 - Fix `[@ocamlformat "disable"]` inside `class type` constructs. (#2525, @EmileTrotignon)
 - Fix the formatting of the `in` keyword when `[@ocamlformat disable]` is attached to a let-binding (#2242, @EmileTrotignon)
 
+### Changes
+- The location of attributes for structure items is now tracked and preserved. (#2247, @EmileTrotignon)
+
 ## 0.26.1 (2023-09-15)
 
 ### Changed

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -331,18 +331,19 @@ module Structure_item = struct
      |Pstr_type (_, {ptype_attributes= atrs; _} :: _)
      |Pstr_typext {ptyext_attributes= atrs; _}
      |Pstr_recmodule ({pmb_expr= {pmod_attributes= atrs; _}; _} :: _)
-     |Pstr_extension (_, atrs)
-     |Pstr_class_type ({pci_attributes= atrs; _} :: _)
-     |Pstr_class ({pci_attributes= atrs; _} :: _) ->
+     |Pstr_extension (_, atrs) ->
         List.exists ~f:Attr.is_doc atrs
     | Pstr_exception
         { ptyexn_attributes= atrs1
         ; ptyexn_constructor= {pext_attributes= atrs2; _}
         ; _ } ->
         List.exists ~f:Attr.is_doc atrs1 || List.exists ~f:Attr.is_doc atrs2
-        | Pstr_open
-        {popen_attributes= ea; _}
-    | Pstr_modtype {pmtd_ext_attrs=ea; _} -> Ext_attrs.has_doc ea
+    | Pstr_open {popen_attributes= ea; _}
+     |Pstr_class_type ({pci_attributes= ea; _} :: _)
+     |Pstr_class ({pci_attributes= ea; _} :: _)
+     |Pstr_modtype {pmtd_ext_attrs= ea; _} ->
+      print_endline "hey";
+        Ext_attrs.has_doc ea
     | Pstr_module
         {pmb_ext_attrs= ea; pmb_expr= {pmod_attributes= attrs; _}; _}
      |Pstr_include
@@ -426,14 +427,15 @@ module Signature_item = struct
      |Psig_type (_, {ptype_attributes= atrs; _} :: _)
      |Psig_typesubst ({ptype_attributes= atrs; _} :: _)
      |Psig_typext {ptyext_attributes= atrs; _}
-     |Psig_extension (_, atrs)
-     |Psig_class_type ({pci_attributes= atrs; _} :: _)
-     |Psig_class ({pci_attributes= atrs; _} :: _) ->
-        List.exists ~f:Attr.is_doc atrs
-    (* two attribute list *)
-    | Psig_modtype {pmtd_ext_attrs= ea; _}
+     |Psig_extension (_, atrs) ->
+        List.exists ~f:Attr.is_doc atrs (* two attribute list *)
+    | Psig_class_type ({pci_attributes= ea; _} :: _)
+     |Psig_class ({pci_attributes= ea; _} :: _)
+     |Psig_modtype {pmtd_ext_attrs= ea; _}
      |Psig_modtypesubst {pmtd_ext_attrs= ea; _}
      |Psig_modsubst {pms_ext_attrs= ea; _} ->
+      print_endline "hey";
+
         Ext_attrs.has_doc ea
     | Psig_exception
         { ptyexn_attributes= atrs1

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -326,7 +326,6 @@ module Structure_item = struct
     | Pstr_attribute atr -> Attr.is_doc atr
     (* one attribute list *)
     | Pstr_eval (_, atrs)
-     |Pstr_value {pvbs_bindings= {pvb_attributes= atrs; _} :: _; _}
      |Pstr_primitive {pval_attributes= atrs; _}
      |Pstr_typext {ptyext_attributes= atrs; _}
      |Pstr_recmodule ({pmb_expr= {pmod_attributes= atrs; _}; _} :: _)
@@ -341,7 +340,8 @@ module Structure_item = struct
      |Pstr_class_type ({pci_attributes= ea; _} :: _)
      |Pstr_class ({pci_attributes= ea; _} :: _)
      |Pstr_modtype {pmtd_ext_attrs= ea; _}
-     |Pstr_type (_, {ptype_attributes= ea; _} :: _) ->
+     |Pstr_type (_, {ptype_attributes= ea; _} :: _)
+     |Pstr_value {pvbs_bindings= {pvb_attributes= ea; _} :: _; _} ->
         Ext_attrs.has_doc ea
     | Pstr_module
         {pmb_ext_attrs= ea; pmb_expr= {pmod_attributes= attrs; _}; _}
@@ -507,7 +507,9 @@ module Signature_item = struct
 end
 
 module Lb = struct
-  let has_doc itm = List.exists ~f:Attr.is_doc itm.pvb_attributes
+  let has_doc itm =
+    List.exists ~f:Attr.is_doc itm.pvb_attributes.attrs_before
+    || List.exists ~f:Attr.is_doc itm.pvb_attributes.attrs_after
 
   let is_simple (i, (c : Conf.t)) =
     Poly.(c.fmt_opts.module_item_spacing.v = `Compact)
@@ -706,7 +708,7 @@ let attributes = function
   | Exp x -> x.pexp_attributes
   | Fpe _ | Fpc _ -> []
   | Vc _ -> []
-  | Lb x -> x.pvb_attributes
+  | Lb x -> attrs_of_ext_attrs x.pvb_attributes
   | Bo _ -> []
   | Mb x -> attrs_of_ext_attrs x.pmb_ext_attrs
   | Md x -> attrs_of_ext_attrs x.pmd_ext_attrs

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -432,14 +432,13 @@ module Signature_item = struct
      |Psig_modtypesubst {pmtd_ext_attrs= ea; _}
      |Psig_modsubst {pms_ext_attrs= ea; _} ->
         Ext_attrs.has_doc ea
-
     | Psig_include
         {pincl_mod= {pmty_attributes= atrs; _}; pincl_attributes= ea; _}
      |Psig_exception
         { ptyexn_attributes= ea
         ; ptyexn_constructor= {pext_attributes= atrs; _}
         ; _ }
-    | Psig_recmodule
+     |Psig_recmodule
         ({pmd_type= {pmty_attributes= atrs; _}; pmd_ext_attrs= ea; _} :: _)
      |Psig_module {pmd_ext_attrs= ea; pmd_type= {pmty_attributes= atrs; _}; _}
       ->

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -421,26 +421,28 @@ module Signature_item = struct
     match itm.psig_desc with
     | Psig_attribute atr -> Attr.is_doc atr
     | Psig_extension (_, atrs) -> List.exists ~f:Attr.is_doc atrs
-    | Psig_class_type ({pci_attributes= ea; _} :: _)
+    | Psig_value {pval_attributes= ea; _}
+     |Psig_type (_, {ptype_attributes= ea; _} :: _)
+     |Psig_typesubst ({ptype_attributes= ea; _} :: _)
+     |Psig_typext {ptyext_attributes= ea; _}
+     |Psig_open {popen_attributes= ea; _}
+     |Psig_class_type ({pci_attributes= ea; _} :: _)
      |Psig_class ({pci_attributes= ea; _} :: _)
      |Psig_modtype {pmtd_ext_attrs= ea; _}
      |Psig_modtypesubst {pmtd_ext_attrs= ea; _}
-     |Psig_modsubst {pms_ext_attrs= ea; _}
-     |Psig_open {popen_attributes= ea; _}
-     |Psig_type (_, {ptype_attributes= ea; _} :: _)
-     |Psig_typesubst ({ptype_attributes= ea; _} :: _)
-     |Psig_value {pval_attributes= ea; _}
-     |Psig_typext {ptyext_attributes= ea; _} ->
+     |Psig_modsubst {pms_ext_attrs= ea; _} ->
         Ext_attrs.has_doc ea
-    | Psig_recmodule
-        ({pmd_type= {pmty_attributes= atrs; _}; pmd_ext_attrs= ea; _} :: _)
-     |Psig_module {pmd_ext_attrs= ea; pmd_type= {pmty_attributes= atrs; _}; _}
-     |Psig_include
+
+    | Psig_include
         {pincl_mod= {pmty_attributes= atrs; _}; pincl_attributes= ea; _}
      |Psig_exception
         { ptyexn_attributes= ea
         ; ptyexn_constructor= {pext_attributes= atrs; _}
-        ; _ } ->
+        ; _ }
+    | Psig_recmodule
+        ({pmd_type= {pmty_attributes= atrs; _}; pmd_ext_attrs= ea; _} :: _)
+     |Psig_module {pmd_ext_attrs= ea; pmd_type= {pmty_attributes= atrs; _}; _}
+      ->
         Ext_attrs.has_doc ea || (List.exists ~f:Attr.is_doc) atrs
     | Psig_type (_, [])
      |Psig_typesubst []
@@ -708,8 +710,8 @@ let attributes = function
   | Mb x -> attrs_of_ext_attrs x.pmb_ext_attrs
   | Md x -> attrs_of_ext_attrs x.pmd_ext_attrs
   | Cl x -> x.pcl_attributes
-  | Cd x -> x.pci_attributes
-  | Ctd x -> x.pci_attributes
+  | Cd x -> attrs_of_ext_attrs x.pci_attributes
+  | Ctd x -> attrs_of_ext_attrs x.pci_attributes
   | Mty x -> x.pmty_attributes
   | Mod x -> x.pmod_attributes
   | Sig _ -> []

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -331,7 +331,6 @@ module Structure_item = struct
      |Pstr_type (_, {ptype_attributes= atrs; _} :: _)
      |Pstr_typext {ptyext_attributes= atrs; _}
      |Pstr_recmodule ({pmb_expr= {pmod_attributes= atrs; _}; _} :: _)
-     |Pstr_open {popen_attributes= atrs; _}
      |Pstr_extension (_, atrs)
      |Pstr_class_type ({pci_attributes= atrs; _} :: _)
      |Pstr_class ({pci_attributes= atrs; _} :: _) ->
@@ -341,7 +340,9 @@ module Structure_item = struct
         ; ptyexn_constructor= {pext_attributes= atrs2; _}
         ; _ } ->
         List.exists ~f:Attr.is_doc atrs1 || List.exists ~f:Attr.is_doc atrs2
-    | Pstr_modtype {pmtd_ext_attrs; _} -> Ext_attrs.has_doc pmtd_ext_attrs
+        | Pstr_open
+        {popen_attributes= ea; _}
+    | Pstr_modtype {pmtd_ext_attrs=ea; _} -> Ext_attrs.has_doc ea
     | Pstr_module
         {pmb_ext_attrs= ea; pmb_expr= {pmod_attributes= attrs; _}; _}
      |Pstr_include
@@ -425,7 +426,6 @@ module Signature_item = struct
      |Psig_type (_, {ptype_attributes= atrs; _} :: _)
      |Psig_typesubst ({ptype_attributes= atrs; _} :: _)
      |Psig_typext {ptyext_attributes= atrs; _}
-     |Psig_open {popen_attributes= atrs; _}
      |Psig_extension (_, atrs)
      |Psig_class_type ({pci_attributes= atrs; _} :: _)
      |Psig_class ({pci_attributes= atrs; _} :: _) ->
@@ -438,8 +438,12 @@ module Signature_item = struct
     | Psig_exception
         { ptyexn_attributes= atrs1
         ; ptyexn_constructor= {pext_attributes= atrs2; _}
-        ; _ } ->
+        ; _ }
+     |Psig_open
+        {popen_attributes= {attrs_before= atrs1; attrs_after= atrs2; _}; _}
+      ->
         List.exists ~f:Attr.is_doc atrs1 || List.exists ~f:Attr.is_doc atrs2
+    (* three attribute list *)
     | Psig_recmodule
         ({pmd_type= {pmty_attributes= atrs; _}; pmd_ext_attrs= ea; _} :: _)
      |Psig_module {pmd_ext_attrs= ea; pmd_type= {pmty_attributes= atrs; _}; _}

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -698,7 +698,7 @@ let attrs_of_ext_attrs ea = ea.attrs_before @ ea.attrs_after
 let attributes = function
   | Pld _ -> []
   | Typ x -> x.ptyp_attributes
-  | Td x -> x.ptype_attributes.attrs_before @ x.ptype_attributes.attrs_after
+  | Td x -> attrs_of_ext_attrs x.ptype_attributes
   | Cty x -> x.pcty_attributes
   | Pat x -> x.ppat_attributes
   | Exp x -> x.pexp_attributes

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -339,15 +339,14 @@ module Structure_item = struct
     | Pstr_exception
         { ptyexn_attributes= atrs1
         ; ptyexn_constructor= {pext_attributes= atrs2; _}
-        ; _ }
-     |Pstr_include
-        {pincl_mod= {pmod_attributes= atrs1; _}; pincl_attributes= atrs2; _}
-      ->
+        ; _ } ->
         List.exists ~f:Attr.is_doc atrs1 || List.exists ~f:Attr.is_doc atrs2
     | Pstr_modtype {pmtd_ext_attrs; _} -> Ext_attrs.has_doc pmtd_ext_attrs
-    | Pstr_module {pmb_ext_attrs; pmb_expr= {pmod_attributes; _}; _} ->
-        Ext_attrs.has_doc pmb_ext_attrs
-        || List.exists ~f:Attr.is_doc pmod_attributes
+    | Pstr_module
+        {pmb_ext_attrs= ea; pmb_expr= {pmod_attributes= attrs; _}; _}
+     |Pstr_include
+        {pincl_mod= {pmod_attributes= attrs; _}; pincl_attributes= ea; _} ->
+        Ext_attrs.has_doc ea || List.exists ~f:Attr.is_doc attrs
     | Pstr_value {pvbs_bindings= []; _}
      |Pstr_type (_, [])
      |Pstr_recmodule []
@@ -436,9 +435,7 @@ module Signature_item = struct
      |Psig_modtypesubst {pmtd_ext_attrs= ea; _}
      |Psig_modsubst {pms_ext_attrs= ea; _} ->
         Ext_attrs.has_doc ea
-    | Psig_include
-        {pincl_mod= {pmty_attributes= atrs1; _}; pincl_attributes= atrs2; _}
-     |Psig_exception
+    | Psig_exception
         { ptyexn_attributes= atrs1
         ; ptyexn_constructor= {pext_attributes= atrs2; _}
         ; _ } ->
@@ -446,7 +443,8 @@ module Signature_item = struct
     | Psig_recmodule
         ({pmd_type= {pmty_attributes= atrs; _}; pmd_ext_attrs= ea; _} :: _)
      |Psig_module {pmd_ext_attrs= ea; pmd_type= {pmty_attributes= atrs; _}; _}
-      ->
+     |Psig_include
+        {pincl_mod= {pmty_attributes= atrs; _}; pincl_attributes= ea; _} ->
         Ext_attrs.has_doc ea || (List.exists ~f:Attr.is_doc) atrs
     | Psig_type (_, [])
      |Psig_typesubst []

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -329,11 +329,6 @@ module Structure_item = struct
      |Pstr_recmodule ({pmb_expr= {pmod_attributes= atrs; _}; _} :: _)
      |Pstr_extension (_, atrs) ->
         List.exists ~f:Attr.is_doc atrs
-    | Pstr_exception
-        { ptyexn_attributes= atrs1
-        ; ptyexn_constructor= {pext_attributes= atrs2; _}
-        ; _ } ->
-        List.exists ~f:Attr.is_doc atrs1 || List.exists ~f:Attr.is_doc atrs2
     | Pstr_open {popen_attributes= ea; _}
      |Pstr_class_type ({pci_attributes= ea; _} :: _)
      |Pstr_class ({pci_attributes= ea; _} :: _)
@@ -346,7 +341,11 @@ module Structure_item = struct
     | Pstr_module
         {pmb_ext_attrs= ea; pmb_expr= {pmod_attributes= attrs; _}; _}
      |Pstr_include
-        {pincl_mod= {pmod_attributes= attrs; _}; pincl_attributes= ea; _} ->
+        {pincl_mod= {pmod_attributes= attrs; _}; pincl_attributes= ea; _}
+     |Pstr_exception
+        { ptyexn_attributes= ea
+        ; ptyexn_constructor= {pext_attributes= attrs; _}
+        ; _ } ->
         Ext_attrs.has_doc ea || List.exists ~f:Attr.is_doc attrs
     | Pstr_value {pvbs_bindings= []; _}
      |Pstr_type (_, [])
@@ -421,9 +420,7 @@ module Signature_item = struct
   let has_doc itm =
     match itm.psig_desc with
     | Psig_attribute atr -> Attr.is_doc atr
-    (* one attribute list *)
-    | Psig_extension (_, atrs) ->
-        List.exists ~f:Attr.is_doc atrs (* two attribute list *)
+    | Psig_extension (_, atrs) -> List.exists ~f:Attr.is_doc atrs
     | Psig_class_type ({pci_attributes= ea; _} :: _)
      |Psig_class ({pci_attributes= ea; _} :: _)
      |Psig_modtype {pmtd_ext_attrs= ea; _}
@@ -432,20 +429,18 @@ module Signature_item = struct
      |Psig_open {popen_attributes= ea; _}
      |Psig_type (_, {ptype_attributes= ea; _} :: _)
      |Psig_typesubst ({ptype_attributes= ea; _} :: _)
-     |Psig_value {pval_attributes= ea; _} 
+     |Psig_value {pval_attributes= ea; _}
      |Psig_typext {ptyext_attributes= ea; _} ->
         Ext_attrs.has_doc ea
-    | Psig_exception
-        { ptyexn_attributes= atrs1
-        ; ptyexn_constructor= {pext_attributes= atrs2; _}
-        ; _ } ->
-        List.exists ~f:Attr.is_doc atrs1 || List.exists ~f:Attr.is_doc atrs2
-    (* three attribute list *)
     | Psig_recmodule
         ({pmd_type= {pmty_attributes= atrs; _}; pmd_ext_attrs= ea; _} :: _)
      |Psig_module {pmd_ext_attrs= ea; pmd_type= {pmty_attributes= atrs; _}; _}
      |Psig_include
-        {pincl_mod= {pmty_attributes= atrs; _}; pincl_attributes= ea; _} ->
+        {pincl_mod= {pmty_attributes= atrs; _}; pincl_attributes= ea; _}
+     |Psig_exception
+        { ptyexn_attributes= ea
+        ; ptyexn_constructor= {pext_attributes= atrs; _}
+        ; _ } ->
         Ext_attrs.has_doc ea || (List.exists ~f:Attr.is_doc) atrs
     | Psig_type (_, [])
      |Psig_typesubst []

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -106,6 +106,10 @@ module Ext = struct
 end
 
 module Ext_attrs = struct
+  let has_attrs = function
+    | {attrs_extension= _; attrs_before= []; attrs_after= []} -> false
+    | _ -> true
+
   let has_doc ea =
     List.exists ~f:Attr.is_doc ea.attrs_before
     || List.exists ~f:Attr.is_doc ea.attrs_after
@@ -503,9 +507,7 @@ module Signature_item = struct
 end
 
 module Lb = struct
-  let has_doc itm =
-    List.exists ~f:Attr.is_doc itm.pvb_attributes.attrs_before
-    || List.exists ~f:Attr.is_doc itm.pvb_attributes.attrs_after
+  let has_doc itm = Ext_attrs.has_doc itm.pvb_attributes
 
   let is_simple (i, (c : Conf.t)) =
     Poly.(c.fmt_opts.module_item_spacing.v = `Compact)
@@ -547,9 +549,7 @@ module Md = struct
 end
 
 module Td = struct
-  let has_doc itm =
-    List.exists ~f:Attr.is_doc itm.ptype_attributes.attrs_before
-    || List.exists ~f:Attr.is_doc itm.ptype_attributes.attrs_after
+  let has_doc itm = Ext_attrs.has_doc itm.ptype_attributes
 
   let is_simple (i, (c : Conf.t)) =
     match c.fmt_opts.module_item_spacing.v with

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -326,7 +326,6 @@ module Structure_item = struct
     | Pstr_attribute atr -> Attr.is_doc atr
     (* one attribute list *)
     | Pstr_eval (_, atrs)
-     |Pstr_primitive {pval_attributes= atrs; _}
      |Pstr_typext {ptyext_attributes= atrs; _}
      |Pstr_recmodule ({pmb_expr= {pmod_attributes= atrs; _}; _} :: _)
      |Pstr_extension (_, atrs) ->
@@ -341,7 +340,8 @@ module Structure_item = struct
      |Pstr_class ({pci_attributes= ea; _} :: _)
      |Pstr_modtype {pmtd_ext_attrs= ea; _}
      |Pstr_type (_, {ptype_attributes= ea; _} :: _)
-     |Pstr_value {pvbs_bindings= {pvb_attributes= ea; _} :: _; _} ->
+     |Pstr_value {pvbs_bindings= {pvb_attributes= ea; _} :: _; _}
+     |Pstr_primitive {pval_attributes= ea; _} ->
         Ext_attrs.has_doc ea
     | Pstr_module
         {pmb_ext_attrs= ea; pmb_expr= {pmod_attributes= attrs; _}; _}
@@ -422,9 +422,7 @@ module Signature_item = struct
     match itm.psig_desc with
     | Psig_attribute atr -> Attr.is_doc atr
     (* one attribute list *)
-    | Psig_value {pval_attributes= atrs; _}
-     |Psig_typext {ptyext_attributes= atrs; _}
-     |Psig_extension (_, atrs) ->
+    | Psig_typext {ptyext_attributes= atrs; _} | Psig_extension (_, atrs) ->
         List.exists ~f:Attr.is_doc atrs (* two attribute list *)
     | Psig_class_type ({pci_attributes= ea; _} :: _)
      |Psig_class ({pci_attributes= ea; _} :: _)
@@ -433,7 +431,8 @@ module Signature_item = struct
      |Psig_modsubst {pms_ext_attrs= ea; _}
      |Psig_open {popen_attributes= ea; _}
      |Psig_type (_, {ptype_attributes= ea; _} :: _)
-     |Psig_typesubst ({ptype_attributes= ea; _} :: _) ->
+     |Psig_typesubst ({ptype_attributes= ea; _} :: _)
+     |Psig_value {pval_attributes= ea; _} ->
         Ext_attrs.has_doc ea
     | Psig_exception
         { ptyexn_attributes= atrs1

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -326,7 +326,6 @@ module Structure_item = struct
     | Pstr_attribute atr -> Attr.is_doc atr
     (* one attribute list *)
     | Pstr_eval (_, atrs)
-     |Pstr_typext {ptyext_attributes= atrs; _}
      |Pstr_recmodule ({pmb_expr= {pmod_attributes= atrs; _}; _} :: _)
      |Pstr_extension (_, atrs) ->
         List.exists ~f:Attr.is_doc atrs
@@ -341,7 +340,8 @@ module Structure_item = struct
      |Pstr_modtype {pmtd_ext_attrs= ea; _}
      |Pstr_type (_, {ptype_attributes= ea; _} :: _)
      |Pstr_value {pvbs_bindings= {pvb_attributes= ea; _} :: _; _}
-     |Pstr_primitive {pval_attributes= ea; _} ->
+     |Pstr_primitive {pval_attributes= ea; _}
+     |Pstr_typext {ptyext_attributes= ea; _} ->
         Ext_attrs.has_doc ea
     | Pstr_module
         {pmb_ext_attrs= ea; pmb_expr= {pmod_attributes= attrs; _}; _}
@@ -422,7 +422,7 @@ module Signature_item = struct
     match itm.psig_desc with
     | Psig_attribute atr -> Attr.is_doc atr
     (* one attribute list *)
-    | Psig_typext {ptyext_attributes= atrs; _} | Psig_extension (_, atrs) ->
+    | Psig_extension (_, atrs) ->
         List.exists ~f:Attr.is_doc atrs (* two attribute list *)
     | Psig_class_type ({pci_attributes= ea; _} :: _)
      |Psig_class ({pci_attributes= ea; _} :: _)
@@ -432,7 +432,8 @@ module Signature_item = struct
      |Psig_open {popen_attributes= ea; _}
      |Psig_type (_, {ptype_attributes= ea; _} :: _)
      |Psig_typesubst ({ptype_attributes= ea; _} :: _)
-     |Psig_value {pval_attributes= ea; _} ->
+     |Psig_value {pval_attributes= ea; _} 
+     |Psig_typext {ptyext_attributes= ea; _} ->
         Ext_attrs.has_doc ea
     | Psig_exception
         { ptyexn_attributes= atrs1

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -234,3 +234,7 @@ val parenze_mty : module_type xt -> bool
 val parenze_mod : module_expr xt -> bool
 (** [parenze_mod xmod] holds when module_expr-in-context [xmod] should be
     parenthesized. *)
+
+module Ext_attrs : sig
+  val has_attrs : ext_attrs -> bool
+end

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -90,14 +90,14 @@ module Right = struct
 
   (* exception C of ... * ... * < ... > *)
   let type_exception = function
-    | {ptyexn_attributes; _} when Ast.Ext_attrs.has_attrs ptyexn_attributes
+    | {ptyexn_attributes= {attrs_after= _ :: _; _}; _}
       ->
         false
     | {ptyexn_constructor; _} -> extension_constructor ptyexn_constructor
 
   (* val x : < ... > *)
   let value_description = function
-    | {pval_attributes; _} when Ast.Ext_attrs.has_attrs pval_attributes ->
+    | {pval_attributes= {attrs_after= _ :: _; _}; _} ->
         false
     | {pval_prim= _ :: _; _} -> false
     | {pval_type= ct; _} -> core_type ct

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -59,7 +59,9 @@ module Right = struct
     | {pcd_args= args; _} -> constructor_arguments args
 
   let type_declaration = function
-    | {ptype_attributes= _ :: _; _} -> false
+    | { ptype_attributes= {attrs_before= _ :: _; _} | {attrs_after= _ :: _; _}
+      ; _ } ->
+        false
     | {ptype_cstrs= _ :: _ as cstrs; _} ->
         (* type a = ... constraint left = < ... > *)
         list ~elt:(fun (_left, right, _loc) -> core_type right) cstrs

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -59,7 +59,7 @@ module Right = struct
     | {pcd_args= args; _} -> constructor_arguments args
 
   let type_declaration = function
-    | {ptype_attributes; _} when Ast.Ext_attrs.has_attrs ptype_attributes ->
+    | {ptype_attributes={attrs_after=_::_; _}; _} ->
         false
     | {ptype_cstrs= _ :: _ as cstrs; _} ->
         (* type a = ... constraint left = < ... > *)

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -95,7 +95,10 @@ module Right = struct
 
   (* exception C of ... * ... * < ... > *)
   let type_exception = function
-    | {ptyexn_attributes= _ :: _; _} -> false
+    | { ptyexn_attributes=
+          {attrs_before= _ :: _; _} | {attrs_after= _ :: _; _}
+      ; _ } ->
+        false
     | {ptyexn_constructor; _} -> extension_constructor ptyexn_constructor
 
   (* val x : < ... > *)

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -73,9 +73,7 @@ module Right = struct
         list ~elt:constructor_declaration cdecls
 
   let type_extension = function
-    | {ptyext_attributes; _} when Ast.Ext_attrs.has_attrs ptyext_attributes
-      ->
-        false
+    | {ptyext_attributes= {attrs_after= _ :: _; _}; _} -> false
     (* type a += A of ... * ... * < ... > *)
     | {ptyext_constructors; _} ->
         list ~elt:extension_constructor ptyext_constructors

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -59,8 +59,7 @@ module Right = struct
     | {pcd_args= args; _} -> constructor_arguments args
 
   let type_declaration = function
-    | {ptype_attributes={attrs_after=_::_; _}; _} ->
-        false
+    | {ptype_attributes= {attrs_after= _ :: _; _}; _} -> false
     | {ptype_cstrs= _ :: _ as cstrs; _} ->
         (* type a = ... constraint left = < ... > *)
         list ~elt:(fun (_left, right, _loc) -> core_type right) cstrs

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -75,7 +75,10 @@ module Right = struct
         list ~elt:constructor_declaration cdecls
 
   let type_extension = function
-    | {ptyext_attributes= _ :: _; _} -> false
+    | { ptyext_attributes=
+          {attrs_before= _ :: _; _} | {attrs_after= _ :: _; _}
+      ; _ } ->
+        false
     (* type a += A of ... * ... * < ... > *)
     | {ptyext_constructors; _} ->
         list ~elt:extension_constructor ptyext_constructors

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -59,8 +59,7 @@ module Right = struct
     | {pcd_args= args; _} -> constructor_arguments args
 
   let type_declaration = function
-    | { ptype_attributes= {attrs_before= _ :: _; _} | {attrs_after= _ :: _; _}
-      ; _ } ->
+    | {ptype_attributes; _} when Ast.Ext_attrs.has_attrs ptype_attributes ->
         false
     | {ptype_cstrs= _ :: _ as cstrs; _} ->
         (* type a = ... constraint left = < ... > *)
@@ -75,9 +74,8 @@ module Right = struct
         list ~elt:constructor_declaration cdecls
 
   let type_extension = function
-    | { ptyext_attributes=
-          {attrs_before= _ :: _; _} | {attrs_after= _ :: _; _}
-      ; _ } ->
+    | {ptyext_attributes; _} when Ast.Ext_attrs.has_attrs ptyext_attributes
+      ->
         false
     (* type a += A of ... * ... * < ... > *)
     | {ptyext_constructors; _} ->
@@ -95,16 +93,14 @@ module Right = struct
 
   (* exception C of ... * ... * < ... > *)
   let type_exception = function
-    | { ptyexn_attributes=
-          {attrs_before= _ :: _; _} | {attrs_after= _ :: _; _}
-      ; _ } ->
+    | {ptyexn_attributes; _} when Ast.Ext_attrs.has_attrs ptyexn_attributes
+      ->
         false
     | {ptyexn_constructor; _} -> extension_constructor ptyexn_constructor
 
   (* val x : < ... > *)
   let value_description = function
-    | { pval_attributes= {attrs_before= _ :: _; _} | {attrs_after= _ :: _; _}
-      ; _ } ->
+    | {pval_attributes; _} when Ast.Ext_attrs.has_attrs pval_attributes ->
         false
     | {pval_prim= _ :: _; _} -> false
     | {pval_type= ct; _} -> core_type ct

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -97,7 +97,9 @@ module Right = struct
 
   (* val x : < ... > *)
   let value_description = function
-    | {pval_attributes= _ :: _; _} -> false
+    | { pval_attributes= {attrs_before= _ :: _; _} | {attrs_after= _ :: _; _}
+      ; _ } ->
+        false
     | {pval_prim= _ :: _; _} -> false
     | {pval_type= ct; _} -> core_type ct
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3585,7 +3585,9 @@ and fmt_type_extension c ctx
     ; ptyext_loc } =
   let c = update_config_attrs c ptyext_attributes in
   let ext = ptyext_attributes.attrs_extension in
-  let doc, _doc_after, attrs_before, attrs_after = fmt_docstring_around_item_attrs ~force_before:true c ptyext_attributes in
+  let doc, _doc_after, attrs_before, attrs_after =
+    fmt_docstring_around_item_attrs ~force_before:true c ptyext_attributes
+  in
   let fmt_ctor ctor = hvbox 0 (fmt_extension_constructor c ctx ctor) in
   Cmts.fmt c ptyext_loc
   @@ hvbox 2
@@ -3611,17 +3613,24 @@ and fmt_type_extension c ctx
 and fmt_type_exception ~pre c ctx
     {ptyexn_attributes= item_attrs; ptyexn_constructor; ptyexn_loc} =
   let {pext_attributes= cons_attrs; _} = ptyexn_constructor in
-  let docs, item_attrs = extract_doc_attrs [] item_attrs in
+  let docs, attrs_before = extract_doc_attrs [] item_attrs.attrs_before in
+  let docs, attrs_after = extract_doc_attrs docs item_attrs.attrs_after in
   let docs, cons_attrs = extract_doc_attrs docs cons_attrs in
   let doc_before, doc_after = fmt_docstring_around_item' c docs in
   let ptyexn_constructor =
     {ptyexn_constructor with pext_attributes= cons_attrs}
   in
+  let ext = item_attrs.attrs_extension in
   Cmts.fmt c ptyexn_loc
     (hvbox 0
        ( doc_before
-       $ hvbox 2 (pre $ fmt_extension_constructor c ctx ptyexn_constructor)
-       $ fmt_item_attributes c ~pre:(Break (1, 0)) item_attrs
+       $ hvbox 2
+           ( pre
+           $ fmt_extension_suffix c ext
+           $ fmt_attributes c ~pre:(Break (1, 0)) attrs_before
+           $ fmt "@ "
+           $ fmt_extension_constructor c ctx ptyexn_constructor )
+       $ fmt_item_attributes c ~pre:(Break (1, 0)) attrs_after
        $ doc_after ) )
 
 and fmt_extension_constructor c ctx ec =
@@ -3796,7 +3805,7 @@ and fmt_signature c ctx itms =
   let ast x = Sig x in
   fmt_item_list c ctx update_config ast fmt_item itms
 
-and fmt_signature_item c ?ext {ast= si; _} =
+and fmt_signature_item c {ast= si; _} =
   protect c (Sig si)
   @@
   let fmt_cmts_before = Cmts.Toplevel.fmt_before c si.psig_loc in
@@ -3807,7 +3816,7 @@ and fmt_signature_item c ?ext {ast= si; _} =
   match si.psig_desc with
   | Psig_attribute attr -> fmt_floating_attributes_and_docstrings c [attr]
   | Psig_exception exc ->
-      let pre = str "exception" $ fmt_extension_suffix c ext $ space_break in
+      let pre = str "exception" in
       hvbox 2 (fmt_type_exception ~pre c ctx exc)
   | Psig_extension (ext, atrs) ->
       let doc_before, doc_after, atrs = fmt_docstring_around_item c atrs in
@@ -4404,8 +4413,8 @@ and fmt_type c ?eq rec_flag decls ctx =
   let ast x = Td x in
   fmt_item_list c ctx update_config ast fmt_decl decls
 
-and fmt_structure_item c ~last:last_item ?ext ~semisemi
-    {ctx= parent_ctx; ast= si} =
+and fmt_structure_item c ~last:last_item ~semisemi {ctx= parent_ctx; ast= si}
+    =
   protect c (Str si)
   @@
   let ctx = Str si in
@@ -4424,7 +4433,7 @@ and fmt_structure_item c ~last:last_item ?ext ~semisemi
       $ cbox 0 ~name:"eval" (fmt_expression c (sub_exp ~ctx exp))
       $ fmt_item_attributes c ~pre:Space atrs
   | Pstr_exception extn_constr ->
-      let pre = str "exception" $ fmt_extension_suffix c ext $ space_break in
+      let pre = str "exception" in
       hvbox 2 ~name:"exn" (fmt_type_exception ~pre c ctx extn_constr)
   | Pstr_include {pincl_mod; pincl_attributes= attributes; pincl_loc} ->
       update_config_maybe_disabled_attrs c pincl_loc attributes
@@ -4442,9 +4451,8 @@ and fmt_structure_item c ~last:last_item ?ext ~semisemi
         fmt_or
           (is_override popen_override)
           ( str "open!"
-          $ fmt_if (Option.is_some attributes.attrs_extension) "@ "
-          $ opt ext (fun _ -> str " " $ fmt_extension_suffix c ext) )
-          (str "open" $ fmt_extension_suffix c ext)
+          $ fmt_if (Option.is_some attributes.attrs_extension) "@ " )
+          (str "open")
       in
       fmt_module_statement c ~attributes ~keyword (sub_mod ~ctx popen_expr)
   | Pstr_primitive vd -> fmt_value_description c ctx vd

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -187,8 +187,7 @@ let update_config_maybe_disabled_k c loc l ~if_disabled enabled =
 
 let update_config_maybe_disabled_attrs c loc attrs f =
   let l = attrs.attrs_before @ attrs.attrs_after in
-  let c = update_config c l in
-  maybe_disabled c loc l f
+  update_config_maybe_disabled c loc l f
 
 let update_config_maybe_disabled_block c loc l f =
   let fmt bdy = {empty with opn= Some (open_vbox 2); bdy; cls= close_box} in
@@ -495,9 +494,10 @@ let extract_doc_attrs acc attrs =
     [doc-comments] and [doc-comment-tag-only] options Returns the tuple
     [doc_before, doc_after, attrs] *)
 let fmt_docstring_around_item ?is_val ?force_before ?fit c attrs =
-  let docs, attrs = extract_doc_attrs [] attrs in
+  let doc1, attrs = doc_atrs attrs in
+  let doc2, attrs = doc_atrs attrs in
   let doc_before, doc_after =
-    fmt_docstring_around_item' ?is_val ?force_before ?fit c docs
+    fmt_docstring_around_item' ?is_val ?force_before ?fit c doc1 doc2
   in
   (doc_before, doc_after, attrs)
 
@@ -3613,7 +3613,14 @@ and fmt_type_exception ~pre c ctx
   let docs, attrs_before = extract_doc_attrs [] item_attrs.attrs_before in
   let docs, attrs_after = extract_doc_attrs docs item_attrs.attrs_after in
   let docs, cons_attrs = extract_doc_attrs docs cons_attrs in
-  let doc_before, doc_after = fmt_docstring_around_item' c docs in
+  let doc1, doc2 =
+    match docs with
+    | [] -> (None, None)
+    | [elt] -> (Some elt, None)
+    | [doc1; doc2] -> (Some doc1, Some doc2)
+    | _ -> assert false
+  in
+  let doc_before, doc_after = fmt_docstring_around_item' c doc1 doc2 in
   let ptyexn_constructor =
     {ptyexn_constructor with pext_attributes= cons_attrs}
   in

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3616,6 +3616,7 @@ and fmt_type_exception ~pre c ctx
   let {pext_attributes= cons_attrs; _} = ptyexn_constructor in
   (* Here, the order is very important. We need the attrs_after to be at the
      end of the list. *)
+  (* On 4.08 the doc is attached to the constructor *)
   let docs, cons_attrs = extract_doc_attrs [] cons_attrs in
   let docs, attrs_after = extract_doc_attrs docs item_attrs.attrs_after in
   let docs, attrs_before = extract_doc_attrs docs item_attrs.attrs_before in
@@ -4470,7 +4471,7 @@ and fmt_structure_item c ~last:last_item ~semisemi {ctx= parent_ctx; ast= si}
       fmt_recmodule c ctx mbs fmt_module_binding (fun x -> Mb x) sub_mb
   | Pstr_type (rec_flag, decls) -> fmt_type c rec_flag decls ctx
   | Pstr_typext te -> fmt_type_extension c ctx te
-  | Pstr_value {pvbs_rec= rec_flag; pvbs_bindings= bindings; pvbs_has_ext= _}
+  | Pstr_value {pvbs_rec= rec_flag; pvbs_bindings= bindings }
     ->
       let update_config c i =
         update_config ~quiet:true c

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2492,8 +2492,10 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                                  (hvbox 0
                                     ( str "let" $ break 1 0
                                     $ Cmts.fmt_before c popen_loc
-                                    $ fmt_or override (str "open!") (str "open")
-                                    $ opt ext (fun _ -> fmt_if override (str " "))
+                                    $ fmt_or override (str "open!")
+                                        (str "open")
+                                    $ opt ext (fun _ ->
+                                          fmt_if override (str " ") )
                                     $ fmt_extension_suffix c ext ) )
                                (sub_mod ~ctx popen_expr)
                            $ Cmts.fmt_after c popen_loc
@@ -4151,8 +4153,7 @@ and fmt_module_statement c ~attributes ?keyword mod_expr =
              ( fmt_opt keyword
              $ fmt_extension_suffix c attributes.attrs_extension
              $ fmt_attributes c ~pre:(Break (1, 0)) attrs_before
-             $ space_break
-             $ fmt_opt blk.pro )
+             $ space_break $ fmt_opt blk.pro )
          $ blk.psp $ blk.bdy ) )
   $ blk.esp $ fmt_opt blk.epi
   $ fmt_item_attributes c ~pre:Blank attrs_after
@@ -4462,7 +4463,7 @@ and fmt_structure_item c ~last:last_item ~semisemi {ctx= parent_ctx; ast= si}
         fmt_or
           (is_override popen_override)
           ( str "open!"
-          $ fmt_if (Option.is_some attributes.attrs_extension) space_break)
+          $ fmt_if (Option.is_some attributes.attrs_extension) space_break )
           (str "open")
       in
       fmt_module_statement c ~attributes ~keyword (sub_mod ~ctx popen_expr)
@@ -4471,8 +4472,7 @@ and fmt_structure_item c ~last:last_item ~semisemi {ctx= parent_ctx; ast= si}
       fmt_recmodule c ctx mbs fmt_module_binding (fun x -> Mb x) sub_mb
   | Pstr_type (rec_flag, decls) -> fmt_type c rec_flag decls ctx
   | Pstr_typext te -> fmt_type_extension c ctx te
-  | Pstr_value {pvbs_rec= rec_flag; pvbs_bindings= bindings }
-    ->
+  | Pstr_value {pvbs_rec= rec_flag; pvbs_bindings= bindings} ->
       let update_config c i =
         update_config ~quiet:true c
           (i.pvb_attributes.attrs_before @ i.pvb_attributes.attrs_after)
@@ -4535,7 +4535,7 @@ and fmt_let c ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr ~loc_in
   Params.Exp.wrap c.conf ~parens:(parens || has_attr) ~fits_breaks:false
     (vbox 0
        ( hvbox 0 (list_fl bindings fmt_binding)
-       $ ( if blank_line_after_in then  str "\n" $ cut_break
+       $ ( if blank_line_after_in then str "\n" $ cut_break
            else break 1000 indent_after_in )
        $ hvbox 0 fmt_expr ) )
   $ fmt_atrs

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -489,7 +489,7 @@ let extract_doc_attrs docs attrs =
   in
   let docs, attrs = extract_once docs attrs in
   let docs, attrs = extract_once docs attrs in
-  List.rev docs, attrs
+  (List.rev docs, attrs)
 
 (** Formats docstrings and decides where to place them Handles the
     [doc-comments] and [doc-comment-tag-only] options Returns the tuple
@@ -2489,12 +2489,12 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                        ( hvbox 0
                            ( fmt_module_statement c ~attributes
                                ~keyword:
-                                 ( hvbox 0
-                                     ( str "let" $ break 1 0
-                                     $ Cmts.fmt_before c popen_loc
-                                     $ fmt_or override (str "open!") (str "open")
-                                     $ opt ext (fun _ -> fmt_if override " ")
-                                     $ fmt_extension_suffix c ext ) )
+                                 (hvbox 0
+                                    ( str "let" $ break 1 0
+                                    $ Cmts.fmt_before c popen_loc
+                                    $ fmt_or override (str "open!") (str "open")
+                                    $ opt ext (fun _ -> fmt_if override " ")
+                                    $ fmt_extension_suffix c ext ) )
                                (sub_mod ~ctx popen_expr)
                            $ Cmts.fmt_after c popen_loc
                            $ str " in" )
@@ -2859,8 +2859,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
              (sub_exp ~ctx e) )
       $ fmt_atrs
 
-and fmt_let_bindings c ~parens ~has_attr ~fmt_atrs ~fmt_expr ~loc_in
-    rec_flag bindings body =
+and fmt_let_bindings c ~parens ~has_attr ~fmt_atrs ~fmt_expr ~loc_in rec_flag
+    bindings body =
   let indent_after_in =
     match body.pexp_desc with
     | Pexp_let _ | Pexp_letmodule _
@@ -2877,8 +2877,8 @@ and fmt_let_bindings c ~parens ~has_attr ~fmt_atrs ~fmt_expr ~loc_in
         0
     | _ -> c.conf.fmt_opts.indent_after_in.v
   in
-  fmt_let c ~rec_flag ~bindings ~parens ~has_attr ~fmt_atrs ~fmt_expr
-    ~loc_in ~body_loc:body.pexp_loc ~indent_after_in
+  fmt_let c ~rec_flag ~bindings ~parens ~has_attr ~fmt_atrs ~fmt_expr ~loc_in
+    ~body_loc:body.pexp_loc ~indent_after_in
 
 and fmt_class_structure c ~ctx ?ext self_ fields =
   let update_config c i =
@@ -3051,8 +3051,8 @@ and fmt_class_expr c ({ast= exp; ctx= ctx0} as xexp) =
       in
       let fmt_expr = fmt_class_expr c (sub_cl ~ctx body) in
       let has_attr = not (List.is_empty pcl_attributes) in
-      fmt_let c ~rec_flag:lbs.pvbs_rec ~bindings ~parens ~loc_in
-        ~has_attr ~fmt_atrs ~fmt_expr ~body_loc:body.pcl_loc ~indent_after_in
+      fmt_let c ~rec_flag:lbs.pvbs_rec ~bindings ~parens ~loc_in ~has_attr
+        ~fmt_atrs ~fmt_expr ~body_loc:body.pcl_loc ~indent_after_in
   | Pcl_constraint (e, t) ->
       hvbox 2
         (wrap_fits_breaks ~space:false c.conf "(" ")"
@@ -3350,8 +3350,7 @@ and fmt_class_params c ctx params =
        ( wrap_fits_breaks c.conf "[" "]" (list_fl params fmt_param)
        $ space_break ) )
 
-and fmt_type_declaration c ?(pre = "") ?name ?(eq = "=") {ast= decl; _}
-    =
+and fmt_type_declaration c ?(pre = "") ?name ?(eq = "=") {ast= decl; _} =
   protect c (Td decl)
   @@
   let { ptype_name= {txt; loc}
@@ -3615,8 +3614,8 @@ and fmt_type_extension c ctx
 and fmt_type_exception ~pre c ctx
     {ptyexn_attributes= item_attrs; ptyexn_constructor; ptyexn_loc} =
   let {pext_attributes= cons_attrs; _} = ptyexn_constructor in
-  (* Here, the order is very important. We need the attrs_after to be at the end
-    of the list. *)
+  (* Here, the order is very important. We need the attrs_after to be at the
+     end of the list. *)
   let docs, cons_attrs = extract_doc_attrs [] cons_attrs in
   let docs, attrs_after = extract_doc_attrs docs item_attrs.attrs_after in
   let docs, attrs_before = extract_doc_attrs docs item_attrs.attrs_before in
@@ -3628,7 +3627,9 @@ and fmt_type_exception ~pre c ctx
     | _ -> assert false
   in
   let doc_before, doc_after = fmt_docstring_around_item' c doc1 doc2 in
-  let ptyexn_constructor = {ptyexn_constructor with pext_attributes= cons_attrs} in
+  let ptyexn_constructor =
+    {ptyexn_constructor with pext_attributes= cons_attrs}
+  in
   let ext = item_attrs.attrs_extension in
   Cmts.fmt c ptyexn_loc
     (hvbox 0
@@ -3638,7 +3639,7 @@ and fmt_type_exception ~pre c ctx
            $ fmt_extension_suffix c ext
            $ fmt_attributes c ~pre:(Break (1, 0)) attrs_before
            $ fmt "@ "
-           $ fmt_extension_constructor c ctx ptyexn_constructor)
+           $ fmt_extension_constructor c ctx ptyexn_constructor )
        $ fmt_item_attributes c ~pre:(Break (1, 0)) attrs_after
        $ doc_after ) )
 
@@ -3886,8 +3887,7 @@ and fmt_signature_item c {ast= si; _} =
   | Psig_typext te -> fmt_type_extension c ctx te
   | Psig_value vd -> fmt_value_description c ctx vd
   | Psig_class cl -> fmt_class_types c ~pre:"class" ~sep:":" cl
-  | Psig_class_type cl ->
-      fmt_class_types c ~pre:"class type" ~sep:"=" cl
+  | Psig_class_type cl -> fmt_class_types c ~pre:"class type" ~sep:"=" cl
   | Psig_typesubst decls -> fmt_type c ~eq:":=" Recursive decls ctx
 
 and fmt_class_types c ~pre ~sep cls =
@@ -4508,8 +4508,7 @@ and fmt_structure_item c ~last:last_item ~semisemi {ctx= parent_ctx; ast= si}
         $ hvbox_if (not box) 0 ~name:"ext2" (fmt_item_extension c ctx ext)
         $ fmt_item_attributes c ~pre:Space atrs
         $ doc_after )
-  | Pstr_class_type cl ->
-      fmt_class_types c ~pre:"class type" ~sep:"=" cl
+  | Pstr_class_type cl -> fmt_class_types c ~pre:"class type" ~sep:"=" cl
   | Pstr_class cls -> fmt_class_exprs c cls
 
 and fmt_let c ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr ~loc_in
@@ -4649,8 +4648,7 @@ and fmt_value_binding c ~rec_flag ?in_ ?epi
     in
     box_fun_decl_args c 4 (Params.Align.fun_decl c.conf ~decl ~pattern ~args)
   in
-  doc1
-  $ cmts_before
+  doc1 $ cmts_before
   $ hvbox 0
       ( hvbox indent
           ( hvbox_if toplevel 0

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4174,14 +4174,13 @@ and fmt_with_constraint c ctx ~pre = function
       let m2 = Some (sub_mty ~ctx m2) in
       str pre $ break 1 2
       $ fmt_module c ctx "module type" m1 [] None ~rec_flag:false m2
-          ~attrs:(Ast_helper.Attr.ext_attrs ())
+          ~attrs:Ast_helper.Attr.empty_ext_attrs
   | Pwith_modtypesubst (m1, m2) ->
       let m1 = {m1 with txt= Some (str_longident m1.txt)} in
       let m2 = Some (sub_mty ~ctx m2) in
       str pre $ break 1 2
       $ fmt_module c ctx ~eqty:":=" "module type" m1 [] None ~rec_flag:false
-          m2
-          ~attrs:(Ast_helper.Attr.ext_attrs ())
+          m2 ~attrs:Ast_helper.Attr.empty_ext_attrs
 
 and fmt_mod_apply c ctx loc attrs ~parens ~dock_struct me_f arg =
   match me_f.pmod_desc with

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2493,7 +2493,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                                     ( str "let" $ break 1 0
                                     $ Cmts.fmt_before c popen_loc
                                     $ fmt_or override (str "open!") (str "open")
-                                    $ opt ext (fun _ -> fmt_if override " ")
+                                    $ opt ext (fun _ -> fmt_if override (str " "))
                                     $ fmt_extension_suffix c ext ) )
                                (sub_mod ~ctx popen_expr)
                            $ Cmts.fmt_after c popen_loc
@@ -3639,7 +3639,7 @@ and fmt_type_exception ~pre c ctx
            ( pre
            $ fmt_extension_suffix c ext
            $ fmt_attributes c ~pre:(Break (1, 0)) attrs_before
-           $ fmt "@ "
+           $ space_break
            $ fmt_extension_constructor c ctx ptyexn_constructor )
        $ fmt_item_attributes c ~pre:(Break (1, 0)) attrs_after
        $ doc_after ) )
@@ -4462,7 +4462,7 @@ and fmt_structure_item c ~last:last_item ~semisemi {ctx= parent_ctx; ast= si}
         fmt_or
           (is_override popen_override)
           ( str "open!"
-          $ fmt_if (Option.is_some attributes.attrs_extension) "@ " )
+          $ fmt_if (Option.is_some attributes.attrs_extension) space_break)
           (str "open")
       in
       fmt_module_statement c ~attributes ~keyword (sub_mod ~ctx popen_expr)
@@ -4526,7 +4526,7 @@ and fmt_let c ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr ~loc_in
     in
     let rec_flag = first && Asttypes.is_recursive rec_flag in
     fmt_value_binding c ~rec_flag ?in_ binding
-    $ fmt_if_k (not last)
+    $ fmt_if (not last)
         ( match c.conf.fmt_opts.let_and.v with
         | `Sparse -> force_break
         | `Compact -> space_break )

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -171,6 +171,6 @@ module Let_binding = struct
         ; lb_typ= bo.pbop_typ
         ; lb_exp= sub_exp ~ctx bo.pbop_exp
         ; lb_pun= bo.pbop_is_pun
-        ; lb_attrs= (Ast_helper.Attr.ext_attrs ())
+        ; lb_attrs= Ast_helper.Attr.ext_attrs ()
         ; lb_loc= bo.pbop_loc } )
 end

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -146,7 +146,7 @@ module Let_binding = struct
     ; lb_typ: value_constraint option
     ; lb_exp: expression xt
     ; lb_pun: bool
-    ; lb_attrs: attribute list
+    ; lb_attrs: ext_attrs
     ; lb_loc: Location.t }
 
   let of_let_binding ~ctx ~first vb =
@@ -171,6 +171,6 @@ module Let_binding = struct
         ; lb_typ= bo.pbop_typ
         ; lb_exp= sub_exp ~ctx bo.pbop_exp
         ; lb_pun= bo.pbop_is_pun
-        ; lb_attrs= []
+        ; lb_attrs= (Ast_helper.Attr.ext_attrs ())
         ; lb_loc= bo.pbop_loc } )
 end

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -171,6 +171,6 @@ module Let_binding = struct
         ; lb_typ= bo.pbop_typ
         ; lb_exp= sub_exp ~ctx bo.pbop_exp
         ; lb_pun= bo.pbop_is_pun
-        ; lb_attrs= Ast_helper.Attr.ext_attrs ()
+        ; lb_attrs= Ast_helper.Attr.empty_ext_attrs
         ; lb_loc= bo.pbop_loc } )
 end

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -53,7 +53,7 @@ module Let_binding : sig
     ; lb_typ: value_constraint option
     ; lb_exp: expression Ast.xt
     ; lb_pun: bool
-    ; lb_attrs: attribute list
+    ; lb_attrs: ext_attrs
     ; lb_loc: Location.t }
 
   val of_let_binding : ctx:Ast.t -> first:bool -> value_binding -> t

--- a/test/cli/debug.t
+++ b/test/cli/debug.t
@@ -19,6 +19,7 @@
           <def> (a.ml[2,34+0]..[4,59+7])
           comments
             before: (* Intentionally not formatted *)
+                None
             pattern (a.ml[2,34+4]..[2,34+6])
               Ppat_construct "()" (a.ml[2,34+4]..[2,34+6])
               None
@@ -47,6 +48,7 @@
           <def> (a.ml[2,34+0]..[4,59+7])
           comments
             before: (* Intentionally not formatted *)
+                None
             pattern (a.ml[2,34+4]..[2,34+6])
               Ppat_construct "()" (a.ml[2,34+4]..[2,34+6])
               None
@@ -75,6 +77,7 @@
           <def> (a.ml[2,34+0]..[2,34+26])
           comments
             before: (* Intentionally not formatted *)
+                None
             pattern (a.ml[2,34+4]..[2,34+6])
               Ppat_construct "()" (a.ml[2,34+4]..[2,34+6])
               None
@@ -102,6 +105,7 @@
           <def> (a.ml[2,34+0]..[2,34+26])
           comments
             before: (* Intentionally not formatted *)
+                None
             pattern (a.ml[2,34+4]..[2,34+6])
               Ppat_construct "()" (a.ml[2,34+4]..[2,34+6])
               None
@@ -145,6 +149,7 @@
           comments
             before: (* before let-binding *)
              after: (* after let-binding *)
+                None
             pattern (a.ml[2,25+4]..[2,25+6])
               Ppat_construct "()" (a.ml[2,25+4]..[2,25+6])
               None
@@ -158,6 +163,7 @@
                   before: (* after unit *)
               [
                 <def> (a.ml[5,90+2]..[5,90+122])
+                      None
                   pattern (a.ml[5,90+21]..[5,90+22])
                   comments
                     before: (* before x *)
@@ -199,6 +205,7 @@
           comments
             before: (* before let-binding *)
              after: (* after let-binding *)
+                None
             pattern (a.ml[2,25+4]..[2,25+6])
               Ppat_construct "()" (a.ml[2,25+4]..[2,25+6])
               None
@@ -212,6 +219,7 @@
                   before: (* after unit *)
               [
                 <def> (a.ml[5,90+2]..[5,90+122])
+                      None
                   pattern (a.ml[5,90+21]..[5,90+22])
                   comments
                     before: (* before x *)
@@ -253,6 +261,7 @@
           comments
             before: (* before let-binding *)
              after: (* after let-binding *)
+                None
             pattern (a.ml[2,25+4]..[2,25+6])
               Ppat_construct "()" (a.ml[2,25+4]..[2,25+6])
               None
@@ -266,6 +275,7 @@
                 <def> (a.ml[5,90+2]..[10,210+28])
                 comments
                    after: (* after unit *)
+                      None
                   pattern (a.ml[5,90+21]..[5,90+22])
                   comments
                     before: (* before x *)
@@ -306,6 +316,7 @@
           comments
             before: (* before let-binding *)
              after: (* after let-binding *)
+                None
             pattern (a.ml[2,25+4]..[2,25+6])
               Ppat_construct "()" (a.ml[2,25+4]..[2,25+6])
               None
@@ -319,6 +330,7 @@
                 <def> (a.ml[5,90+2]..[10,210+28])
                 comments
                    after: (* after unit *)
+                      None
                   pattern (a.ml[5,90+21]..[5,90+22])
                   comments
                     before: (* before x *)

--- a/test/passing/tests/attributes.ml
+++ b/test/passing/tests/attributes.ml
@@ -1,3 +1,5 @@
+[%foo type[@foo] t = < .. > ]
+
 let _ = (function[@warning "-4"] None -> true | _ -> false) None
 
 let f (x [@warning ""]) = ()

--- a/test/passing/tests/attributes.ml
+++ b/test/passing/tests/attributes.ml
@@ -435,3 +435,5 @@ let _ = f ((1 : int) [@a])
 let _ = f ((1 : int) [@a]) ((1 : int) [@a])
 
 let _ = f ((((1 : int) [@a]) : (int[@b])) [@a]) ((1 : int) [@a])
+
+include [@foo] M [@boo]

--- a/test/passing/tests/attributes.ml.err
+++ b/test/passing/tests/attributes.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/attributes.ml:340 exceeds the margin
+Warning: tests/attributes.ml:342 exceeds the margin

--- a/test/passing/tests/extensions-indent.mli.ref
+++ b/test/passing/tests/extensions-indent.mli.ref
@@ -61,7 +61,6 @@ module%ext T := M
 [%%ext: module T := M]
 
 open%ext M
-
 open! %ext M
 
 [%%ext open M]

--- a/test/passing/tests/extensions.mli
+++ b/test/passing/tests/extensions.mli
@@ -61,7 +61,6 @@ module%ext T := M
 [%%ext: module T := M]
 
 open%ext M
-
 open! %ext M
 
 [%%ext open M]

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -209,6 +209,9 @@ module type S = sig
   class%foo[@foo] x : t
   class type%foo[@foo] x = x
 
+  class%foo x : t [@@foo]
+  class type%foo x = x [@@foo]
+
 end
 
 type t = ..;;

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,5 +1,5 @@
 Warning: tests/js_source.ml:155 exceeds the margin
-Warning: tests/js_source.ml:9532 exceeds the margin
-Warning: tests/js_source.ml:9635 exceeds the margin
-Warning: tests/js_source.ml:9694 exceeds the margin
-Warning: tests/js_source.ml:9776 exceeds the margin
+Warning: tests/js_source.ml:9538 exceeds the margin
+Warning: tests/js_source.ml:9641 exceeds the margin
+Warning: tests/js_source.ml:9700 exceeds the margin
+Warning: tests/js_source.ml:9782 exceeds the margin

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,6 +1,5 @@
-Warning: tests/js_source.ml:162 exceeds the margin
-Warning: tests/js_source.ml:9552 exceeds the margin
-Warning: tests/js_source.ml:9656 exceeds the margin
-Warning: tests/js_source.ml:9715 exceeds the margin
-Warning: tests/js_source.ml:9797 exceeds the margin
-Warning: tests/js_source.ml:10296 exceeds the margin
+Warning: tests/js_source.ml:155 exceeds the margin
+Warning: tests/js_source.ml:9533 exceeds the margin
+Warning: tests/js_source.ml:9636 exceeds the margin
+Warning: tests/js_source.ml:9695 exceeds the margin
+Warning: tests/js_source.ml:9777 exceeds the margin

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,5 +1,5 @@
 Warning: tests/js_source.ml:155 exceeds the margin
-Warning: tests/js_source.ml:9533 exceeds the margin
-Warning: tests/js_source.ml:9636 exceeds the margin
-Warning: tests/js_source.ml:9695 exceeds the margin
-Warning: tests/js_source.ml:9777 exceeds the margin
+Warning: tests/js_source.ml:9532 exceeds the margin
+Warning: tests/js_source.ml:9635 exceeds the margin
+Warning: tests/js_source.ml:9694 exceeds the margin
+Warning: tests/js_source.ml:9776 exceeds the margin

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,5 +1,5 @@
 Warning: tests/js_source.ml:155 exceeds the margin
-Warning: tests/js_source.ml:9539 exceeds the margin
-Warning: tests/js_source.ml:9642 exceeds the margin
-Warning: tests/js_source.ml:9701 exceeds the margin
-Warning: tests/js_source.ml:9783 exceeds the margin
+Warning: tests/js_source.ml:9538 exceeds the margin
+Warning: tests/js_source.ml:9641 exceeds the margin
+Warning: tests/js_source.ml:9700 exceeds the margin
+Warning: tests/js_source.ml:9782 exceeds the margin

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,5 +1,5 @@
 Warning: tests/js_source.ml:155 exceeds the margin
-Warning: tests/js_source.ml:9538 exceeds the margin
-Warning: tests/js_source.ml:9641 exceeds the margin
-Warning: tests/js_source.ml:9700 exceeds the margin
-Warning: tests/js_source.ml:9782 exceeds the margin
+Warning: tests/js_source.ml:9539 exceeds the margin
+Warning: tests/js_source.ml:9642 exceeds the margin
+Warning: tests/js_source.ml:9701 exceeds the margin
+Warning: tests/js_source.ml:9783 exceeds the margin

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,5 +1,6 @@
-Warning: tests/js_source.ml:155 exceeds the margin
-Warning: tests/js_source.ml:9538 exceeds the margin
-Warning: tests/js_source.ml:9641 exceeds the margin
-Warning: tests/js_source.ml:9700 exceeds the margin
-Warning: tests/js_source.ml:9782 exceeds the margin
+Warning: tests/js_source.ml:162 exceeds the margin
+Warning: tests/js_source.ml:9559 exceeds the margin
+Warning: tests/js_source.ml:9663 exceeds the margin
+Warning: tests/js_source.ml:9722 exceeds the margin
+Warning: tests/js_source.ml:9804 exceeds the margin
+Warning: tests/js_source.ml:10303 exceeds the margin

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -184,9 +184,9 @@ and t = int [@@foo]
 
 type%foo t += T [@@foo]
 
-class%foo x = x [@@foo]
+class%foo [@foo] x = x
 
-class type%foo x = x [@@foo]
+class type%foo [@foo] x = x
 
 external%foo x : _ = "" [@@foo]
 
@@ -225,7 +225,13 @@ module type S = sig
   include%foo [@foo] M
 
   open%foo [@foo] M
+
+  class%foo [@foo] x : t
+
+  class type%foo [@foo] x = x
+
   class%foo x : t [@@foo]
+
   class type%foo x = x [@@foo]
 end
 

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -200,8 +200,7 @@ and [@foo] M : S = M
 module type%foo [@foo] S = S
 
 include%foo [@foo] M
-
-open%foo M [@@foo]
+open%foo [@foo] M
 
 (* Signature items *)
 module type S = sig
@@ -225,7 +224,7 @@ module type S = sig
 
   include%foo [@foo] M
 
-  open%foo M [@@foo]
+  open%foo [@foo] M
   class%foo x : t [@@foo]
   class type%foo x = x [@@foo]
 end

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -224,7 +224,6 @@ module type S = sig
   module type%foo [@foo] S = S
 
   include%foo [@foo] M
-
   open%foo [@foo] M
 
   class%foo [@foo] x : t

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -179,8 +179,8 @@ end
 let%foo[@foo] x = 4
 and[@foo] y = x
 
-type%foo t = int [@@foo]
-and t = int [@@foo]
+type%foo[@foo] t = int
+and[@foo] t = int
 
 type%foo t += T [@@foo]
 
@@ -207,8 +207,8 @@ module type S = sig
   val%foo x : t [@@foo]
   external%foo x : t = "" [@@foo]
 
-  type%foo t = int [@@foo]
-  and t' = int [@@foo]
+  type%foo[@foo] t = int
+  and[@foo] t' = int
 
   type%foo t += T [@@foo]
   exception%foo X [@foo]

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -190,7 +190,7 @@ class type%foo [@foo] x = x
 
 external%foo [@foo] x : _ = ""
 
-exception%foo X [@foo]
+exception%foo [@foo] X
 
 module%foo [@foo] M = M
 
@@ -212,7 +212,7 @@ module type S = sig
 
   type%foo [@foo] t += T
 
-  exception%foo X [@foo]
+  exception%foo [@foo] X
 
   module%foo [@foo] M : S
 

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -188,7 +188,7 @@ class%foo [@foo] x = x
 
 class type%foo [@foo] x = x
 
-external%foo x : _ = "" [@@foo]
+external%foo [@foo] x : _ = ""
 
 exception%foo X [@foo]
 
@@ -204,8 +204,8 @@ open%foo [@foo] M
 
 (* Signature items *)
 module type S = sig
-  val%foo x : t [@@foo]
-  external%foo x : t = "" [@@foo]
+  val%foo [@foo] x : t
+  external%foo [@foo] x : t = ""
 
   type%foo[@foo] t = int
   and[@foo] t' = int

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -182,7 +182,7 @@ and[@foo] y = x
 type%foo[@foo] t = int
 and[@foo] t = int
 
-type%foo t += T [@@foo]
+type%foo [@foo] t += T
 
 class%foo [@foo] x = x
 
@@ -210,7 +210,8 @@ module type S = sig
   type%foo[@foo] t = int
   and[@foo] t' = int
 
-  type%foo t += T [@@foo]
+  type%foo [@foo] t += T
+
   exception%foo X [@foo]
 
   module%foo [@foo] M : S

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -199,7 +199,8 @@ and [@foo] M : S = M
 
 module type%foo [@foo] S = S
 
-include%foo M [@@foo]
+include%foo [@foo] M
+
 open%foo M [@@foo]
 
 (* Signature items *)
@@ -222,7 +223,8 @@ module type S = sig
 
   module type%foo [@foo] S = S
 
-  include%foo M [@@foo]
+  include%foo [@foo] M
+
   open%foo M [@@foo]
   class%foo x : t [@@foo]
   class type%foo x = x [@@foo]

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -184,9 +184,9 @@ and t = int [@@foo]
 
 type%foo t += T [@@foo]
 
-class%foo x = x [@@foo]
+class%foo [@foo] x = x
 
-class type%foo x = x [@@foo]
+class type%foo [@foo] x = x
 
 external%foo x : _ = "" [@@foo]
 
@@ -225,7 +225,13 @@ module type S = sig
   include%foo [@foo] M
 
   open%foo [@foo] M
+
+  class%foo [@foo] x : t
+
+  class type%foo [@foo] x = x
+
   class%foo x : t [@@foo]
+
   class type%foo x = x [@@foo]
 end
 

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -200,8 +200,7 @@ and [@foo] M : S = M
 module type%foo [@foo] S = S
 
 include%foo [@foo] M
-
-open%foo M [@@foo]
+open%foo [@foo] M
 
 (* Signature items *)
 module type S = sig
@@ -225,7 +224,7 @@ module type S = sig
 
   include%foo [@foo] M
 
-  open%foo M [@@foo]
+  open%foo [@foo] M
   class%foo x : t [@@foo]
   class type%foo x = x [@@foo]
 end

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -224,7 +224,6 @@ module type S = sig
   module type%foo [@foo] S = S
 
   include%foo [@foo] M
-
   open%foo [@foo] M
 
   class%foo [@foo] x : t

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -179,8 +179,8 @@ end
 let%foo[@foo] x = 4
 and[@foo] y = x
 
-type%foo t = int [@@foo]
-and t = int [@@foo]
+type%foo[@foo] t = int
+and[@foo] t = int
 
 type%foo t += T [@@foo]
 
@@ -207,8 +207,8 @@ module type S = sig
   val%foo x : t [@@foo]
   external%foo x : t = "" [@@foo]
 
-  type%foo t = int [@@foo]
-  and t' = int [@@foo]
+  type%foo[@foo] t = int
+  and[@foo] t' = int
 
   type%foo t += T [@@foo]
   exception%foo X [@foo]

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -190,7 +190,7 @@ class type%foo [@foo] x = x
 
 external%foo [@foo] x : _ = ""
 
-exception%foo X [@foo]
+exception%foo [@foo] X
 
 module%foo [@foo] M = M
 
@@ -212,7 +212,7 @@ module type S = sig
 
   type%foo [@foo] t += T
 
-  exception%foo X [@foo]
+  exception%foo [@foo] X
 
   module%foo [@foo] M : S
 

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -188,7 +188,7 @@ class%foo [@foo] x = x
 
 class type%foo [@foo] x = x
 
-external%foo x : _ = "" [@@foo]
+external%foo [@foo] x : _ = ""
 
 exception%foo X [@foo]
 
@@ -204,8 +204,8 @@ open%foo [@foo] M
 
 (* Signature items *)
 module type S = sig
-  val%foo x : t [@@foo]
-  external%foo x : t = "" [@@foo]
+  val%foo [@foo] x : t
+  external%foo [@foo] x : t = ""
 
   type%foo[@foo] t = int
   and[@foo] t' = int

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -182,7 +182,7 @@ and[@foo] y = x
 type%foo[@foo] t = int
 and[@foo] t = int
 
-type%foo t += T [@@foo]
+type%foo [@foo] t += T
 
 class%foo [@foo] x = x
 
@@ -210,7 +210,8 @@ module type S = sig
   type%foo[@foo] t = int
   and[@foo] t' = int
 
-  type%foo t += T [@@foo]
+  type%foo [@foo] t += T
+
   exception%foo X [@foo]
 
   module%foo [@foo] M : S

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -199,7 +199,8 @@ and [@foo] M : S = M
 
 module type%foo [@foo] S = S
 
-include%foo M [@@foo]
+include%foo [@foo] M
+
 open%foo M [@@foo]
 
 (* Signature items *)
@@ -222,7 +223,8 @@ module type S = sig
 
   module type%foo [@foo] S = S
 
-  include%foo M [@@foo]
+  include%foo [@foo] M
+
   open%foo M [@@foo]
   class%foo x : t [@@foo]
   class type%foo x = x [@@foo]

--- a/test/passing/tests/open-closing-on-separate-line.ml.ref
+++ b/test/passing/tests/open-closing-on-separate-line.ml.ref
@@ -259,36 +259,38 @@ let _ =
   let open [%ext] in
   ()
 
-open A [@@attr]
-open B [@@attr]
+open [@attr] A
+open [@attr] B
 
-open struct
+open [@attr] struct
   type t
-end [@@attr]
+end
 
 open
+  [@attr]
   functor
     (A : S)
     ->
     struct
       type t
-    end [@@attr]
+    end
 
 open
+  [@attr]
   functor
     (_ : S)
     ->
     struct
       type t
-    end [@@attr]
+    end
 
-open A (B) [@@attr]
+open [@attr] A (B)
 
-open (A : S) [@@attr]
+open [@attr] (A : S)
 
-open (val x) [@@attr]
+open [@attr] (val x)
 
-open [%ext] [@@attr]
+open [@attr] [%ext]
 
 let g =
   M.f

--- a/test/passing/tests/open.ml.ref
+++ b/test/passing/tests/open.ml.ref
@@ -251,36 +251,38 @@ let _ =
   let open [%ext] in
   ()
 
-open A [@@attr]
-open B [@@attr]
+open [@attr] A
+open [@attr] B
 
-open struct
+open [@attr] struct
   type t
-end [@@attr]
+end
 
 open
+  [@attr]
   functor
     (A : S)
     ->
     struct
       type t
-    end [@@attr]
+    end
 
 open
+  [@attr]
   functor
     (_ : S)
     ->
     struct
       type t
-    end [@@attr]
+    end
 
-open A (B) [@@attr]
+open [@attr] A (B)
 
-open (A : S) [@@attr]
+open [@attr] (A : S)
 
-open (val x) [@@attr]
+open [@attr] (val x)
 
-open [%ext] [@@attr]
+open [@attr] [%ext]
 
 let g =
   M.f

--- a/test/passing/tests/shortcut_ext_attr.ml
+++ b/test/passing/tests/shortcut_ext_attr.ml
@@ -115,7 +115,6 @@ and M : S = M [@@foo]
 module type%foo S = S [@@foo]
 
 include%foo M [@@foo]
-
 open%foo M [@@foo]
 
 (* Signature items *)

--- a/test/passing/tests/source.ml.err
+++ b/test/passing/tests/source.ml.err
@@ -1,2 +1,2 @@
-Warning: tests/source.ml:705 exceeds the margin
-Warning: tests/source.ml:2322 exceeds the margin
+Warning: tests/source.ml:704 exceeds the margin
+Warning: tests/source.ml:2321 exceeds the margin

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -226,7 +226,7 @@ class type%foo [@foo] x = x
 
 external%foo [@foo] x : _ = ""
 
-exception%foo X [@foo]
+exception%foo [@foo] X
 
 module%foo [@foo] M = M
 
@@ -251,7 +251,7 @@ module type S = sig
 
   type%foo [@foo] t += T
 
-  exception%foo X [@foo]
+  exception%foo [@foo] X
 
   module%foo [@foo] M : S
 

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -236,7 +236,7 @@ and [@foo] M : S = M
 
 module type%foo [@foo] S = S
 
-include%foo M [@@foo]
+include%foo [@foo] M
 
 open%foo M [@@foo]
 
@@ -264,7 +264,7 @@ module type S = sig
 
   module type%foo [@foo] S = S
 
-  include%foo M [@@foo]
+  include%foo [@foo] M
 
   open%foo M [@@foo]
 

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -224,7 +224,7 @@ class%foo [@foo] x = x
 
 class type%foo [@foo] x = x
 
-external%foo x : _ = "" [@@foo]
+external%foo [@foo] x : _ = ""
 
 exception%foo X [@foo]
 
@@ -241,9 +241,9 @@ open%foo [@foo] M
 
 (* Signature items *)
 module type S = sig
-  val%foo x : t [@@foo]
+  val%foo [@foo] x : t
 
-  external%foo x : t = "" [@@foo]
+  external%foo [@foo] x : t = ""
 
   type%foo[@foo] t = int
 

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -237,8 +237,7 @@ and [@foo] M : S = M
 module type%foo [@foo] S = S
 
 include%foo [@foo] M
-
-open%foo M [@@foo]
+open%foo [@foo] M
 
 (* Signature items *)
 module type S = sig
@@ -266,7 +265,7 @@ module type S = sig
 
   include%foo [@foo] M
 
-  open%foo M [@@foo]
+  open%foo [@foo] M
 
   class%foo x : t [@@foo]
 

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -218,7 +218,7 @@ type%foo[@foo] t = int
 
 and[@foo] t = int
 
-type%foo t += T [@@foo]
+type%foo [@foo] t += T
 
 class%foo [@foo] x = x
 
@@ -249,7 +249,7 @@ module type S = sig
 
   and[@foo] t' = int
 
-  type%foo t += T [@@foo]
+  type%foo [@foo] t += T
 
   exception%foo X [@foo]
 

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -220,9 +220,9 @@ and t = int [@@foo]
 
 type%foo t += T [@@foo]
 
-class%foo x = x [@@foo]
+class%foo [@foo] x = x
 
-class type%foo x = x [@@foo]
+class type%foo [@foo] x = x
 
 external%foo x : _ = "" [@@foo]
 
@@ -267,9 +267,9 @@ module type S = sig
 
   open%foo [@foo] M
 
-  class%foo x : t [@@foo]
+  class%foo [@foo] x : t
 
-  class type%foo x = x [@@foo]
+  class type%foo [@foo] x = x
 end
 
 type t = ..

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -214,9 +214,9 @@ let%foo[@foo] x = 4
 
 and[@foo] y = x
 
-type%foo t = int [@@foo]
+type%foo[@foo] t = int
 
-and t = int [@@foo]
+and[@foo] t = int
 
 type%foo t += T [@@foo]
 
@@ -245,9 +245,9 @@ module type S = sig
 
   external%foo x : t = "" [@@foo]
 
-  type%foo t = int [@@foo]
+  type%foo[@foo] t = int
 
-  and t' = int [@@foo]
+  and[@foo] t' = int
 
   type%foo t += T [@@foo]
 

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -361,15 +361,18 @@ module Cf = struct
 end
 
 module Val = struct
-  let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs)
+  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ()) ?(docs = empty_docs)
         ?(prim = []) name typ =
     {
      pval_name = name;
      pval_type = typ;
-     pval_attributes = add_docs_attrs docs attrs;
+     pval_attributes = add_docs_attrs' docs attrs;
      pval_loc = loc;
      pval_prim = prim;
     }
+
+  let mk_exh ~loc ~attrs ~docs ?prim name typ =
+    mk ~loc ~attrs ~docs ?prim name typ 
 end
 
 module Md = struct

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -486,7 +486,7 @@ module Ci = struct
 end
 
 module Type = struct
-  let mk ?(loc = !default_loc) ?(attrs = [])
+  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ())
         ?(docs = empty_docs) ?(text = [])
       ?(params = [])
       ?(cstrs = [])
@@ -502,7 +502,7 @@ module Type = struct
      ptype_private = priv;
      ptype_manifest = manifest;
      ptype_attributes =
-       add_text_attrs text (add_docs_attrs docs attrs);
+       add_text_attrs' text (add_docs_attrs' docs attrs);
      ptype_loc = loc;
     }
 

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -54,8 +54,12 @@ module Attr = struct
     { attr_name = name;
       attr_payload = payload;
       attr_loc = loc }
+
   let ext_attrs ?ext ?(before=[]) ?(after=[]) () =
     {attrs_extension = ext; attrs_before = before; attrs_after = after }
+
+    let empty_ext_attrs =
+   ext_attrs ()
 end
 
 module Typ = struct
@@ -361,7 +365,7 @@ module Cf = struct
 end
 
 module Val = struct
-  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ()) ?(docs = empty_docs)
+  let mk ?(loc = !default_loc) ?(attrs = Attr.empty_ext_attrs) ?(docs = empty_docs)
         ?(prim = []) name typ =
     {
      pval_name = name;
@@ -373,7 +377,7 @@ module Val = struct
 end
 
 module Md = struct
-  let mk ?(loc = !default_loc) ?(attrs=Attr.ext_attrs ())
+  let mk ?(loc = !default_loc) ?(attrs=Attr.empty_ext_attrs)
         ?(docs = empty_docs) ?(text = []) name args typ =
     {
      pmd_name = name;
@@ -385,7 +389,7 @@ module Md = struct
 end
 
 module Ms = struct
-  let mk ?(loc = !default_loc) ?(attrs=Attr.ext_attrs ())
+  let mk ?(loc = !default_loc) ?(attrs=Attr.empty_ext_attrs)
         ?(docs = empty_docs) ?(text = []) name syn =
     {
      pms_name = name;
@@ -396,7 +400,7 @@ module Ms = struct
 end
 
 module Mtd = struct
-  let mk ?(loc = !default_loc) ?(attrs=Attr.ext_attrs ())
+  let mk ?(loc = !default_loc) ?(attrs=Attr.empty_ext_attrs)
         ?(docs = empty_docs) ?(text = []) ?typ name =
     {
      pmtd_name = name;
@@ -407,7 +411,7 @@ module Mtd = struct
 end
 
 module Mb = struct
-  let mk ?(loc = !default_loc) ?(attrs=Attr.ext_attrs ())
+  let mk ?(loc = !default_loc) ?(attrs=Attr.empty_ext_attrs)
         ?(docs = empty_docs) ?(text = []) name args expr =
     {
      pmb_name = name;
@@ -419,7 +423,7 @@ module Mb = struct
 end
 
 module Opn = struct
-  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ()) ?(docs = empty_docs)
+  let mk ?(loc = !default_loc) ?(attrs = Attr.empty_ext_attrs) ?(docs = empty_docs)
         ?(override = Fresh) expr =
     {
      popen_expr = expr;
@@ -430,7 +434,7 @@ module Opn = struct
 end
 
 module Incl = struct
-  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ()) ?(docs = empty_docs) mexpr =
+  let mk ?(loc = !default_loc) ?(attrs = Attr.empty_ext_attrs) ?(docs = empty_docs) mexpr =
     {
      pincl_mod = mexpr;
      pincl_loc = loc;
@@ -440,7 +444,7 @@ module Incl = struct
 end
 
 module Vb = struct
-  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ())  ?(docs = empty_docs)
+  let mk ?(loc = !default_loc) ?(attrs = Attr.empty_ext_attrs)  ?(docs = empty_docs)
         ?(text = []) ?value_constraint ~is_pun pat args expr =
     {
      pvb_pat = pat;
@@ -455,7 +459,7 @@ module Vb = struct
 end
 
 module Ci = struct
-  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ())
+  let mk ?(loc = !default_loc) ?(attrs = Attr.empty_ext_attrs)
         ?(docs = empty_docs) ?(text = [])
         ?(args = []) ?constraint_
         ?(virt = Concrete) ?(params = []) name expr =
@@ -473,7 +477,7 @@ module Ci = struct
 end
 
 module Type = struct
-  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ())
+  let mk ?(loc = !default_loc) ?(attrs = Attr.empty_ext_attrs)
         ?(docs = empty_docs) ?(text = [])
       ?(params = [])
       ?(cstrs = [])
@@ -518,7 +522,7 @@ end
 
 (** Type extensions *)
 module Te = struct
-  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ()) ?(docs = empty_docs)
+  let mk ?(loc = !default_loc) ?(attrs = Attr.empty_ext_attrs) ?(docs = empty_docs)
         ?(params = []) ?(priv = Public) path constructors =
     {
      ptyext_path = path;
@@ -529,7 +533,7 @@ module Te = struct
      ptyext_attributes = add_docs_attrs' docs attrs;
     }
 
-  let mk_exception ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ()) ?(docs = empty_docs)
+  let mk_exception ?(loc = !default_loc) ?(attrs = Attr.empty_ext_attrs) ?(docs = empty_docs)
       constructor =
     {
      ptyexn_constructor = constructor;

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -465,7 +465,7 @@ module Vb = struct
 end
 
 module Ci = struct
-  let mk ?(loc = !default_loc) ?(attrs = [])
+  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ())
         ?(docs = empty_docs) ?(text = [])
         ?(args = []) ?constraint_
         ?(virt = Concrete) ?(params = []) name expr =
@@ -477,9 +477,12 @@ module Ci = struct
      pci_constraint = constraint_;
      pci_expr = expr;
      pci_attributes =
-       add_text_attrs text (add_docs_attrs docs attrs);
+       add_text_attrs' text (add_docs_attrs' docs attrs);
      pci_loc = loc;
     }
+
+  let mk_exh ~text ~loc ~attrs ~docs = mk ~loc ~attrs ~docs ?text
+
 end
 
 module Type = struct

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -396,7 +396,7 @@ module Ms = struct
      pms_loc = loc;
     }
 
-  let mk_exh ~text ~loc ~attrs ~docs = mk ~loc ~attrs ~docs ?text 
+  let mk_exh ~text ~loc ~attrs ~docs = mk ~loc ~attrs ~docs ?text
 end
 
 module Mtd = struct
@@ -450,7 +450,7 @@ module Incl = struct
 end
 
 module Vb = struct
-  let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs)
+  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ())  ?(docs = empty_docs)
         ?(text = []) ?value_constraint ~is_pun pat args expr =
     {
      pvb_pat = pat;
@@ -458,8 +458,7 @@ module Vb = struct
      pvb_expr = expr;
      pvb_constraint=value_constraint;
      pvb_is_pun = is_pun;
-     pvb_attributes =
-       add_text_attrs text (add_docs_attrs docs attrs);
+     pvb_attributes = attrs;
      pvb_loc = loc;
     }
 end

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -544,12 +544,12 @@ module Te = struct
      ptyext_attributes = add_docs_attrs' docs attrs;
     }
 
-  let mk_exception ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs)
+  let mk_exception ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ()) ?(docs = empty_docs)
       constructor =
     {
      ptyexn_constructor = constructor;
      ptyexn_loc = loc;
-     ptyexn_attributes = add_docs_attrs docs attrs;
+     ptyexn_attributes = add_docs_attrs' docs attrs;
     }
 
   let constructor ?(loc = !default_loc) ?(attrs = [])

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -54,12 +54,11 @@ module Attr = struct
     { attr_name = name;
       attr_payload = payload;
       attr_loc = loc }
-
   let ext_attrs ?ext ?(before=[]) ?(after=[]) () =
     {attrs_extension = ext; attrs_before = before; attrs_after = after }
 
-    let empty_ext_attrs =
-   ext_attrs ()
+  let empty_ext_attrs =
+    ext_attrs ()
 end
 
 module Typ = struct

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -370,9 +370,6 @@ module Val = struct
      pval_loc = loc;
      pval_prim = prim;
     }
-
-  let mk_exh ~loc ~attrs ~docs ?prim name typ =
-    mk ~loc ~attrs ~docs ?prim name typ 
 end
 
 module Md = struct
@@ -385,8 +382,6 @@ module Md = struct
      pmd_ext_attrs = add_text_attrs' text (add_docs_attrs' docs attrs);
      pmd_loc = loc;
     }
-
-let mk_exh ~text ~loc ~attrs ~docs = mk ~loc ~attrs ~docs ?text
 end
 
 module Ms = struct
@@ -398,8 +393,6 @@ module Ms = struct
      pms_ext_attrs = add_text_attrs' text (add_docs_attrs' docs attrs);
      pms_loc = loc;
     }
-
-  let mk_exh ~text ~loc ~attrs ~docs = mk ~loc ~attrs ~docs ?text
 end
 
 module Mtd = struct
@@ -411,8 +404,6 @@ module Mtd = struct
      pmtd_ext_attrs = add_text_attrs' text (add_docs_attrs' docs attrs);
      pmtd_loc = loc;
     }
-
-  let mk_exh ~text ~loc ~attrs ~docs ~typ = mk ~loc ~attrs ~docs ?text ?typ
 end
 
 module Mb = struct
@@ -425,8 +416,6 @@ module Mb = struct
      pmb_ext_attrs = add_text_attrs' text (add_docs_attrs' docs attrs);
      pmb_loc = loc;
     }
-
-  let mk_exh ~text ~loc ~attrs ~docs = mk ~loc ~attrs ~docs ?text
 end
 
 module Opn = struct
@@ -448,8 +437,6 @@ module Incl = struct
      pincl_attributes = add_docs_attrs' docs attrs;
     }
 
-  let mk_exh ~loc ~attrs ~docs = mk ~loc ~attrs ~docs
-
 end
 
 module Vb = struct
@@ -461,7 +448,8 @@ module Vb = struct
      pvb_expr = expr;
      pvb_constraint=value_constraint;
      pvb_is_pun = is_pun;
-     pvb_attributes = attrs;
+     pvb_attributes =
+       add_text_attrs' text (add_docs_attrs' docs attrs);
      pvb_loc = loc;
     }
 end
@@ -482,9 +470,6 @@ module Ci = struct
        add_text_attrs' text (add_docs_attrs' docs attrs);
      pci_loc = loc;
     }
-
-  let mk_exh ~text ~loc ~attrs ~docs = mk ~loc ~attrs ~docs ?text
-
 end
 
 module Type = struct

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -382,6 +382,8 @@ module Md = struct
      pmd_ext_attrs = add_text_attrs' text (add_docs_attrs' docs attrs);
      pmd_loc = loc;
     }
+
+let mk_exh ~text ~loc ~attrs ~docs = mk ~loc ~attrs ~docs ?text
 end
 
 module Ms = struct
@@ -393,6 +395,8 @@ module Ms = struct
      pms_ext_attrs = add_text_attrs' text (add_docs_attrs' docs attrs);
      pms_loc = loc;
     }
+
+  let mk_exh ~text ~loc ~attrs ~docs = mk ~loc ~attrs ~docs ?text 
 end
 
 module Mtd = struct
@@ -404,6 +408,8 @@ module Mtd = struct
      pmtd_ext_attrs = add_text_attrs' text (add_docs_attrs' docs attrs);
      pmtd_loc = loc;
     }
+
+  let mk_exh ~text ~loc ~attrs ~docs ~typ = mk ~loc ~attrs ~docs ?text ?typ
 end
 
 module Mb = struct
@@ -416,6 +422,8 @@ module Mb = struct
      pmb_ext_attrs = add_text_attrs' text (add_docs_attrs' docs attrs);
      pmb_loc = loc;
     }
+
+  let mk_exh ~text ~loc ~attrs ~docs = mk ~loc ~attrs ~docs ?text
 end
 
 module Opn = struct

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -427,13 +427,13 @@ module Mb = struct
 end
 
 module Opn = struct
-  let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs)
+  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ()) ?(docs = empty_docs)
         ?(override = Fresh) expr =
     {
      popen_expr = expr;
      popen_override = override;
      popen_loc = loc;
-     popen_attributes = add_docs_attrs docs attrs;
+     popen_attributes = add_docs_attrs' docs attrs;
     }
 end
 

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -438,12 +438,14 @@ module Opn = struct
 end
 
 module Incl = struct
-  let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs) mexpr =
+  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ()) ?(docs = empty_docs) mexpr =
     {
      pincl_mod = mexpr;
      pincl_loc = loc;
-     pincl_attributes = add_docs_attrs docs attrs;
+     pincl_attributes = add_docs_attrs' docs attrs;
     }
+
+  let mk_exh ~loc ~attrs ~docs = mk ~loc ~attrs ~docs
 
 end
 

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -533,7 +533,7 @@ end
 
 (** Type extensions *)
 module Te = struct
-  let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs)
+  let mk ?(loc = !default_loc) ?(attrs = Attr.ext_attrs ()) ?(docs = empty_docs)
         ?(params = []) ?(priv = Public) path constructors =
     {
      ptyext_path = path;
@@ -541,7 +541,7 @@ module Te = struct
      ptyext_constructors = constructors;
      ptyext_private = priv;
      ptyext_loc = loc;
-     ptyext_attributes = add_docs_attrs docs attrs;
+     ptyext_attributes = add_docs_attrs' docs attrs;
     }
 
   let mk_exception ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs)

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -636,9 +636,9 @@ module E = struct
 end
 
 module PVB = struct
-  let map_value_bindings sub { pvbs_bindings; pvbs_rec; pvbs_has_ext } =
+  let map_value_bindings sub { pvbs_bindings; pvbs_rec } =
     let pvbs_bindings = List.map (sub.value_binding sub) pvbs_bindings in
-    { pvbs_bindings; pvbs_rec; pvbs_has_ext }
+    { pvbs_bindings; pvbs_rec }
 end
 
 module P = struct

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -799,7 +799,7 @@ let default_mapper =
         Val.mk
           (map_loc this pval_name)
           (this.typ this pval_type)
-          ~attrs:(this.attributes this pval_attributes)
+          ~attrs:(this.ext_attrs this pval_attributes)
           ~loc:(this.location this pval_loc)
           ~prim:(List.map (map_loc this) pval_prim)
       );

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -295,7 +295,7 @@ module T = struct
   let map_type_exception sub
       {ptyexn_constructor; ptyexn_loc; ptyexn_attributes} =
     let loc = sub.location sub ptyexn_loc in
-    let attrs = sub.attributes sub ptyexn_attributes in
+    let attrs = sub.ext_attrs sub ptyexn_attributes in
     Te.mk_exception ~loc ~attrs
       (sub.extension_constructor sub ptyexn_constructor)
 

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -254,7 +254,7 @@ module T = struct
        ptype_attributes;
        ptype_loc} =
     let loc = sub.location sub ptype_loc in
-    let attrs = sub.attributes sub ptype_attributes in
+    let attrs = sub.ext_attrs sub ptype_attributes in
     Type.mk ~loc ~attrs (map_loc sub ptype_name)
       ~params:(List.map (map_fst (sub.typ sub)) ptype_params)
       ~priv:(Flag.map_private sub ptype_private)

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -751,7 +751,7 @@ module CE = struct
   let class_infos sub f {pci_virt; pci_params = pl; pci_name; pci_expr;
                          pci_loc; pci_attributes; pci_args; pci_constraint} =
     let loc = sub.location sub pci_loc in
-    let attrs = sub.attributes sub pci_attributes in
+    let attrs = sub.ext_attrs sub pci_attributes in
     Ci.mk ~loc ~attrs
      ~virt:(Flag.map_virtual sub pci_virt)
      ~params:(List.map (map_fst (sub.typ sub)) pl)

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -285,7 +285,7 @@ module T = struct
        ptyext_loc;
        ptyext_attributes} =
     let loc = sub.location sub ptyext_loc in
-    let attrs = sub.attributes sub ptyext_attributes in
+    let attrs = sub.ext_attrs sub ptyext_attributes in
     Te.mk ~loc ~attrs
       (map_loc sub ptyext_path)
       (List.map (sub.extension_constructor sub) ptyext_constructors)

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -853,7 +853,7 @@ let default_mapper =
          Opn.mk (this.module_expr this popen_expr)
            ~override:popen_override
            ~loc:(this.location this popen_loc)
-           ~attrs:(this.attributes this popen_attributes)
+           ~attrs:(this.ext_attrs this popen_attributes)
       );
 
     open_description =
@@ -861,7 +861,7 @@ let default_mapper =
          Opn.mk (map_loc this popen_expr)
            ~override:popen_override
            ~loc:(this.location this popen_loc)
-           ~attrs:(this.attributes this popen_attributes)
+           ~attrs:(this.ext_attrs this popen_attributes)
       );
 
     include_description =

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -868,14 +868,14 @@ let default_mapper =
       (fun this {pincl_mod; pincl_attributes; pincl_loc} ->
          Incl.mk (this.module_type this pincl_mod)
            ~loc:(this.location this pincl_loc)
-           ~attrs:(this.attributes this pincl_attributes)
+           ~attrs:(this.ext_attrs this pincl_attributes)
       );
 
     include_declaration =
       (fun this {pincl_mod; pincl_attributes; pincl_loc} ->
          Incl.mk (this.module_expr this pincl_mod)
            ~loc:(this.location this pincl_loc)
-           ~attrs:(this.attributes this pincl_attributes)
+           ~attrs:(this.ext_attrs this pincl_attributes)
       );
 
     value_binding =

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -636,10 +636,9 @@ module E = struct
 end
 
 module PVB = struct
-  let map_value_bindings sub { pvbs_bindings; pvbs_rec; pvbs_extension } =
+  let map_value_bindings sub { pvbs_bindings; pvbs_rec; pvbs_has_ext } =
     let pvbs_bindings = List.map (sub.value_binding sub) pvbs_bindings in
-    let pvbs_extension = map_opt (map_loc sub) pvbs_extension in
-    { pvbs_bindings; pvbs_rec; pvbs_extension }
+    { pvbs_bindings; pvbs_rec; pvbs_has_ext }
 end
 
 module P = struct
@@ -887,7 +886,7 @@ let default_mapper =
            ?value_constraint:(Option.map (map_value_constraint this) pvb_constraint)
            ~is_pun:pvb_is_pun
            ~loc:(this.location this pvb_loc)
-           ~attrs:(this.attributes this pvb_attributes)
+           ~attrs:(this.ext_attrs this pvb_attributes)
       );
     value_bindings = PVB.map_value_bindings;
 

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -70,16 +70,16 @@ let mkcty ~loc ?attrs d = Cty.mk ~loc:(make_loc loc) ?attrs d
 let mkconst ~loc c = Const.mk ~loc:(make_loc loc) c
 let mkfunparam ~loc x = { pparam_loc = make_loc loc; pparam_desc = x }
 
-let pstr_type ((nr, ext), tys) =
-  (Pstr_type (nr, tys), ext)
+let pstr_type (nr, tys) =
+   Pstr_type (nr, tys)
 let pstr_exception (te, ext) =
   (Pstr_exception te, ext)
 
-let psig_type ((nr, ext), tys) =
-  (Psig_type (nr, tys), ext)
-let psig_typesubst ((nr, ext), tys) =
+let psig_type (nr, tys) =
+  Psig_type (nr, tys)
+let psig_typesubst (nr, tys) =
   assert (nr = Recursive); (* see [no_nonrec_flag] *)
-  (Psig_typesubst tys, ext)
+  Psig_typesubst tys
 let psig_exception (te, ext) =
   (Psig_exception te, ext)
 
@@ -1351,11 +1351,11 @@ structure_item:
         { Pstr_primitive $1 }
     | str_type_extension
         { Pstr_typext $1 }
+    | type_declarations
+        { pstr_type $1 }
     )
   | wrap_mkstr_ext(
-      type_declarations
-        { pstr_type $1 }
-    | str_exception_declaration
+     str_exception_declaration
         { pstr_exception $1 }
     )
     { $1 }
@@ -1525,7 +1525,7 @@ open_description:
   { let attrs = Attr.ext_attrs ?ext ~before ~after () in
     let loc = make_loc $sloc in
     let docs = symbol_docs $sloc in
-    Opn.mk id ~override ~attrs ~loc ~docs, ext
+    Opn.mk id ~override ~attrs ~loc ~docs
   }
 ;
 
@@ -1631,17 +1631,17 @@ signature_item:
         { Psig_value $1 }
     | sig_type_extension
         { Psig_typext $1 }
-    )
-    { $1 }
-  | wrap_mksig_ext(
-      type_declarations
+    | type_declarations
         { psig_type $1 }
     | type_subst_declarations
         { psig_typesubst $1 }
-    | sig_exception_declaration
-        { psig_exception $1 }
     | open_description
-        { let (body, ext) = $1 in (Psig_open body, ext) }
+        { Psig_open $1 }
+    )
+    { $1 }
+  | wrap_mksig_ext(
+      sig_exception_declaration
+        { psig_exception $1 }
     )
     { $1 }
 
@@ -2923,7 +2923,7 @@ generic_type_declaration(flag, kind):
       let docs = symbol_docs $sloc in
       let attrs = Attr.ext_attrs ?ext ~before:attrs1 ~after:attrs2 () in
       let loc = make_loc $sloc in
-      (flag, ext),
+      flag,
       Type.mk id ~params ~cstrs ~kind ~priv ?manifest ~attrs ~loc ~docs
     }
 ;

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -1379,6 +1379,29 @@ structure_item:
     { $1 }
 ;
 
+%inline ext_attrs(kw, body):
+  kw
+  ext = ext 
+  before = attributes
+  body = body
+  after = post_item_attributes
+  { let loc = make_loc $sloc in
+    let docs = symbol_docs $sloc in
+    let attrs = Attr.ext_attrs ?ext ~before ~after () in 
+    body ~loc ~attrs ~docs ~text:None }
+
+
+%inline ext_attrs_no_ext(kw, body):
+  kw
+  before = attributes
+  body = body
+  after = post_item_attributes
+  { let loc = make_loc $sloc in
+    let docs = symbol_docs $sloc in
+     let text = Some (symbol_text $symbolstartpos) in
+    let attrs = Attr.ext_attrs ~before ~after () in 
+    body ~loc ~attrs ~docs ~text }
+
 (* A single module binding. *)
 %inline module_binding:
   MODULE

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -476,7 +476,7 @@ let mklbs rf lb =
   } in
   addlb lbs lb
 
-let mk_let_bindings { lbs_bindings; lbs_rec; lbs_has_ext } =
+let mk_let_bindings { lbs_bindings; lbs_rec; lbs_has_ext=_ } =
   let pvbs_bindings =
     List.rev_map
       (fun lb ->
@@ -485,7 +485,7 @@ let mk_let_bindings { lbs_bindings; lbs_rec; lbs_has_ext } =
            lb.lb_pattern lb.lb_args lb.lb_expression)
       lbs_bindings
   in
-  { pvbs_bindings; pvbs_rec = lbs_rec; pvbs_has_ext = lbs_has_ext }
+  { pvbs_bindings; pvbs_rec = lbs_rec }
 
 let val_of_let_bindings ~loc lbs =
   mkstr ~loc (Pstr_value (mk_let_bindings lbs))
@@ -1494,27 +1494,27 @@ module_type_declaration:
 (* Opens. *)
 
 open_declaration:
-    OPEN
-    override = override_flag
-    ext = ext
-    before = attributes
-    me = module_expr
-    after = post_item_attributes
-    { let attrs = Attr.ext_attrs ?ext ~before ~after () in
-      let loc = make_loc $sloc in
-      let docs = symbol_docs $sloc in
-      Opn.mk me ~override ~attrs ~loc ~docs }
+  OPEN
+  override = override_flag
+  ext = ext
+  attrs1 = attributes
+  me = module_expr
+  attrs2 = post_item_attributes
+  { let attrs = Attr.ext_attrs ?ext ~before:attrs1 ~after:attrs2 () in
+    let loc = make_loc $sloc in
+    let docs = symbol_docs $sloc in
+    Opn.mk me ~override ~attrs ~loc ~docs }
 ;
 
 open_description:
   OPEN
   override = override_flag
   ext = ext
-  before = attributes
+  attrs1 = attributes
   id = mkrhs(mod_ext_longident)
-  after = post_item_attributes
+  attrs2 = post_item_attributes
   {
-    let attrs = Attr.ext_attrs ?ext ~before ~after () in
+    let attrs = Attr.ext_attrs ?ext ~before:attrs1 ~after:attrs2 () in
     let loc = make_loc $sloc in
     let docs = symbol_docs $sloc in
     Opn.mk id ~override ~attrs ~loc ~docs
@@ -2524,25 +2524,25 @@ let_bindings(EXT):
 %inline let_binding(EXT):
   LET
   ext = EXT
-  before = attributes
+  attrs1 = attributes
   rec_flag = rec_flag
   body = let_binding_body
-  after = post_item_attributes
+  attrs2 = post_item_attributes
     {
       let docs = symbol_docs $sloc in
-      let attrs = Attr.ext_attrs ?ext ~after ~before () in
+      let attrs = Attr.ext_attrs ?ext ~before:attrs1 ~after:attrs2 () in
       mklbs rec_flag (mklb ~loc:$sloc body ~docs attrs)
     }
 ;
 and_let_binding:
   AND
-  before = attributes
+  attrs1 = attributes
   body = let_binding_body
-  after = post_item_attributes
+  attrs2 = post_item_attributes
     {
       let text = symbol_text $symbolstartpos in
       let docs = symbol_docs $sloc in
-      let attrs = Attr.ext_attrs ~after ~before () in
+      let attrs = Attr.ext_attrs ~before:attrs1 ~after:attrs2 () in
       mklb ~text ~docs ~loc:$sloc body attrs
     }
 ;
@@ -3089,33 +3089,33 @@ str_exception_declaration:
     { $1 }
 | EXCEPTION
   ext = ext
-  before = attributes
+  attrs1 = attributes
   id = mkrhs(constr_ident)
   EQUAL
   lid = mkrhs(constr_longident)
-  attrs_inside = attributes
-  after = post_item_attributes
+  attrs2 = attributes
+  attrs = post_item_attributes
   { let loc = make_loc $sloc in
     let docs = symbol_docs $sloc in
-    let attrs = Attr.ext_attrs ~before ~after ?ext () in
+    let attrs = Attr.ext_attrs ~before:attrs1 ~after:attrs ?ext () in
     Te.mk_exception ~attrs
-      (Te.rebind id lid ~attrs:attrs_inside ~loc ~docs)
+      (Te.rebind id lid ~attrs:attrs2 ~loc ~docs)
   }
 ;
 sig_exception_declaration:
   EXCEPTION
   ext = ext
-  before = attributes
+  attrs1 = attributes
   id = mkrhs(constr_ident)
   vars_args_res = generalized_constructor_arguments
-  attrs_inside = attributes
-  after = post_item_attributes
+  attrs2 = attributes
+  attrs = post_item_attributes
     { let vars, args, res = vars_args_res in
-      let loc = make_loc ($startpos, $endpos(attrs_inside)) in
+      let loc = make_loc ($startpos, $endpos(attrs2)) in
       let docs = symbol_docs $sloc in
-      let attrs = Attr.ext_attrs ~before ~after ?ext () in
+      let attrs = Attr.ext_attrs ~before:attrs1 ~after:attrs ?ext () in
       Te.mk_exception ~attrs
-        (Te.decl id ~vars ~args ?res ~attrs:attrs_inside ~loc ~docs)
+        (Te.decl id ~vars ~args ?res ~attrs:attrs2 ~loc ~docs)
     }
 ;
 %inline let_exception_declaration:
@@ -3177,16 +3177,16 @@ label_declaration_semi:
 %inline type_extension(declaration):
   TYPE
   ext = ext
-  before = attributes
+  attrs1 = attributes
   no_nonrec_flag
   params = type_parameters
   tid = mkrhs(type_longident)
   PLUSEQ
   priv = private_flag
   cs = bar_llist(declaration)
-  after = post_item_attributes
+  attrs2 = post_item_attributes
     { let docs = symbol_docs $sloc in
-      let attrs = Attr.ext_attrs ?ext ~before ~after () in
+      let attrs = Attr.ext_attrs ?ext ~before:attrs1 ~after:attrs2 () in
       Te.mk tid cs ~params ~priv ~attrs ~docs }
 ;
 %inline extension_constructor(opening):

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -510,7 +510,7 @@ let package_type_of_module_type pmty =
 
         (* restrictions below are checked by the 'with_constraint' rule *)
         assert (ptyp.ptype_kind = Ptype_abstract);
-        assert (ptyp.ptype_attributes = []);
+        assert (ptyp.ptype_attributes.attrs_before @ ptyp.ptype_attributes.attrs_after = []);
         let ty =
           match ptyp.ptype_manifest with
           | Some ty -> ty
@@ -2940,7 +2940,7 @@ generic_type_declaration(flag, kind):
     {
       let (kind, priv, manifest) = kind_priv_manifest in
       let docs = symbol_docs $sloc in
-      let attrs = attrs1 @ attrs2 in
+      let attrs = Attr.ext_attrs ?ext ~before:attrs1 ~after:attrs2 () in
       let loc = make_loc $sloc in
       (flag, ext),
       Type.mk id ~params ~cstrs ~kind ~priv ?manifest ~attrs ~loc ~docs
@@ -2957,7 +2957,7 @@ generic_type_declaration(flag, kind):
     {
       let (kind, priv, manifest) = kind_priv_manifest in
       let docs = symbol_docs $sloc in
-      let attrs = attrs1 @ attrs2 in
+      let attrs = Attr.ext_attrs ~before:attrs1 ~after:attrs2 () in
       let loc = make_loc $sloc in
       let text = symbol_text $symbolstartpos in
       Type.mk id ~params ~cstrs ~kind ~priv ?manifest ~attrs ~loc ~docs ~text

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -1353,6 +1353,8 @@ structure_item:
         { Pstr_modtype $1 }
     | include_statement(module_expr)
         { Pstr_include $1 }
+    | open_declaration
+        { Pstr_open $1 }
     )
   | wrap_mkstr_ext(
       primitive_declaration
@@ -1365,8 +1367,6 @@ structure_item:
         { pstr_typext $1 }
     | str_exception_declaration
         { pstr_exception $1 }
-    | open_declaration
-        { let (body, ext) = $1 in (Pstr_open body, ext) }
     | class_declarations
         { let (ext, l) = $1 in (Pstr_class l, ext) }
     | class_type_declarations
@@ -1517,29 +1517,26 @@ module_type_declaration:
 (* Opens. *)
 
 open_declaration:
-  OPEN
-  override = override_flag
-  ext = ext
-  attrs1 = attributes
-  me = module_expr
-  attrs2 = post_item_attributes
-  {
-    let attrs = attrs1 @ attrs2 in
-    let loc = make_loc $sloc in
-    let docs = symbol_docs $sloc in
-    Opn.mk me ~override ~attrs ~loc ~docs, ext
-  }
+    OPEN
+    override = override_flag
+    ext = ext 
+    before = attributes
+    me = module_expr
+    after = post_item_attributes
+    { let attrs = Attr.ext_attrs ?ext ~before ~after () in 
+      let loc = make_loc $sloc in
+      let docs = symbol_docs $sloc in
+      Opn.mk me ~override ~loc ~attrs ~docs }
 ;
 
 open_description:
   OPEN
   override = override_flag
   ext = ext
-  attrs1 = attributes
+  before = attributes
   id = mkrhs(mod_ext_longident)
-  attrs2 = post_item_attributes
-  {
-    let attrs = attrs1 @ attrs2 in
+  after = post_item_attributes
+  { let attrs = Attr.ext_attrs ?ext ~before ~after () in 
     let loc = make_loc $sloc in
     let docs = symbol_docs $sloc in
     Opn.mk id ~override ~attrs ~loc ~docs, ext

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -70,15 +70,11 @@ let mkcty ~loc ?attrs d = Cty.mk ~loc:(make_loc loc) ?attrs d
 let mkconst ~loc c = Const.mk ~loc:(make_loc loc) c
 let mkfunparam ~loc x = { pparam_loc = make_loc loc; pparam_desc = x }
 
-let pstr_typext (te, ext) =
-  (Pstr_typext te, ext)
 let pstr_type ((nr, ext), tys) =
   (Pstr_type (nr, tys), ext)
 let pstr_exception (te, ext) =
   (Pstr_exception te, ext)
 
-let psig_typext (te, ext) =
-  (Psig_typext te, ext)
 let psig_type ((nr, ext), tys) =
   (Psig_type (nr, tys), ext)
 let psig_typesubst ((nr, ext), tys) =
@@ -1353,12 +1349,12 @@ structure_item:
         { Pstr_primitive $1 }
     | primitive_declaration
         { Pstr_primitive $1 }
+    | str_type_extension
+        { Pstr_typext $1 }
     )
   | wrap_mkstr_ext(
       type_declarations
         { pstr_type $1 }
-    | str_type_extension
-        { pstr_typext $1 }
     | str_exception_declaration
         { pstr_exception $1 }
     )
@@ -1633,6 +1629,8 @@ signature_item:
         { Psig_value $1 }
     | value_description
         { Psig_value $1 }
+    | sig_type_extension
+        { Psig_typext $1 }
     )
     { $1 }
   | wrap_mksig_ext(
@@ -1640,8 +1638,6 @@ signature_item:
         { psig_type $1 }
     | type_subst_declarations
         { psig_typesubst $1 }
-    | sig_type_extension
-        { psig_typext $1 }
     | sig_exception_declaration
         { psig_exception $1 }
     | open_description
@@ -3150,18 +3146,17 @@ label_declaration_semi:
 %inline type_extension(declaration):
   TYPE
   ext = ext
-  attrs1 = attributes
+  before = attributes
   no_nonrec_flag
   params = type_parameters
   tid = mkrhs(type_longident)
   PLUSEQ
   priv = private_flag
   cs = bar_llist(declaration)
-  attrs2 = post_item_attributes
+  after = post_item_attributes
     { let docs = symbol_docs $sloc in
-      let attrs = attrs1 @ attrs2 in
-      Te.mk tid cs ~params ~priv ~attrs ~docs,
-      ext }
+      let attrs = Attr.ext_attrs ?ext ~before ~after () in
+      Te.mk tid cs ~params ~priv ~attrs ~docs }
 ;
 %inline extension_constructor(opening):
     extension_constructor_declaration(opening)

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -1108,15 +1108,15 @@ and value_binding =
     pvb_expr: expression;
     pvb_constraint: value_constraint option;
     pvb_is_pun: bool;
-    pvb_attributes: attributes;
+    pvb_attributes: ext_attrs;
     pvb_loc: Location.t;
   }(** [let pat : type_constraint = exp] *)
 
 and value_bindings =
   {
     pvbs_bindings: value_binding list;
+    pvbs_has_ext: bool;
     pvbs_rec: rec_flag;
-    pvbs_extension: string loc option
   }
 
 and module_binding =

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -972,7 +972,7 @@ and 'a open_infos =
      popen_expr: 'a;
      popen_override: override_flag;
      popen_loc: Location.t;
-     popen_attributes: attributes;
+     popen_attributes: ext_attrs;
     }
 (** Values of type ['a open_infos] represents:
     - [open! X] when {{!open_infos.popen_override}[popen_override]}

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -551,7 +551,7 @@ and type_declaration =
      ptype_kind: type_kind;
      ptype_private: private_flag;  (** for [= private ...] *)
      ptype_manifest: core_type option;  (** represents [= T] *)
-     ptype_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+     ptype_attributes: ext_attrs;  (** [... [\@\@id1] [\@\@id2]] *)
      ptype_loc: Location.t;
     }
 (**

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -752,7 +752,7 @@ and 'a class_infos =
      pci_constraint: class_type option;
      pci_expr: 'a;
      pci_loc: Location.t;
-     pci_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+     pci_attributes: ext_attrs;  (** [... [\@\@id1] [\@\@id2]] *)
     }
 (** Values of type [class_expr class_infos] represents:
     - [class c = ...]

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -997,7 +997,7 @@ and 'a include_infos =
     {
      pincl_mod: 'a;
      pincl_loc: Location.t;
-     pincl_attributes: attributes;
+     pincl_attributes: ext_attrs;
     }
 
 and include_description = module_type include_infos

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -529,7 +529,7 @@ and value_description =
      pval_name: string loc;
      pval_type: core_type;
      pval_prim: string loc list;
-     pval_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+     pval_attributes: ext_attrs;  (** [... [\@\@id1] [\@\@id2]] *)
      pval_loc: Location.t;
     }
 (** Values of type {!value_description} represents:

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -658,7 +658,7 @@ and type_exception =
   {
     ptyexn_constructor : extension_constructor;
     ptyexn_loc : Location.t;
-    ptyexn_attributes : attributes;  (** [... [\@\@id1] [\@\@id2]] *)
+    ptyexn_attributes : ext_attrs;  (** [... [\@\@id1] [\@\@id2]] *)
   }
 (** Definition of a new exception ([exception E]). *)
 

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -639,7 +639,7 @@ and type_extension =
      ptyext_constructors: extension_constructor list;
      ptyext_private: private_flag;
      ptyext_loc: Location.t;
-     ptyext_attributes: attributes;  (** ... [\@\@id1] [\@\@id2] *)
+     ptyext_attributes: ext_attrs;  (** ... [\@\@id1] [\@\@id2] *)
     }
 (**
    Definition of new extensions constructors for the extensive sum type [t]

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -1115,7 +1115,6 @@ and value_binding =
 and value_bindings =
   {
     pvbs_bindings: value_binding list;
-    pvbs_has_ext: bool;
     pvbs_rec: rec_flag;
   }
 

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -616,7 +616,7 @@ and type_kind i ppf x =
 
 and type_extension i ppf x =
   line i ppf "type_extension %a\n" fmt_location x.ptyext_loc;
-  attributes i ppf x.ptyext_attributes;
+  ext_attrs i ppf x.ptyext_attributes;
   let i = i+1 in
   line i ppf "ptyext_path = %a\n" fmt_longident_loc x.ptyext_path;
   line i ppf "ptyext_params =\n";

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -709,7 +709,7 @@ and class_type_field i ppf x =
 and class_infos : 'a. _ -> (_ -> _ -> 'a -> _) -> _ -> _ -> 'a class_infos -> _ =
  fun label f i ppf x ->
   line i ppf "%s %a\n" label fmt_location x.pci_loc;
-  attributes i ppf x.pci_attributes;
+  ext_attrs i ppf x.pci_attributes;
   let i = i+1 in
   line i ppf "pci_virt = %a\n" fmt_virtual_flag x.pci_virt;
   line i ppf "pci_params =\n";

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -558,7 +558,7 @@ and type_parameter i ppf (x, _variance) = core_type i ppf x
 and type_declaration i ppf x =
   line i ppf "type_declaration %a %a\n" fmt_string_loc x.ptype_name
        fmt_location x.ptype_loc;
-  attributes i ppf x.ptype_attributes;
+  ext_attrs i ppf x.ptype_attributes;
   let i = i+1 in
   line i ppf "ptype_params =\n";
   list (i+1) type_parameter ppf x.ptype_params;

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -627,7 +627,7 @@ and type_extension i ppf x =
 
 and type_exception i ppf x =
   line i ppf "type_exception %a\n" fmt_location x.ptyexn_loc;
-  attributes i ppf x.ptyexn_attributes;
+  ext_attrs i ppf x.ptyexn_attributes;
   let i = i+1 in
   line i ppf "ptyext_constructor =\n";
   let i = i+1 in

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -1081,7 +1081,7 @@ and case i ppf {pc_lhs; pc_guard; pc_rhs} =
 
 and value_binding i ppf x =
   line i ppf "<def> %a\n" fmt_location x.pvb_loc;
-  attributes (i+1) ppf x.pvb_attributes;
+  ext_attrs (i+1) ppf x.pvb_attributes;
   pattern (i+1) ppf x.pvb_pat;
   Option.iter (value_constraint (i+1) ppf) x.pvb_constraint;
   expression (i+1) ppf x.pvb_expr

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -1104,7 +1104,7 @@ and open_infos : 'a. _ -> (_ -> _ -> 'a -> _) -> _ -> _ ->  'a open_infos -> _ =
  fun label f i ppf x ->
   line i ppf "%s %a %a\n" label fmt_override_flag x.popen_override
     fmt_location x.popen_loc;
-  attributes i ppf x.popen_attributes;
+  ext_attrs i ppf x.popen_attributes;
   f (i+1) ppf x.popen_expr
 
 and open_description i = open_infos "open_description" longident_loc i
@@ -1114,7 +1114,7 @@ and open_declaration i = open_infos "open_declaration" module_expr i
 and include_infos : 'a. _ -> (_ -> _ -> 'a -> _) -> _ -> _ -> 'a include_infos -> _ =
  fun label f i ppf x ->
   line i ppf "%s %a\n" label fmt_location x.pincl_loc;
-  attributes i ppf x.pincl_attributes;
+  ext_attrs i ppf x.pincl_attributes;
   f (i+1) ppf x.pincl_mod
 
 and include_description i = include_infos "include_description" module_type i

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -549,7 +549,7 @@ and type_constraint i ppf constraint_ =
 and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_string_loc
        x.pval_name fmt_location x.pval_loc;
-  attributes i ppf x.pval_attributes;
+  ext_attrs i ppf x.pval_attributes;
   core_type (i+1) ppf x.pval_type;
   list (i+1) string_loc ppf x.pval_prim
 


### PR DESCRIPTION
This implements issue #2109, and will be useful for reworking parentheses.
The implementation is a bit naive, as far as I know it is fine, but it almost looks too good to be true.
Maybe the `~pre` argument needs to be changed, I would like someone to get a look into it, its beyond my understanding as of now.