### PR TITLE
Consistent docking of argument functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 ### Bug fixes
 
-- Avoid adding breaks inside `~label:(fun` and base the indentation on the label. (#2271, @Julow)
+- Avoid adding breaks inside `~label:(fun` and base the indentation on the label. (#2271, #2291, @Julow)
 - Fix non-stabilizing comments attached to private/virtual/mutable keywords (#2272, @gpetiot)
 - Fix formatting of comments in "disable" chunks (#2279, @gpetiot)
 

--- a/test/passing/tests/eliom_ext.eliom
+++ b/test/passing/tests/eliom_ext.eliom
@@ -9,6 +9,20 @@ let%client () =
     (fun () ->
       Lwt.async (fun () -> log "Hello from the client to the server!") )
 
+let%client () =
+  Eliom_client.onload
+  (* NB The service underlying the server_function isn't available on the
+     client before loading the page. *) ~foo:(fun () ->
+      Lwt.async (fun () -> log "Hello from the client to the server!") )
+
+let%client () =
+  Eliom_client.onload
+  (* NB The service underlying the server_function isn't available on the
+     client before loading the page. *)
+    ~foo:(fun () ->
+      Lwt.async (fun () -> log "Hello from the client to the server!") )
+    bar
+
 [%%shared
 type some_type = int * string list [@@deriving json]
 

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7652,3 +7652,11 @@ let () =
                               -> () )
 
 let () = ((one_mississippi, two_mississippi, three_mississippi, four_mississippi) : Mississippi.t * Mississippi.t * Mississippi.t * Mississippi.t)
+
+let _ =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ~bbbbbbbbbbbbbbbbbbbbbbbbbbbb:(fun (_ :
+                                         (ccccccccccccc * ddddddddddddddddddddddddddddd)
+                                         eeee) -> FFFFFFFFF gg)
+    ~h
+;;

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9875,3 +9875,11 @@ let () =
   ((one_mississippi, two_mississippi, three_mississippi, four_mississippi)
    : Mississippi.t * Mississippi.t * Mississippi.t * Mississippi.t)
 ;;
+
+let _ =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ~bbbbbbbbbbbbbbbbbbbbbbbbbbbb:(fun (_ :
+                                          (ccccccccccccc * ddddddddddddddddddddddddddddd)
+                                            eeee) -> FFFFFFFFF gg)
+    ~h
+;;

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9878,8 +9878,8 @@ let () =
 
 let _ =
   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    ~bbbbbbbbbbbbbbbbbbbbbbbbbbbb:(fun (_ :
-                                          (ccccccccccccc * ddddddddddddddddddddddddddddd)
-                                            eeee) -> FFFFFFFFF gg)
+    ~bbbbbbbbbbbbbbbbbbbbbbbbbbbb:(fun
+                                    (_ : (ccccccccccccc * ddddddddddddddddddddddddddddd) eeee)
+                                    -> FFFFFFFFF gg)
     ~h
 ;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9875,3 +9875,11 @@ let () =
   ((one_mississippi, two_mississippi, three_mississippi, four_mississippi)
     : Mississippi.t * Mississippi.t * Mississippi.t * Mississippi.t)
 ;;
+
+let _ =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ~bbbbbbbbbbbbbbbbbbbbbbbbbbbb:(fun (_ :
+                                         (ccccccccccccc * ddddddddddddddddddddddddddddd)
+                                         eeee) -> FFFFFFFFF gg)
+    ~h
+;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9878,8 +9878,8 @@ let () =
 
 let _ =
   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    ~bbbbbbbbbbbbbbbbbbbbbbbbbbbb:(fun (_ :
-                                         (ccccccccccccc * ddddddddddddddddddddddddddddd)
-                                         eeee) -> FFFFFFFFF gg)
+    ~bbbbbbbbbbbbbbbbbbbbbbbbbbbb:(fun
+      (_ : (ccccccccccccc * ddddddddddddddddddddddddddddd) eeee)
+    -> FFFFFFFFF gg)
     ~h
 ;;


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/2274

This comes with a lot of code duplication. I have not been able to generalize the formatting for unnamed functions. I plan to open a follow up PR to clean this up.