### PR TITLE
ocp-indent-compat: Docked match after infix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@
 
 - Restore short form for first-class modules: `((module M) : (module S))` is formatted as `(module M : S)`) (#2280, #2300, @gpetiot, @Julow)
 - Restore short form formatting of record field aliases (#2282, @gpetiot)
-- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2281, #2284, #2289, #2299, #2302, #2309, #2310, #2311, #2313, @gpetiot, @Julow)
+- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2281, #2284, #2289, #2299, #2302, #2309, #2310, #2311, #2313, #2316, @gpetiot, @Julow)
 - Improve formatting of class signatures (#2301, @gpetiot, @Julow)
 
 ### New features

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1629,7 +1629,7 @@ and fmt_pat_cons c ~parens args =
 
 and fmt_match c ?epi ~parens ?ext ctx xexp cs e0 keyword =
   let ctx0 = xexp.ctx in
-  let indent = Params.match_indent c.conf ~ctx:ctx0 in
+  let indent = Params.match_indent c.conf ~parens ~ctx:ctx0 in
   hvbox indent
     ( fmt_opt epi
     $ Params.Exp.wrap c.conf ~parens ~disambiguate:true

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1627,19 +1627,21 @@ and fmt_pat_cons c ~parens args =
   Params.Exp.Infix_op_arg.wrap c.conf ~parens ~parens_nested:false
     (list_fl groups fmt_op_arg_group)
 
-and fmt_match c ~parens ?ext ctx xexp cs e0 keyword =
-  let indent = Params.match_indent c.conf ~ctx:xexp.ctx in
+and fmt_match c ?epi ~parens ?ext ctx xexp cs e0 keyword =
+  let ctx0 = xexp.ctx in
+  let indent = Params.match_indent c.conf ~ctx:ctx0 in
   hvbox indent
-    ( Params.Exp.wrap c.conf ~parens ~disambiguate:true
-    @@ Params.Align.match_ c.conf
-    @@ ( hvbox 0
-           ( str keyword
-           $ fmt_extension_suffix c ext
-           $ fmt_attributes c xexp.ast.pexp_attributes
-           $ fmt "@;<1 2>"
-           $ fmt_expression c (sub_exp ~ctx e0)
-           $ fmt "@ with" )
-       $ fmt "@ " $ fmt_cases c ctx cs ) )
+    ( fmt_opt epi
+    $ Params.Exp.wrap c.conf ~parens ~disambiguate:true
+      @@ Params.Align.match_ c.conf ~xexp
+      @@ ( hvbox 0
+             ( str keyword
+             $ fmt_extension_suffix c ext
+             $ fmt_attributes c xexp.ast.pexp_attributes
+             $ fmt "@;<1 2>"
+             $ fmt_expression c (sub_exp ~ctx e0)
+             $ fmt "@ with" )
+         $ fmt "@ " $ fmt_cases c ctx cs ) )
 
 and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
     ?ext ({ast= exp; ctx= ctx0} as xexp) =
@@ -2357,8 +2359,9 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                | `No -> ")"
                | `Space -> " )"
                | `Closing_on_separate_line -> "@;<1000 -2>)" ) ) )
-  | Pexp_match (e0, cs) -> fmt_match c ~parens ?ext ctx xexp cs e0 "match"
-  | Pexp_try (e0, cs) -> fmt_match c ~parens ?ext ctx xexp cs e0 "try"
+  | Pexp_match (e0, cs) ->
+      fmt_match c ?epi ~parens ?ext ctx xexp cs e0 "match"
+  | Pexp_try (e0, cs) -> fmt_match c ?epi ~parens ?ext ctx xexp cs e0 "try"
   | Pexp_pack (me, pt) ->
       let outer_parens = parens && has_attr in
       let inner_parens = true in

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -57,6 +57,7 @@ module Exp = struct
             ->
               true
           | _ -> false )
+        | Pexp_match _ | Pexp_try _ -> true
         | _ -> false
   end
 
@@ -529,6 +530,9 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
 let match_indent ?(default = 0) (c : Conf.t) ~(ctx : Ast.t) =
   match (c.fmt_opts.match_indent_nested.v, ctx) with
   | `Always, _ | _, (Top | Sig _ | Str _) -> c.fmt_opts.match_indent.v
+  | _, Exp {pexp_desc= Pexp_infix _; _} when c.fmt_opts.ocp_indent_compat.v
+    ->
+      2 (* Match is docked *)
   | _ -> default
 
 let function_indent ?(default = 0) (c : Conf.t) ~(ctx : Ast.t) =
@@ -560,7 +564,16 @@ module Align = struct
 
   let infix_op = general
 
-  let match_ = general
+  let match_ (c : Conf.t) ~xexp:{ast; ctx} t =
+    (* Matches on the RHS of an infix are docked in ocp-indent-compat. *)
+    let docked =
+      match ctx with
+      | Exp {pexp_desc= Pexp_infix (_, _, rhs); _} when phys_equal rhs ast ->
+          c.fmt_opts.ocp_indent_compat.v
+      | _ -> false
+    in
+    let align = (not c.fmt_opts.align_symbol_open_paren.v) && not docked in
+    hvbox_if align 0 t
 
   let function_ (c : Conf.t) ~parens ~(ctx0 : Ast.t) ~self t =
     let align =

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -527,11 +527,11 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
       ; break_end_branch= noop
       ; space_between_branches= fmt "@ " }
 
-let match_indent ?(default = 0) (c : Conf.t) ~(ctx : Ast.t) =
+let match_indent ?(default = 0) (c : Conf.t) ~parens ~(ctx : Ast.t) =
   match (c.fmt_opts.match_indent_nested.v, ctx) with
   | `Always, _ | _, (Top | Sig _ | Str _) -> c.fmt_opts.match_indent.v
-  | _, Exp {pexp_desc= Pexp_infix _; _} when c.fmt_opts.ocp_indent_compat.v
-    ->
+  | _, Exp {pexp_desc= Pexp_infix _; _}
+    when c.fmt_opts.ocp_indent_compat.v && parens ->
       2 (* Match is docked *)
   | _ -> default
 

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -124,7 +124,7 @@ val get_if_then_else :
   -> fmt_cond:(expression Ast.xt -> Fmt.t)
   -> if_then_else
 
-val match_indent : ?default:int -> Conf.t -> ctx:Ast.t -> int
+val match_indent : ?default:int -> Conf.t -> parens:bool -> ctx:Ast.t -> int
 (** [match_indent c ~ctx ~default] returns the indentation used for the
     pattern-matching in context [ctx], depending on the `match-indent-nested`
     option, or using the [default] indentation (0 if not provided) if the

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -148,7 +148,7 @@ module Align : sig
 
   val infix_op : Conf.t -> Fmt.t -> Fmt.t
 
-  val match_ : Conf.t -> Fmt.t -> Fmt.t
+  val match_ : Conf.t -> xexp:expression Ast.xt -> Fmt.t -> Fmt.t
 
   val function_ :
     Conf.t -> parens:bool -> ctx0:Ast.t -> self:expression -> Fmt.t -> Fmt.t

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7762,3 +7762,10 @@ let _ =
   $$ ( try group with [] -> impossible "previous match"
     | [cmt] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt )
   $$ bar
+
+let _ =
+  x == exp
+  ||
+  match x with
+  | {pexp_desc= Pexp_constraint (e, _); _} -> loop e
+  | _ -> false

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7750,3 +7750,15 @@ end = struct
   external unsafe_memset : t -> pos:int -> len:int -> char -> unit = "bigstring_memset_stub"
   [@@noalloc]
 end
+
+let _ =
+  foo
+  $$ ( match group with [] -> impossible "previous match"
+    | [cmt] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt )
+  $$ bar
+
+let _ =
+  foo
+  $$ ( try group with [] -> impossible "previous match"
+    | [cmt] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt )
+  $$ bar

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9974,3 +9974,19 @@ end = struct
     = "bigstring_memset_stub"
   [@@noalloc]
 end
+
+let _ =
+  foo
+  $$ (match group with
+    | [] -> impossible "previous match"
+    | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
+  $$ bar
+;;
+
+let _ =
+  foo
+  $$ (try group with
+    | [] -> impossible "previous match"
+    | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
+  $$ bar
+;;

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9990,3 +9990,11 @@ let _ =
     | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
   $$ bar
 ;;
+
+let _ =
+  x == exp
+  ||
+  match x with
+  | { pexp_desc = Pexp_constraint (e, _); _ } -> loop e
+  | _ -> false
+;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9974,3 +9974,19 @@ end = struct
     = "bigstring_memset_stub"
   [@@noalloc]
 end
+
+let _ =
+  foo
+  $$ (match group with
+    | [] -> impossible "previous match"
+    | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
+  $$ bar
+;;
+
+let _ =
+  foo
+  $$ (try group with
+    | [] -> impossible "previous match"
+    | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
+  $$ bar
+;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9990,3 +9990,11 @@ let _ =
     | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
   $$ bar
 ;;
+
+let _ =
+  x == exp
+  ||
+  match x with
+  | { pexp_desc = Pexp_constraint (e, _); _ } -> loop e
+  | _ -> false
+;;


### PR DESCRIPTION
This implements the `~epi` mechanism for matches.

Some care is needed to disable alignment and set the right indentation for potentially docked matches.