### PR TITLE
Use the recovery-parser as the default parser

### DIFF
--- a/lib/Extended_ast.mli
+++ b/lib/Extended_ast.mli
@@ -13,6 +13,8 @@ open Parser_extended
 
 include module type of Parsetree
 
+type 'a recovered = 'a Parser_recovery.t
+
 type use_file = toplevel_phrase list
 
 type repl_file = repl_phrase list
@@ -33,7 +35,11 @@ val of_syntax : Syntax.t -> any_t
 
 module Parse : sig
   val ast :
-    'a t -> preserve_beginend:bool -> input_name:string -> string -> 'a
+       'a t
+    -> preserve_beginend:bool
+    -> input_name:string
+    -> string
+    -> 'a recovered
 end
 
 val equal_core_type : core_type -> core_type -> bool

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -52,11 +52,11 @@ let normalize_parse_result ast_kind ast comments =
 let normalize_code conf (m : Ast_mapper.mapper) txt =
   let input_name = "<output>" in
   match Parse_with_comments.parse_toplevel conf ~input_name ~source:txt with
-  | First {ast; comments; _} ->
+  | First {ast= ast, _; comments; _} ->
       normalize_parse_result Use_file
         (List.map ~f:(m.toplevel_phrase m) ast)
         comments
-  | Second {ast; comments; _} ->
+  | Second {ast= ast, _; comments; _} ->
       normalize_parse_result Repl_file
         (List.map ~f:(m.repl_phrase m) ast)
         comments

--- a/lib/Parse_with_comments.mli
+++ b/lib/Parse_with_comments.mli
@@ -41,8 +41,8 @@ val parse_toplevel :
   -> Conf.t
   -> input_name:string
   -> source:string
-  -> ( Extended_ast.use_file with_comments
-     , Extended_ast.repl_file with_comments )
+  -> ( Extended_ast.use_file t with_comments
+     , Extended_ast.repl_file t with_comments )
      Either.t
 (** Variant of {!parse} that uses {!Extended_ast.Parse.toplevel}. This
     function handles [conf.parse_toplevel_phrases]. *)

--- a/lib/dune
+++ b/lib/dune
@@ -23,6 +23,8 @@
    -open
    Parser_extended
    -open
+   Parser_recovery
+   -open
    Ocamlformat_stdlib
    -open
    Ocamlformat_result.Global_scope))

--- a/vendor/parser-recovery/lib/parser_recovery.mli
+++ b/vendor/parser-recovery/lib/parser_recovery.mli
@@ -1,5 +1,16 @@
-val structure : Lexing.lexbuf -> Parsetree.structure
+type 'a t = 'a * [`Recovered | `Not_recovered]
 
-val signature : Lexing.lexbuf -> Parsetree.signature
+val structure : Lexing.lexbuf -> Parsetree.structure t
 
-val use_file : Lexing.lexbuf -> Parsetree.toplevel_phrase list
+val signature : Lexing.lexbuf -> Parsetree.signature t
+
+val use_file : Lexing.lexbuf -> Parsetree.toplevel_phrase list t
+
+val core_type : Lexing.lexbuf -> Parsetree.core_type t
+
+val module_type : Lexing.lexbuf -> Parsetree.module_type t
+
+val expression : Lexing.lexbuf -> Parsetree.expression t
+
+module Parser = Parser
+module Lexer = Lexer


### PR DESCRIPTION
This is an experiment.
If we find it worth it to experiment in this direction, let's not merge #2333 as it is today, we can remove the numeric feature, but keep the vendored parser.

Most of the tests are OK, but I didn't spend time trying to fix the failing ones. The most obvious fix is to not print the `merlin.hole` nodes added by the recovery.

What do you think of it?