### PR TITLE
Remove double parenthesis around tuple in a match

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ### Bug fixes
 
+- Remove double parenthesis around tuple in a match (#2308, @Julow)
 - Consistent indentation of `fun (type a) ->` that follow `fun x ->` (#2294, @Julow)
 - Avoid adding breaks inside `~label:(fun` and base the indentation on the label. (#2271, #2291, #2293, #2298, @Julow)
 - Fix non-stabilizing comments attached to private/virtual/mutable keywords (#2272, @gpetiot)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3006,11 +3006,16 @@ and fmt_case c ctx ~first ~last case =
     | (Pexp_match _ | Pexp_try _), `Align -> last
     | _ -> false
   in
-  let symbol_parens = Exp.is_symbol xrhs.ast in
+  let body_has_parens =
+    match xrhs.ast.pexp_desc with
+    | Pexp_tuple _ when Poly.(c.conf.fmt_opts.parens_tuple.v = `Always) ->
+        true
+    | _ -> Exp.is_symbol xrhs.ast
+  in
   let parens_branch, parens_for_exp =
     if align_nested_match then (false, Some false)
     else if c.conf.fmt_opts.leading_nested_match_parens.v then (false, None)
-    else (parenze_exp xrhs && not symbol_parens, Some false)
+    else (parenze_exp xrhs && not body_has_parens, Some false)
   in
   (* side effects of Cmts.fmt_before before [fmt_lhs] is important *)
   let leading_cmt = Cmts.fmt_before c pc_lhs.ppat_loc in

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -45,13 +45,14 @@ type cases =
   ; break_after_arrow: Fmt.t
   ; open_paren_branch: Fmt.t
   ; break_after_opening_paren: Fmt.t
+  ; expr_parens: bool option
   ; close_paren_branch: Fmt.t }
 
 val get_cases :
      Conf.t
+  -> ctx:Ast.t
   -> first:bool
-  -> indent:int
-  -> parens_branch:bool
+  -> last:bool
   -> xbch:expression Ast.xt
   -> cases
 

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -1790,12 +1790,12 @@ let rec del_min : type n. n succ avl -> int * (n avl, n succ avl) sum =
   | Node (bal, (Node _ as l), x, r) -> (
     match del_min l with
     | y, Inr l -> (y, Inr (Node (bal, l, x, r)))
-    | y, Inl l -> (
+    | y, Inl l ->
         ( y
         , match bal with
           | Same -> Inr (Node (Less, l, x, r))
           | More -> Inl (Node (Same, l, x, r))
-          | Less -> rotl l x r ) ) )
+          | Less -> rotl l x r ) )
 
 type _ avl_del =
   | Dsame : 'n avl -> 'n avl_del


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/2278

The formatting for tuples doesn't respect the `~parens` mechanism due to the `parens_tuple` option.
It's not implemented in `Ast` because it depends on an option. Perhaps we need a new mechanism on top ?