### PR TITLE
Shorter syntax for first class modules

### DIFF
--- a/lib/Extended_ast.ml
+++ b/lib/Extended_ast.ml
@@ -142,6 +142,7 @@ module Parse = struct
       | {ppat_desc= Ppat_record (fields, flag); _} as e ->
           let fields = List.map ~f:(pat_record_field m) fields in
           {e with ppat_desc= Ppat_record (fields, flag)}
+      (* [(module M) : (module T)] -> [(module M : T)] *)
       | { ppat_desc=
             Ppat_constraint
               ( {ppat_desc= Ppat_unpack (name, None); ppat_attributes= []; _}
@@ -184,6 +185,17 @@ module Parse = struct
              && not (Std_longident.is_monadic_binding longident) ->
           let label_loc = {txt= op; loc= loc_op} in
           {e with pexp_desc= Pexp_infix (label_loc, m.expr m l, m.expr m r)}
+      (* [(module M) : (module T)] -> [(module M : T)] *)
+      | { pexp_desc=
+            Pexp_constraint
+              ( {pexp_desc= Pexp_pack (name, None); pexp_attributes= []; pexp_loc; _}
+              , {ptyp_desc= Ptyp_package pt; ptyp_attributes= []; ptyp_loc; _} )
+        ; _ } as p when Migrate_ast.Location.compare_start ptyp_loc pexp_loc > 0 ->
+          (* Match locations to differentiate between the two position for the
+             constraint, we want to shorten the second:
+             - [let _ : (module S) = (module M)]
+             - [let _ = ((module M) : (module S))] *)
+          {p with pexp_desc= Pexp_pack (name, Some pt)}
       | e -> Ast_mapper.default_mapper.expr m e
     in
     Ast_mapper.{default_mapper with expr; pat; binding_op}

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -141,6 +141,11 @@ let make_mapper conf ~ignore_doc_comments =
           (Pat.or_ ~loc:loc1 ~attrs:attrs1
              (Pat.or_ ~loc:loc2 ~attrs:attrs2 pat1 pat2)
              pat3 )
+    | Ppat_constraint (pat1, {ptyp_desc= Ptyp_poly ([], _t); _}) ->
+        (* The parser put the same type constraint in two different nodes:
+           [let _ : typ = exp] is represented as [let _ : typ = (exp :
+           typ)]. *)
+        m.pat m pat1
     | _ -> Ast_mapper.default_mapper.pat m pat
   in
   let typ (m : Ast_mapper.mapper) typ =

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1981,7 +1981,7 @@
 (rule
  (alias runtest)
  (package ocamlformat)
- (action (diff tests/first_class_module.ml first_class_module.ml.stdout)))
+ (action (diff tests/first_class_module.ml.ref first_class_module.ml.stdout)))
 
 (rule
  (alias runtest)

--- a/test/passing/tests/first_class_module.ml.ref
+++ b/test/passing/tests/first_class_module.ml.ref
@@ -109,5 +109,7 @@ let _ =
 
 (* Three form that have an equivalent AST: *)
 let x : (module S) = (module M)
-let x = ((module M) : (module S))
+
+let x = (module M : S)
+
 let x = (module M : S)


### PR DESCRIPTION
Follow-up on  https://github.com/ocaml-ppx/ocamlformat/pull/2280, which implements patterns.

The long form for module packing is automatically rewritten into the
short form:

    let _ = ((module M) : (module S))
    let _ = (module M : S)

The following code has an equivalent AST but is not shortened:

    let _ : (module S) = (module M)