### PR TITLE
Keep literal char value during parsing

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -264,7 +264,7 @@ let fmt_constant c ?epi {pconst_desc; pconst_loc= loc} =
   match pconst_desc with
   | Pconst_integer (lit, suf) | Pconst_float (lit, suf) ->
       str lit $ opt suf char
-  | Pconst_char _ -> wrap "'" "'" @@ str (Source.char_literal c.source loc)
+  | Pconst_char (_, s) -> wrap "'" "'" @@ str s
   | Pconst_string (s, loc', Some delim) ->
       Cmts.fmt c loc'
       @@ wrap_k (str ("{" ^ delim ^ "|")) (str ("|" ^ delim ^ "}")) (str s)

--- a/lib/Literal_lexer.mli
+++ b/lib/Literal_lexer.mli
@@ -10,5 +10,3 @@
 (**************************************************************************)
 
 val string : [`Normalize | `Preserve] -> string -> string option
-
-val char : string -> string option

--- a/lib/Literal_lexer.mll
+++ b/lib/Literal_lexer.mll
@@ -89,32 +89,10 @@ and string_aux mode = parse
       { store_string_char (Lexing.lexeme_char lexbuf 0);
         string_aux mode lexbuf }
 
-and char = parse
-  | "\'" newline "\'"
-      { "\\n" }
-  | "\'" ([^ '\\' '\'' '\010' '\013'] as x) "\'"
-      { String.make 1 x }
-  | "\'" ("\\" ['\\' '\'' '\"' 'n' 't' 'b' 'r' ' '] as x) "\'"
-      { x }
-  | "\'" ("\\" ['0'-'9'] ['0'-'9'] ['0'-'9'] as x) "\'"
-      { x }
-  | "\'" ("\\" 'o' ['0'-'3'] ['0'-'7'] ['0'-'7'] as x) "\'"
-      { x }
-  | "\'" ("\\" 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F'] as x) "\'"
-      { x }
-  | _
-      { raise Parse_error }
-
 {
   let string mode s =
     let lexbuf = Lexing.from_string s in
     match string mode lexbuf with
-    | s -> Some s
-    | exception Parse_error -> None
-
-  let char s =
-    let lexbuf = Lexing.from_string s in
-    match char lexbuf with
     | s -> Some s
     | exception Parse_error -> None
 }

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -131,10 +131,6 @@ let string_literal t mode loc =
   Option.value_exn ~message:"Parse error while reading string literal"
     (Literal_lexer.string mode (string_at t loc))
 
-let char_literal t loc =
-  Option.value_exn ~message:"Parse error while reading char literal"
-    (Literal_lexer.char (string_at t loc))
-
 let begins_line ?(ignore_spaces = true) t (l : Location.t) =
   if not ignore_spaces then Position.column l.loc_start = 0
   else

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -47,8 +47,6 @@ val find_token_before :
 
 val string_literal : t -> [`Normalize | `Preserve] -> Location.t -> string
 
-val char_literal : t -> Location.t -> string
-
 val is_long_pmod_functor : t -> module_expr -> bool
 (** [is_long_pmod_functor source mod_exp] holds if [mod_exp] is a
     [Pmod_functor] expression that is expressed in long ('functor (M) ->')

--- a/test/unit/test_literal_lexer.ml
+++ b/test/unit/test_literal_lexer.ml
@@ -1,8 +1,6 @@
 open Base
 open Ocamlformat_lib
 
-let single_quote = '\''
-
 let double_quote = '"'
 
 let backslash = '\\'
@@ -50,32 +48,4 @@ let tests_string =
         ~expected_preserve:(String.of_char_list [backslash; 'n'])
         ~expected_normalize:(String.of_char_list [newline]) ]
 
-let tests_char =
-  let test_opt name s ~expected =
-    ( "char: " ^ name
-    , `Quick
-    , fun () ->
-        let got = Literal_lexer.char s in
-        Alcotest.check
-          (Alcotest.option Alcotest.string)
-          Stdlib.__LOC__ expected got )
-  in
-  let test name s ~expected = test_opt name s ~expected:(Some expected) in
-  [ test_opt "not a character literal" {|c|} ~expected:None
-  ; test "escaped newline"
-      (String.of_char_list [single_quote; newline; single_quote])
-      ~expected:(String.of_char_list [backslash; 'n'])
-  ; test "letter" {|'c'|} ~expected:"c"
-  ; test "escaped backslash" {|'\\'|} ~expected:{|\\|}
-  ; test "escaped single quote" {|'\''|} ~expected:{|\'|}
-  ; test "escaped double quote" {|'\"'|} ~expected:{|\"|}
-  ; test "backslash n" {|'\n'|} ~expected:{|\n|}
-  ; test "backslash t" {|'\t'|} ~expected:{|\t|}
-  ; test "backslash b" {|'\b'|} ~expected:{|\b|}
-  ; test "backslash r" {|'\r'|} ~expected:{|\r|}
-  ; test "backslash space" {|'\ '|} ~expected:{|\ |}
-  ; test "decimal escape" {|'\123'|} ~expected:{|\123|}
-  ; test "octal escape" {|'\o356'|} ~expected:{|\o356|}
-  ; test "hex escape" {|'\xde'|} ~expected:{|\xde|} ]
-
-let tests = tests_string @ tests_char
+let tests = tests_string

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -44,7 +44,7 @@ module Const = struct
   let nativeint ?loc ?(suffix='n') i =
     integer ?loc ~suffix (Nativeint.to_string i)
   let float ?loc ?suffix f = mk ?loc (Pconst_float (f, suffix))
-  let char ?loc c = mk ?loc (Pconst_char c)
+  let char ?loc c s = mk ?loc (Pconst_char (c, s))
   let string ?quotation_delimiter ?(loc= !default_loc) s =
     mk ~loc (Pconst_string (s, loc, quotation_delimiter))
 end

--- a/vendor/parser-extended/ast_helper.mli
+++ b/vendor/parser-extended/ast_helper.mli
@@ -46,7 +46,7 @@ val with_default_loc: loc -> (unit -> 'a) -> 'a
 module Const : sig
   val mk: ?loc:loc -> constant_desc -> constant
 
-  val char : ?loc:loc -> char -> constant
+  val char : ?loc:loc -> char -> string -> constant
   val string :
     ?quotation_delimiter:string -> ?loc:Location.t -> string -> constant
   val integer : ?loc:loc -> ?suffix:char -> string -> constant

--- a/vendor/parser-extended/lexer.mll
+++ b/vendor/parser-extended/lexer.mll
@@ -482,17 +482,17 @@ rule token = parse
   | "\'" newline "\'"
       { update_loc lexbuf None 1 false 1;
         (* newline is ('\013'* '\010') *)
-        CHAR '\n' }
+        CHAR ('\n', "\\n") }
   | "\'" ([^ '\\' '\'' '\010' '\013'] as c) "\'"
-      { CHAR c }
-  | "\'\\" (['\\' '\'' '\"' 'n' 't' 'b' 'r' ' '] as c) "\'"
-      { CHAR (char_for_backslash c) }
-  | "\'\\" ['0'-'9'] ['0'-'9'] ['0'-'9'] "\'"
-      { CHAR(char_for_decimal_code lexbuf 2) }
-  | "\'\\" 'o' ['0'-'7'] ['0'-'7'] ['0'-'7'] "\'"
-      { CHAR(char_for_octal_code lexbuf 3) }
-  | "\'\\" 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F'] "\'"
-      { CHAR(char_for_hexadecimal_code lexbuf 3) }
+      { CHAR (c, String.make 1 c) }
+  | "\'" ("\\" (['\\' '\'' '\"' 'n' 't' 'b' 'r' ' '] as c) as s) "\'"
+      { CHAR (char_for_backslash c, s) }
+  | "\'" ("\\" ['0'-'9'] ['0'-'9'] ['0'-'9'] as s) "\'"
+      { CHAR (char_for_decimal_code lexbuf 2, s) }
+  | "\'" ("\\" 'o' ['0'-'7'] ['0'-'7'] ['0'-'7'] as s) "\'"
+      { CHAR (char_for_octal_code lexbuf 3, s) }
+  | "\'" ("\\" 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F'] as s) "\'"
+      { CHAR (char_for_hexadecimal_code lexbuf 3, s) }
   | "\'" ("\\" _ as esc)
       { error lexbuf (Illegal_escape (esc, None)) }
   | "\'\'"

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -465,7 +465,7 @@ let mk_directive ~loc name arg =
 %token BARBAR                 "||"
 %token BARRBRACKET            "|]"
 %token BEGIN                  "begin"
-%token <char> CHAR            "'a'" (* just an example *)
+%token <char * string> CHAR   "'a'" (* just an example *)
 %token CLASS                  "class"
 %token COLON                  ":"
 %token COLONCOLON             "::"
@@ -3382,7 +3382,8 @@ meth_list:
 constant:
   | INT          { let (n, m) = $1 in
                    mkconst ~loc:$sloc (Pconst_integer (n, m)) }
-  | CHAR         { mkconst ~loc:$sloc (Pconst_char $1) }
+  | CHAR         { let (c, s) = $1 in
+                   mkconst ~loc:$sloc (Pconst_char (c, s)) }
   | STRING       { let (s, strloc, d) = $1 in
                    mkconst ~loc:$sloc (Pconst_string (s,strloc,d)) }
   | FLOAT        { let (f, m) = $1 in

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -29,7 +29,10 @@ type constant_desc =
      Suffixes [[g-z][G-Z]] are accepted by the parser.
      Suffixes except ['l'], ['L'] and ['n'] are rejected by the typechecker
   *)
-  | Pconst_char of char * string  (** Character such as ['c']. *)
+  | Pconst_char of char * string
+      (** [Pconst_char (c, s)] describes a character [c] and its literal string representation [s].
+
+          e.g. the character ['\n'] is represented by the literal string ["\\n"]. *)
   | Pconst_string of string * Location.t * string option
       (** Constant string such as ["constant"] or
           [{delim|other constant|delim}].

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -29,7 +29,7 @@ type constant_desc =
      Suffixes [[g-z][G-Z]] are accepted by the parser.
      Suffixes except ['l'], ['L'] and ['n'] are rejected by the typechecker
   *)
-  | Pconst_char of char  (** Character such as ['c']. *)
+  | Pconst_char of char * string  (** Character such as ['c']. *)
   | Pconst_string of string * Location.t * string option
       (** Constant string such as ["constant"] or
           [{delim|other constant|delim}].

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -98,7 +98,7 @@ let fmt_constant i f x =
   let i = i+1 in
   match x.pconst_desc with
   | Pconst_integer (j,m) -> line i f "PConst_int (%s,%a)\n" j fmt_char_option m
-  | Pconst_char (c, s) -> line i f "PConst_char %02x %s\n" (Char.code c) s
+  | Pconst_char (c, s) -> line i f "PConst_char (%02x,%s)\n" (Char.code c) s
   | Pconst_string (s, strloc, None) ->
       line i f "PConst_string(%S,%a,None)\n" s fmt_location strloc
   | Pconst_string (s, strloc, Some delim) ->

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -98,7 +98,7 @@ let fmt_constant i f x =
   let i = i+1 in
   match x.pconst_desc with
   | Pconst_integer (j,m) -> line i f "PConst_int (%s,%a)\n" j fmt_char_option m
-  | Pconst_char (c) -> line i f "PConst_char %02x\n" (Char.code c)
+  | Pconst_char (c, s) -> line i f "PConst_char %02x %s\n" (Char.code c) s
   | Pconst_string (s, strloc, None) ->
       line i f "PConst_string(%S,%a,None)\n" s fmt_location strloc
   | Pconst_string (s, strloc, Some delim) ->


### PR DESCRIPTION
Keep the info that is already computed by the OCaml lexer instead of maintaining a second lexer.

It's a bit more tricky for string literals because of the `break-string-literals` option (https://github.com/ocaml-ppx/ocamlformat/pull/932#issuecomment-539504338)