### PR TITLE
Fix crash with module unpack with constraint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 
+- Fix crash due to `module T = (val (x : (module S)))` (#2370, @Julow)
 - Fix invalid formatting of `then begin end` (#2369, @Julow)
 - Protect match after `fun _ : _ ->` (#2352, @Julow)
 - Fix invalid formatting of `(::)` (#2347, @Julow)

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1388,15 +1388,7 @@ end = struct
        |Pstr_class _ | Pstr_class_type _ | Pstr_include _ | Pstr_attribute _
         ->
           assert false )
-    | Mod {pmod_desc= Pmod_unpack (e1, _, _); _} -> (
-      match e1 with
-      | { pexp_desc=
-            Pexp_constraint
-              (e, {ptyp_desc= Ptyp_package _; ptyp_attributes= []; _})
-        ; pexp_attributes= []
-        ; _ } ->
-          assert (e == exp)
-      | e -> assert (e == exp) )
+    | Mod {pmod_desc= Pmod_unpack (e1, _, _); _} -> assert (e1 == exp)
     | Cl ctx ->
         let rec loop ctx =
           match ctx.pcl_desc with

--- a/test/passing/tests/first_class_module.ml
+++ b/test/passing/tests/first_class_module.ml
@@ -111,3 +111,6 @@ let _ =
 let x : (module S) = (module M)
 let x = ((module M) : (module S))
 let x = (module M : S)
+
+(* Unpack containing a [pexp_constraint]. *)
+module T = (val (x : (module S)))

--- a/test/passing/tests/first_class_module.ml.ref
+++ b/test/passing/tests/first_class_module.ml.ref
@@ -113,3 +113,6 @@ let x : (module S) = (module M)
 let x = (module M : S)
 
 let x = (module M : S)
+
+(* Unpack containing a [pexp_constraint]. *)
+module T = (val (x : (module S)))


### PR DESCRIPTION
The crash was caused by an Ast rule that is outdated since #2191.