### PR TITLE
ocp-indent-compat: Docked fun on same line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,7 @@
 
 - Restore short form for first-class modules: `((module M) : (module S))` is formatted as `(module M : S)`) (#2280, #2300, @gpetiot, @Julow)
 - Restore short form formatting of record field aliases (#2282, @gpetiot)
-- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2214, #2281, #2284, #2289, #2299, #2302, #2309, #2310, #2311, #2313, #2316, @gpetiot, @Julow)
+- Tweaks the JaneStreet profile to be more consistent with ocp-indent (#2214, #2281, #2284, #2289, #2299, #2302, #2309, #2310, #2311, #2313, #2316, #2362, @gpetiot, @Julow)
 - Improve formatting of class signatures (#2301, @gpetiot, @Julow)
 - JaneStreet profile: treat comments as doc-comments (#2261, #2344, #2354, @gpetiot, @Julow)
 - Don't indent attributes after a let/val/external (#2317, @Julow)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1511,8 +1511,8 @@ and fmt_infix_op_args c ~parens xexp op_args =
   let groups =
     let width xe = expression_width c xe in
     let not_simple arg = not (is_simple c.conf width arg) in
-    let break (has_cmts, _, _, (_, arg1)) (_, _, _, (_, arg2)) =
-      has_cmts || not_simple arg1 || not_simple arg2
+    let break (cmts_before1, _, (_, arg1)) (_, _, (_, arg2)) =
+      Option.is_some cmts_before1 || not_simple arg1 || not_simple arg2
     in
     let break_infix =
       match c.conf.fmt_opts.break_infix.v with
@@ -1523,7 +1523,7 @@ and fmt_infix_op_args c ~parens xexp op_args =
         | Some p when Prec.compare p InfixOp1 < 0 -> `Fit_or_vertical
         | Some _ ->
             if
-              List.exists op_args ~f:(fun (_, _, _, (_, {ast= arg; _})) ->
+              List.exists op_args ~f:(fun (_, _, (_, {ast= arg; _})) ->
                   match Ast.prec_ast (Exp arg) with
                   | Some p when Prec.compare p Apply <= 0 -> true
                   | Some _ -> false
@@ -1568,17 +1568,19 @@ and fmt_infix_op_args c ~parens xexp op_args =
     let indent = if first_grp && parens then -2 else 0 in
     hovbox indent
       (list_fl args
-         (fun ~first ~last (_, cmts_before, cmts_after, (op, xarg)) ->
+         (fun ~first ~last (cmts_before, cmts_after, (op, xarg)) ->
            let very_first = first_grp && first in
            let very_last = last_grp && last in
-           let epi =
+           let epi, before_arg =
              let break =
                if very_last && is_not_indented xarg then fmt "@ "
                else fmt_if (not very_first) " "
              in
-             op $ break $ cmts_after
+             match cmts_after with
+             | Some c -> (noop, op $ break $ c)
+             | None -> (op $ break, noop)
            in
-           cmts_before
+           fmt_opt cmts_before $ before_arg
            $ fmt_arg ~epi ~very_last xarg
            $ fmt_if_k (not last) (break 1 0) ) )
     $ fmt_if_k (not last_grp) (break 1 0)
@@ -1836,9 +1838,12 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             | Some op ->
                 (* side effects of Cmts.fmt_before before fmt_expression is
                    important *)
-                let has_cmts = Cmts.has_before c.cmts op.loc in
                 let adj = break 1000 0 in
-                let fmt_before_cmts = Cmts.fmt_before ~adj c op.loc in
+                let fmt_before_cmts =
+                  if Cmts.has_before c.cmts op.loc then
+                    Some (Cmts.fmt_before ~adj c op.loc)
+                  else None
+                in
                 (* The comments before the first arg are put there, so that
                    they are printed after the operator and the box is
                    correctly broken before the following arguments. Keeping
@@ -1847,12 +1852,18 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    before the operator in some cases and make the formatting
                    unstable. *)
                 let fmt_after_cmts =
-                  Cmts.fmt_after c op.loc
-                  $ Cmts.fmt_before ~adj c arg.ast.pexp_loc
+                  if
+                    Cmts.has_after c.cmts op.loc
+                    || Cmts.has_before c.cmts arg.ast.pexp_loc
+                  then
+                    Some
+                      ( Cmts.fmt_after c op.loc
+                      $ Cmts.fmt_before ~adj c arg.ast.pexp_loc )
+                  else None
                 in
                 let fmt_op = fmt_str_loc c op in
-                (has_cmts, fmt_before_cmts, fmt_after_cmts, (fmt_op, arg))
-            | None -> (false, noop, noop, (noop, arg)) )
+                (fmt_before_cmts, fmt_after_cmts, (fmt_op, arg))
+            | None -> (None, None, (noop, arg)) )
       in
       hvbox_if outer_wrap 0
         (Params.parens_if outer_wrap c.conf
@@ -2078,8 +2089,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         ( hvbox indent_wrap
             (fmt_infix_op_args c ~parens xexp
                (List.mapi l ~f:(fun i e ->
-                    (false, noop, noop, (fmt_if (i > 0) "::", sub_exp ~ctx e)) )
-               ) )
+                    (None, None, (fmt_if (i > 0) "::", sub_exp ~ctx e)) ) ) )
         $ fmt_atrs )
   | Pexp_construct (lid, Some arg) ->
       Params.parens_if parens c.conf

--- a/test/passing/tests/infix_bind-break.ml.ref
+++ b/test/passing/tests/infix_bind-break.ml.ref
@@ -184,8 +184,7 @@ let f =
   (* fooooooooooooooo foooooooooooooooo *)
   Ok ()
   >>= (* *)
-  function
-  | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
+  function Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 let f =
   Ok ()
@@ -198,8 +197,7 @@ let f =
   Ok ()
   >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo
          foooooooooooooooo *)
-  function
-  | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
+  function Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 (** The tests below are testing a dropped comment with
     `--no-break-infix-before-func` *)

--- a/test/passing/tests/infix_bind-fit_or_vertical-break.ml.ref
+++ b/test/passing/tests/infix_bind-fit_or_vertical-break.ml.ref
@@ -189,8 +189,7 @@ let f =
   (* fooooooooooooooo foooooooooooooooo *)
   Ok ()
   >>= (* *)
-  function
-  | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
+  function Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 let f =
   Ok ()
@@ -203,8 +202,7 @@ let f =
   Ok ()
   >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo
          foooooooooooooooo *)
-  function
-  | Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
+  function Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 (** The tests below are testing a dropped comment with
     `--no-break-infix-before-func` *)

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7873,3 +7873,81 @@ let () =
      | _ -> ())
   | _ -> ()
 ;;
+
+(* ocp-indent-compat: Docked fun after apply only if on the same line. *)
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo:(fun foo -> bar)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo:(fun foo -> bar)
+       ~fooooooooooooooooooooooooooooooo
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo:(fun foo ->
+         match bar with
+         | Some _ -> foo
+         | None -> baz)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (fun foo -> bar)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (fun foo ->
+    match bar with
+    | Some _ -> foo
+    | None -> baz)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       (fun foo ->
+          match bar with
+          | Some _ -> foo
+          | None -> baz)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooofooooooooooooooooooooooooooooooofoooooooooo
+       (fun foo ->
+          match bar with
+          | Some _ -> foo
+          | None -> baz)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> foooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (function foo -> bar)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (function
+    | Some _ -> foo
+    | None -> baz)
+;;

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -10109,3 +10109,81 @@ let () =
        | _ -> ())
   | _ -> ()
 ;;
+
+(* ocp-indent-compat: Docked fun after apply only if on the same line. *)
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo:(fun foo -> bar)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo:(fun foo -> bar)
+       ~fooooooooooooooooooooooooooooooo
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo:(fun foo ->
+         match bar with
+         | Some _ -> foo
+         | None -> baz)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (fun foo -> bar)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (fun foo ->
+    match bar with
+    | Some _ -> foo
+    | None -> baz)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       (fun foo ->
+          match bar with
+          | Some _ -> foo
+          | None -> baz)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooofooooooooooooooooooooooooooooooofoooooooooo
+       (fun foo ->
+          match bar with
+          | Some _ -> foo
+          | None -> baz)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> foooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (function foo -> bar)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (function
+    | Some _ -> foo
+    | None -> baz)
+;;

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -10109,3 +10109,81 @@ let () =
       | _ -> ())
   | _ -> ()
 ;;
+
+(* ocp-indent-compat: Docked fun after apply only if on the same line. *)
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo:(fun foo -> bar)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo:(fun foo -> bar)
+       ~fooooooooooooooooooooooooooooooo
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo:(fun foo ->
+         match bar with
+         | Some _ -> foo
+         | None -> baz)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (fun foo -> bar)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (fun foo ->
+    match bar with
+    | Some _ -> foo
+    | None -> baz)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       ~fooooooooooooooooooooooooooooooo
+       (fun foo ->
+         match bar with
+         | Some _ -> foo
+         | None -> baz)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooofooooooooooooooooooooooooooooooofoooooooooo
+       (fun foo ->
+         match bar with
+         | Some _ -> foo
+         | None -> baz)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> foooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (function foo -> bar)
+;;
+
+let _ =
+  fooooooooooooooooooooooooooooooo
+  |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (function
+    | Some _ -> foo
+    | None -> baz)
+;;


### PR DESCRIPTION
A fun/function after an apply must be docked only if it starts on the first line of the apply.