### PR TITLE
Fix non-stabilizing comments attached to private/virtual/mutable keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 ### Bug fixes
 
-- Fix non-stabilizing comments attached to private/virtual/mutable keywords (#<PR_NUMBER>, @gpetiot)
+- Fix non-stabilizing comments attached to private/virtual/mutable keywords (#2272, @gpetiot)
 
 ### Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,8 @@
 
 ### Bug fixes
 
-- Fix non-stabilizing comments attached to private/virtual/mutable keywords (#2272, @gpetiot)
 - Avoid adding breaks inside `~label:(fun` and base the indentation on the label. (#2271, @Julow)
+- Fix non-stabilizing comments attached to private/virtual/mutable keywords (#2272, @gpetiot)
 
 ### Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+- Fix non-stabilizing comments attached to private/virtual/mutable keywords (#<PR_NUMBER>, @gpetiot)
+
 ### Changes
 
 ### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -341,37 +341,38 @@ let fmt_direction_flag = function
   | Upto -> fmt "@ to "
   | Downto -> fmt "@ downto "
 
-let fmt_private c loc = hvbox 0 @@ Cmts.fmt c loc @@ str "private"
+let fmt_private ?(pro = fmt "@ ") c loc =
+  pro $ hvbox 0 @@ Cmts.fmt c loc @@ str "private"
 
-let fmt_virtual c loc = hvbox 0 @@ Cmts.fmt c loc @@ str "virtual"
+let fmt_virtual ?(pro = fmt "@ ") c loc =
+  pro $ hvbox 0 @@ Cmts.fmt c loc @@ str "virtual"
 
-let fmt_mutable c loc = hvbox 0 @@ Cmts.fmt c loc @@ str "mutable"
+let fmt_mutable ?(pro = fmt "@ ") c loc =
+  pro $ hvbox 0 @@ Cmts.fmt c loc @@ str "mutable"
 
 let fmt_private_flag c = function
-  | Private loc -> fmt "@ " $ fmt_private c loc
+  | Private loc -> fmt_private c loc
   | Public -> noop
 
 let fmt_virtual_flag c = function
-  | Virtual loc -> fmt "@ " $ fmt_virtual c loc
+  | Virtual loc -> fmt_virtual c loc
   | Concrete -> noop
 
 let fmt_mutable_flag c = function
-  | Mutable loc -> fmt_mutable c loc $ fmt "@ "
+  | Mutable loc -> fmt_mutable ~pro:noop c loc $ fmt "@ "
   | Immutable -> noop
-
-let opt_flag ~f c x = opt x (fun x -> fmt "@ " $ f c x)
 
 let fmt_mutable_virtual_flag c = function
   | {mv_mut= Some m; mv_virt= Some v} when Location.compare_start v m < 1 ->
-      opt_flag c (Some v) ~f:fmt_virtual $ opt_flag c (Some m) ~f:fmt_mutable
+      fmt_virtual c v $ fmt_mutable c m
   | {mv_mut; mv_virt} ->
-      opt_flag c mv_mut ~f:fmt_mutable $ opt_flag c mv_virt ~f:fmt_virtual
+      opt mv_mut (fmt_mutable c) $ opt mv_virt (fmt_virtual c)
 
 let fmt_private_virtual_flag c = function
   | {pv_priv= Some p; pv_virt= Some v} when Location.compare_start v p < 1 ->
-      opt_flag c ~f:fmt_virtual (Some v) $ opt_flag c ~f:fmt_private (Some p)
+      fmt_virtual c v $ fmt_private c p
   | {pv_priv; pv_virt} ->
-      opt_flag c ~f:fmt_private pv_priv $ opt_flag c ~f:fmt_virtual pv_virt
+      opt pv_priv (fmt_private c) $ opt pv_virt (fmt_virtual c)
 
 let virtual_or_override = function
   | Cfk_virtual _ -> noop

--- a/test/passing/tests/comments.ml
+++ b/test/passing/tests/comments.ml
@@ -308,6 +308,6 @@ let _ = f ( (*x*)!(*a*) (*b*) x (*c*) y ) y
 
 type a = b (* a *) as (* b *) 'c (* c *)
 
-type t = { mutable
+type t = { (* comment before mutable *) mutable
  (* really long comment that doesn't fit on the same line as other stuff *)
  x : int }

--- a/test/passing/tests/comments.ml
+++ b/test/passing/tests/comments.ml
@@ -307,3 +307,7 @@ let _ = (*x*)!(*a*) (*b*) x (*c*) y
 let _ = f ( (*x*)!(*a*) (*b*) x (*c*) y ) y
 
 type a = b (* a *) as (* b *) 'c (* c *)
+
+type t = { mutable
+ (* really long comment that doesn't fit on the same line as other stuff *)
+ x : int }

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -416,3 +416,10 @@ let _ =
     y
 
 type a = b (* a *) as (* b *) 'c (* c *)
+
+type t =
+  { mutable
+      (* really long comment that doesn't fit on the same line as other
+         stuff *)
+      x:
+      int }

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -418,7 +418,8 @@ let _ =
 type a = b (* a *) as (* b *) 'c (* c *)
 
 type t =
-  { mutable
+  { (* comment before mutable *)
+    mutable
       (* really long comment that doesn't fit on the same line as other
          stuff *)
       x:


### PR DESCRIPTION
Fix #2269 