### PR TITLE
Update to cmdliner 1.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - macos-latest
@@ -20,6 +21,7 @@ jobs:
           - 4.13.x
 
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
 
     steps:
       # Clone the project

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -664,7 +664,7 @@ COMMON OPTIONS
            Show version information.
 
 EXIT STATUS
-       ocamlformat exits with the following status:
+       ocamlformat exits with:
 
        0   on success.
 

--- a/ocamlformat-rpc-help.txt
+++ b/ocamlformat-rpc-help.txt
@@ -66,7 +66,7 @@ COMMON OPTIONS
            Show version information.
 
 EXIT STATUS
-       ocamlformat-rpc exits with the following status:
+       ocamlformat-rpc exits with:
 
        0   on success.
 

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -9,7 +9,8 @@ homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {not(with-test) & >= "1.1.0"}
+  "cmdliner" {with-test & >= "1.2.0"}
   "dune" {>= "2.8"}
   "ocamlformat-lib" {= version}
   "ocamlformat-rpc-lib" {with-test & = version}


### PR DESCRIPTION
The package remains compatible with `cmdliner >= 1.1.0` but the tests now need `>= 1.2.0`.