### PR TITLE
Align pattern alias

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -974,12 +974,13 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
       in
       hovbox 0
         (wrap_fits_breaks_if ~space:false c.conf parens "(" ")"
-           ( fmt_pattern c ?parens:paren_pat (sub_pat ~ctx pat)
-           $ fmt "@ as@ "
-           $ Cmts.fmt c loc
-               (wrap_if
-                  (Std_longident.String_id.is_symbol txt)
-                  "( " " )" (str txt) ) ) )
+           (hovbox 0
+              ( fmt_pattern c ?parens:paren_pat (sub_pat ~ctx pat)
+              $ fmt "@ as@ "
+              $ Cmts.fmt c loc
+                  (wrap_if
+                     (Std_longident.String_id.is_symbol txt)
+                     "( " " )" (str txt) ) ) ) )
   | Ppat_constant const -> fmt_constant c const
   | Ppat_interval (l, u) -> fmt_constant c l $ str " .. " $ fmt_constant c u
   | Ppat_tuple pats ->
@@ -2402,7 +2403,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
           [ { pstr_desc=
                 Pstr_eval
                   ( ( {pexp_desc= Pexp_sequence _; pexp_attributes= []; _} as
-                    e1 )
+                      e1 )
                   , _ )
             ; pstr_loc= _ } ] )
     when Source.extension_using_sugar ~name:ext ~payload:e1.pexp_loc
@@ -2488,7 +2489,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
           [ ( { pstr_desc=
                   Pstr_eval
                     ( ( {pexp_desc= Pexp_infix _; pexp_attributes= []; _} as
-                      e1 )
+                        e1 )
                     , _ )
               ; pstr_loc= _ } as str ) ] )
     when List.is_empty pexp_attributes

--- a/test/passing/tests/indicate_multiline_delimiters-cosl.ml.ref
+++ b/test/passing/tests/indicate_multiline_delimiters-cosl.ml.ref
@@ -49,3 +49,14 @@ let contrived =
   List.map l ~f:(fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
       f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   )
+
+let x =
+  match y with
+  | Empty | Leaf _ -> assert false
+  | Node
+      ( {left= lr_left; key= _; value= fooooooo; height= _; right= lr_right}
+      as lr_node
+      ) ->
+      left_node.right <- lr_left ;
+      root_node.left <- lr_right ;
+      lr_node.right <- tree

--- a/test/passing/tests/indicate_multiline_delimiters-cosl.ml.ref
+++ b/test/passing/tests/indicate_multiline_delimiters-cosl.ml.ref
@@ -55,7 +55,7 @@ let x =
   | Empty | Leaf _ -> assert false
   | Node
       ( {left= lr_left; key= _; value= fooooooo; height= _; right= lr_right}
-      as lr_node
+        as lr_node
       ) ->
       left_node.right <- lr_left ;
       root_node.left <- lr_right ;

--- a/test/passing/tests/indicate_multiline_delimiters-space.ml.ref
+++ b/test/passing/tests/indicate_multiline_delimiters-space.ml.ref
@@ -43,3 +43,13 @@ let contrived =
 let contrived =
   List.map l ~f:(fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
       f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa )
+
+let x =
+  match y with
+  | Empty | Leaf _ -> assert false
+  | Node
+      ( {left= lr_left; key= _; value= fooooooo; height= _; right= lr_right}
+      as lr_node ) ->
+      left_node.right <- lr_left ;
+      root_node.left <- lr_right ;
+      lr_node.right <- tree

--- a/test/passing/tests/indicate_multiline_delimiters-space.ml.ref
+++ b/test/passing/tests/indicate_multiline_delimiters-space.ml.ref
@@ -49,7 +49,7 @@ let x =
   | Empty | Leaf _ -> assert false
   | Node
       ( {left= lr_left; key= _; value= fooooooo; height= _; right= lr_right}
-      as lr_node ) ->
+        as lr_node ) ->
       left_node.right <- lr_left ;
       root_node.left <- lr_right ;
       lr_node.right <- tree

--- a/test/passing/tests/indicate_multiline_delimiters.ml
+++ b/test/passing/tests/indicate_multiline_delimiters.ml
@@ -43,3 +43,13 @@ let contrived =
 let contrived =
   List.map l ~f:(fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
       f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+
+let x =
+  match y with
+  | Empty | Leaf _ -> assert false
+  | Node
+      ({left= lr_left; key= _; value= fooooooo; height= _; right= lr_right}
+      as lr_node) ->
+      left_node.right <- lr_left ;
+      root_node.left <- lr_right ;
+      lr_node.right <- tree

--- a/test/passing/tests/indicate_multiline_delimiters.ml
+++ b/test/passing/tests/indicate_multiline_delimiters.ml
@@ -49,7 +49,7 @@ let x =
   | Empty | Leaf _ -> assert false
   | Node
       ({left= lr_left; key= _; value= fooooooo; height= _; right= lr_right}
-      as lr_node) ->
+       as lr_node) ->
       left_node.right <- lr_left ;
       root_node.left <- lr_right ;
       lr_node.right <- tree


### PR DESCRIPTION
The rhs of a `as` in a pattern should be aligned to the lhs when parenthesis are added.

Increases readability, especially when there are nested parenthesis.