### PR TITLE
test_branch: Numstat and run ocp-indent once

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,4 +98,4 @@ jobs:
         shell: bash
         env:
           OCP_INDENT_CONFIG: ${{ matrix.ocp_indent_config }}
-          TEST_BRANCH_ARGS: ${{ matrix.ocp_indent && '-o' || '' }}
+          TEST_BRANCH_ARGS: ${{ matrix.ocp_indent && '-o -s' || '' }}

--- a/test-extra/Makefile
+++ b/test-extra/Makefile
@@ -133,3 +133,11 @@ test_margins:
 apply_ocp:
 	@echo "Running ocp-indent with options '$(OCP_INDENT_CONFIG)'"
 	@-find $(ALL_DIRS) $(FIND_ARGS) | parallel ocp-indent --config "$(OCP_INDENT_CONFIG)" --inplace
+
+# Number of addition and deletion in each files in a parsable format
+.PHONY: test_numstat
+test_numstat:
+	@for dir in $(ALL_DIRS); do git -C $$dir diff --numstat; done | { \
+	tadd=0; tdel=0; \
+	while read add del _; do tadd=$$((tadd + add)); tdel=$$((tdel + del)); done; \
+	echo "Total: +$$tadd -$$tdel"; }

--- a/tools/test_branch.sh
+++ b/tools/test_branch.sh
@@ -11,7 +11,7 @@
 #                                                                    #
 ######################################################################
 
-# usage: test_branch.sh [-n] [-o] [-l] [-a=rev] [-b=rev] [<option>=<value>*] [<option>=<value>*]
+# usage: test_branch.sh [-n] [-o] [-l] [-s] [-a=rev] [-b=rev] [<option>=<value>*] [<option>=<value>*]
 #
 # -a set the base branch and -b the test branch. The default value for
 # the base branch is the merge-base between the test branch and main.
@@ -26,6 +26,8 @@
 #
 # If -l is passed, it will not pull the latest version of the source code used
 # for testing.
+#
+# If -s is passed, show the total diff summary instead of the diffs.
 #
 # The first arg is the value of OCAMLFORMAT to be used when formatting
 # using the base branch (a)
@@ -42,13 +44,15 @@ arg_b=
 arg_n=0
 arg_o=0
 arg_l=0
-while getopts "a:b:nol" opt; do
+arg_s=0
+while getopts "a:b:nols" opt; do
   case "$opt" in
     a) arg_a=$OPTARG ;;
     b) arg_b=$OPTARG ;;
     n) arg_n=1 ;;
     o) arg_o=1 ;;
     l) arg_l=1 ;;
+    s) arg_s=1 ;;
   esac
 done
 shift $((OPTIND-1))
@@ -110,5 +114,8 @@ fi
 apply_ocp=()
 if [[ $arg_o -eq 1 ]]; then apply_ocp=(apply_ocp); fi
 
+last_action=test_diff
+if [[ $arg_s -eq 1 ]]; then last_action=test_numstat; fi
+
 OCAMLFORMAT="$opts_a" make -C test-extra "OCAMLFORMAT_EXE=$exe_a" test "${apply_ocp[@]}" test_stage
-OCAMLFORMAT="$opts_b" make -C test-extra "OCAMLFORMAT_EXE=$exe_b" test "${apply_ocp[@]}" test_diff
+OCAMLFORMAT="$opts_b" make -C test-extra "OCAMLFORMAT_EXE=$exe_b" test "${apply_ocp[@]}" "$last_action"

--- a/tools/test_branch.sh
+++ b/tools/test_branch.sh
@@ -28,7 +28,7 @@
 # If -l is passed, it will not pull the latest version of the source code used
 # for testing.
 #
-# If -s is passed, show the total diff summary instead of the diffs.
+# If -s is passed, diffs are not shown.
 #
 # The first arg is the value of OCAMLFORMAT to be used when formatting
 # using the base branch (a)
@@ -119,6 +119,5 @@ if [[ $arg_o -ge 1 ]]; then run apply_ocp; fi
 run test_stage
 OCAMLFORMAT="$opts_b" run "OCAMLFORMAT_EXE=$exe_b" test
 if [[ $arg_o -ge 2 ]]; then run apply_ocp; fi
-if [[ $arg_s -eq 1 ]]; then run test_numstat
-else run test_diff
-fi
+if [[ $arg_s -eq 0 ]]; then run test_diff; fi
+run test_numstat

--- a/tools/test_branch.sh
+++ b/tools/test_branch.sh
@@ -20,7 +20,8 @@
 # If -n is passed, values of -a and -b are paths to ocamlformat binaries
 # instead of revs.
 #
-# If -o is passed, ocp-indent is applied after ocamlformat in each pass.
+# If -o is passed, ocp-indent is applied after ocamlformat in the first pass.
+# Pass it twice to apply ocp-indent after each passes.
 # Options can be passed to it using the 'OCP_INDENT_CONFIG' environment
 # variable.
 #
@@ -50,7 +51,7 @@ while getopts "a:b:nols" opt; do
     a) arg_a=$OPTARG ;;
     b) arg_b=$OPTARG ;;
     n) arg_n=1 ;;
-    o) arg_o=1 ;;
+    o) arg_o=$((arg_o + 1)) ;;
     l) arg_l=1 ;;
     s) arg_s=1 ;;
   esac
@@ -106,16 +107,18 @@ else
   exe_b=`realpath $arg_b`
 fi
 
-make -C test-extra test_setup test_unstage test_clean
+run () { make -C test-extra "$@"; }
+
+run test_setup test_unstage test_clean
 if [[ $arg_l -eq 0 ]]; then
-  make -C test-extra test_pull
+  run test_pull
 fi
 
-apply_ocp=()
-if [[ $arg_o -eq 1 ]]; then apply_ocp=(apply_ocp); fi
-
-last_action=test_diff
-if [[ $arg_s -eq 1 ]]; then last_action=test_numstat; fi
-
-OCAMLFORMAT="$opts_a" make -C test-extra "OCAMLFORMAT_EXE=$exe_a" test "${apply_ocp[@]}" test_stage
-OCAMLFORMAT="$opts_b" make -C test-extra "OCAMLFORMAT_EXE=$exe_b" test "${apply_ocp[@]}" "$last_action"
+OCAMLFORMAT="$opts_a" run "OCAMLFORMAT_EXE=$exe_a" test
+if [[ $arg_o -ge 1 ]]; then run apply_ocp; fi
+run test_stage
+OCAMLFORMAT="$opts_b" run "OCAMLFORMAT_EXE=$exe_b" test
+if [[ $arg_o -ge 2 ]]; then run apply_ocp; fi
+if [[ $arg_s -eq 1 ]]; then run test_numstat
+else run test_diff
+fi


### PR DESCRIPTION
Numstat are useful to measure the impact of a change wrt ocp-indent-compatibility.
The other change allows to show the difference in indentation between the two tools (taken from https://github.com/ocaml-ppx/ocamlformat/pull/2314)