### PR TITLE
tools/printast: Print extended AST

### DIFF
--- a/lib/Extended_ast.ml
+++ b/lib/Extended_ast.ml
@@ -28,6 +28,18 @@ type 'a t =
   | Repl_file : repl_file t
   | Documentation : Odoc_parser.Ast.t t
 
+type any_t = Any : 'a t -> any_t [@@unboxed]
+
+let of_syntax = function
+  | Syntax.Structure -> Any Structure
+  | Signature -> Any Signature
+  | Use_file -> Any Use_file
+  | Core_type -> Any Core_type
+  | Module_type -> Any Module_type
+  | Expression -> Any Expression
+  | Repl_file -> Any Repl_file
+  | Documentation -> Any Documentation
+
 let equal (type a) (_ : a t) : a -> a -> bool = Poly.equal
 
 let map (type a) (x : a t) (m : Ast_mapper.mapper) : a -> a =

--- a/lib/Extended_ast.mli
+++ b/lib/Extended_ast.mli
@@ -27,6 +27,10 @@ type 'a t =
   | Repl_file : repl_file t
   | Documentation : Odoc_parser.Ast.t t
 
+type any_t = Any : 'a t -> any_t [@@unboxed]
+
+val of_syntax : Syntax.t -> any_t
+
 module Parse : sig
   val ast :
     'a t -> preserve_beginend:bool -> input_name:string -> string -> 'a

--- a/lib/Std_ast.ml
+++ b/lib/Std_ast.ml
@@ -25,6 +25,8 @@ type 'a t =
   | Repl_file : unit t
   | Documentation : unit t
 
+type any_t = Any : 'a t -> any_t
+
 let equal (type a) (_ : a t) : a -> a -> bool = Poly.equal
 
 let map (type a) (x : a t) (m : Ast_mapper.mapper) : a -> a =

--- a/lib/Std_ast.mli
+++ b/lib/Std_ast.mli
@@ -28,6 +28,8 @@ type 'a t =
   | Repl_file : unit t
   | Documentation : unit t
 
+type any_t = Any : 'a t -> any_t
+
 module Parse : sig
   val ast : 'a t -> input_name:string -> string -> 'a
 end

--- a/lib/Syntax.ml
+++ b/lib/Syntax.ml
@@ -18,3 +18,10 @@ type t =
   | Expression
   | Repl_file
   | Documentation
+
+let of_fname fname =
+  match Filename.extension fname with
+  | ".ml" | ".mlt" | ".eliom" -> Some Use_file
+  | ".mli" | ".eliomi" -> Some Signature
+  | ".mld" -> Some Documentation
+  | _ -> None

--- a/lib/Syntax.mli
+++ b/lib/Syntax.mli
@@ -19,5 +19,5 @@ type t =
   | Repl_file
   | Documentation
 
-(** The expected syntax of a file given its name. *)
 val of_fname : string -> t option
+(** The expected syntax of a file given its name. *)

--- a/lib/Syntax.mli
+++ b/lib/Syntax.mli
@@ -18,3 +18,6 @@ type t =
   | Expression
   | Repl_file
   | Documentation
+
+(** The expected syntax of a file given its name. *)
+val of_fname : string -> t option

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -478,8 +478,7 @@ let parse_and_format (type a b) (fg : a Extended_ast.t)
   in
   Ok (Eol_compat.normalize_eol ~exclude_locs:strlocs ~line_endings formatted)
 
-let std_of_extended (type a) : a Extended_ast.t -> Std_ast.any_t =
-  function
+let std_of_extended (type a) : a Extended_ast.t -> Std_ast.any_t = function
   | Extended_ast.Structure -> Std_ast.Any Std_ast.Structure
   | Signature -> Any Signature
   | Use_file -> Any Use_file
@@ -490,8 +489,8 @@ let std_of_extended (type a) : a Extended_ast.t -> Std_ast.any_t =
   | Documentation -> Any Documentation
 
 let parse_and_format syntax =
-  let Extended_ast.Any ext = Extended_ast.of_syntax syntax in
-  let Std_ast.Any std = std_of_extended ext in
+  let (Extended_ast.Any ext) = Extended_ast.of_syntax syntax in
+  let (Std_ast.Any std) = std_of_extended ext in
   parse_and_format ext std
 
 let numeric (type a b) (fg : a list Extended_ast.t)

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -478,15 +478,21 @@ let parse_and_format (type a b) (fg : a Extended_ast.t)
   in
   Ok (Eol_compat.normalize_eol ~exclude_locs:strlocs ~line_endings formatted)
 
-let parse_and_format = function
-  | Syntax.Structure -> parse_and_format Structure Structure
-  | Syntax.Signature -> parse_and_format Signature Signature
-  | Syntax.Use_file -> parse_and_format Use_file Use_file
-  | Syntax.Core_type -> parse_and_format Core_type Core_type
-  | Syntax.Module_type -> parse_and_format Module_type Module_type
-  | Syntax.Expression -> parse_and_format Expression Expression
-  | Syntax.Repl_file -> parse_and_format Repl_file Repl_file
-  | Syntax.Documentation -> parse_and_format Documentation Documentation
+let std_of_extended (type a) : a Extended_ast.t -> Std_ast.any_t =
+  function
+  | Extended_ast.Structure -> Std_ast.Any Std_ast.Structure
+  | Signature -> Any Signature
+  | Use_file -> Any Use_file
+  | Core_type -> Any Core_type
+  | Module_type -> Any Module_type
+  | Expression -> Any Expression
+  | Repl_file -> Any Repl_file
+  | Documentation -> Any Documentation
+
+let parse_and_format syntax =
+  let Extended_ast.Any ext = Extended_ast.of_syntax syntax in
+  let Std_ast.Any std = std_of_extended ext in
+  parse_and_format ext std
 
 let numeric (type a b) (fg : a list Extended_ast.t)
     (std_fg : b list Std_ast.t) ~input_name ~source ~range (conf : Conf.t) =

--- a/tools/printast/README.md
+++ b/tools/printast/README.md
@@ -1,6 +1,6 @@
 # printast
 
-Equivalent of `ocamlc -dparsetree` for the extended AST.
+Equivalent of `ocamlc -dparsetree` for the normalized extended AST.
 
 Usage:
 

--- a/tools/printast/README.md
+++ b/tools/printast/README.md
@@ -1,0 +1,9 @@
+# printast
+
+Equivalent of `ocamlc -dparsetree` for the extended AST.
+
+Usage:
+
+```
+dune exec -- tools/printast/printast.exe test.ml
+```

--- a/tools/printast/dune
+++ b/tools/printast/dune
@@ -1,3 +1,3 @@
 (executable
  (name printast)
- (libraries ocamlformat-lib.parser_extended))
+ (libraries ocamlformat-lib stdio))

--- a/tools/printast/dune
+++ b/tools/printast/dune
@@ -1,0 +1,3 @@
+(executable
+ (name printast)
+ (libraries ocamlformat-lib.parser_extended))

--- a/tools/printast/printast.ml
+++ b/tools/printast/printast.ml
@@ -21,6 +21,8 @@ let () =
   let inputf = get_arg () in
   let ppf, parser_name = get_ppf inputf in
   Printf.printf "Reading %S as %s\n" inputf parser_name ;
-  In_channel.with_open_text inputf (fun ic ->
+  let ic = open_in inputf in
+  let finally () = close_in ic in
+  Fun.protect (fun ic ->
       let lexbuf = Lexing.from_channel ic in
       ppf lexbuf )

--- a/tools/printast/printast.ml
+++ b/tools/printast/printast.ml
@@ -1,0 +1,26 @@
+open Parser_extended
+
+let get_arg () =
+  if Array.length Sys.argv < 2 then (
+    Printf.eprintf "Not enough argument\n" ;
+    exit 2 )
+  else Sys.argv.(1)
+
+let parse_and_print parsef printf lexbuf =
+  printf Format.std_formatter (parsef lexbuf)
+
+let get_ppf fname =
+  match Filename.extension fname with
+  | ".mli" ->
+      (parse_and_print Parse.interface Printast.interface, "interface")
+  | _ ->
+      ( parse_and_print Parse.implementation Printast.implementation
+      , "implementation" )
+
+let () =
+  let inputf = get_arg () in
+  let ppf, parser_name = get_ppf inputf in
+  Printf.printf "Reading %S as %s\n" inputf parser_name ;
+  In_channel.with_open_text inputf (fun ic ->
+      let lexbuf = Lexing.from_channel ic in
+      ppf lexbuf )

--- a/tools/printast/printast.ml
+++ b/tools/printast/printast.ml
@@ -10,9 +10,13 @@ let get_arg () =
 
 let () =
   let inputf = get_arg () in
-  let syntax = Option.value ~default:Syntax.Use_file (Syntax.of_fname inputf) in
-  let E.Any kind = E.of_syntax syntax in
-  Printf.printf "Reading %S\n" inputf;
+  let syntax =
+    Option.value ~default:Syntax.Use_file (Syntax.of_fname inputf)
+  in
+  let (E.Any kind) = E.of_syntax syntax in
+  Printf.printf "Reading %S\n" inputf ;
   let content = In_channel.read_all inputf in
-  let ast = E.Parse.ast kind ~preserve_beginend:true ~input_name:inputf content in
+  let ast =
+    E.Parse.ast kind ~preserve_beginend:true ~input_name:inputf content
+  in
   E.Printast.ast kind Format.std_formatter ast


### PR DESCRIPTION
This is the equivalent of `ocamlc -dparsetree` for out "extended AST".

Usage:

    dune exec -- tools/printast/printast.exe test.ml