### PR TITLE
[debug] Output the *.ast filenames on stderr

### DIFF
--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -369,7 +369,7 @@ let format (type a b) (fg : a Extended_ast.t) (std_fg : b Std_ast.t)
             let args = args ~suffix:".unequal-ast" in
             internal_error [`Ast_changed] args
         else
-          dump_ast std_fg ~suffix:".ast"
+          dump_ast std_fg ~suffix:""
             (Normalize_std_ast.ast std_fg conf std_t_new.ast)
           |> function
           | Some file ->

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -367,7 +367,14 @@ let format (type a b) (fg : a Extended_ast.t) (std_fg : b Std_ast.t)
               args
           else
             let args = args ~suffix:".unequal-ast" in
-            internal_error [`Ast_changed] args ) ;
+            internal_error [`Ast_changed] args
+        else
+          dump_ast std_fg ~suffix:".ast"
+            (Normalize_std_ast.ast std_fg conf std_t_new.ast)
+          |> function
+          | Some file ->
+              if i = 1 then Format.eprintf "[DEBUG] AST structure: %s\n" file
+          | None -> () ) ;
       check_comments conf cmts_t ~old:t ~new_:t_new ;
       (* Too many iteration ? *)
       if i >= conf.opr_opts.max_iters.v then (

--- a/test/cli/debug.t
+++ b/test/cli/debug.t
@@ -7,7 +7,7 @@
   >     A.x
   > EOF
 
-  $ (ocamlformat --debug a.ml) 2>&1 | sed 's/\([^ ]*\.boxes\.ml$\)/<file>.boxes.ml/g'
+  $ (ocamlformat --debug a.ml) 2>&1 | sed -e 's/\([^ ]*\.boxes\.ml$\)/<file>.boxes.ml/g' -e 's/\([^ ]*\.ast$\)/<file>.ast/g'
   AST:
   Ptop_def
     [
@@ -63,6 +63,7 @@
         ]
     ]
   
+  [DEBUG] AST structure: <file>.ast
   AST:
   Ptop_def
     [
@@ -130,7 +131,7 @@
   > (* after let-binding *)
   > EOF
 
-  $ (ocamlformat --debug a.ml) 2>&1 | sed 's/\([^ ]*\.boxes\.ml$\)/<file>.boxes.ml/g'
+  $ (ocamlformat --debug a.ml) 2>&1 | sed -e 's/\([^ ]*\.boxes\.ml$\)/<file>.boxes.ml/g' -e 's/\([^ ]*\.ast$\)/<file>.ast/g'
   AST:
   Ptop_def
     [
@@ -236,6 +237,7 @@
         ]
     ]
   
+  [DEBUG] AST structure: <file>.ast
   AST:
   Ptop_def
     [


### PR DESCRIPTION
Follow-up of #2320

I find it more convenient to jump to the AST structure when using `--debug` instead of running `tools/printast/printast.exe`.

Disjunctions don't work on `sed` apparently, even with `-E`, if it gets too complicated one day we can switch to an ocaml binary to do the substitutions (like we did in dune-release cram tests)