### PR TITLE
Requires ocp-indent 1.8.1 with tests

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -58,7 +58,13 @@
     :with-test
     (= :version)))
   (ocp-indent
-   (>= 1.8.0))
+   (or
+    (and
+     (= :with-test false)
+     (>= 1.8.0))
+    (and
+     :with-test
+     (>= 1.8.1))))
   stdio
   (uuseg
    (>= 10.0.0))

--- a/ocamlformat-lib.opam
+++ b/ocamlformat-lib.opam
@@ -21,7 +21,7 @@ depends: [
   "menhirSdk" {>= "20201216"}
   "ocaml-version" {>= "3.5.0"}
   "ocamlformat-rpc-lib" {with-test & = version}
-  "ocp-indent" {>= "1.8.0"}
+  "ocp-indent" {with-test = "false" & >= "1.8.0" | with-test & >= "1.8.1"}
   "stdio"
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}


### PR DESCRIPTION
Caught by ocaml-ci bounds check.