### PR TITLE
Dock indent a fun passed as a labelled argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+- Avoid adding breaks inside `~label:(fun` and base the indentation on the label. (#2271, @Julow)
+
 ### Changes
 
 ### New features

--- a/lib/Conf_decl.ml
+++ b/lib/Conf_decl.ml
@@ -438,8 +438,8 @@ let removed_option ~names ~since ~msg =
 let update store ~config ~from:new_from ~name ~value ~inline =
   List.find_map store
     ~f:(fun
-         (Pack {names; parse; update; allow_inline; get_value; to_string; _})
-       ->
+      (Pack {names; parse; update; allow_inline; get_value; to_string; _})
+    ->
       if List.exists names ~f:(String.equal name) then
         if inline && not allow_inline then
           Some (Error (Error.Misplaced (name, value)))

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7642,3 +7642,11 @@ let bind t ~f =
          | Yield { value = a; state = s } ->
            Yield { value = a; state = Sequence { state = s; next }, rest }))
     ~init:(empty, t)
+
+let () =
+  very_long_function_name
+    ~very_long_argument_label:(fun
+                                very_long_argument_name_one
+                                very_long_argument_name_two
+                                very_long_argument_name_three
+                              -> () )

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9865,3 +9865,12 @@ let bind t ~f =
            Yield { value = a; state = Sequence { state = s; next }, rest }))
     ~init:(empty, t)
 ;;
+
+let () =
+  very_long_function_name
+    ~very_long_argument_label:(fun
+                                very_long_argument_name_one
+                                very_long_argument_name_two
+                                very_long_argument_name_three
+                                -> ())
+;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9869,8 +9869,8 @@ let bind t ~f =
 let () =
   very_long_function_name
     ~very_long_argument_label:(fun
-                                very_long_argument_name_one
-                                very_long_argument_name_two
-                                very_long_argument_name_three
-                              -> ())
+      very_long_argument_name_one
+      very_long_argument_name_two
+      very_long_argument_name_three
+    -> ())
 ;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9865,3 +9865,12 @@ let bind t ~f =
            Yield { value = a; state = Sequence { state = s; next }, rest }))
     ~init:(empty, t)
 ;;
+
+let () =
+  very_long_function_name
+    ~very_long_argument_label:(fun
+                                very_long_argument_name_one
+                                very_long_argument_name_two
+                                very_long_argument_name_three
+                              -> ())
+;;

--- a/test/passing/tests/labelled_args-414.ml.ref
+++ b/test/passing/tests/labelled_args-414.ml.ref
@@ -1,3 +1,11 @@
 let _ =
   let f ~y = y + 1 in
   f ~(y : int)
+
+let () =
+  very_long_function_name
+    ~very_long_argument_label:(fun
+                                very_long_argument_name_one
+                                very_long_argument_name_two
+                                very_long_argument_name_three
+                              -> () )

--- a/test/passing/tests/labelled_args-414.ml.ref
+++ b/test/passing/tests/labelled_args-414.ml.ref
@@ -5,7 +5,16 @@ let _ =
 let () =
   very_long_function_name
     ~very_long_argument_label:(fun
-                                very_long_argument_name_one
-                                very_long_argument_name_two
-                                very_long_argument_name_three
-                              -> () )
+      very_long_argument_name_one
+      very_long_argument_name_two
+      very_long_argument_name_three
+    -> () )
+
+let () =
+  very_long_function_name
+    ~very_long_argument_label:(* foo *)
+    (fun
+      very_long_argument_name_one
+      very_long_argument_name_two
+      very_long_argument_name_three
+    -> () )

--- a/test/passing/tests/labelled_args.ml
+++ b/test/passing/tests/labelled_args.ml
@@ -5,7 +5,16 @@ let _ =
 let () =
   very_long_function_name
     ~very_long_argument_label:(fun
-                                very_long_argument_name_one
-                                very_long_argument_name_two
-                                very_long_argument_name_three
-                              -> () )
+      very_long_argument_name_one
+      very_long_argument_name_two
+      very_long_argument_name_three
+    -> () )
+
+let () =
+  very_long_function_name
+    ~very_long_argument_label:(* foo *)
+    (fun
+      very_long_argument_name_one
+      very_long_argument_name_two
+      very_long_argument_name_three
+    -> () )

--- a/test/passing/tests/labelled_args.ml
+++ b/test/passing/tests/labelled_args.ml
@@ -1,3 +1,11 @@
 let _ =
   let f ~y = y + 1 in
   f ~y:(y : int)
+
+let () =
+  very_long_function_name
+    ~very_long_argument_label:(fun
+                                very_long_argument_name_one
+                                very_long_argument_name_two
+                                very_long_argument_name_three
+                              -> () )


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/2265

Avoid adding breaks inside `~label:(fun` and base the indentation on the label. This is similar to what we've done to functions in 92ba086.

Some care is needed for comments between the `:` and the `(fun`