### PR TITLE
JaneStreet profile: add extra parens around tuple with type annotation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 ### Changes
 
+- JaneStreet profile: add extra parens around tuple with type annotation (#<PR_NUMBER>, @gpetiot)
+
 ### New features
 
 ## 0.25.1 (2023-03-06)

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -26,20 +26,28 @@ let ( init
     , register_reset
     , leading_nested_match_parens
     , parens_ite
-    , ocaml_version ) =
+    , ocaml_version
+    , ocp_indent_compat ) =
   let l = ref [] in
   let leading_nested_match_parens = ref false in
   let parens_ite = ref false in
   let ocaml_version = ref Ocaml_version.sys_version in
+  let ocp_indent_compat = ref false in
   let register f = l := f :: !l in
   let init (conf : Conf.t) =
     leading_nested_match_parens :=
       conf.fmt_opts.leading_nested_match_parens.v ;
     parens_ite := conf.fmt_opts.parens_ite.v ;
     ocaml_version := conf.opr_opts.ocaml_version.v ;
+    ocp_indent_compat := conf.fmt_opts.ocp_indent_compat.v ;
     List.iter !l ~f:(fun f -> f ())
   in
-  (init, register, leading_nested_match_parens, parens_ite, ocaml_version)
+  ( init
+  , register
+  , leading_nested_match_parens
+  , parens_ite
+  , ocaml_version
+  , ocp_indent_compat )
 
 (** [fit_margin c x] returns [true] if and only if [x] does not exceed 1/3 of
     the margin. *)
@@ -2174,6 +2182,9 @@ end = struct
     | Exp {pexp_desc= Pexp_indexop_access {pia_kind= Builtin idx; _}; _}, _
       when idx == exp ->
         false
+    | Exp {pexp_desc= Pexp_constraint (e, _); _}, {pexp_desc= Pexp_tuple _; _}
+      when e == exp && !ocp_indent_compat ->
+        true
     | ( Exp
           { pexp_desc=
               Pexp_indexop_access

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7642,3 +7642,5 @@ let bind t ~f =
          | Yield { value = a; state = s } ->
            Yield { value = a; state = Sequence { state = s; next }, rest }))
     ~init:(empty, t)
+
+let () = ((one_mississippi, two_mississippi, three_mississippi, four_mississippi) : Mississippi.t * Mississippi.t * Mississippi.t * Mississippi.t)

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9865,3 +9865,8 @@ let bind t ~f =
            Yield { value = a; state = Sequence { state = s; next }, rest }))
     ~init:(empty, t)
 ;;
+
+let () =
+  ((one_mississippi, two_mississippi, three_mississippi, four_mississippi)
+   : Mississippi.t * Mississippi.t * Mississippi.t * Mississippi.t)
+;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9865,3 +9865,8 @@ let bind t ~f =
            Yield { value = a; state = Sequence { state = s; next }, rest }))
     ~init:(empty, t)
 ;;
+
+let () =
+  ((one_mississippi, two_mississippi, three_mississippi, four_mississippi)
+    : Mississippi.t * Mississippi.t * Mississippi.t * Mississippi.t)
+;;


### PR DESCRIPTION
Fix #2273

It makes sense to re-use the `ocp-indent-compat` flag to set this behavior, it will be easier to scrap it off once Jane Street is ready to drop `ocp-indent`.