### PR TITLE
JaneStreet profile: add extra parens around pattern-matching with type annotation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 
 - Restore short form formatting of module patterns with a module type constraint (`((module M) : (module S))` formatted as `(module M : S)`) (#2280, @gpetiot)
 - Restore short form formatting of record field aliases (#2282, @gpetiot)
-- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2281, #2284, @gpetiot, @Julow)
+- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2281, #2284, #<PR_NUMBER>, @gpetiot, @Julow)
 
 ### New features
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 
 - Restore short form formatting of module patterns with a module type constraint (`((module M) : (module S))` formatted as `(module M : S)`) (#2280, @gpetiot)
 - Restore short form formatting of record field aliases (#2282, @gpetiot)
-- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2281, #2284, #<PR_NUMBER>, @gpetiot, @Julow)
+- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2281, #2284, #2289, @gpetiot, @Julow)
 
 ### New features
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2182,7 +2182,8 @@ end = struct
     | Exp {pexp_desc= Pexp_indexop_access {pia_kind= Builtin idx; _}; _}, _
       when idx == exp ->
         false
-    | Exp {pexp_desc= Pexp_constraint (e, _); _}, {pexp_desc= Pexp_tuple _; _}
+    | ( Exp {pexp_desc= Pexp_constraint (e, _); _}
+      , {pexp_desc= Pexp_tuple _ | Pexp_match _ | Pexp_try _; _} )
       when e == exp && !ocp_indent_compat ->
         true
     | ( Exp

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2182,7 +2182,7 @@ end = struct
     | Exp {pexp_desc= Pexp_indexop_access {pia_kind= Builtin idx; _}; _}, _
       when idx == exp ->
         false
-    | ( Exp {pexp_desc= Pexp_constraint (e, _); _}
+    | ( Exp {pexp_desc= Pexp_constraint (e, _) | Pexp_coerce (e, _, _); _}
       , {pexp_desc= Pexp_tuple _ | Pexp_match _ | Pexp_try _; _} )
       when e == exp && !ocp_indent_compat ->
         true

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -313,7 +313,18 @@ module Let_binding = struct
             when Source.type_constraint_is_first typ exp.pexp_loc ->
               Cmts.relocate cmts ~src:body.pexp_loc ~before:exp.pexp_loc
                 ~after:exp.pexp_loc ;
-              (xpat, `Other (xargs, sub_typ ~ctx typ), sub_exp ~ctx exp)
+              let typ_ctx = Exp xbody.ast in
+              let exp_ctx =
+                (* The type constraint is moved to the pattern, so we need to
+                   replace the context from [Pexp_constraint] to [Pexp_fun].
+                   This won't be necessary once the normalization is moved to
+                   [Extended_ast]. *)
+                let pat = Ast_helper.Pat.any () in
+                Exp (Ast_helper.Exp.fun_ Nolabel None pat exp)
+              in
+              ( xpat
+              , `Other (xargs, sub_typ ~ctx:typ_ctx typ)
+              , sub_exp ~ctx:exp_ctx exp )
           (* The type constraint is always printed before the declaration for
              functions, for other value bindings we preserve its position. *)
           | Pexp_constraint (exp, typ), _ when not (List.is_empty xargs) ->

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7654,3 +7654,4 @@ let () =
 let () = ((one_mississippi, two_mississippi, three_mississippi, four_mississippi) : Mississippi.t * Mississippi.t * Mississippi.t * Mississippi.t)
 
 let _ = ((match foo with | Bar -> bar | Baz -> baz) : string)
+let _ = ((match foo with | Bar -> bar | Baz -> baz) :> string)

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7652,3 +7652,5 @@ let () =
                               -> () )
 
 let () = ((one_mississippi, two_mississippi, three_mississippi, four_mississippi) : Mississippi.t * Mississippi.t * Mississippi.t * Mississippi.t)
+
+let _ = ((match foo with | Bar -> bar | Baz -> baz) : string)

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9875,3 +9875,10 @@ let () =
   ((one_mississippi, two_mississippi, three_mississippi, four_mississippi)
    : Mississippi.t * Mississippi.t * Mississippi.t * Mississippi.t)
 ;;
+
+let _ =
+  (match foo with
+   | Bar -> bar
+   | Baz -> baz
+            : string)
+;;

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9877,8 +9877,8 @@ let () =
 ;;
 
 let _ =
-  (match foo with
-   | Bar -> bar
-   | Baz -> baz
-            : string)
+  ((match foo with
+     | Bar -> bar
+     | Baz -> baz)
+   : string)
 ;;

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9882,3 +9882,10 @@ let _ =
      | Baz -> baz)
    : string)
 ;;
+
+let _ =
+  ((match foo with
+     | Bar -> bar
+     | Baz -> baz)
+   :> string)
+;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9882,3 +9882,10 @@ let _ =
     | Baz -> baz)
     : string)
 ;;
+
+let _ =
+  ((match foo with
+    | Bar -> bar
+    | Baz -> baz)
+    :> string)
+;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9877,8 +9877,8 @@ let () =
 ;;
 
 let _ =
-  (match foo with
-   | Bar -> bar
-   | Baz -> baz
+  ((match foo with
+    | Bar -> bar
+    | Baz -> baz)
     : string)
 ;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9875,3 +9875,10 @@ let () =
   ((one_mississippi, two_mississippi, three_mississippi, four_mississippi)
     : Mississippi.t * Mississippi.t * Mississippi.t * Mississippi.t)
 ;;
+
+let _ =
+  (match foo with
+   | Bar -> bar
+   | Baz -> baz
+    : string)
+;;


### PR DESCRIPTION
Fix #2266

This is a dirty hack in `Sugar.ml`, one day we should rewrite the parsetree to remove the need for `Sugar.Let_binding.type_cstr` (the change is very heavy).