### PR TITLE
Preserve functor concrete syntax in the Parsetree

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1350,7 +1350,7 @@ end = struct
          |Pexp_field (e, _)
          |Pexp_lazy e
          |Pexp_letexception (_, e)
-         |Pexp_letmodule (_, _, e)
+         |Pexp_letmodule (_, _, _, e)
          |Pexp_newtype (_, e)
          |Pexp_open (_, e)
          |Pexp_letopen (_, e)
@@ -1932,7 +1932,7 @@ end = struct
         | Pexp_let (_, e)
          |Pexp_letop {body= e; _}
          |Pexp_letexception (_, e)
-         |Pexp_letmodule (_, _, e) -> (
+         |Pexp_letmodule (_, _, _, e) -> (
           match cls with Match | Then | ThenElse -> continue e | _ -> false )
         | Pexp_match _ when match cls with Then -> true | _ -> false ->
             false
@@ -2000,7 +2000,7 @@ end = struct
       | Pexp_let (_, e)
        |Pexp_letop {body= e; _}
        |Pexp_letexception (_, e)
-       |Pexp_letmodule (_, _, e) ->
+       |Pexp_letmodule (_, _, _, e) ->
           continue e
       | Pexp_ifthenelse (eN, None) -> continue (List.last_exn eN).if_body
       | Pexp_extension (ext, PStr [{pstr_desc= Pstr_eval (e, _); _}])

--- a/lib/Extended_ast.ml
+++ b/lib/Extended_ast.ml
@@ -215,7 +215,42 @@ module Parse = struct
           {p with pexp_desc= Pexp_pack (name, Some pt)}
       | e -> Ast_mapper.default_mapper.expr m e
     in
-    Ast_mapper.{default_mapper with expr; pat; binding_op}
+    let module_expr (m : Ast_mapper.mapper) me =
+      let me =
+        match me with
+        (* [functor () -> functor () -> E] => [functor () () -> E] *)
+        | { pmod_desc=
+              Pmod_functor
+                ( args
+                , { pmod_desc= Pmod_functor (args', me')
+                  ; pmod_attributes= []
+                  ; _ } )
+          ; pmod_attributes= []
+          ; _ } ->
+            {me with pmod_desc= Pmod_functor (args @ args', me')}
+        | x -> x
+      in
+      Ast_mapper.default_mapper.module_expr m me
+    in
+    let module_type (m : Ast_mapper.mapper) mt =
+      let mt =
+        match mt with
+        (* [functor () -> functor () -> E] => [functor () () -> E] *)
+        | { pmty_desc=
+              Pmty_functor
+                ( args
+                , { pmty_desc= Pmty_functor (args', mt')
+                  ; pmty_attributes= []
+                  ; _ } )
+          ; pmty_attributes= []
+          ; _ } ->
+            {mt with pmty_desc= Pmty_functor (args @ args', mt')}
+        | x -> x
+      in
+      Ast_mapper.default_mapper.module_type m mt
+    in
+    Ast_mapper.
+      {default_mapper with expr; pat; binding_op; module_expr; module_type}
 
   let ast (type a) (fg : a t) ~preserve_beginend ~input_name str : a =
     map fg (normalize_mapper ~preserve_beginend)

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -104,29 +104,6 @@ let extend_loc_to_include_attributes (loc : Location.t) (l : attributes) =
   else
     {loc with loc_end= {loc.loc_end with pos_cnum= loc_end.loc_end.pos_cnum}}
 
-let is_long_functor_syntax (t : t) ~(from : Location.t) = function
-  | Unit -> false
-  | Named ({loc= _; _}, _) -> (
-    (* since 4.12 the functor keyword is just before the loc of the functor
-       parameter *)
-    match
-      find_token_before t
-        ~filter:(function COMMENT _ | DOCSTRING _ -> false | _ -> true)
-        from.loc_start
-    with
-    | Some (Parser.FUNCTOR, _) -> true
-    | _ -> false )
-
-let is_long_pmod_functor t {pmod_desc; pmod_loc= from; _} =
-  match pmod_desc with
-  | Pmod_functor (fp, _) -> is_long_functor_syntax t ~from fp
-  | _ -> false
-
-let is_long_pmty_functor t {pmty_desc; pmty_loc= from; _} =
-  match pmty_desc with
-  | Pmty_functor (fp, _) -> is_long_functor_syntax t ~from fp
-  | _ -> false
-
 let string_literal t mode loc =
   Option.value_exn ~message:"Parse error while reading string literal"
     (Literal_lexer.string mode (string_at t loc))

--- a/lib/Source.mli
+++ b/lib/Source.mli
@@ -47,16 +47,6 @@ val find_token_before :
 
 val string_literal : t -> [`Normalize | `Preserve] -> Location.t -> string
 
-val is_long_pmod_functor : t -> module_expr -> bool
-(** [is_long_pmod_functor source mod_exp] holds if [mod_exp] is a
-    [Pmod_functor] expression that is expressed in long ('functor (M) ->')
-    form in source. *)
-
-val is_long_pmty_functor : t -> module_type -> bool
-(** [is_long_pmty_functor source mod_type] holds if [mod_type] is a
-    [Pmty_functor] type that is expressed in long ('functor (M) ->') form in
-    source. *)
-
 val begins_line : ?ignore_spaces:bool -> t -> Location.t -> bool
 
 val ends_line : t -> Location.t -> bool

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -163,41 +163,6 @@ let sequence cmts xexp =
   in
   sequence_ xexp
 
-(* The sugar is different when used with the [functor] keyword. The syntax
-   M(A : A)(B : B) cannot handle [_] as module name. *)
-let rec functor_type cmts ~for_functor_kw ~source_is_long
-    ({ast= mty; _} as xmty) =
-  let ctx = Mty mty in
-  match mty with
-  | {pmty_desc= Pmty_functor (fp, body); pmty_loc; pmty_attributes}
-    when for_functor_kw
-         || (List.is_empty pmty_attributes && not (source_is_long mty)) ->
-      let body = sub_mty ~ctx body in
-      let xargs, xbody =
-        match pmty_attributes with
-        | [] -> functor_type cmts ~for_functor_kw ~source_is_long body
-        | _ -> ([], body)
-      in
-      (Location.mkloc fp pmty_loc :: xargs, xbody)
-  | _ -> ([], xmty)
-
-(* The sugar is different when used with the [functor] keyword. The syntax
-   M(A : A)(B : B) cannot handle [_] as module name. *)
-let rec functor_ cmts ~for_functor_kw ~source_is_long ({ast= me; _} as xme) =
-  let ctx = Mod me in
-  match me with
-  | {pmod_desc= Pmod_functor (fp, body); pmod_loc; pmod_attributes}
-    when for_functor_kw
-         || (List.is_empty pmod_attributes && not (source_is_long me)) ->
-      let body = sub_mod ~ctx body in
-      let xargs, xbody_me =
-        match pmod_attributes with
-        | [] -> functor_ cmts ~for_functor_kw ~source_is_long body
-        | _ -> ([], body)
-      in
-      (Location.mkloc fp pmod_loc :: xargs, xbody_me)
-  | _ -> ([], xme)
-
 let mod_with pmty =
   let rec mod_with_ ({ast= me; _} as xme) =
     let ctx = Mty me in

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -51,26 +51,6 @@ val sequence :
 (** [sequence cmts exp] returns the list of expressions (with the optional
     extension) from a sequence of expressions [exp]. *)
 
-val functor_type :
-     Cmts.t
-  -> for_functor_kw:bool
-  -> source_is_long:(module_type -> bool)
-  -> module_type Ast.xt
-  -> functor_parameter loc list * module_type Ast.xt
-(** [functor_type cmts for_functor_kw m] returns the list of module types
-    applied to the functor of module type [m]. [for_functor_kw] indicates if
-    the keyword [functor] is used. *)
-
-val functor_ :
-     Cmts.t
-  -> for_functor_kw:bool
-  -> source_is_long:(module_expr -> bool)
-  -> module_expr Ast.xt
-  -> functor_parameter loc list * module_expr Ast.xt
-(** [functor_ cmts for_functor_kw m] returns the list of module types applied
-    to the functor of module [m]. [for_functor_kw] indicates if the keyword
-    [functor] is used. *)
-
 val mod_with :
      module_type Ast.xt
   -> (with_constraint list * Warnings.loc * attributes) list

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -320,10 +320,7 @@ let y =
     (* b *)
     x
 
-module A (* A *) () =
-  (* B *)
-  (* C *)
-  B
+module A (* A *) () (* B *) = (* C *) B
 
 let kk = (* foo *) (module A : T)
 

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -145,7 +145,7 @@ module Exp = struct
   let indexop_access ?loc ?attrs pia_lhs pia_kind pia_paren pia_rhs =
     mk ?loc ?attrs (Pexp_indexop_access {pia_lhs; pia_kind; pia_paren; pia_rhs})
   let override ?loc ?attrs a = mk ?loc ?attrs (Pexp_override a)
-  let letmodule ?loc ?attrs a b c= mk ?loc ?attrs (Pexp_letmodule (a, b, c))
+  let letmodule ?loc ?attrs a b c d = mk ?loc ?attrs (Pexp_letmodule (a, b, c, d))
   let letexception ?loc ?attrs a b = mk ?loc ?attrs (Pexp_letexception (a, b))
   let assert_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_assert a)
   let lazy_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_lazy a)
@@ -367,9 +367,10 @@ end
 
 module Md = struct
   let mk ?(loc = !default_loc) ?(attrs = [])
-        ?(docs = empty_docs) ?(text = []) name typ =
+        ?(docs = empty_docs) ?(text = []) name args typ =
     {
      pmd_name = name;
+     pmd_args = args;
      pmd_type = typ;
      pmd_attributes =
        add_text_attrs text (add_docs_attrs docs attrs);
@@ -403,9 +404,10 @@ end
 
 module Mb = struct
   let mk ?(loc = !default_loc) ?(attrs = [])
-        ?(docs = empty_docs) ?(text = []) name expr =
+        ?(docs = empty_docs) ?(text = []) name args expr =
     {
      pmb_name = name;
+     pmb_args = args;
      pmb_expr = expr;
      pmb_attributes =
        add_text_attrs text (add_docs_attrs docs attrs);

--- a/vendor/parser-extended/ast_helper.mli
+++ b/vendor/parser-extended/ast_helper.mli
@@ -170,7 +170,8 @@ module Exp:
       -> expression
     val override: ?loc:loc -> ?attrs:attrs -> (str * expression) list
                   -> expression
-    val letmodule: ?loc:loc -> ?attrs:attrs -> str_opt -> module_expr
+    val letmodule: ?loc:loc -> ?attrs:attrs -> str_opt
+                   -> functor_parameter with_loc list -> module_expr
                    -> expression -> expression
     val letexception:
       ?loc:loc -> ?attrs:attrs -> extension_constructor -> expression
@@ -338,7 +339,7 @@ module Str:
 module Md:
   sig
     val mk: ?loc:loc -> ?attrs:attrs -> ?docs:docs -> ?text:text ->
-      str_opt -> module_type -> module_declaration
+      str_opt -> functor_parameter with_loc list -> module_type -> module_declaration
   end
 
 (** Module substitutions *)
@@ -359,7 +360,7 @@ module Mtd:
 module Mb:
   sig
     val mk: ?loc:loc -> ?attrs:attrs -> ?docs:docs -> ?text:text ->
-      str_opt -> module_expr -> module_binding
+      str_opt -> functor_parameter with_loc list -> module_expr -> module_binding
   end
 
 (** Opens *)

--- a/vendor/parser-extended/ast_helper.mli
+++ b/vendor/parser-extended/ast_helper.mli
@@ -259,7 +259,7 @@ module Mty:
     val alias: ?loc:loc -> ?attrs:attrs -> lid -> module_type
     val signature: ?loc:loc -> ?attrs:attrs -> signature -> module_type
     val functor_: ?loc:loc -> ?attrs:attrs ->
-      functor_parameter -> module_type -> module_type
+      functor_parameter list -> module_type -> module_type
     val with_: ?loc:loc -> ?attrs:attrs -> module_type ->
       with_constraint list -> module_type
     val typeof_: ?loc:loc -> ?attrs:attrs -> module_expr -> module_type
@@ -275,7 +275,7 @@ module Mod:
     val ident: ?loc:loc -> ?attrs:attrs -> lid -> module_expr
     val structure: ?loc:loc -> ?attrs:attrs -> structure -> module_expr
     val functor_: ?loc:loc -> ?attrs:attrs ->
-      functor_parameter -> module_expr -> module_expr
+      functor_parameter list -> module_expr -> module_expr
     val apply: ?loc:loc -> ?attrs:attrs -> module_expr -> module_expr ->
       module_expr
     val constraint_: ?loc:loc -> ?attrs:attrs -> module_expr -> module_type ->

--- a/vendor/parser-extended/ast_helper.mli
+++ b/vendor/parser-extended/ast_helper.mli
@@ -259,7 +259,7 @@ module Mty:
     val alias: ?loc:loc -> ?attrs:attrs -> lid -> module_type
     val signature: ?loc:loc -> ?attrs:attrs -> signature -> module_type
     val functor_: ?loc:loc -> ?attrs:attrs ->
-      functor_parameter list -> module_type -> module_type
+      functor_parameter with_loc list -> module_type -> module_type
     val with_: ?loc:loc -> ?attrs:attrs -> module_type ->
       with_constraint list -> module_type
     val typeof_: ?loc:loc -> ?attrs:attrs -> module_expr -> module_type
@@ -275,7 +275,7 @@ module Mod:
     val ident: ?loc:loc -> ?attrs:attrs -> lid -> module_expr
     val structure: ?loc:loc -> ?attrs:attrs -> structure -> module_expr
     val functor_: ?loc:loc -> ?attrs:attrs ->
-      functor_parameter list -> module_expr -> module_expr
+      functor_parameter with_loc list -> module_expr -> module_expr
     val apply: ?loc:loc -> ?attrs:attrs -> module_expr -> module_expr ->
       module_expr
     val constraint_: ?loc:loc -> ?attrs:attrs -> module_expr -> module_type ->

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -345,9 +345,9 @@ module MT = struct
     | Pmty_ident s -> ident ~loc ~attrs (map_loc sub s)
     | Pmty_alias s -> alias ~loc ~attrs (map_loc sub s)
     | Pmty_signature sg -> signature ~loc ~attrs (sub.signature sub sg)
-    | Pmty_functor (param, mt) ->
+    | Pmty_functor (params, mt) ->
         functor_ ~loc ~attrs
-          (map_functor_param sub param)
+          (List.map (map_functor_param sub) params)
           (sub.module_type sub mt)
     | Pmty_with (mt, l) ->
         with_ ~loc ~attrs (sub.module_type sub mt)
@@ -409,9 +409,9 @@ module M = struct
     match desc with
     | Pmod_ident x -> ident ~loc ~attrs (map_loc sub x)
     | Pmod_structure str -> structure ~loc ~attrs (sub.structure sub str)
-    | Pmod_functor (param, body) ->
+    | Pmod_functor (params, body) ->
         functor_ ~loc ~attrs
-          (map_functor_param sub param)
+          (List.map (map_functor_param sub) params)
           (sub.module_expr sub body)
     | Pmod_apply (m1, m2) ->
         apply ~loc ~attrs (sub.module_expr sub m1) (sub.module_expr sub m2)

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -330,9 +330,14 @@ module CT = struct
       (List.map (sub.class_type_field sub) pcsig_fields)
 end
 
-let map_functor_param sub = function
-  | Unit -> Unit
-  | Named (s, mt) -> Named (map_loc sub s, sub.module_type sub mt)
+let map_functor_param sub {loc; txt} =
+  let loc = sub.location sub loc in
+  let txt =
+    match txt with
+    | Unit -> Unit
+    | Named (s, mt) -> Named (map_loc sub s, sub.module_type sub mt)
+  in
+  {loc; txt}
 
 module MT = struct
   (* Type expressions for the module language *)

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -546,8 +546,10 @@ module E = struct
     | Pexp_override sel ->
         override ~loc ~attrs
           (List.map (map_tuple (map_loc sub) (sub.expr sub)) sel)
-    | Pexp_letmodule (s, me, e) ->
-        letmodule ~loc ~attrs (map_loc sub s) (sub.module_expr sub me)
+    | Pexp_letmodule (s, args, me, e) ->
+        letmodule ~loc ~attrs (map_loc sub s)
+          (List.map (map_functor_param sub) args)
+          (sub.module_expr sub me)
           (sub.expr sub e)
     | Pexp_letexception (cd, e) ->
         letexception ~loc ~attrs
@@ -775,9 +777,10 @@ let default_mapper =
     let_bindings = LB.map_let_bindings;
 
     module_declaration =
-      (fun this {pmd_name; pmd_type; pmd_attributes; pmd_loc} ->
+      (fun this {pmd_name; pmd_args; pmd_type; pmd_attributes; pmd_loc} ->
          Md.mk
            (map_loc this pmd_name)
+           (List.map (map_functor_param this) pmd_args)
            (this.module_type this pmd_type)
            ~attrs:(this.attributes this pmd_attributes)
            ~loc:(this.location this pmd_loc)
@@ -802,8 +805,10 @@ let default_mapper =
       );
 
     module_binding =
-      (fun this {pmb_name; pmb_expr; pmb_attributes; pmb_loc} ->
-         Mb.mk (map_loc this pmb_name) (this.module_expr this pmb_expr)
+      (fun this {pmb_name; pmb_args; pmb_expr; pmb_attributes; pmb_loc} ->
+         Mb.mk (map_loc this pmb_name)
+           (List.map (map_functor_param this) pmb_args)
+           (this.module_expr this pmb_expr)
            ~attrs:(this.attributes this pmb_attributes)
            ~loc:(this.location this pmb_loc)
       );

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -1089,10 +1089,10 @@ parse_any_longident:
 functor_arg:
     (* An anonymous and untyped argument. *)
     LPAREN RPAREN
-      { Unit }
+      { mkloc Unit (make_loc $sloc) }
   | (* An argument accompanied with an explicit type. *)
     LPAREN x = mkrhs(module_name) COLON mty = module_type RPAREN
-      { Named (x, mty) }
+      { mkloc (Named (x, mty)) (make_loc $sloc) }
 ;
 
 module_name:
@@ -1428,10 +1428,12 @@ module_type:
       mkrhs(mty_longident)
         { Pmty_ident $1 }
     | LPAREN RPAREN MINUSGREATER module_type
-        { Pmty_functor([Unit], $4) }
+        { let arg_loc = make_loc ($startpos($1), $endpos($2)) in
+          Pmty_functor([mkloc Unit arg_loc], $4) }
     | module_type MINUSGREATER module_type
         %prec below_WITH
-        { Pmty_functor([Named (mknoloc None, $1)], $3) }
+        { let arg_loc = make_loc $loc($1) in
+          Pmty_functor([mkloc (Named (mknoloc None, $1)) arg_loc], $3) }
     | module_type WITH separated_nonempty_llist(AND, with_constraint)
         { Pmty_with($1, $3) }
 /*  | LPAREN MODULE mkrhs(mod_longident) RPAREN

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -862,8 +862,8 @@ and module_type =
 and module_type_desc =
   | Pmty_ident of Longident.t loc  (** [Pmty_ident(S)] represents [S] *)
   | Pmty_signature of signature  (** [sig ... end] *)
-  | Pmty_functor of functor_parameter * module_type
-      (** [functor(X : MT1) -> MT2] *)
+  | Pmty_functor of functor_parameter list * module_type
+      (** [functor (X1 : MT1) ... (Xn : MTn) -> MT] *)
   | Pmty_with of module_type * with_constraint list  (** [MT with ...] *)
   | Pmty_typeof of module_expr  (** [module type of ME] *)
   | Pmty_extension of extension  (** [[%id]] *)
@@ -1010,8 +1010,8 @@ and module_expr =
 and module_expr_desc =
   | Pmod_ident of Longident.t loc  (** [X] *)
   | Pmod_structure of structure  (** [struct ... end] *)
-  | Pmod_functor of functor_parameter * module_expr
-      (** [functor(X : MT1) -> ME] *)
+  | Pmod_functor of functor_parameter list * module_expr
+      (** [functor (X1 : MT1) ... (Xn : MTn) -> ME] *)
   | Pmod_apply of module_expr * module_expr  (** [ME1(ME2)] *)
   | Pmod_constraint of module_expr * module_type  (** [(ME : MT)] *)
   | Pmod_unpack of expression * package_type option * package_type option

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -408,7 +408,7 @@ and expression_desc =
   | Pexp_setinstvar of label loc * expression  (** [x <- 2] *)
   | Pexp_override of (label loc * expression) list
       (** [{< x1 = E1; ...; xn = En >}] *)
-  | Pexp_letmodule of string option loc * module_expr * expression
+  | Pexp_letmodule of string option loc * functor_parameter loc list * module_expr * expression
       (** [let module M = ME in E] *)
   | Pexp_letexception of extension_constructor * expression
       (** [let exception C in E] *)
@@ -914,6 +914,7 @@ and signature_item_desc =
 and module_declaration =
     {
      pmd_name: string option loc;
+     pmd_args: functor_parameter loc list;
      pmd_type: module_type;
      pmd_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
      pmd_loc: Location.t;
@@ -1078,6 +1079,7 @@ and let_bindings =
 and module_binding =
     {
      pmb_name: string option loc;
+     pmb_args: functor_parameter loc list;
      pmb_expr: module_expr;
      pmb_attributes: attributes;
      pmb_loc: Location.t;

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -862,7 +862,7 @@ and module_type =
 and module_type_desc =
   | Pmty_ident of Longident.t loc  (** [Pmty_ident(S)] represents [S] *)
   | Pmty_signature of signature  (** [sig ... end] *)
-  | Pmty_functor of functor_parameter list * module_type
+  | Pmty_functor of functor_parameter loc list * module_type
       (** [functor (X1 : MT1) ... (Xn : MTn) -> MT] *)
   | Pmty_with of module_type * with_constraint list  (** [MT with ...] *)
   | Pmty_typeof of module_expr  (** [module type of ME] *)
@@ -1010,7 +1010,7 @@ and module_expr =
 and module_expr_desc =
   | Pmod_ident of Longident.t loc  (** [X] *)
   | Pmod_structure of structure  (** [struct ... end] *)
-  | Pmod_functor of functor_parameter list * module_expr
+  | Pmod_functor of functor_parameter loc list * module_expr
       (** [functor (X1 : MT1) ... (Xn : MTn) -> ME] *)
   | Pmod_apply of module_expr * module_expr  (** [ME1(ME2)] *)
   | Pmod_constraint of module_expr * module_type  (** [(ME : MT)] *)

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -778,8 +778,12 @@ and class_declaration i ppf x =
   line i ppf "pci_expr =\n";
   class_expr (i+1) ppf x.pci_expr;
 
-and functor_parameter i ppf = function
-  | Unit -> line i ppf "Unit\n"
+and functor_parameter i ppf x =
+  line i ppf "functor_parameter %a\n" fmt_location x.loc;
+  let i = i+1 in
+  match x.txt with
+  | Unit ->
+      line i ppf "Unit\n"
   | Named (s, mt) ->
       line i ppf "Named %a\n" fmt_str_opt_loc s;
       module_type i ppf mt

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -778,6 +778,12 @@ and class_declaration i ppf x =
   line i ppf "pci_expr =\n";
   class_expr (i+1) ppf x.pci_expr;
 
+and functor_parameter i ppf = function
+  | Unit -> line i ppf "Unit\n"
+  | Named (s, mt) ->
+      line i ppf "Named %a\n" fmt_str_opt_loc s;
+      module_type i ppf mt
+
 and module_type i ppf x =
   line i ppf "module_type %a\n" fmt_location x.pmty_loc;
   attributes i ppf x.pmty_attributes;
@@ -788,13 +794,10 @@ and module_type i ppf x =
   | Pmty_signature (s) ->
       line i ppf "Pmty_signature\n";
       signature i ppf s;
-  | Pmty_functor (Unit, mt2) ->
-      line i ppf "Pmty_functor ()\n";
-      module_type i ppf mt2;
-  | Pmty_functor (Named (s, mt1), mt2) ->
-      line i ppf "Pmty_functor %a\n" fmt_str_opt_loc s;
-      module_type i ppf mt1;
-      module_type i ppf mt2;
+  | Pmty_functor (params, mt) ->
+      line i ppf "Pmty_functor\n";
+      list i functor_parameter ppf params;
+      module_type i ppf mt
   | Pmty_with (mt, l) ->
       line i ppf "Pmty_with\n";
       module_type i ppf mt;
@@ -902,13 +905,10 @@ and module_expr i ppf x =
   | Pmod_structure (s) ->
       line i ppf "Pmod_structure\n";
       structure i ppf s;
-  | Pmod_functor (Unit, me) ->
-      line i ppf "Pmod_functor ()\n";
-      module_expr i ppf me;
-  | Pmod_functor (Named (s, mt), me) ->
-      line i ppf "Pmod_functor %a\n" fmt_str_opt_loc s;
-      module_type i ppf mt;
-      module_expr i ppf me;
+  | Pmod_functor (params, me) ->
+      line i ppf "Pmod_functor\n";
+      list i functor_parameter ppf params;
+      module_expr i ppf me
   | Pmod_apply (me1, me2) ->
       line i ppf "Pmod_apply\n";
       module_expr i ppf me1;

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -429,8 +429,9 @@ and expression i ppf x =
   | Pexp_override (l) ->
       line i ppf "Pexp_override\n";
       list i string_x_expression ppf l;
-  | Pexp_letmodule (s, me, e) ->
+  | Pexp_letmodule (s, args, me, e) ->
       line i ppf "Pexp_letmodule %a\n" fmt_str_opt_loc s;
+      list i functor_parameter ppf args;
       module_expr i ppf me;
       expression i ppf e;
   | Pexp_letexception (cd, e) ->
@@ -998,12 +999,14 @@ and module_type_declaration i ppf x =
 and module_declaration i ppf pmd =
   line i ppf "module_declaration %a %a\n" fmt_str_opt_loc pmd.pmd_name
     fmt_location pmd.pmd_loc;
+  list i functor_parameter ppf pmd.pmd_args;
   attributes i ppf pmd.pmd_attributes;
   module_type (i+1) ppf pmd.pmd_type;
 
 and module_binding i ppf x =
   line i ppf "module_binding %a %a\n" fmt_str_opt_loc x.pmb_name
     fmt_location x.pmb_loc;
+  list i functor_parameter ppf x.pmb_args;
   attributes i ppf x.pmb_attributes;
   module_expr (i+1) ppf x.pmb_expr
 


### PR DESCRIPTION
I was reminded of the state of the functors while working on the new syntax.

This simplifies the formatting, removes the sugaring, the need to relocate comments and the need to lookup the source.