### PR TITLE
Fix context consistency for class fields

### DIFF
--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -155,6 +155,9 @@ val sub_exp : ctx:t -> expression -> expression xt
 val sub_cl : ctx:t -> class_expr -> class_expr xt
 (** Construct a class_expr-in-context. *)
 
+val sub_cf : ctx:t -> class_field -> class_field xt
+(** Construct a class_field-in-context. *)
+
 val sub_mty : ctx:t -> module_type -> module_type xt
 (** Construct a module_type-in-context. *)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2694,7 +2694,7 @@ and fmt_class_structure c ~ctx ?ext self_ fields =
         $ Params.parens c.conf
             (fmt_pattern c ~parens:false (sub_pat ~ctx self_)) )
   in
-  let fmt_item c ctx ~prev:_ ~next:_ i = fmt_class_field c ctx i in
+  let fmt_item c ctx ~prev:_ ~next:_ i = fmt_class_field c (sub_cf ~ctx i) in
   let ast x = Clf x in
   hvbox 2
     ( hvbox 0 (str "object" $ fmt_extension_suffix c ext $ self_)
@@ -2918,7 +2918,7 @@ and fmt_class_field_kind c ctx = function
       , fmt "@;<1 2>="
       , fmt "@ " $ fmt_expression c (sub_exp ~ctx e) )
 
-and fmt_class_field c ctx cf =
+and fmt_class_field c {ast= cf; _} =
   protect c (Clf cf)
   @@
   let fmt_cmts_before = Cmts.Toplevel.fmt_before c cf.pcf_loc in
@@ -2927,6 +2927,7 @@ and fmt_class_field c ctx cf =
     fmt_docstring_around_item ~fit:true c cf.pcf_attributes
   in
   let fmt_atrs = fmt_item_attributes c ~pre:(Break (1, 0)) atrs in
+  let ctx = Clf cf in
   (fun k ->
     fmt_cmts_before
     $ hvbox 0 ~name:"clf"


### PR DESCRIPTION
Found about this while tweaking the formatting of class fields for the ocp-indent compatibility.