### PR TITLE
Fix parens on array literals with attrs when used as function args

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 - Preserve position of comments around constructor record (#2237, @EmileTrotignon)
 - Preserve position of comments around external declaration strings (#2238, @EmileTrotignon, @gpetiot)
 - Preserve position of comments around module pack expressions (#2234, @EmileTrotignon, @gpetiot)
+- Correctly parenthesize array literals with attributes in argument positions (#2250, @ccasin)
 
 ### Changes
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2271,13 +2271,15 @@ end = struct
         when List.exists args ~f:(fun (_, e0) ->
                  match (e0.pexp_desc, e0.pexp_attributes) with
                  | Pexp_list _, _ :: _ when e0 == exp -> true
+                 | Pexp_array _, _ :: _ when e0 == exp -> true
                  | _ -> false ) ->
           true
       | _ -> (
         match exp.pexp_desc with
-        | Pexp_list _ -> false
+        | Pexp_list _ | Pexp_array _ -> false
         | _ -> Exp.has_trailing_attributes exp || parenze () ) )
     | _, {pexp_desc= Pexp_list _; _} -> false
+    | _, {pexp_desc= Pexp_array _; _} -> false
     | _, exp when Exp.has_trailing_attributes exp -> true
     | _ -> false
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1935,16 +1935,18 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
               $ fmt_if_k parens (closing_paren c ~force ~offset:(-3)) ) )
   | Pexp_array [] ->
       hvbox 0
-        ( wrap_fits_breaks c.conf "[|" "|]" (Cmts.fmt_within c pexp_loc)
-        $ fmt_atrs )
+        (Params.parens_if parens c.conf
+           ( wrap_fits_breaks c.conf "[|" "|]" (Cmts.fmt_within c pexp_loc)
+           $ fmt_atrs ) )
   | Pexp_array e1N ->
       let p = Params.get_array_expr c.conf in
       hvbox_if has_attr 0
-        ( p.box
-            (fmt_expressions c (expression_width c) (sub_exp ~ctx) e1N
-               (sub_exp ~ctx >> fmt_expression c)
-               p pexp_loc )
-        $ fmt_atrs )
+        (Params.parens_if parens c.conf
+           ( p.box
+               (fmt_expressions c (expression_width c) (sub_exp ~ctx) e1N
+                  (sub_exp ~ctx >> fmt_expression c)
+                  p pexp_loc )
+           $ fmt_atrs ) )
   | Pexp_list e1N ->
       let p = Params.get_list_expr c.conf in
       let offset =

--- a/test/passing/tests/attributes.ml
+++ b/test/passing/tests/attributes.ml
@@ -247,6 +247,8 @@ let _ = f ((f @@ a) [@attr])
 
 let _ = f 1 ([e; f] [@a])
 
+let _ = f 1 ([|e; f|] [@a])
+
 let _ =
   object
     method g = (a <- b) [@a]

--- a/test/passing/tests/attributes.ml.err
+++ b/test/passing/tests/attributes.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/attributes.ml:340 exceeds the margin
+Warning: tests/attributes.ml:342 exceeds the margin


### PR DESCRIPTION
Currently, `ocamlformat` is incorrectly formatting array literals with attributes when used as function arguments.  For example:

```
let x = f ([| 1 |] [@foo])
```

is being misformatted as 

```
let x = f [| 1 |] [@foo]
```

(And then it detects the bug and gives a "Cannot process" error)

This PR fixes that.  There are changes in two files (plus a test):
- In `Fmt_ast`, the result of `parenze_exp` was being ignored for array literals.  Now it isn't.
- in `Ast`, the `parenze_exp` function was saying that array literals should be parenthesized too often, but this went unnoticed because its result was being ignored in `Fmt_ast`.  Now it follows the same rules used for list literals.

Credit to @antalsz for noticing this bug.