### PR TITLE
GA: Reuse build artifacts when running test_branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,10 @@ jobs:
 
       - name: Check help files
         run: opam exec -- dune build @help --auto-promote
+
+      - name: Upload binary
+        if: ${{ matrix.platform.name == 'ubuntu-latest' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ocamlformat-${{ matrix.platform.name }}-${{ matrix.platform.target_arch }}
+          path: _build/install/default/bin/ocamlformat

--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -5,20 +5,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  test-branch:
+    needs: build
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-        ocaml-compiler:
-          # Don't include every versions. OCaml-CI already covers that
-          - 4.13.x
         profile:
           - conventional
           - ocamlformat
           - janestreet
-
-    runs-on: ${{ matrix.os }}
 
     steps:
       # Clone the project
@@ -26,15 +21,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Setup
-      - name: Setup OCaml ${{ matrix.ocaml-version }}
-        uses: ocaml/setup-ocaml@v2
+      - name: Fetch main build of ocamlformat
+        uses: dawidd6/action-download-artifact@v2
         with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          workflow: build.yml
+          branch: main
+          name: ocamlformat-${{ matrix.platform.name }}-${{ matrix.platform.target_arch }}
+          path: ocamlformat-a
 
-      - name: Opam dependencies
-        run: opam install --deps-only -t ./ocamlformat.opam
+      - name: Fetch new build of ocamlformat
+        uses: actions/download-artifact@v3
+        with:
+          name: ocamlformat-${{ matrix.platform.name }}-${{ matrix.platform.target_arch }}
+          path: ocamlformat-b
 
       - name: Test ${{ matrix.profile }} profile
-        run: opam exec -- ./tools/test_branch.sh -a origin/${{ github.event.pull_request.base.ref }} -b HEAD 'profile=${{ matrix.profile }}'
+        run: ./tools/test_branch.sh -n -a ocamlformat-a -b ocamlformat-b 'profile=${{ matrix.profile }}'
         shell: bash


### PR DESCRIPTION
Avoid building ocamlformat for every test_branch jobs. Artifacts are uploaded after the main build job and downloaded by the test_branch builds.

This is not ready for review. I'm opening a PR to debug more easily (triggers are unreliable on my fork)