### PR TITLE
Don't mix comments and docstrings

### DIFF
--- a/lib/Cmt.mli
+++ b/lib/Cmt.mli
@@ -13,7 +13,11 @@ open Migrate_ast
 
 type t
 
-val create : string -> Location.t -> t
+val create_comment : string -> Location.t -> t
+
+val create_docstring : string -> Location.t -> t
+
+val is_docstring : t -> bool
 
 val loc : t -> Location.t
 

--- a/lib/Cmt.mli
+++ b/lib/Cmt.mli
@@ -11,7 +11,7 @@
 
 open Migrate_ast
 
-type t = private {txt: string; loc: Location.t}
+type t
 
 val create : string -> Location.t -> t
 

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -161,7 +161,7 @@ end = struct
 
   let of_list cmts =
     List.fold cmts ~init:empty ~f:(fun map cmt ->
-        let pos = cmt.Cmt.loc.loc_start in
+        let pos = (Cmt.loc cmt).loc_start in
         Map.add_multi map ~key:pos ~data:cmt )
 
   let to_list map = List.concat (Map.data map)
@@ -188,16 +188,16 @@ end = struct
       | _ -> true
     in
     match to_list cmts with
-    | Cmt.{loc; _} :: _ as cmtl
-      when is_adjacent ~filter:ignore_docstrings src prev loc -> (
+    | cmt :: _ as cmtl
+      when is_adjacent ~filter:ignore_docstrings src prev (Cmt.loc cmt) -> (
       match
         List.group cmtl ~break:(fun l1 l2 ->
             not (is_adjacent src (Cmt.loc l1) (Cmt.loc l2)) )
       with
-      | [cmtl] when is_adjacent src (List.last_exn cmtl).loc next ->
+      | [cmtl] when is_adjacent src (Cmt.loc (List.last_exn cmtl)) next ->
           let open Location in
-          let first_loc = (List.hd_exn cmtl).loc in
-          let last_loc = (List.last_exn cmtl).loc in
+          let first_loc = Cmt.loc (List.hd_exn cmtl) in
+          let last_loc = Cmt.loc (List.last_exn cmtl) in
           let same_line_as_prev l =
             prev.loc_end.pos_lnum = l.loc_start.pos_lnum
           in
@@ -211,7 +211,9 @@ end = struct
             | 0, _ -> `After_prev
             | 1, 1 ->
                 if
-                  Location.compare_start_col (List.last_exn cmtl).loc next
+                  Location.compare_start_col
+                    (Cmt.loc (List.last_exn cmtl))
+                    next
                   <= 0
                 then `Before_next
                 else `After_prev
@@ -229,8 +231,8 @@ end = struct
           let prev, next =
             if not (same_line_as_prev next) then
               let next, prev =
-                List.partition_tf cmtl ~f:(fun {Cmt.loc= l; _} ->
-                    match decide l with
+                List.partition_tf cmtl ~f:(fun cmt ->
+                    match decide (Cmt.loc cmt) with
                     | `After_prev -> false
                     | `Before_next -> true )
               in
@@ -249,10 +251,10 @@ let add_cmts t position loc ?deep_loc cmts =
     let key =
       match deep_loc with
       | Some deep_loc ->
-          let cmt = List.last_exn cmtl in
+          let cmt_loc = Cmt.loc (List.last_exn cmtl) in
           if
-            is_adjacent t.source deep_loc cmt.loc
-            && not (Source.begins_line ~ignore_spaces:true t.source cmt.loc)
+            is_adjacent t.source deep_loc cmt_loc
+            && not (Source.begins_line ~ignore_spaces:true t.source cmt_loc)
           then deep_loc
           else loc
       | None -> loc
@@ -294,8 +296,8 @@ let rec place t loc_tree ?prev_loc ?deep_loc locs cmts =
       | Some prev_loc -> add_cmts t `After prev_loc cmts ?deep_loc
       | None ->
           if t.debug then
-            List.iter (CmtSet.to_list cmts) ~f:(fun {Cmt.txt; _} ->
-                Format_.eprintf "lost: %s@\n%!" txt ) ) ;
+            List.iter (CmtSet.to_list cmts) ~f:(fun cmt ->
+                Format_.eprintf "lost: %s@\n%!" (Cmt.txt cmt) ) ) ;
       deep_loc
 
 (** Relocate comments, for Ast transformations such as sugaring. *)
@@ -321,8 +323,8 @@ let relocate (t : t) ~src ~before ~after =
 
 let relocate_cmts_before (t : t) ~src ~sep ~dst =
   let f map =
-    Multimap.partition_multi map ~src ~dst ~f:(fun Cmt.{loc; _} ->
-        Location.compare_end loc sep < 0 )
+    Multimap.partition_multi map ~src ~dst ~f:(fun cmt ->
+        Location.compare_end (Cmt.loc cmt) sep < 0 )
   in
   update_cmts t `Before ~f ; update_cmts t `Within ~f
 
@@ -446,7 +448,8 @@ let find_cmts ?(filter = Fn.const true) t pos loc =
       update_cmts t pos ~f:(Map.set ~key:loc ~data:not_picked) ;
       picked )
 
-let break_comment_group source margin {Cmt.loc= a; _} {Cmt.loc= b; _} =
+let break_comment_group source margin a b =
+  let a = Cmt.loc a and b = Cmt.loc b in
   let vertical_align =
     Location.line_difference a b = 1 && Location.compare_start_col a b = 0
   in
@@ -461,7 +464,7 @@ let break_comment_group source margin {Cmt.loc= a; _} {Cmt.loc= b; _} =
     && (vertical_align || horizontal_align) )
 
 module Asterisk_prefixed = struct
-  let split Cmt.{txt; loc= {Location.loc_start; _}} =
+  let split txt {Location.loc_start; _} =
     let len = Position.column loc_start + 3 in
     let pat =
       String.Search_pattern.create
@@ -583,17 +586,18 @@ module Ocp_indent_compat = struct
       @@ doc
 end
 
-let fmt_cmt (conf : Conf.t) (cmt : Cmt.t) ~fmt_code pos =
+let fmt_cmt (conf : Conf.t) cmt ~fmt_code pos =
+  let loc = Cmt.loc cmt in
   let offset =
-    let pos = cmt.loc.Location.loc_start in
+    let pos = loc.Location.loc_start in
     pos.pos_cnum - pos.pos_bol + 2
   in
   let mode =
-    match cmt.txt with
+    match Cmt.txt cmt with
     | "" -> impossible "not produced by parser"
     (* "(**)" is not parsed as a docstring but as a regular comment
        containing '*' and would be rewritten as "(***)" *)
-    | "*" when Location.width cmt.loc = 4 -> `Verbatim ""
+    | "*" when Location.width loc = 4 -> `Verbatim ""
     | "*" -> `Verbatim "*"
     | "$" -> `Verbatim "$"
     (* Qtest pragmas *)
@@ -613,15 +617,14 @@ let fmt_cmt (conf : Conf.t) (cmt : Cmt.t) ~fmt_code pos =
         match fmt_code conf ~offset source with
         | Ok formatted -> `Code (formatted, cls)
         | Error (`Msg _) -> `Unwrapped (str, None) )
-    | str when Char.equal str.[0] '=' -> `Verbatim cmt.txt
-    | _ -> (
+    | txt when Char.equal txt.[0] '=' -> `Verbatim txt
+    | txt -> (
         let txt =
           (* Windows compatibility *)
           let filter = function '\r' -> false | _ -> true in
-          String.filter cmt.txt ~f:filter
+          String.filter txt ~f:filter
         in
-        let cmt = Cmt.create txt cmt.loc in
-        match Asterisk_prefixed.split cmt with
+        match Asterisk_prefixed.split txt loc with
         | [] | [""] -> impossible "not produced by split_asterisk_prefixed"
         (* Comments like [(*\n*)] would be normalized as [(* *)] *)
         | [""; ""] when conf.fmt_opts.ocp_indent_compat.v ->
@@ -640,8 +643,7 @@ let fmt_cmt (conf : Conf.t) (cmt : Cmt.t) ~fmt_code pos =
   | `Code (code, cls) -> Cinaps.fmt ~cls code
   | `Wrapped (x, epi) -> str "(*" $ fill_text x ~epi
   | `Unwrapped (x, ln) when conf.fmt_opts.ocp_indent_compat.v ->
-      Ocp_indent_compat.fmt ~fmt_code conf x ~loc:cmt.loc ~offset pos
-        ~post:ln
+      Ocp_indent_compat.fmt ~fmt_code conf x ~loc ~offset pos ~post:ln
   | `Unwrapped (x, _) -> Unwrapped.fmt ~offset x
   | `Asterisk_prefixed x -> Asterisk_prefixed.fmt x
 
@@ -661,9 +663,12 @@ let fmt_cmts_aux t (conf : Conf.t) cmts ~fmt_code pos =
                  wrap "(*" "*)" (str (Cmt.txt cmt)) ) )
          $
          match next with
-         | Some ({loc= next; _} :: _) ->
-             let Cmt.{loc= last; _} = List.last_exn group in
-             fmt_if (Location.line_difference last next > 1) "\n" $ fmt "@ "
+         | Some (next :: _) ->
+             let last = List.last_exn group in
+             fmt_if
+               (Location.line_difference (Cmt.loc last) (Cmt.loc next) > 1)
+               "\n"
+             $ fmt "@ "
          | _ -> noop ) )
 
 (** Format comments for loc. *)
@@ -674,7 +679,7 @@ let fmt_cmts t conf ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@\n") ?(adj = eol)
   | None | Some [] -> noop
   | Some cmts ->
       let epi =
-        let ({loc= last_loc; _} : Cmt.t) = List.last_exn cmts in
+        let last_loc = Cmt.loc (List.last_exn cmts) in
         let eol_cmt = Source.ends_line t.source last_loc in
         let adj_cmt = eol_cmt && Location.line_difference last_loc loc = 1 in
         fmt_or_k eol_cmt (fmt_or_k adj_cmt adj eol) (fmt_opt epi)
@@ -707,7 +712,8 @@ module Toplevel = struct
     let open Fmt in
     match found with
     | None | Some [] -> noop
-    | Some (({loc= first_loc; _} : Cmt.t) :: _ as cmts) ->
+    | Some (first :: _ as cmts) ->
+        let first_loc = Cmt.loc first in
         let pro =
           match pos with
           | Before -> noop
@@ -719,7 +725,7 @@ module Toplevel = struct
               else break 1 0
         in
         let epi =
-          let ({loc= last_loc; _} : Cmt.t) = List.last_exn cmts in
+          let last_loc = Cmt.loc (List.last_exn cmts) in
           match pos with
           | Before | Within ->
               if Source.ends_line t.source last_loc then
@@ -751,8 +757,8 @@ let drop_inside t loc =
   let clear pos =
     update_cmts t pos
       ~f:
-        (Multimap.filter ~f:(fun {Cmt.loc= cmt_loc; _} ->
-             not (Location.contains loc cmt_loc) ) )
+        (Multimap.filter ~f:(fun cmt ->
+             not (Location.contains loc (Cmt.loc cmt)) ) )
   in
   clear `Before ;
   clear `Within ;
@@ -780,23 +786,23 @@ let remaining_before t loc = Map.find_multi t.cmts_before loc
 
 let remaining_locs t = Set.to_list t.remaining
 
-let is_docstring (conf : Conf.t) (Cmt.{txt; loc} as cmt) =
-  match txt with
+let is_docstring (conf : Conf.t) cmt =
+  match Cmt.txt cmt with
   | "" | "*" -> Either.Second cmt
-  | _ when Char.equal txt.[0] '*' ->
+  | txt when Char.equal txt.[0] '*' ->
       (* Doc comments here (comming directly from the lexer) include their
          leading star [*]. It is not part of the docstring and should be
          dropped. When [ocp-indent-compat] is set, regular comments are
          treated as doc-comments. *)
       let txt = String.drop_prefix txt 1 in
-      let cmt = Cmt.create txt loc in
+      let cmt = Cmt.create txt (Cmt.loc cmt) in
       if conf.fmt_opts.parse_docstrings.v then Either.First cmt
       else Either.Second cmt
-  | _ when Char.equal txt.[0] '$' -> Either.Second cmt
-  | _
+  | txt when Char.equal txt.[0] '$' -> Either.Second cmt
+  | txt
     when conf.fmt_opts.ocp_indent_compat.v
          && conf.fmt_opts.parse_docstrings.v ->
       (* In ocp_indent_compat mode, comments are parsed like docstrings. *)
-      let cmt = Cmt.create txt loc in
+      let cmt = Cmt.create txt (Cmt.loc cmt) in
       Either.First cmt
   | _ -> Either.Second cmt

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -114,8 +114,8 @@ let collection_last_cmt ?pro c (loc : Location.t) locs =
       with
       | [] -> noop
       | (_, semicolon_loc) :: _ ->
-          Cmts.fmt_after ?pro c last ~filter:(fun Cmt.{loc; _} ->
-              Location.compare loc semicolon_loc >= 0 ) )
+          Cmts.fmt_after ?pro c last ~filter:(fun cmt ->
+              Location.compare (Cmt.loc cmt) semicolon_loc >= 0 ) )
 
 let fmt_elements_collection ?pro ?(first_sep = true) ?(last_sep = true) c
     (p : Params.elements_collection) f loc fmt_x xs =
@@ -488,9 +488,10 @@ let sequence_blank_line c (l1 : Location.t) (l2 : Location.t) =
   | `Preserve_one ->
       let rec loop prev_pos = function
         | cmt :: tl ->
+            let loc = Cmt.loc cmt in
             (* Check empty line before each comment *)
-            Source.empty_line_between c.source prev_pos cmt.Cmt.loc.loc_start
-            || loop cmt.Cmt.loc.loc_end tl
+            Source.empty_line_between c.source prev_pos loc.loc_start
+            || loop loc.loc_end tl
         | [] ->
             (* Check empty line after all comments *)
             Source.empty_line_between c.source prev_pos l2.loc_start

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -33,7 +33,7 @@ let dedup_cmts fragment ast comments =
                 ; _ } ]
         ; _ }
         when Ast.Attr.is_doc atr ->
-          docs := Set.add !docs (Cmt.create ("*" ^ doc) pexp_loc) ;
+          docs := Set.add !docs (Cmt.create_docstring doc pexp_loc) ;
           atr
       | _ -> Ast_mapper.default_mapper.attribute m atr
     in
@@ -187,7 +187,7 @@ let diff_docstrings c x y =
     docstring c ~normalize_code (Cmt.txt cmt)
   in
   let norm z =
-    let f cmt = Cmt.create (docstring cmt) (Cmt.loc cmt) in
+    let f cmt = Cmt.create_docstring (docstring cmt) (Cmt.loc cmt) in
     Set.of_list (module Cmt.Comparator_no_loc) (List.map ~f z)
   in
   diff ~f:norm ~cmt_kind:`Doc_comment x y
@@ -197,7 +197,9 @@ let diff_cmts (conf : Conf.t) x y =
   let normalize_code = normalize_code conf mapper in
   let norm z =
     let norm_non_code cmt =
-      Cmt.create (Docstring.normalize_text (Cmt.txt cmt)) (Cmt.loc cmt)
+      Cmt.create_comment
+        (Docstring.normalize_text (Cmt.txt cmt))
+        (Cmt.loc cmt)
     in
     let f z =
       match Cmt.txt z with
@@ -211,7 +213,7 @@ let diff_cmts (conf : Conf.t) x y =
             let source = String.sub ~pos:1 ~len str in
             let loc = Cmt.loc z in
             let offset = start_column loc + 3 in
-            Cmt.create (normalize_code ~offset source) loc
+            Cmt.create_comment (normalize_code ~offset source) loc
           else norm_non_code z
     in
     Set.of_list (module Cmt.Comparator_no_loc) (List.map ~f z)

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -33,7 +33,7 @@ let dedup_cmts fragment ast comments =
                 ; _ } ]
         ; _ }
         when is_doc atr ->
-          docs := Set.add !docs (Cmt.create ("*" ^ doc) pexp_loc) ;
+          docs := Set.add !docs (Cmt.create_docstring doc pexp_loc) ;
           atr
       | _ -> Ast_mapper.default_mapper.attribute m atr
     in
@@ -206,7 +206,7 @@ let moved_docstrings fragment c s1 s2 =
   let d2 = docstrings fragment s2 in
   let equal (_, x) (_, y) = String.equal (docstring c x) (docstring c y) in
   let cmt_kind = `Doc_comment in
-  let cmt (loc, x) = Cmt.create x loc in
+  let cmt (loc, x) = Cmt.create_docstring x loc in
   let dropped x = {Cmt.kind= `Dropped (cmt x); cmt_kind} in
   let added x = {Cmt.kind= `Added (cmt x); cmt_kind} in
   let modified (x, y) = {Cmt.kind= `Modified (cmt x, cmt y); cmt_kind} in

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -51,9 +51,9 @@ let normalize_code conf (m : Ast_mapper.mapper) txt =
   | {ast; comments; _} ->
       let comments = dedup_cmts Structure ast comments in
       let print_comments fmt (l : Cmt.t list) =
-        List.sort l ~compare:(fun {Cmt.loc= a; _} {Cmt.loc= b; _} ->
-            Migrate_ast.Location.compare a b )
-        |> List.iter ~f:(fun {Cmt.txt; _} -> Format.fprintf fmt "%s," txt)
+        List.sort l ~compare:(fun a b ->
+            Migrate_ast.Location.compare (Cmt.loc a) (Cmt.loc b) )
+        |> List.iter ~f:(fun cmt -> Format.fprintf fmt "%s," (Cmt.txt cmt))
       in
       let ast = m.structure m ast in
       Format.asprintf "AST,%a,COMMENTS,[%a]" Printast.implementation ast

--- a/lib/Parse_with_comments.ml
+++ b/lib/Parse_with_comments.ml
@@ -84,9 +84,11 @@ let parse ?(disable_w50 = false) parse fragment (conf : Conf.t) ~input_name
         let ast = parse fragment ~input_name source in
         Warnings.check_fatal () ;
         let comments =
-          List.map
-            ~f:(fun (txt, loc) -> Cmt.create txt loc)
-            (Lexer.comments ())
+          let mk_cmt = function
+            | `Comment txt, loc -> Cmt.create_comment txt loc
+            | `Docstring txt, loc -> Cmt.create_docstring txt loc
+          in
+          List.map ~f:mk_cmt (Lexer.comments ())
         in
         let tokens =
           let lexbuf, _ = fresh_lexbuf source in

--- a/vendor/parser-extended/lexer.mll
+++ b/vendor/parser-extended/lexer.mll
@@ -289,17 +289,18 @@ let warn_latin1 lexbuf =
     (Location.curr lexbuf)
     "ISO-Latin1 characters in identifiers"
 
-let handle_docstrings = ref true
-let comment_list = ref []
+type comment = [ `Comment of string | `Docstring of string ]
 
-let add_comment com =
-  comment_list := com :: !comment_list
+let handle_docstrings = ref true
+let comment_list : (comment * _) list ref = ref []
+
+let add_comment (txt, loc) =
+  comment_list := (`Comment txt, loc) :: !comment_list
 
 let add_docstring_comment ds =
-  let com =
-    ("*" ^ Docstrings.docstring_body ds, Docstrings.docstring_loc ds)
-  in
-    add_comment com
+  let txt = Docstrings.docstring_body ds
+  and loc = Docstrings.docstring_loc ds in
+  comment_list := (`Docstring txt, loc) :: !comment_list
 
 let comments () = List.rev !comment_list
 


### PR DESCRIPTION
What is a docstring is now dictated by the lexer, which removes a class of bugs and remove some ugly code.

Comments and docstrings can still easily be mixed and the `is_docstring` function is still necessary to handle ocp-indent-compat. This is improved on in https://github.com/ocaml-ppx/ocamlformat/pull/2371, from which this PR is extracted.