### PR TITLE
Consistent indentation of newtypes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ### Bug fixes
 
+- Consistent indentation of `fun (type a) ->` that follow `fun x ->` (#2294, @Julow)
 - Avoid adding breaks inside `~label:(fun` and base the indentation on the label. (#2271, #2291, #2293, @Julow)
 - Fix non-stabilizing comments attached to private/virtual/mutable keywords (#2272, @gpetiot)
 - Fix formatting of comments in "disable" chunks (#2279, @gpetiot)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1358,7 +1358,7 @@ and fmt_label_arg ?(box = true) ?epi ?parens ?eol c
                ~pro:(fmt_label lbl ":@;<0 2>")
                ~box ?epi ?parens xarg )
         $ cmts_after )
-  | (Labelled _ | Optional _), Pexp_fun _ ->
+  | (Labelled _ | Optional _), (Pexp_fun _ | Pexp_newtype _) ->
       (* Side effects of Cmts.fmt c.cmts before Sugar.fun_ is important. *)
       let cmt_before = Cmts.fmt_before c arg.pexp_loc in
       let xargs, xbody = Sugar.fun_ c.cmts xarg in
@@ -1366,7 +1366,7 @@ and fmt_label_arg ?(box = true) ?epi ?parens ?eol c
       let body =
         let box =
           match xbody.ast.pexp_desc with
-          | Pexp_fun _ | Pexp_function _ -> Some false
+          | Pexp_fun _ | Pexp_newtype _ | Pexp_function _ -> Some false
           | _ -> None
         in
         fmt "@ " $ fmt_expression c ?box xbody
@@ -4212,7 +4212,7 @@ and fmt_value_binding c ~rec_flag ?ext ?in_ ?epi ctx
     | Pexp_function _ ->
         Params.function_indent c.conf ~ctx
           ~default:c.conf.fmt_opts.let_binding_indent.v
-    | Pexp_fun _ -> c.conf.fmt_opts.let_binding_indent.v - 1
+    | Pexp_fun _ | Pexp_newtype _ -> c.conf.fmt_opts.let_binding_indent.v - 1
     | _ -> c.conf.fmt_opts.let_binding_indent.v
   in
   let f {attr_name= {loc; _}; _} =

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -3020,21 +3020,21 @@ let t' = subst' d t
 type (_, _) eq = Refl : ('a, 'a) eq
 
 let magic : 'a 'b. 'a -> 'b =
-  fun (type a b) (x : a) ->
-   let module M =
-     (functor
-       (T : sig
-          type 'a t
-        end)
-       ->
-       struct
-         let f (Refl : (a T.t, b T.t) eq) = (x :> b)
+ fun (type a b) (x : a) ->
+  let module M =
+    (functor
+      (T : sig
+         type 'a t
        end)
-       (struct
-         type 'a t = unit
-       end)
-   in
-   M.f Refl
+      ->
+      struct
+        let f (Refl : (a T.t, b T.t) eq) = (x :> b)
+      end)
+      (struct
+        type 'a t = unit
+      end)
+  in
+  M.f Refl
 ;;
 
 (* Variance and subtyping *)
@@ -3042,18 +3042,18 @@ let magic : 'a 'b. 'a -> 'b =
 type (_, +_) eq = Refl : ('a, 'a) eq
 
 let magic : 'a 'b. 'a -> 'b =
-  fun (type a b) (x : a) ->
-   let bad_proof (type a) = (Refl : (< m : a >, < m : a >) eq :> (< m : a >, < >) eq) in
-   let downcast : type a. (a, < >) eq -> < > -> a =
-     fun (type a) (Refl : (a, < >) eq) (s : < >) -> (s :> a)
-   in
-   (downcast
-      bad_proof
-      (object
-         method m = x
-       end
-        :> < >))
-     #m
+ fun (type a b) (x : a) ->
+  let bad_proof (type a) = (Refl : (< m : a >, < m : a >) eq :> (< m : a >, < >) eq) in
+  let downcast : type a. (a, < >) eq -> < > -> a =
+   fun (type a) (Refl : (a, < >) eq) (s : < >) -> (s :> a)
+  in
+  (downcast
+     bad_proof
+     (object
+        method m = x
+      end
+       :> < >))
+    #m
 ;;
 
 (* Record patterns *)
@@ -3496,13 +3496,13 @@ let pair (type s1 s2) t1 t2 =
 open Typ
 
 let rec to_string : 'a. 'a Typ.typ -> 'a -> string =
-  fun (type s) t x ->
-   match (t : s typ) with
-   | Int eq -> string_of_int (TypEq.apply eq x)
-   | String eq -> Printf.sprintf "%S" (TypEq.apply eq x)
-   | Pair (module P) ->
-     let x1, x2 = TypEq.apply P.eq x in
-     Printf.sprintf "(%s,%s)" (to_string P.t1 x1) (to_string P.t2 x2)
+ fun (type s) t x ->
+  match (t : s typ) with
+  | Int eq -> string_of_int (TypEq.apply eq x)
+  | String eq -> Printf.sprintf "%S" (TypEq.apply eq x)
+  | Pair (module P) ->
+    let x1, x2 = TypEq.apply P.eq x in
+    Printf.sprintf "(%s,%s)" (to_string P.t1 x1) (to_string P.t2 x2)
 ;;
 
 (* Wrapping maps *)

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -2890,40 +2890,40 @@ let t' = subst' d t
 type (_, _) eq = Refl : ('a, 'a) eq
 
 let magic : 'a 'b. 'a -> 'b =
-  fun (type a b) (x : a) ->
-   let module M =
-     (functor
-       (T : sig
-          type 'a t
-        end)
-       ->
-       struct
-         let f (Refl : (a T.t, b T.t) eq) = (x :> b)
+ fun (type a b) (x : a) ->
+  let module M =
+    (functor
+      (T : sig
+         type 'a t
        end)
-       (struct
-         type 'a t = unit
-       end)
-   in
-   M.f Refl
+      ->
+      struct
+        let f (Refl : (a T.t, b T.t) eq) = (x :> b)
+      end)
+      (struct
+        type 'a t = unit
+      end)
+  in
+  M.f Refl
 
 (* Variance and subtyping *)
 
 type (_, +_) eq = Refl : ('a, 'a) eq
 
 let magic : 'a 'b. 'a -> 'b =
-  fun (type a b) (x : a) ->
-   let bad_proof (type a) =
-     (Refl : (< m: a >, < m: a >) eq :> (< m: a >, < >) eq)
-   in
-   let downcast : type a. (a, < >) eq -> < > -> a =
-     fun (type a) (Refl : (a, < >) eq) (s : < >) -> (s :> a)
-   in
-   (downcast bad_proof
-      ( object
-          method m = x
-        end
-        :> < > ) )
-     #m
+ fun (type a b) (x : a) ->
+  let bad_proof (type a) =
+    (Refl : (< m: a >, < m: a >) eq :> (< m: a >, < >) eq)
+  in
+  let downcast : type a. (a, < >) eq -> < > -> a =
+   fun (type a) (Refl : (a, < >) eq) (s : < >) -> (s :> a)
+  in
+  (downcast bad_proof
+     ( object
+         method m = x
+       end
+       :> < > ) )
+    #m
 
 (* Record patterns *)
 
@@ -3362,13 +3362,13 @@ let pair (type s1 s2) t1 t2 =
 open Typ
 
 let rec to_string : 'a. 'a Typ.typ -> 'a -> string =
-  fun (type s) t x ->
-   match (t : s typ) with
-   | Int eq -> string_of_int (TypEq.apply eq x)
-   | String eq -> Printf.sprintf "%S" (TypEq.apply eq x)
-   | Pair (module P) ->
-       let x1, x2 = TypEq.apply P.eq x in
-       Printf.sprintf "(%s,%s)" (to_string P.t1 x1) (to_string P.t2 x2)
+ fun (type s) t x ->
+  match (t : s typ) with
+  | Int eq -> string_of_int (TypEq.apply eq x)
+  | String eq -> Printf.sprintf "%S" (TypEq.apply eq x)
+  | Pair (module P) ->
+      let x1, x2 = TypEq.apply P.eq x in
+      Printf.sprintf "(%s,%s)" (to_string P.t1 x1) (to_string P.t2 x2)
 
 (* Wrapping maps *)
 module type MapT = sig


### PR DESCRIPTION
Closes https://github.com/ocaml-ppx/ocamlformat/issues/2287

Formatting for Pexp_newtype must follow Pexp_fun for consistency.