### PR TITLE
ocp-indent-compat: add missing break before attribute at the end of an expression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@
 
 - Restore short form for first-class modules: `((module M) : (module S))` is formatted as `(module M : S)`) (#2280, #2300, @gpetiot, @Julow)
 - Restore short form formatting of record field aliases (#2282, @gpetiot)
-- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2214, #2281, #2284, #2289, #2299, #2302, #2309, #2310, #2311, #2313, #2316, @gpetiot, @Julow)
+- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2214, #2281, #2284, #2289, #2299, #2302, #2309, #2310, #2311, #2313, #2316, #<PR_NUMBER>, @gpetiot, @Julow)
 - Improve formatting of class signatures (#2301, @gpetiot, @Julow)
 - JaneStreet profile: treat comments as doc-comments (#2261, @gpetiot)
 - Don't indent attributes after a let/val/external (#2317, @Julow)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@
 
 - Restore short form for first-class modules: `((module M) : (module S))` is formatted as `(module M : S)`) (#2280, #2300, @gpetiot, @Julow)
 - Restore short form formatting of record field aliases (#2282, @gpetiot)
-- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2214, #2281, #2284, #2289, #2299, #2302, #2309, #2310, #2311, #2313, #2316, #<PR_NUMBER>, @gpetiot, @Julow)
+- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2214, #2281, #2284, #2289, #2299, #2302, #2309, #2310, #2311, #2313, #2316, #2321, @gpetiot, @Julow)
 - Improve formatting of class signatures (#2301, @gpetiot, @Julow)
 - JaneStreet profile: treat comments as doc-comments (#2261, @gpetiot)
 - Don't indent attributes after a let/val/external (#2317, @Julow)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -601,11 +601,7 @@ and fmt_attribute c ~key {attr_name; attr_payload; attr_loc} =
 and fmt_attributes_aux c ?pre ?suf ~key attrs =
   let num = List.length attrs in
   fmt_if_k (num > 0)
-    ( opt pre (function
-        (* Breaking before an attribute can confuse ocp-indent that will
-           produce a suboptimal indentation. *)
-        | Space when c.conf.fmt_opts.ocp_indent_compat.v -> sp Blank
-        | pre -> sp pre )
+    ( opt pre sp
     $ hvbox_if (num > 1) 0
         (hvbox 0 (list attrs "@ " (fmt_attribute c ~key)) $ opt suf str) )
 

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,7 +1,7 @@
-Warning: tests/js_source.ml:155 exceeds the margin
-Warning: tests/js_source.ml:3554 exceeds the margin
-Warning: tests/js_source.ml:9514 exceeds the margin
-Warning: tests/js_source.ml:9617 exceeds the margin
-Warning: tests/js_source.ml:9636 exceeds the margin
-Warning: tests/js_source.ml:9676 exceeds the margin
-Warning: tests/js_source.ml:9760 exceeds the margin
+Warning: tests/js_source.ml:160 exceeds the margin
+Warning: tests/js_source.ml:3559 exceeds the margin
+Warning: tests/js_source.ml:9520 exceeds the margin
+Warning: tests/js_source.ml:9623 exceeds the margin
+Warning: tests/js_source.ml:9642 exceeds the margin
+Warning: tests/js_source.ml:9682 exceeds the margin
+Warning: tests/js_source.ml:9766 exceeds the margin

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -83,7 +83,8 @@ let () =
   and[@foo] y = 4 in
   [%foo
     (let module M = M in
-     ()) [@foo]];
+     ())
+    [@foo]];
   [%foo
     (let open M in
      ()) [@foo]];
@@ -98,18 +99,21 @@ let () =
   [%foo
     while () do
       ()
-    done [@foo]];
+    done
+    [@foo]];
   [%foo
     for x = () to () do
       ()
-    done [@foo]];
+    done
+               [@foo]];
   [%foo assert true [@foo]];
   [%foo lazy x [@foo]];
   [%foo object end [@foo]];
   [%foo
     begin
       3
-    end [@foo]];
+    end
+    [@foo]];
   [%foo new x [@foo]];
   [%foo
     match[@foo] () with
@@ -131,7 +135,8 @@ class x =
     method virtual x : t [@@foo]
     method! private x = 3 [@@foo]
     initializer x [@@foo]
-  end [@foo]
+  end
+  [@foo]
 
 (* Class type expressions *)
 class type t = object
@@ -9456,7 +9461,8 @@ fun contents -> { contents = contents [@foo] };;
 
 ();
 (();
- ()) [@foo]
+ ())
+[@foo]
 
 (* https://github.com/LexiFi/gen_js_api/issues/61 *)
 
@@ -9783,7 +9789,8 @@ let[@a
              and y = b in
              x + y]
              | _ -> .) ->
-    y [@attr
+    y
+    [@attr
        (* ... *)
       (* ... *)
       attr (* ... *)]

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -83,7 +83,8 @@ let () =
   and[@foo] y = 4 in
   [%foo
     (let module M = M in
-    ()) [@foo]];
+    ())
+    [@foo]];
   [%foo
     (let open M in
      ()) [@foo]];
@@ -98,18 +99,21 @@ let () =
   [%foo
     while () do
       ()
-    done [@foo]];
+    done
+    [@foo]];
   [%foo
     for x = () to () do
       ()
-    done [@foo]];
+    done
+    [@foo]];
   [%foo assert true [@foo]];
   [%foo lazy x [@foo]];
   [%foo object end [@foo]];
   [%foo
     begin
       3
-    end [@foo]];
+    end
+    [@foo]];
   [%foo new x [@foo]];
   [%foo
     match[@foo] () with
@@ -131,7 +135,8 @@ class x =
       method virtual x : t [@@foo]
       method! private x = 3 [@@foo]
       initializer x [@@foo]
-    end [@foo]
+    end
+    [@foo]
 
 (* Class type expressions *)
 class type t = object
@@ -9456,7 +9461,8 @@ fun contents -> { contents = contents [@foo] };;
 
 ();
 (();
- ()) [@foo]
+ ())
+[@foo]
 
 (* https://github.com/LexiFi/gen_js_api/issues/61 *)
 
@@ -9783,10 +9789,11 @@ let[@a
                          and y = b in
                          x + y]
              | _ -> .) ->
-    y [@attr
-        (* ... *)
-        (* ... *)
-        attr (* ... *)]
+    y
+    [@attr
+      (* ... *)
+      (* ... *)
+      attr (* ... *)]
 ;;
 
 let x =


### PR DESCRIPTION
Extracted from #2314 