### PR TITLE
Avoid breaking after the 'mutable' keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 
 - Consistent indentation of `fun (type a) ->` that follow `fun x ->` (#2294, @Julow)
 - Avoid adding breaks inside `~label:(fun` and base the indentation on the label. (#2271, #2291, #2293, #2298, @Julow)
-- Fix non-stabilizing comments attached to private/virtual/mutable keywords (#2272, @gpetiot)
+- Fix non-stabilizing comments attached to private/virtual/mutable keywords (#2272, #2307, @gpetiot, @Julow)
 - Fix formatting of comments in "disable" chunks (#2279, @gpetiot)
 - Fix indentation of trailing double-semicolons (#2295, @gpetiot)
 - Remove extra parentheses around module packs (#2305, @Julow, @gpetiot)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -347,8 +347,8 @@ let fmt_private ?(pro = fmt "@ ") c loc =
 let fmt_virtual ?(pro = fmt "@ ") c loc =
   pro $ hvbox 0 @@ Cmts.fmt c loc @@ str "virtual"
 
-let fmt_mutable ?(pro = fmt "@ ") c loc =
-  pro $ hvbox 0 @@ Cmts.fmt c loc @@ str "mutable"
+let fmt_mutable ?(pro = fmt "@ ") ?(epi = noop) c loc =
+  pro $ hvbox 0 (Cmts.fmt c loc (str "mutable")) $ epi
 
 let fmt_private_flag c = function
   | Private loc -> fmt_private c loc
@@ -358,8 +358,8 @@ let fmt_virtual_flag c = function
   | Virtual loc -> fmt_virtual c loc
   | Concrete -> noop
 
-let fmt_mutable_flag c = function
-  | Mutable loc -> fmt_mutable ~pro:noop c loc $ fmt "@ "
+let fmt_mutable_flag ?pro ?epi c = function
+  | Mutable loc -> fmt_mutable ?pro ?epi c loc
   | Immutable -> noop
 
 let fmt_mutable_virtual_flag c = function
@@ -3226,9 +3226,12 @@ and fmt_label_declaration c ctx ?(last = false) decl =
         ( hvbox 3
             ( hvbox 4
                 ( hvbox 2
-                    ( fmt_mutable_flag c pld_mutable
-                    $ fmt_str_loc c pld_name $ fmt_if field_loose " "
-                    $ fmt ":@ "
+                    ( hovbox 2
+                        ( fmt_mutable_flag ~pro:noop ~epi:(fmt "@ ") c
+                            pld_mutable
+                        $ fmt_str_loc c pld_name $ fmt_if field_loose " "
+                        $ fmt ":" )
+                    $ fmt "@ "
                     $ fmt_core_type c (sub_typ ~ctx pld_type)
                     $ fmt_semicolon )
                 $ cmt_after_type )

--- a/test/passing/tests/comments_in_record.ml
+++ b/test/passing/tests/comments_in_record.ml
@@ -80,3 +80,22 @@ type program =
     prog_struct_types : lltype list;  (* data structures *)
     prog_lib_funcs : func list;       (* library functions *)
   }
+
+type t =
+  { mutable ci_fixed: IntervalSet.t
+  ; mutable ci_spilled:
+      (* spilled stack slots (reg.loc = Stack (Local n)) still in use *)
+      IntervalSet.t }
+
+type t =
+  { mutable ci_fixed: IntervalSet.t
+  ; mutable
+      (* spilled stack slots (reg.loc = Stack (Local n)) still in use *)
+      ci_spilled:
+      IntervalSet.t }
+
+type t =
+  { mutable ci_fixed: IntervalSet.t
+  ; mutable ci_spilled
+      (* spilled stack slots (reg.loc = Stack (Local n)) still in use *):
+      IntervalSet.t }

--- a/test/passing/tests/comments_in_record.ml.ref
+++ b/test/passing/tests/comments_in_record.ml.ref
@@ -79,3 +79,24 @@ type program =
   { prog_globals: global list (* global variables *)
   ; prog_struct_types: lltype list (* data structures *)
   ; prog_lib_funcs: func list (* library functions *) }
+
+type t =
+  { mutable ci_fixed: IntervalSet.t
+  ; mutable
+      ci_spilled:
+      (* spilled stack slots (reg.loc = Stack (Local n)) still in use *)
+      IntervalSet.t }
+
+type t =
+  { mutable ci_fixed: IntervalSet.t
+  ; mutable
+      (* spilled stack slots (reg.loc = Stack (Local n)) still in use *)
+      ci_spilled:
+      IntervalSet.t }
+
+type t =
+  { mutable ci_fixed: IntervalSet.t
+  ; mutable
+      ci_spilled
+      (* spilled stack slots (reg.loc = Stack (Local n)) still in use *):
+      IntervalSet.t }

--- a/test/passing/tests/comments_in_record.ml.ref
+++ b/test/passing/tests/comments_in_record.ml.ref
@@ -82,8 +82,7 @@ type program =
 
 type t =
   { mutable ci_fixed: IntervalSet.t
-  ; mutable
-      ci_spilled:
+  ; mutable ci_spilled:
       (* spilled stack slots (reg.loc = Stack (Local n)) still in use *)
       IntervalSet.t }
 
@@ -96,7 +95,6 @@ type t =
 
 type t =
   { mutable ci_fixed: IntervalSet.t
-  ; mutable
-      ci_spilled
+  ; mutable ci_spilled
       (* spilled stack slots (reg.loc = Stack (Local n)) still in use *):
       IntervalSet.t }


### PR DESCRIPTION
The mutable keyword is allowed to break due to comment. Make sure this happen only when necessary.