### PR TITLE
CI: Fix Windows and faster test-branch

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,46 @@
+name: Build on Linux
+
+# Build and run tests on ubuntu-latest.
+# The built binary is uploaded for later use in test-branch.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-linux:
+    strategy:
+      matrix:
+        ocaml-compiler:
+          # Don't include every versions. OCaml-CI already covers that
+          - 4.13.x
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # Clone the project
+      - uses: actions/checkout@v2
+
+      # Setup
+      - name: Setup OCaml ${{ matrix.ocaml-version }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - name: Opam dependencies
+        run: opam install --deps-only -t .
+
+      - name: Runtest
+        run: opam exec -- dune runtest
+
+      - name: Check manpages
+        run: opam exec -- dune build @gen_manpage --auto-promote
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: ocamlformat-${{ runner.os }}-${{ runner.arch }}
+          path: _build/install/default/bin/ocamlformat

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         ocaml-compiler:
           # Don't include every versions. OCaml-CI already covers that
-          - 4.13.x
+          - 4.14.x
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-others.yml
+++ b/.github/workflows/build-others.yml
@@ -33,6 +33,9 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          opam-repositories: |
+            opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
+            default: https://github.com/ocaml/opam-repository.git
 
       - name: Opam dependencies
         run: opam install --deps-only -t .

--- a/.github/workflows/build-others.yml
+++ b/.github/workflows/build-others.yml
@@ -20,7 +20,7 @@ jobs:
           - windows-latest
         ocaml-compiler:
           # Don't include every versions. OCaml-CI already covers that
-          - 4.13.x
+          - 4.14.x
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-others.yml
+++ b/.github/workflows/build-others.yml
@@ -1,0 +1,41 @@
+name: Build on other platforms
+
+# Build and run tests on platforms others than Linux, doing less tests and
+# running asynchronously from other jobs.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-others:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+        ocaml-compiler:
+          # Don't include every versions. OCaml-CI already covers that
+          - 4.13.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # Clone the project
+      - uses: actions/checkout@v2
+
+      # Setup
+      - name: Setup OCaml ${{ matrix.ocaml-version }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - name: Opam dependencies
+        run: opam install --deps-only -t .
+
+      - name: Runtest
+        run: opam exec -- dune runtest

--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Test OCamlformat on other projects
 
 on:
   push:
@@ -8,49 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
-        ocaml-compiler:
-          # Don't include every versions. OCaml-CI already covers that
-          - 4.13.x
-
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
-
-    steps:
-      # Clone the project
-      - uses: actions/checkout@v2
-
-      # Setup
-      - name: Setup OCaml ${{ matrix.ocaml-version }}
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-
-      - name: Opam dependencies
-        run: opam install --deps-only -t .
-
-      - name: Runtest
-        run: opam exec -- dune runtest
-
-      - name: Check manpages
-        run: opam exec -- dune build @gen_manpage --auto-promote
-
-      - name: Upload binary
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: ocamlformat-${{ runner.os }}-${{ runner.arch }}
-          path: _build/install/default/bin/ocamlformat
-
   test-branch:
-    needs: build
+    needs: build-linux
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -78,7 +37,7 @@ jobs:
       - name: Fetch main build of ocamlformat
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: build.yml
+          workflow: build-linux.yml
           workflow_conclusion: ""
           check_artifacts: true
           branch: main


### PR DESCRIPTION
- Split the `build` jobs into two: one for linux and one for others platforms.
  The linux build is faster and is a dependency for the `test-branch` job (which is moved in a different file), which should start faster.
  This removes some ifs and allow to add more checks to the linux job without worrying about build time.

- Fix the windows build by adding the default opam-repository as explained in https://github.com/ocaml-opam/opam-repository-mingw#updates

- Use OCaml 4.14 in CI.
