### PR TITLE
Fix crash with exp-grouping and if-then-else

### DIFF
--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -426,15 +426,15 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
     else if parens_bch then wrap "(" ")" (wrap_breaks k)
     else k
   in
-  let get_parens_breaks ~opn_hint:(oh_space, oh_other)
-      ~cls_hint:(ch_sp, ch_sl) =
+  let get_parens_breaks ~opn_hint_indent ~cls_hint:(ch_sp, ch_sl) =
     let brk hint = fits_breaks "" ~hint "" in
+    let oh_other = ((if beginend then 1 else 0), opn_hint_indent) in
     if beginend then
       let _, offset = ch_sl in
       wrap_k (brk oh_other) (break 1000 offset)
     else
       match imd with
-      | `Space -> wrap_k (brk oh_space) (brk ch_sp)
+      | `Space -> wrap_k (brk (1, opn_hint_indent)) (brk ch_sp)
       | `No -> wrap_k (brk oh_other) noop
       | `Closing_on_separate_line -> wrap_k (brk oh_other) (brk ch_sl)
   in
@@ -460,8 +460,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:
-              (get_parens_breaks
-                 ~opn_hint:((1, 0), (0, 0))
+              (get_parens_breaks ~opn_hint_indent:0
                  ~cls_hint:((1, 0), (1000, -2)) )
       ; box_expr= Some false
       ; expr_pro= None
@@ -492,8 +491,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:
-              (get_parens_breaks
-                 ~opn_hint:((1, 2), (0, 2))
+              (get_parens_breaks ~opn_hint_indent:2
                  ~cls_hint:((1, 0), (1000, 0)) )
       ; box_expr= Some false
       ; expr_pro=
@@ -516,8 +514,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:
-              (get_parens_breaks
-                 ~opn_hint:((1, 2), (0, 2))
+              (get_parens_breaks ~opn_hint_indent:2
                  ~cls_hint:((1, 0), (1000, 0)) )
       ; box_expr= None
       ; expr_pro= Some (break_unless_newline 1000 2)
@@ -546,8 +543,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:
-              (get_parens_breaks
-                 ~opn_hint:((1, 0), (0, 0))
+              (get_parens_breaks ~opn_hint_indent:0
                  ~cls_hint:((1, 0), (1000, -2)) )
       ; box_expr= Some false
       ; expr_pro= None

--- a/test/passing/tests/exp_grouping-parens.ml.ref
+++ b/test/passing/tests/exp_grouping-parens.ml.ref
@@ -204,6 +204,8 @@ let _ =
   [| (let a = b in
       c ) |]
 
+let () = if a then b (* asd *)
+
 [@@@ocamlformat "if-then-else=compact"]
 
 let _ =
@@ -214,6 +216,8 @@ let _ =
   else (
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
     Fooo fooo )
+
+let () = if a then b (* asd *)
 
 [@@@ocamlformat "if-then-else=fit-or-vertical"]
 
@@ -227,6 +231,10 @@ let _ =
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
     Fooo fooo )
 
+let () =
+  if a then
+    b (* asd *)
+
 [@@@ocamlformat "if-then-else=keyword-first"]
 
 let _ =
@@ -239,6 +247,8 @@ let _ =
   else (
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
     Fooo fooo )
+
+let () = if a then b (* asd *)
 
 [@@@ocamlformat "if-then-else=k-r"]
 
@@ -295,3 +305,5 @@ let _ =
     market_data_items := ()
   end
   [@landmark "parse_constant_dividends"]
+
+let () = if a then b (* asd *)

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -122,6 +122,11 @@ let _ = a :: ( let a = b in c )
 let _ = [ ( let a = b in c ) ]
 let _ = [| ( let a = b in c ) |]
 
+let () =
+  if a then begin b
+    (* asd *)
+  end
+
 [@@@ocamlformat "if-then-else=compact"]
 
 let _ =
@@ -134,6 +139,11 @@ let _ =
   else begin
     foo.fooooo <- Fooo.foo fooo foo.fooooo;
     Fooo fooo
+  end
+
+let () =
+  if a then begin b
+    (* asd *)
   end
 
 [@@@ocamlformat "if-then-else=fit-or-vertical"]
@@ -150,6 +160,11 @@ let _ =
     Fooo fooo
   end
 
+let () =
+  if a then begin b
+    (* asd *)
+  end
+
 [@@@ocamlformat "if-then-else=keyword-first"]
 
 let _ =
@@ -162,6 +177,11 @@ let _ =
   else begin
     foo.fooooo <- Fooo.foo fooo foo.fooooo;
     Fooo fooo
+  end
+
+let () =
+  if a then begin b
+    (* asd *)
   end
 
 [@@@ocamlformat "if-then-else=k-r"]
@@ -223,4 +243,9 @@ let _ = begin%ext (* foo *) x y end
 let _ =
   begin[@landmark "parse_constant_dividends"]
     market_data_items := ()
+  end
+
+let () =
+  if a then begin b
+    (* asd *)
   end

--- a/test/passing/tests/exp_grouping.ml.ref
+++ b/test/passing/tests/exp_grouping.ml.ref
@@ -214,6 +214,11 @@ let _ =
   [| (let a = b in
       c ) |]
 
+let () =
+  if a then begin b
+    (* asd *)
+  end
+
 [@@@ocamlformat "if-then-else=compact"]
 
 let _ =
@@ -227,6 +232,11 @@ let _ =
   else begin
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
     Fooo fooo
+  end
+
+let () =
+  if a then begin b
+    (* asd *)
   end
 
 [@@@ocamlformat "if-then-else=fit-or-vertical"]
@@ -244,6 +254,12 @@ let _ =
     Fooo fooo
   end
 
+let () =
+  if a then begin
+    b
+  (* asd *)
+  end
+
 [@@@ocamlformat "if-then-else=keyword-first"]
 
 let _ =
@@ -259,6 +275,12 @@ let _ =
   else begin
     foo.fooooo <- Fooo.foo fooo foo.fooooo ;
     Fooo fooo
+  end
+
+let () =
+  if a
+  then begin b
+    (* asd *)
   end
 
 [@@@ocamlformat "if-then-else=k-r"]
@@ -333,3 +355,9 @@ let _ =
     market_data_items := ()
   end
   [@landmark "parse_constant_dividends"]
+
+let () =
+  if a then begin
+    b
+  (* asd *)
+  end


### PR DESCRIPTION
Closes: https://github.com/ocaml-ppx/ocamlformat/issues/2368

The formatting for if-then-else did not account for the begin-end in some cases and generated invalid syntax.