### PR TITLE
Update the preview script

### DIFF
--- a/test-extra/Makefile
+++ b/test-extra/Makefile
@@ -19,7 +19,7 @@ JS_DIRS= \
 # By default, test projects used as regression tests
 DIRS= \
 	code/ocamlformat code/infer code/js_of_ocaml code/dune code/owl \
-	code/irmin code/index code/dune-release code/mirage $(JS_DIRS)
+	code/irmin code/index code/dune-release code/mirage code/ppxlib $(JS_DIRS)
 
 # Extra test directories, for which looser checking is done
 XDIRS=code/ocaml
@@ -51,6 +51,7 @@ code/index: URI = https://github.com/mirage/index
 code/mirage: URI = https://github.com/mirage/mirage
 code/dune-release: URI = https://github.com/ocamllabs/dune-release
 code/owl: URI = https://github.com/owlbarn/owl
+code/ppxlib: URI = https://github.com/ocaml-ppx/ppxlib
 
 code/base: URI = https://github.com/janestreet/base.git
 code/base_bigstring: URI = https://github.com/janestreet/base_bigstring.git

--- a/test-extra/Makefile
+++ b/test-extra/Makefile
@@ -9,17 +9,12 @@
 #                                                                    #
 ######################################################################
 
-JS_DIRS= \
-	code/base code/base_bigstring code/base_quickcheck code/core code/core_bench \
-	code/core_compat code/core_extended code/core_kernel code/core_profiler \
-	code/core_unix
-
 # To test all source files below a directory
 #       make DIRS=<directory> test
 # By default, test projects used as regression tests
 DIRS= \
-	code/ocamlformat code/infer code/js_of_ocaml code/dune code/owl \
-	code/irmin code/index code/dune-release code/mirage code/ppxlib $(JS_DIRS)
+	code/ocamlformat code/infer code/js_of_ocaml code/dune code/irmin code/index \
+	code/dune-release code/mirage code/ppxlib code/base
 
 # Extra test directories, for which looser checking is done
 XDIRS=code/ocaml
@@ -29,7 +24,7 @@ PRUNE_DIRS= \
 	code/ocamlformat/test code/ocamlformat/vendor/parser-recovery \
 	code/ocaml/experimental code/ocaml/testsuite/tests/parse-errors \
 	code/dune/test code/dune/vendor code/dune/otherlibs code/dune/example \
-	code/infer/sledge/vendor/llvm-dune code/mirage/test code/owl
+	code/infer/sledge/vendor/llvm-dune code/mirage/test
 
 ALL_DIRS=$(DIRS) $(XDIRS)
 
@@ -47,23 +42,10 @@ code/js_of_ocaml: URI = https://github.com/ocsigen/js_of_ocaml.git
 code/ocaml: URI = https://github.com/ocaml/ocaml.git
 code/dune: URI = https://github.com/ocaml/dune.git
 code/irmin: URI = https://github.com/mirage/irmin
-code/index: URI = https://github.com/mirage/index
 code/mirage: URI = https://github.com/mirage/mirage
 code/dune-release: URI = https://github.com/ocamllabs/dune-release
-code/owl: URI = https://github.com/owlbarn/owl
 code/ppxlib: URI = https://github.com/ocaml-ppx/ppxlib
-
 code/base: URI = https://github.com/janestreet/base.git
-code/base_bigstring: URI = https://github.com/janestreet/base_bigstring.git
-code/base_quickcheck: URI = https://github.com/janestreet/base_quickcheck.git
-
-code/core: URI = https://github.com/janestreet/core.git
-code/core_bench: URI = https://github.com/janestreet/core_bench.git
-code/core_compat: URI = https://github.com/janestreet/core_compat.git
-code/core_extended: URI = https://github.com/janestreet/core_extended.git
-code/core_kernel: URI = https://github.com/janestreet/core_kernel.git
-code/core_profiler: URI = https://github.com/janestreet/core_profiler.git
-code/core_unix: URI = https://github.com/janestreet/core_unix.git
 
 .PHONY: test_setup
 test_setup: $(ALL_DIRS)

--- a/tools/preview_new_release.sh
+++ b/tools/preview_new_release.sh
@@ -110,6 +110,10 @@ while IFS=, read git_platform namespace dir; do
 
   $dune build @fmt --auto-promote &> "$log_dir/$dir.log" || true;
   uncomment_version "$version" .ocamlformat
-  git commit --all -m "Preview: upgrade to ocamlformat $version (unreleased)"
-  git push -u "$fork" "$preview_branch"
+  git commit --all -m "Preview: Upgrade to ocamlformat $version (unreleased)
+
+The aim of this commit is to gather feedback.
+
+Changelog can be found here: https://github.com/ocaml-ppx/ocamlformat/blob/main/CHANGES.md"
+  git push -fu "$fork" "$preview_branch"
 done < "$dirname/projects.data"

--- a/tools/preview_new_release.sh
+++ b/tools/preview_new_release.sh
@@ -100,14 +100,16 @@ while IFS=, read git_platform namespace project; do
 
   echo "Cloning from $upstream"
   clone_dir="$preview_dir/$project"
-  git clone --quiet --single-branch --depth=1 --filter=blob:none --no-checkout --recurse-submodules "$upstream" "$clone_dir"
+  git clone --quiet --single-branch --filter=blob:none --recurse-submodules "$upstream" "$clone_dir"
   cd "$clone_dir"
   git checkout -b "$preview_branch" --quiet
 
   dune=dune
+  comment_version $version .ocamlformat
 
   case "$namespace/$project" in
     "tezos/tezos")
+      git commit --quiet --all -m "Update .ocamlformat"
       bash scripts/lint.sh --update-ocamlformat
       ;;
     "ocaml/dune")
@@ -116,7 +118,6 @@ while IFS=, read git_platform namespace project; do
       ;;
   esac
 
-  comment_version $version .ocamlformat
   $dune build @fmt --auto-promote &> "$log_dir/$project.log" || true
   uncomment_version "$version" .ocamlformat
   git diff --shortstat

--- a/tools/preview_new_release.sh
+++ b/tools/preview_new_release.sh
@@ -1,134 +1,115 @@
 #!/usr/bin/env bash
 
-######################################################################
-#                                                                    #
-#                            OCamlFormat                             #
-#                                                                    #
-#  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.  #
-#                                                                    #
-#  This source code is licensed under the MIT license found in the   #
-#  LICENSE file in the root directory of this source tree.           #
-#                                                                    #
-######################################################################
-
 set -o errexit
 set -o nounset
 
-github_user_=
-github_user_set=0
-gitlab_user_=
-gitlab_user_set=0
-version=
+github_prefix_set=0
+gitlab_prefix_set=0
 version_set=0
-prefix=
 prefix_set=0
 
 function usage()
 {
-    echo "usage: $0 -u <GITHUB_USERNAME> -y <GITLAB_USERNAME> -v <RELEASE> [-p <PREFIX>]"
+  echo "usage: $0 -u <GITHUB_URL_PREFIX> -y <GITLAB_URL_PREFIX> -v <RELEASE> -p <PREFIX>"
+  echo "Url prefix is of the form 'git@github.com:my_user'."
 }
 
 function comment_version()
 {
-    version=$1
-    file=$2
-    sed -i --follow-symlinks -e "s/^version\(.*\)/#version = $version/" $file
+  version=$1
+  file=$2
+  sed -i --follow-symlinks -e "s/^version\(.*\)/#version = $version/" $file
 }
 
 function uncomment_version()
 {
-    version=$1
-    file=$2
-    sed -i --follow-symlinks -e "s/^#version\(.*\)/version = $version/" $file
+  version=$1
+  file=$2
+  sed -i --follow-symlinks -e "s/^#version\(.*\)/version = $version/" $file
 }
 
 while getopts ":u:y:v:p:" opt; do
-    case "$opt" in
-        u)
-            github_user=$OPTARG;
-            github_user_set=1;
-            ;;
-        y)
-            gitlab_user=$OPTARG;
-            gitlab_user_set=1;
-            ;;
-        v)
-            version=$OPTARG;
-            version_set=1;
-            ;;
-        p)
-            prefix=$OPTARG;
-            prefix_set=1;
-            ;;
-        *)
-            usage;
-            exit 1;
-            ;;
-    esac
-done;
+  case "$opt" in
+    u)
+      github_prefix=$OPTARG
+      github_prefix_set=1
+      ;;
+    y)
+      gitlab_prefix=$OPTARG
+      gitlab_prefix_set=1
+      ;;
+    v)
+      version=$OPTARG
+      version_set=1
+      ;;
+    p)
+      prefix=$OPTARG
+      prefix_set=1
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
 
-if [ "$github_user_set" = 0 ] || [ "$gitlab_user_set" = 0 ] || [ "$version_set" = 0 ]; then
-    usage;
-    exit 1;
+if [[ "$github_prefix_set" -eq 0 ]] ||
+  [[ "$gitlab_prefix_set" -eq 0 ]] ||
+  [[ "$version_set" -eq 0 ]] ||
+  [[ "$prefix_set" -eq 0 ]]; then
+  usage
+  exit 1
 fi;
 
 preview_branch=preview-ocamlformat-$version
 
-if [ "$prefix_set" = 0 ]; then
-    prefix=$HOME;
-fi;
+preview_dir=$prefix/$preview_branch
+log_dir=$preview_dir/logs
 
-preview_dir=$prefix/$preview_branch;
-log_dir=$preview_dir/logs;
+rm -rf "$preview_dir" &> /dev/null || true
+mkdir -p "$log_dir"
 
-rm -rf $preview_dir &> /dev/null || true;
-mkdir -p $log_dir;
+dirname=`dirname $0`
 
-dirname=`dirname $0`;
+while IFS=, read git_platform namespace dir; do
+  cd $preview_dir;
 
-while read line; do
-    cd $preview_dir;
+  case "$git_platform" in
+    "github")
+      fork="$github_prefix/$dir"
+      upstream="https://github.com/$namespace/$dir"
+      ;;
+    "gitlab")
+      fork="$gitlab_prefix/$dir.git"
+      upstream="https://gitlab.com/$namespace/$dir.git"
+      ;;
+    *)
+      echo "Unknown git platform: $git_platform"
+      continue
+      ;;
+  esac;
 
-    git_platform=`echo $line | cut -d "," -f 1`;
-    namespace=`echo $line | cut -d "," -f 2`;
-    dir=`echo $line | cut -d "," -f 3`;
-    echo "=> Checking $namespace/$dir";
+  echo "=> Checking $namespace/$dir"
 
-    case "$git_platform" in
-        "github")
-            user=$github_user;
-            ;;
-        "gitlab")
-            user=$gitlab_user;
-            ;;
-        *)
-            ;;
-    esac;
+  git clone --single-branch --depth=1 --filter=blob:none --no-checkout --recurse-submodules "$upstream" "$dir"
+  cd "$dir"
+  git checkout -b "$preview_branch" --quiet
 
-    fork="git@$git_platform.com:$user/$dir.git";
-    upstream="git@$git_platform.com:$namespace/$dir.git";
-    git clone --single-branch --depth=1 --filter=blob:none --no-checkout --recurse-submodules $fork $dir;
-    cd $dir;
-    git remote add upstream $upstream;
-    git checkout -b $preview_branch --quiet;
-    comment_version $version .ocamlformat;
+  comment_version $version .ocamlformat
+  dune=dune
 
-    if [ "$namespace/$dir" == "tezos/tezos" ]; then
-        bash scripts/lint.sh --update-ocamlformat;
-    fi;
+  case "$namespace/$dir" in
+    "tezos/tezos")
+      bash scripts/lint.sh --update-ocamlformat
+      ;;
+    "ocaml/dune")
+      make release
+      dune=_build/default/bin/dune.exe
+      ;;
+  esac
 
-    dune=dune;
-    if [ "$namespace/$dir" == "ocaml/dune" ]; then
-        make release;
-        dune=_build/default/bin/dune.exe;
-    fi;
-
-    $dune build @fmt &> $log_dir/$dir.log || true;
-    $dune promote &> /dev/null;
-    uncomment_version $version .ocamlformat;
-    git commit --all -m "Preview: upgrade to ocamlformat $version";
-
-    if [ "$namespace/$dir" == "tezos/tezos" ]; then
-        bash scripts/lint.sh --update-ocamlformat;
-    fi;
-done < $dirname/projects.data;
+  $dune build @fmt --auto-promote &> "$log_dir/$dir.log" || true;
+  uncomment_version "$version" .ocamlformat
+  git commit --all -m "Preview: upgrade to ocamlformat $version (unreleased)"
+  git push -u "$fork" "$preview_branch"
+done < "$dirname/projects.data"

--- a/tools/preview_new_release.sh
+++ b/tools/preview_new_release.sh
@@ -66,9 +66,16 @@ preview_branch=preview-ocamlformat-$version
 
 preview_dir=$prefix/$preview_branch
 log_dir=$preview_dir/logs
+bin_dir=$preview_dir/bin
 
 rm -rf "$preview_dir" &> /dev/null || true
-mkdir -p "$log_dir"
+mkdir -p "$log_dir" "$bin_dir"
+
+# Build the currently checked out version of OCamlformat and copy the binary in
+# a directory that will not change
+dune build @install
+cp -L _build/install/default/bin/ocamlformat "$bin_dir/ocamlformat"
+PATH=$bin_dir:$PATH
 
 while IFS=, read git_platform namespace project; do
 

--- a/tools/preview_new_release.sh
+++ b/tools/preview_new_release.sh
@@ -119,6 +119,7 @@ while IFS=, read git_platform namespace project; do
   comment_version $version .ocamlformat
   $dune build @fmt --auto-promote &> "$log_dir/$project.log" || true
   uncomment_version "$version" .ocamlformat
+  git diff --shortstat
   git commit --quiet --all -m "Preview: Upgrade to ocamlformat $version (unreleased)
 
 The aim of this commit is to gather feedback.

--- a/tools/projects.data
+++ b/tools/projects.data
@@ -7,6 +7,5 @@ github,ocaml,odoc
 github,tarides,dune-release
 github,ocaml-ppx,ppxlib
 github,ocsigen,js_of_ocaml
-github,owlbarn,owl
 github,realworldocaml,mdx
 gitlab,tezos,tezos

--- a/tools/projects.data
+++ b/tools/projects.data
@@ -1,13 +1,7 @@
 github,facebook,flow
 github,mirage,alcotest
-github,mirage,decompress
-github,mirage,digestif
-github,mirage,index
 github,mirage,irmin
 github,mirage,mirage
-github,mirage,ocaml-cohttp
-github,mirage,ocaml-conduit
-github,mirage,ocaml-git
 github,ocaml,dune
 github,ocaml,ocaml-lsp
 github,ocaml,odoc

--- a/tools/projects.data
+++ b/tools/projects.data
@@ -5,7 +5,7 @@ github,mirage,mirage
 github,ocaml,dune
 github,ocaml,ocaml-lsp
 github,ocaml,odoc
-github,ocamllabs,dune-release
+github,tarides,dune-release
 github,ocaml-ppx,ppxlib
 github,ocsigen,js_of_ocaml
 github,owlbarn,owl

--- a/tools/projects.data
+++ b/tools/projects.data
@@ -1,4 +1,3 @@
-github,facebook,flow
 github,mirage,alcotest
 github,mirage,irmin
 github,mirage,mirage


### PR DESCRIPTION
I've used the preview script and made some changes.

- Refactored the script itself to automate more and to remove edge cases.

- Some projects are removed from the list of previews:
  + `owl` and `flow`: They haven't been updated in a while and the diff is now meaningless.
  + mirage projects: To avoid spamming the mirage maintainers, only `alcotest` and `mirage` and previewed.

- Changed the list of projects used in `test_branch`.
  I added `ppxlib`, which has unusual code and removed projects that have similar code source.

If anyone want to add its projects to this list, this is possible.