### PR TITLE
test_branch: Run ocp-indent for the Janestreet profile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,10 @@ jobs:
           - conventional
           - ocamlformat
           - janestreet
+        include:
+          - test_branch_args:
+          - test_branch_args: -o
+            profile: janestreet
 
     steps:
       # Clone the project
@@ -79,5 +83,5 @@ jobs:
       - name: Test ${{ matrix.profile }} profile
         run: |
           chmod +x ocamlformat-a/ocamlformat ocamlformat-b/ocamlformat
-          ./tools/test_branch.sh -n -a ocamlformat-a/ocamlformat -b ocamlformat-b/ocamlformat 'profile=${{ matrix.profile }}'
+          ./tools/test_branch.sh ${{ matrix.test_branch_args }} -n -a ocamlformat-a/ocamlformat -b ocamlformat-b/ocamlformat 'profile=${{ matrix.profile }}'
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,12 +54,13 @@ jobs:
           - ocamlformat
           - janestreet
         include:
-          - test_branch_args:
-          - test_branch_args: -o
+          - ocp_indent: true
+            ocp_indent_config: JaneStreet
             profile: janestreet
 
     steps:
       - name: Install dependencies
+        if: ${{ matrix.ocp_indent }}
         run: sudo apt install -y ocp-indent
 
       # Clone the project
@@ -86,5 +87,8 @@ jobs:
       - name: Test ${{ matrix.profile }} profile
         run: |
           chmod +x ocamlformat-a/ocamlformat ocamlformat-b/ocamlformat
-          ./tools/test_branch.sh ${{ matrix.test_branch_args }} -n -a ocamlformat-a/ocamlformat -b ocamlformat-b/ocamlformat 'profile=${{ matrix.profile }}'
+          ./tools/test_branch.sh $TEST_BRANCH_ARGS -n -a ocamlformat-a/ocamlformat -b ocamlformat-b/ocamlformat 'profile=${{ matrix.profile }}'
         shell: bash
+        env:
+          OCP_INDENT_CONFIG: ${{ matrix.ocp_indent_config }}
+          TEST_BRANCH_ARGS: ${{ matrix.ocp_indent && "-o" || "" }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,9 @@ jobs:
             profile: janestreet
 
     steps:
+      - name: Install dependencies
+        run: apt install -y ocp-indent
+
       # Clone the project
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,4 +91,4 @@ jobs:
         shell: bash
         env:
           OCP_INDENT_CONFIG: ${{ matrix.ocp_indent_config }}
-          TEST_BRANCH_ARGS: ${{ matrix.ocp_indent && "-o" || "" }}
+          TEST_BRANCH_ARGS: ${{ matrix.ocp_indent && '-o' || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: apt install -y ocp-indent
+        run: sudo apt install -y ocp-indent
 
       # Clone the project
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,9 +59,11 @@ jobs:
             profile: janestreet
 
     steps:
-      - name: Install dependencies
+      - name: Install ocp-indent
         if: ${{ matrix.ocp_indent }}
-        run: sudo apt install -y ocp-indent
+        run: |
+          sudo apt install -y ocp-indent
+          sudo touch /etc/ocamlfind.conf
 
       # Clone the project
       - uses: actions/checkout@v3

--- a/test-extra/Makefile
+++ b/test-extra/Makefile
@@ -9,12 +9,17 @@
 #                                                                    #
 ######################################################################
 
-JS_DIRS=code/base code/base_bigstring code/base_quickcheck code/core code/core_bench code/core_compat code/core_extended code/core_kernel code/core_profiler code/core_unix
+JS_DIRS= \
+	code/base code/base_bigstring code/base_quickcheck code/core code/core_bench \
+	code/core_compat code/core_extended code/core_kernel code/core_profiler \
+	code/core_unix
 
 # To test all source files below a directory
 #       make DIRS=<directory> test
 # By default, test projects used as regression tests
-DIRS=code/ocamlformat code/infer code/js_of_ocaml code/dune code/owl code/irmin code/index code/dune-release code/mirage $(JS_DIRS)
+DIRS= \
+	code/ocamlformat code/infer code/js_of_ocaml code/dune code/owl \
+	code/irmin code/index code/dune-release code/mirage $(JS_DIRS)
 
 # Extra test directories, for which looser checking is done
 XDIRS=code/ocaml
@@ -24,7 +29,7 @@ PRUNE_DIRS= \
 	code/ocamlformat/test code/ocamlformat/vendor/parser-recovery \
 	code/ocaml/experimental code/ocaml/testsuite/tests/parse-errors \
 	code/dune/test code/dune/vendor code/dune/otherlibs code/dune/example \
-	code/infer/sledge/vendor/llvm-dune
+	code/infer/sledge/vendor/llvm-dune code/mirage/test code/owl
 
 ALL_DIRS=$(DIRS) $(XDIRS)
 
@@ -46,8 +51,6 @@ code/index: URI = https://github.com/mirage/index
 code/mirage: URI = https://github.com/mirage/mirage
 code/dune-release: URI = https://github.com/ocamllabs/dune-release
 code/owl: URI = https://github.com/owlbarn/owl
-
-PRUNE_DIRS += code/mirage/test code/owl
 
 code/base: URI = https://github.com/janestreet/base.git
 code/base_bigstring: URI = https://github.com/janestreet/base_bigstring.git
@@ -92,20 +95,20 @@ test_stage:
 .PHONY: test_unstage
 test_unstage:
 	@for dir in $(ALL_DIRS); do \
-	  git -C $$dir reset HEAD .; \
+	  git -C $$dir reset --quiet HEAD .; \
 	done
 
 .PHONY: test_clean
 test_clean:
 	@for dir in $(ALL_DIRS); do \
-	  git -C $$dir checkout -- .; \
-	  git -C $$dir clean -f; \
-	done
+	  git -C $$dir checkout --quiet -- .; \
+	  git -C $$dir clean --quiet -f; \
+	done 2>/dev/null
 
 .PHONY: test_pull
 test_pull:
 	@for dir in $(ALL_DIRS); do \
-	  git -C $$dir pull; \
+	  git -C $$dir pull --quiet; \
 	done
 
 FIND_ARGS= \
@@ -116,11 +119,11 @@ FIND_ARGS= \
 
 .PHONY: test_inplace
 test_inplace:
-	@find $(DIRS) $(FIND_ARGS) | parallel "$(OCAMLFORMAT_EXE)" --no-version-check --enable-outside-detected-project -i
+	@find $(DIRS) $(FIND_ARGS) | parallel "$(OCAMLFORMAT_EXE)" --no-version-check --enable-outside-detected-project --quiet -i
 
 .PHONY: test_extra
 test_extra:
-	@find $(XDIRS) $(FIND_ARGS) | parallel "$(OCAMLFORMAT_EXE)" --no-version-check --enable-outside-detected-project --quiet -i
+	@-find $(XDIRS) $(FIND_ARGS) | parallel "$(OCAMLFORMAT_EXE)" --no-version-check --enable-outside-detected-project --quiet -i
 
 .PHONY: test_margins
 test_margins:

--- a/test-extra/Makefile
+++ b/test-extra/Makefile
@@ -66,12 +66,9 @@ test_setup: $(ALL_DIRS)
 
 .PHONY: test
 test: test_setup
+	@echo "Running $(OCAMLFORMAT_EXE) with options '$(OCAMLFORMAT)'"
 	@$(MAKE) test_inplace
 	@-$(MAKE) test_extra
-	@for dir in $(ALL_DIRS); do \
-	  test -z "$$(git -C $$dir diff --quiet)" \
-	    || (echo FAIL test $$dir; exit 1); \
-	done
 
 .PHONY: test_status
 test_status:
@@ -128,3 +125,8 @@ test_extra:
 .PHONY: test_margins
 test_margins:
 	@for i in {100..40}; do echo $$i; OCAMLFORMAT_MARGIN=$$i $(MAKE) test || break; done
+
+.PHONY: apply_ocp
+apply_ocp:
+	@echo "Running ocp-indent with options '$(OCP_INDENT_CONFIG)'"
+	@-find $(ALL_DIRS) $(FIND_ARGS) | parallel ocp-indent --inplace

--- a/test-extra/Makefile
+++ b/test-extra/Makefile
@@ -132,4 +132,4 @@ test_margins:
 .PHONY: apply_ocp
 apply_ocp:
 	@echo "Running ocp-indent with options '$(OCP_INDENT_CONFIG)'"
-	@-find $(ALL_DIRS) $(FIND_ARGS) | parallel ocp-indent --inplace
+	@-find $(ALL_DIRS) $(FIND_ARGS) | parallel ocp-indent --config "$(OCP_INDENT_CONFIG)" --inplace

--- a/tools/test_branch.sh
+++ b/tools/test_branch.sh
@@ -11,7 +11,7 @@
 #                                                                    #
 ######################################################################
 
-# usage: test_branch.sh [-n] [-o] [-a=rev] [-b=rev] [<option>=<value>*] [<option>=<value>*]
+# usage: test_branch.sh [-n] [-o] [-l] [-a=rev] [-b=rev] [<option>=<value>*] [<option>=<value>*]
 #
 # -a set the base branch and -b the test branch. The default value for
 # the base branch is the merge-base between the test branch and main.
@@ -23,6 +23,9 @@
 # If -o is passed, ocp-indent is applied after ocamlformat in each pass.
 # Options can be passed to it using the 'OCP_INDENT_CONFIG' environment
 # variable.
+#
+# If -l is passed, it will not pull the latest version of the source code used
+# for testing.
 #
 # The first arg is the value of OCAMLFORMAT to be used when formatting
 # using the base branch (a)
@@ -38,12 +41,14 @@ arg_a=
 arg_b=
 arg_n=0
 arg_o=0
-while getopts "a:b:no" opt; do
+arg_l=0
+while getopts "a:b:nol" opt; do
   case "$opt" in
     a) arg_a=$OPTARG ;;
     b) arg_b=$OPTARG ;;
     n) arg_n=1 ;;
     o) arg_o=1 ;;
+    l) arg_l=1 ;;
   esac
 done
 shift $((OPTIND-1))
@@ -97,7 +102,10 @@ else
   exe_b=`realpath $arg_b`
 fi
 
-make -C test-extra test_setup test_unstage test_clean test_pull
+make -C test-extra test_setup test_unstage test_clean
+if [[ $arg_l -eq 0 ]]; then
+  make -C test-extra test_pull
+fi
 
 apply_ocp=()
 if [[ $arg_o -eq 1 ]]; then apply_ocp=(apply_ocp); fi

--- a/tools/test_branch.sh
+++ b/tools/test_branch.sh
@@ -11,7 +11,7 @@
 #                                                                    #
 ######################################################################
 
-# usage: test_branch.sh [-n] [-a=rev] [-b=rev] [<option>=<value>*] [<option>=<value>*]
+# usage: test_branch.sh [-n] [-o] [-a=rev] [-b=rev] [<option>=<value>*] [<option>=<value>*]
 #
 # -a set the base branch and -b the test branch. The default value for
 # the base branch is the merge-base between the test branch and main.
@@ -19,6 +19,10 @@
 #
 # If -n is passed, values of -a and -b are paths to ocamlformat binaries
 # instead of revs.
+#
+# If -o is passed, ocp-indent is applied after ocamlformat in each pass.
+# Options can be passed to it using the 'OCP_INDENT_CONFIG' environment
+# variable.
 #
 # The first arg is the value of OCAMLFORMAT to be used when formatting
 # using the base branch (a)
@@ -33,11 +37,13 @@ set -e
 arg_a=
 arg_b=
 arg_n=0
-while getopts "a:b:n" opt; do
+arg_o=0
+while getopts "a:b:no" opt; do
   case "$opt" in
     a) arg_a=$OPTARG ;;
     b) arg_b=$OPTARG ;;
     n) arg_n=1 ;;
+    o) arg_o=1 ;;
   esac
 done
 shift $((OPTIND-1))
@@ -93,5 +99,8 @@ fi
 
 make -C test-extra test_setup test_unstage test_clean test_pull
 
-OCAMLFORMAT="$opts_a" make -C test-extra "OCAMLFORMAT_EXE=$exe_a" test test_stage
-OCAMLFORMAT="$opts_b" make -C test-extra "OCAMLFORMAT_EXE=$exe_b" test test_diff
+apply_ocp=()
+if [[ $arg_o -eq 1 ]]; then apply_ocp=(apply_ocp); fi
+
+OCAMLFORMAT="$opts_a" make -C test-extra "OCAMLFORMAT_EXE=$exe_a" test "${apply_ocp[@]}" test_stage
+OCAMLFORMAT="$opts_b" make -C test-extra "OCAMLFORMAT_EXE=$exe_b" test "${apply_ocp[@]}" test_diff


### PR DESCRIPTION
Allow to run ocp-indent after each formatting steps on test_branch. This is used in CI for the `janestreet` profile.

Also add an option to `test_branch.sh` avoid pulling repositories and reduce the amount of logs. This is useful when running locally.