### PR TITLE
ocp-indent-compat: Fix comment changed

### DIFF
--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -794,7 +794,7 @@ let remaining_locs t = Set.to_list t.remaining
 let is_docstring (conf : Conf.t) (Cmt.{txt; loc} as cmt) =
   match txt with
   | "" | "*" -> Either.Second cmt
-  | _ when Char.equal txt.[0] '*' || conf.fmt_opts.ocp_indent_compat.v ->
+  | _ when Char.equal txt.[0] '*' ->
       (* Doc comments here (comming directly from the lexer) include their
          leading star [*]. It is not part of the docstring and should be
          dropped. When [ocp-indent-compat] is set, regular comments are
@@ -803,4 +803,10 @@ let is_docstring (conf : Conf.t) (Cmt.{txt; loc} as cmt) =
       let cmt = Cmt.create txt loc in
       if conf.fmt_opts.parse_docstrings.v then Either.First cmt
       else Either.Second cmt
+  | _
+    when conf.fmt_opts.ocp_indent_compat.v
+         && conf.fmt_opts.parse_docstrings.v ->
+      (* In ocp_indent_compat mode, comments are parsed like docstrings. *)
+      let cmt = Cmt.create txt loc in
+      Either.First cmt
   | _ -> Either.Second cmt

--- a/test/passing/tests/doc_comments-after.ml.ref
+++ b/test/passing/tests/doc_comments-after.ml.ref
@@ -309,3 +309,7 @@ let a = 1
         let _ = x in
         f @@ g @@ h @@ fun x -> y
     ]} *)
+
+(**{v
+  foo
+   v}*)

--- a/test/passing/tests/doc_comments-before-except-val.ml.ref
+++ b/test/passing/tests/doc_comments-before-except-val.ml.ref
@@ -309,3 +309,7 @@ let a = 1
         let _ = x in
         f @@ g @@ h @@ fun x -> y
     ]} *)
+
+(**{v
+  foo
+   v}*)

--- a/test/passing/tests/doc_comments-before.ml.ref
+++ b/test/passing/tests/doc_comments-before.ml.ref
@@ -309,3 +309,7 @@ let a = 1
         let _ = x in
         f @@ g @@ h @@ fun x -> y
     ]} *)
+
+(**{v
+  foo
+   v}*)

--- a/test/passing/tests/doc_comments.ml
+++ b/test/passing/tests/doc_comments.ml
@@ -305,3 +305,10 @@ let a = 1
        let _ = x in
        f @@ g @@ h @@ fun x -> y
     ]} *)
+
+
+(**{v
+
+  foo
+
+v}*)

--- a/test/passing/tests/doc_comments.ml.ref
+++ b/test/passing/tests/doc_comments.ml.ref
@@ -309,3 +309,7 @@ let a = 1
         let _ = x in
         f @@ g @@ h @@ fun x -> y
     ]} *)
+
+(**{v
+  foo
+   v}*)

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7824,3 +7824,9 @@ class x =
       object
         method x = y
       end
+
+(*{v
+
+      foo
+
+v}*)

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -10068,3 +10068,7 @@ class x =
   object
     method x = y
   end
+
+(*{v
+      foo
+  v}*)

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -10068,3 +10068,7 @@ class x =
   object
     method x = y
   end
+
+(*{v
+      foo
+  v}*)


### PR DESCRIPTION
The first character of a comment was removed as if it was `*`, even when it wasn't.