### PR TITLE
Doc: Unwanted break before a unwrapped code span

### DIFF
--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -133,8 +133,7 @@ let fmt_code_block c s1 s2 =
         fmt_code original )
   | Some _ -> fmt_code original
 
-let fmt_code_span s =
-  hovbox 0 (wrap "[" "]" (str (escape_balanced_brackets s)))
+let fmt_code_span s = wrap "[" "]" (str (escape_balanced_brackets s))
 
 let fmt_math_span s = hovbox 2 (wrap "{m " "}" (str s))
 

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7953,3 +7953,6 @@ let _ =
 ;;
 
 (* *)
+
+(** xxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx
+    xxxx] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx] *)

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -10189,3 +10189,7 @@ let _ =
 ;;
 
 (* *)
+
+(** xxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx
+    xxxx] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    [xxxxxxx] *)

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -10191,5 +10191,4 @@ let _ =
 (* *)
 
 (** xxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx
-    xxxx] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    [xxxxxxx] *)
+    xxxx] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx] *)

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -10189,3 +10189,7 @@ let _ =
 ;;
 
 (* *)
+
+(** xxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx
+    xxxx] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    [xxxxxxx] *)

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -10191,5 +10191,4 @@ let _ =
 (* *)
 
 (** xxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx
-    xxxx] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    [xxxxxxx] *)
+    xxxx] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx] *)


### PR DESCRIPTION
In `wrap-docstrings=false` mode, the uneeded box around code spans cause a break.