### PR TITLE
Improve formatting of class signatures arrow-types

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2705,8 +2705,7 @@ and fmt_class_type c ({ast= typ; _} as xtyp) =
   Cmts.fmt c pcty_loc
   @@
   let parens = parenze_cty xtyp in
-  ( hvbox 0
-  @@ Params.parens_if parens c.conf
+  ( Params.parens_if parens c.conf
   @@
   let ctx = Cty typ in
   match pcty_desc with

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2721,8 +2721,8 @@ and fmt_class_type c ({ast= typ; _} as xtyp) =
       Cmts.relocate c.cmts ~src:pcty_loc
         ~before:(List.hd_exn ctl).pap_type.ptyp_loc ~after:ct2.pcty_loc ;
       let xct2 = sub_cty ~ctx ct2 in
-      list ctl "@;-> " (fmt_arrow_param c ctx)
-      $ fmt "@;-> "
+      list ctl (arrow_sep c ~parens) (fmt_arrow_param c ctx)
+      $ fmt (arrow_sep c ~parens)
       $ hvbox 0 (Cmts.fmt_before c ct2.pcty_loc $ fmt_class_type c xct2)
       $ fmt_attributes c atrs
   | Pcty_extension ext -> fmt_extension c ctx ext $ fmt_attributes c atrs

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -915,6 +915,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to class_sig.mli.stdout
+   (with-stderr-to class_sig.mli.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/class_sig.mli})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/class_sig.mli class_sig.mli.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/class_sig.mli.err class_sig.mli.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to class_type.ml.stdout
    (with-stderr-to class_type.ml.stderr
      (run %{bin:ocamlformat} --margin-check --max-iters=3 %{dep:tests/class_type.ml})))))

--- a/test/passing/tests/attributes.ml
+++ b/test/passing/tests/attributes.ml
@@ -152,9 +152,7 @@ let f y = fun [@test] y -> ()
 let (f [@test]) = fun y -> fun [@test] y -> ()
 
 module type T = sig
-  class subst :
-    ((ident -> ident)[@attr])
-    -> (ident -> ident)
+  class subst : ((ident -> ident)[@attr]) -> (ident -> ident)
     -> object
          inherit mapper
        end[@attr]

--- a/test/passing/tests/attributes.ml.err
+++ b/test/passing/tests/attributes.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/attributes.ml:342 exceeds the margin
+Warning: tests/attributes.ml:340 exceeds the margin

--- a/test/passing/tests/class_sig.mli
+++ b/test/passing/tests/class_sig.mli
@@ -1,5 +1,4 @@
-class c :
-  'a
+class c : 'a
   -> object
        val x : 'b
      end

--- a/test/passing/tests/class_sig.mli
+++ b/test/passing/tests/class_sig.mli
@@ -1,0 +1,5 @@
+class c :
+  'a
+  -> object
+       val x : 'b
+     end

--- a/test/passing/tests/class_type.ml.ref
+++ b/test/passing/tests/class_type.ml.ref
@@ -1,12 +1,10 @@
 class c : x -> y -> z = object end
 
-class c :
-  (* fooooooooooooo foooooooooo *) xxxxxxxxxxxxxx
+class c : (* fooooooooooooo foooooooooo *) xxxxxxxxxxxxxx
   -> (* fooooooooo foooooooooo *) yyyyyyyyyyyyyy
   -> (* fooooooooooooo fooooooooooo *) zzzzzzzzzzzzzzzzzz = object end
 
-class c :
-  (* fooooooooooooo foooooooooo *) xxxxxxxxxxxxxx (* fooooooooooo *)
+class c : (* fooooooooooooo foooooooooo *) xxxxxxxxxxxxxx (* fooooooooooo *)
   -> (* fooooooooo foooooooooo *) yyyyyyyyyyyyyy (* foooooooooooooo *)
   -> (* fooooooooooooo fooooooooooo *)
      zzzzzzzzzzzzzzzzzz

--- a/test/passing/tests/js_sig.mli
+++ b/test/passing/tests/js_sig.mli
@@ -13,3 +13,7 @@ exception Second_exception
 
 (** {e foooooooo oooooooooo ooooooooo ooooooooo} {{!some ref} fooooooooooooo
     oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
+
+class c : 'a -> object
+  val x : 'b
+end

--- a/test/passing/tests/js_sig.mli.ref
+++ b/test/passing/tests/js_sig.mli.ref
@@ -15,3 +15,9 @@ exception Second_exception
 
 (** {e foooooooo oooooooooo ooooooooo ooooooooo} {{!some ref} fooooooooooooo oooooooo
     oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
+
+class c :
+  'a
+  -> object
+       val x : 'b
+     end

--- a/test/passing/tests/js_sig.mli.ref
+++ b/test/passing/tests/js_sig.mli.ref
@@ -16,8 +16,7 @@ exception Second_exception
 (** {e foooooooo oooooooooo ooooooooo ooooooooo} {{!some ref} fooooooooooooo oooooooo
     oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
 
-class c :
-  'a
+class c : 'a
   -> object
        val x : 'b
      end

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,7 +1,7 @@
 Warning: tests/js_source.ml:156 exceeds the margin
 Warning: tests/js_source.ml:3558 exceeds the margin
-Warning: tests/js_source.ml:9542 exceeds the margin
-Warning: tests/js_source.ml:9645 exceeds the margin
-Warning: tests/js_source.ml:9664 exceeds the margin
-Warning: tests/js_source.ml:9704 exceeds the margin
-Warning: tests/js_source.ml:9786 exceeds the margin
+Warning: tests/js_source.ml:9539 exceeds the margin
+Warning: tests/js_source.ml:9642 exceeds the margin
+Warning: tests/js_source.ml:9661 exceeds the margin
+Warning: tests/js_source.ml:9701 exceeds the margin
+Warning: tests/js_source.ml:9783 exceeds the margin

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -6116,8 +6116,7 @@ let o =
 ;;
 
 module M : sig
-  class x :
-    int
+  class x : int
     -> object
       method m : int
     end
@@ -6129,8 +6128,7 @@ end = struct
 end
 
 module M : sig
-  class c :
-    'a
+  class c : 'a
     -> object
       val x : 'b
     end
@@ -7038,8 +7036,7 @@ end
 
 (* Bad (not regular) *)
 module rec M : sig
-  class ['a] c :
-    'a
+  class ['a] c : 'a
     -> object
       method map : ('a -> 'b) -> 'b M.c
     end

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -6116,8 +6116,7 @@ let o =
 ;;
 
 module M : sig
-  class x :
-    int
+  class x : int
     -> object
          method m : int
        end
@@ -6129,8 +6128,7 @@ end = struct
 end
 
 module M : sig
-  class c :
-    'a
+  class c : 'a
     -> object
          val x : 'b
        end
@@ -7038,8 +7036,7 @@ end
 
 (* Bad (not regular) *)
 module rec M : sig
-  class ['a] c :
-    'a
+  class ['a] c : 'a
     -> object
          method map : ('a -> 'b) -> 'b M.c
        end

--- a/test/passing/tests/object.ml
+++ b/test/passing/tests/object.ml
@@ -87,17 +87,12 @@ class t ~a =
 class type mapper = [%test]
 
 module type A = sig
-  class mapper :
-    int
-    -> x:int
-    -> ?y:int
+  class mapper : int -> x:int -> ?y:int
     -> object
          method xxxxxxxxxxxxxxxxxxxxxxxxxxx : int
        end
 
-  class tttttttttttt :
-    aaaaaaaaaaaaaaaaaa:int
-    -> bbbbbbbbbbbbbbbbbbbbb:float
+  class tttttttttttt : aaaaaaaaaaaaaaaaaa:int -> bbbbbbbbbbbbbbbbbbbbb:float
     -> cccccccccccccccccccc
 
   class c :

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -5889,8 +5889,7 @@ let o =
   end
 
 module M : sig
-  class x :
-    int
+  class x : int
     -> object
          method m : int
        end
@@ -5902,8 +5901,7 @@ end = struct
 end
 
 module M : sig
-  class c :
-    'a
+  class c : 'a
     -> object
          val x : 'b
        end
@@ -6818,8 +6816,7 @@ end
 
 (* Bad (not regular) *)
 module rec M : sig
-  class ['a] c :
-    'a
+  class ['a] c : 'a
     -> object
          method map : ('a -> 'b) -> 'b M.c
        end


### PR DESCRIPTION
Related to #2288

Minor improvement, although it can be argued it's worse when the arrow-type has more than 1 element that don't fit on the first line. I'm not really convinced by the new output either, this PR is open for discussion.

To really fix this issue we would need to break more things, especially having the "object" at the end of the line would be a more involved change (similar to using the `block` type like it's done for modules).