### PR TITLE
Adjust indentation of class-expr function body

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 - Improve formatting of class signatures (#2301, @gpetiot, @Julow)
 - JaneStreet profile: treat comments as doc-comments (#2261, @gpetiot)
 - Don't indent attributes after a let/val/external (#2317, @Julow)
+- Adjust indentation of class-expr function body (#<PR_NUMBER>, @gpetiot)
 
 ### New features
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@
 - Improve formatting of class signatures (#2301, @gpetiot, @Julow)
 - JaneStreet profile: treat comments as doc-comments (#2261, @gpetiot)
 - Don't indent attributes after a let/val/external (#2317, @Julow)
-- Adjust indentation of class-expr function body (#<PR_NUMBER>, @gpetiot)
+- Adjust indentation of class-expr function body (#2328, @gpetiot)
 
 ### New features
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2808,7 +2808,12 @@ and fmt_class_expr c ?eol ({ast= exp; ctx= ctx0} as xexp) =
            $ fmt_atrs ) )
   | Pcl_fun _ ->
       let xargs, xbody = Sugar.cl_fun c.cmts xexp in
-      let indent = match ctx0 with Cl _ -> 3 | _ -> 0 in
+      let indent =
+        match ctx0 with
+        | Cl {pcl_desc= Pcl_fun _; _} -> 0
+        | Cl _ -> 3
+        | _ -> 0
+      in
       hvbox indent
         (Params.parens_if parens c.conf
            ( hovbox 2

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2781,7 +2781,7 @@ and fmt_class_type c ({ast= typ; _} as xtyp) =
         $ fmt_class_type c (sub_cty ~ctx cl) ) )
   $ fmt_docstring c ~pro:(fmt "@ ") doc
 
-and fmt_class_expr c ?eol ({ast= exp; _} as xexp) =
+and fmt_class_expr c ?eol ({ast= exp; ctx= ctx0} as xexp) =
   protect c (Cl exp)
   @@
   let {pcl_desc; pcl_loc; pcl_attributes} = exp in
@@ -2808,8 +2808,8 @@ and fmt_class_expr c ?eol ({ast= exp; _} as xexp) =
            $ fmt_atrs ) )
   | Pcl_fun _ ->
       let xargs, xbody = Sugar.cl_fun c.cmts xexp in
-      hvbox
-        (if Option.is_none eol then 2 else 1)
+      let indent = match ctx0 with Cl _ -> 3 | _ -> 0 in
+      hvbox indent
         (Params.parens_if parens c.conf
            ( hovbox 2
                ( box_fun_decl_args c 0

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7810,3 +7810,17 @@ include S1
 type input =
   { name: string
   ; action: [`Format | `Numeric of range] }
+
+let x =
+  fun [@foo] x ->
+    fun [@foo] y ->
+      object
+        method x = y
+      end
+
+class x =
+  fun [@foo] x ->
+    fun [@foo] y ->
+      object
+        method x = y
+      end

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -10053,3 +10053,18 @@ type input =
   { name : string
   ; action : [ `Format | `Numeric of range ]
   }
+
+let x =
+  fun [@foo] x ->
+  fun [@foo] y ->
+  object
+    method x = y
+  end
+;;
+
+class x =
+  fun [@foo] x ->
+  fun [@foo] y ->
+  object
+    method x = y
+  end

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -10053,3 +10053,18 @@ type input =
   { name : string
   ; action : [ `Format | `Numeric of range ]
   }
+
+let x =
+  fun [@foo] x ->
+  fun [@foo] y ->
+  object
+    method x = y
+  end
+;;
+
+class x =
+  fun [@foo] x ->
+  fun [@foo] y ->
+  object
+    method x = y
+  end

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -121,17 +121,17 @@ let () =
 (* Class expressions *)
 class x =
   fun [@foo] x ->
-    let[@foo] x = 3 in
-    object
-      inherit x [@@foo]
-      val x = 3 [@@foo]
-      val virtual x : t [@@foo]
-      val! mutable x = 3 [@@foo]
-      method x = 3 [@@foo]
-      method virtual x : t [@@foo]
-      method! private x = 3 [@@foo]
-      initializer x [@@foo]
-    end [@foo]
+  let[@foo] x = 3 in
+  object
+    inherit x [@@foo]
+    val x = 3 [@@foo]
+    val virtual x : t [@@foo]
+    val! mutable x = 3 [@@foo]
+    method x = 3 [@@foo]
+    method virtual x : t [@@foo]
+    method! private x = 3 [@@foo]
+    initializer x [@@foo]
+  end [@foo]
 
 (* Class type expressions *)
 class type t = object

--- a/test/passing/tests/object.ml
+++ b/test/passing/tests/object.ml
@@ -155,11 +155,11 @@ class tttttttttttttttttttttttttt x y =
   let open Mod in
   let x = 2 in
   (fun x ->
-    object
-      inherit f a
+     object
+       inherit f a
 
-      method x a b = a + b
-    end )
+       method x a b = a + b
+     end )
     0
 
 class c =

--- a/test/passing/tests/object.ml
+++ b/test/passing/tests/object.ml
@@ -295,3 +295,17 @@ class a x = object end
 class a x = object end
 
 class a x = object (self) end
+
+let x =
+ fun [@foo] x ->
+  fun [@foo] y ->
+   object
+     method x = y
+   end
+
+class x =
+  fun [@foo] x ->
+  fun [@foo] y ->
+  object
+    method x = y
+  end

--- a/test/passing/tests/shortcut_ext_attr.ml
+++ b/test/passing/tests/shortcut_ext_attr.ml
@@ -36,25 +36,25 @@ let () =
 (* Class expressions *)
 class x =
   fun [@foo] x ->
-    let[@foo] x = 33 in
-    object
-      inherit x [@@foo]
+  let[@foo] x = 33 in
+  object
+    inherit x [@@foo]
 
-      val x = 333 [@@foo]
+    val x = 333 [@@foo]
 
-      val virtual x : t [@@foo]
+    val virtual x : t [@@foo]
 
-      val! mutable x = 3 [@@foo]
+    val! mutable x = 3 [@@foo]
 
-      method x = 3 [@@foo]
+    method x = 3 [@@foo]
 
-      method virtual x : t [@@foo]
+    method virtual x : t [@@foo]
 
-      method! private x = 3 [@@foo]
+    method! private x = 3 [@@foo]
 
-      initializer x [@@foo]
-    end
-    [@foo]
+    initializer x [@@foo]
+  end
+  [@foo]
 
 (* Class type expressions *)
 class type t = object

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -134,25 +134,25 @@ let () =
 (* Class expressions *)
 class x =
   fun [@foo] x ->
-    let[@foo] x = 3 in
-    object
-      inherit x [@@foo]
+  let[@foo] x = 3 in
+  object
+    inherit x [@@foo]
 
-      val x = 3 [@@foo]
+    val x = 3 [@@foo]
 
-      val virtual x : t [@@foo]
+    val virtual x : t [@@foo]
 
-      val! mutable x = 3 [@@foo]
+    val! mutable x = 3 [@@foo]
 
-      method x = 3 [@@foo]
+    method x = 3 [@@foo]
 
-      method virtual x : t [@@foo]
+    method virtual x : t [@@foo]
 
-      method! private x = 3 [@@foo]
+    method! private x = 3 [@@foo]
 
-      initializer x [@@foo]
-    end
-    [@foo]
+    initializer x [@@foo]
+  end
+  [@foo]
 
 (* Class type expressions *)
 class type t = object
@@ -5859,9 +5859,9 @@ class c (v : int) =
 
     inherit
       (fun v ->
-        object
-          method v : string = v
-        end )
+         object
+           method v : string = v
+         end )
         "42"
   end
 ;;


### PR DESCRIPTION
The goal is to not increase the indentation when

```ocaml
class x =
  object
  end
```

becomes:

```ocaml
class x =
  fun x ->
  object
  end
```

but also fix the indentation (regarding the beginning of the `fun` keyword instead of the parenthesis) of:

```ocaml
      (fun v ->
         object
           method v : string = v
         end )
```