### PR TITLE
Remove parens around match sugared type constraint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@
 
 - Restore short form for first-class modules: `((module M) : (module S))` is formatted as `(module M : S)`) (#2280, #2300, @gpetiot, @Julow)
 - Restore short form formatting of record field aliases (#2282, @gpetiot)
-- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2281, #2284, #2289, #2299, #2302, @gpetiot, @Julow)
+- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2281, #2284, #2289, #2299, #2302, #2310, @gpetiot, @Julow)
 - Improve formatting of class signatures (#2301, @gpetiot, @Julow)
 
 ### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -699,16 +699,16 @@ and fmt_type_cstr c ?constraint_ctx xtyp =
 
 and type_constr_and_body c xbody =
   let body = xbody.ast in
-  let ctx = Exp body in
-  let fmt_cstr_and_xbody typ exp =
-    ( Some (fmt_type_cstr c ~constraint_ctx:`Fun (sub_typ ~ctx typ))
-    , sub_exp ~ctx exp )
-  in
   match xbody.ast.pexp_desc with
   | Pexp_constraint (exp, typ) ->
       Cmts.relocate c.cmts ~src:body.pexp_loc ~before:exp.pexp_loc
         ~after:exp.pexp_loc ;
-      fmt_cstr_and_xbody typ exp
+      let typ_ctx = Exp body in
+      let exp_ctx =
+        Exp Ast_helper.(Exp.fun_ Nolabel None (Pat.any ()) exp)
+      in
+      ( Some (fmt_type_cstr c ~constraint_ctx:`Fun (sub_typ ~ctx:typ_ctx typ))
+      , sub_exp ~ctx:exp_ctx exp )
   | _ -> (None, xbody)
 
 and fmt_arrow_param c ctx {pap_label= lI; pap_loc= locI; pap_type= tI} =

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7663,3 +7663,12 @@ let _ =
                                          eeee) -> FFFFFFFFF gg)
     ~h
 ;;
+
+let _ =
+  fooooooooooooooooooooooooooooooooooooooo
+    fooooooooooooooooooooooooooooooooooooooo
+    fooooooooooooooooooooooooooooooooooooooo
+    ~f:(fun (type a) foooooooooooooooooooooooooooooooooo : 'a ->
+      match fooooooooooooooooooooooooooooooooooooooo with
+      | Fooooooooooooooooooooooooooooooooooooooo -> x
+      | Fooooooooooooooooooooooooooooooooooooooo -> x )

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9871,3 +9871,13 @@ let _ =
         (_ : (ccccccccccccc * ddddddddddddddddddddddddddddd) eeee) -> FFFFFFFFF gg)
     ~h
 ;;
+
+let _ =
+  fooooooooooooooooooooooooooooooooooooooo
+    fooooooooooooooooooooooooooooooooooooooo
+    fooooooooooooooooooooooooooooooooooooooo
+    ~f:(fun (type a) foooooooooooooooooooooooooooooooooo : 'a ->
+      match fooooooooooooooooooooooooooooooooooooooo with
+      | Fooooooooooooooooooooooooooooooooooooooo -> x
+      | Fooooooooooooooooooooooooooooooooooooooo -> x)
+;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9871,3 +9871,13 @@ let _ =
         (_ : (ccccccccccccc * ddddddddddddddddddddddddddddd) eeee) -> FFFFFFFFF gg)
     ~h
 ;;
+
+let _ =
+  fooooooooooooooooooooooooooooooooooooooo
+    fooooooooooooooooooooooooooooooooooooooo
+    fooooooooooooooooooooooooooooooooooooooo
+    ~f:(fun (type a) foooooooooooooooooooooooooooooooooo : 'a ->
+      match fooooooooooooooooooooooooooooooooooooooo with
+      | Fooooooooooooooooooooooooooooooooooooooo -> x
+      | Fooooooooooooooooooooooooooooooooooooooo -> x)
+;;


### PR DESCRIPTION
    fun a : t ->
      match b with

The AST for the code above looks like

    Pexp_fun (<a>, Pexp_constraint (Pexp_match _, <t>))

We must not use it as a context as this would add parenthesis in ocp-indent-compat mode. Instead, create a ghost expression that do not contain `Pexp_constraint` and use that as the context for the `match`.