### PR TITLE
Remove extra parentheses around module packs

### DIFF
--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -328,24 +328,29 @@ module A (* A *) () =
 
 let kk = (* foo *) (module A : T)
 
-let kk = ((* foo *) (module A : T))
+let kk = (module (* foo *) A : T)
 
-let kk = ((module A : T) (* foo *))
+let kk = (module A : T (* foo *))
 
-let kk = ((* foo *) (module A : T) (* foo *))
+let kk = (module (* foo *) A : T (* foo *))
 
 let kk =
   (* before exp *)
-  ((* before exp_pack *)
-   (module (* before A *) A (* after A *))
-   (* after exp_pack *) )
+  ( module (* before exp_pack *)
+           (* before A *)
+             A
+             (* after A *)
+             (* after exp_pack *) )
 (* after exp *)
 
 let kk =
   (* before exp *)
-  ((* before exp_pack *)
-   (module (* before A *) A (* after A *) : (* before S *) S (* after S *))
-   (* after exp_pack *) )
+  ( module (* before exp_pack *)
+           (* before A *)
+             A
+             (* after A *) : (* before S *) S
+  (* after S *)
+  (* after exp_pack *) )
 (* after exp *)
 
 let _ = assert (foo (bar + baz <= quux))

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7663,3 +7663,5 @@ let _ =
                                          eeee) -> FFFFFFFFF gg)
     ~h
 ;;
+
+let _ = f ((module M : S))

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9897,3 +9897,5 @@ let _ =
                                     -> FFFFFFFFF gg)
     ~h
 ;;
+
+let _ = f (module M : S)

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9897,3 +9897,5 @@ let _ =
       -> FFFFFFFFF gg)
     ~h
 ;;
+
+let _ = f (module M : S)

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -2202,10 +2202,7 @@ expr:
 
 simple_expr:
   | LPAREN e = seq_expr RPAREN
-      { match e.pexp_desc with
-        | Pexp_pack _ ->
-            mkexp ~loc:$sloc (Pexp_parens e)
-        | _ -> reloc_exp ~loc:$sloc e }
+      { reloc_exp ~loc:$sloc e }
   | LPAREN seq_expr error
       { unclosed "(" $loc($1) ")" $loc($3) }
   | LPAREN seq_expr type_constraint RPAREN

--- a/vendor/parser-recovery/lib/parser.mly
+++ b/vendor/parser-recovery/lib/parser.mly
@@ -2148,10 +2148,7 @@ expr [@recover.expr Annot.Exp.mk ()]:
 
 simple_expr:
   | LPAREN e = seq_expr RPAREN
-      { match e.pexp_desc with
-        | Pexp_pack _ ->
-            mkexp ~loc:$sloc (Pexp_parens e)
-        | _ -> reloc_exp ~loc:$sloc e }
+      { reloc_exp ~loc:$sloc e }
   | LPAREN seq_expr type_constraint RPAREN
       { mkexp_constraint ~loc:$sloc $2 $3 }
   | indexop_expr(DOT, seq_expr, { None })


### PR DESCRIPTION
The extra parentheses were preserved during formatting:

    let x = f ((module M : S))

This have been introduced in https://github.com/ocaml-ppx/ocamlformat/pull/2234 to fix comments.
This is a draft PR because it introduce regressions in comments.