### PR TITLE
[debug] Output the *.boxes.ml filenames on stderr

### DIFF
--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -275,10 +275,13 @@ let format (type a b) (fg : a Extended_ast.t) (std_fg : b Std_ast.t)
       in
       (contents, cmts_t)
     in
-    if conf.opr_opts.debug.v then
-      format ~box_debug:true |> fst
-      |> dump_formatted ~suffix:".boxes"
-      |> (ignore : string option -> unit) ;
+    ( if conf.opr_opts.debug.v then
+        format ~box_debug:true |> fst
+        |> dump_formatted ~suffix:".boxes"
+        |> function
+        | Some file ->
+            if i = 1 then Format.eprintf "[DEBUG] Box structure: %s\n" file
+        | None -> () ) ;
     let fmted, cmts_t = format ~box_debug:false in
     let conf =
       if conf.opr_opts.debug.v then conf

--- a/test/cli/debug.t
+++ b/test/cli/debug.t
@@ -7,7 +7,7 @@
   >     A.x
   > EOF
 
-  $ (ocamlformat --debug a.ml) 2>&1 | sed 's/\/.*\/\(.*\.boxes\.ml\)/<tmp>\/\1/'
+  $ (ocamlformat --debug a.ml) 2>&1 | sed 's/\([^ ]*\.boxes\.ml$\)/<file>.boxes.ml/g'
   AST:
   Ptop_def
     [
@@ -35,7 +35,7 @@
         ]
     ]
   
-  [DEBUG] Box structure: <tmp>/a.boxes.ml
+  [DEBUG] Box structure: <file>.boxes.ml
   AST:
   Ptop_def
     [
@@ -130,7 +130,7 @@
   > (* after let-binding *)
   > EOF
 
-  $ (ocamlformat --debug a.ml) 2>&1 | sed 's/\/.*\/\(.*\.boxes\.ml\)/<tmp>\/\1/'
+  $ (ocamlformat --debug a.ml) 2>&1 | sed 's/\([^ ]*\.boxes\.ml$\)/<file>.boxes.ml/g'
   AST:
   Ptop_def
     [
@@ -183,7 +183,7 @@
         ]
     ]
   
-  [DEBUG] Box structure: <tmp>/a.boxes.ml
+  [DEBUG] Box structure: <file>.boxes.ml
   AST:
   Ptop_def
     [

--- a/test/cli/debug.t
+++ b/test/cli/debug.t
@@ -7,7 +7,7 @@
   >     A.x
   > EOF
 
-  $ ocamlformat --debug a.ml
+  $ (ocamlformat --debug a.ml) 2>&1 | sed 's/\/.*\/\(.*\.boxes\.ml\)/<tmp>\/\1/'
   AST:
   Ptop_def
     [
@@ -35,6 +35,7 @@
         ]
     ]
   
+  [DEBUG] Box structure: <tmp>/a.boxes.ml
   AST:
   Ptop_def
     [
@@ -129,7 +130,7 @@
   > (* after let-binding *)
   > EOF
 
-  $ ocamlformat --debug a.ml
+  $ (ocamlformat --debug a.ml) 2>&1 | sed 's/\/.*\/\(.*\.boxes\.ml\)/<tmp>\/\1/'
   AST:
   Ptop_def
     [
@@ -182,6 +183,7 @@
         ]
     ]
   
+  [DEBUG] Box structure: <tmp>/a.boxes.ml
   AST:
   Ptop_def
     [

--- a/test/cli/dune
+++ b/test/cli/dune
@@ -3,6 +3,6 @@
  (deps %{bin:ocamlformat}))
 
 (cram
- (applies_to large_string conf removed_option repl_file_errors)
+ (applies_to large_string conf removed_option repl_file_errors debug)
  (enabled_if
   (<> %{os_type} Win32)))


### PR DESCRIPTION
I've got a path that is hard to guess (`/var/folders/0w/1cq3286x3953d_fkq269nsv00000gn/T/js2.boxes.ml`) when debugging the box structure. That would be useful to output the filename (it is even clickable in VS code).

In the future, maybe add a dependency to `Logs` for nicer messages?

Edit: it looks like `sed` is not installed on the windows image, I'm disabling the test on windows