### PR TITLE
Fix indentation of doc-strings in classes

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2730,11 +2730,7 @@ and fmt_class_signature c ~ctx ~parens ?ext self_ fields =
     $ fmt_extension_suffix c ext
     $ self_ $ fmt "@ "
     $ hvbox 0
-        ( ( match fields with
-          | {pctf_desc= Pctf_attribute a; _} :: _ when Attr.is_doc a ->
-              str "\n"
-          | _ -> noop )
-        $ fmt_if_k (List.is_empty fields)
+        ( fmt_if_k (List.is_empty fields)
             (Cmts.fmt_within ~pro:noop c (Ast.location ctx))
         $ fmt_item_list c ctx update_config ast fmt_item fields )
     $ fmt_if (not (List.is_empty fields)) "@;<1000 -2>"

--- a/test/passing/tests/class_sig.mli
+++ b/test/passing/tests/class_sig.mli
@@ -19,6 +19,5 @@ class c (* a *) : (* b *) int (* c *) -> (* d *) object (* e *) end (* f *)
 class c : object end
 
 class c : object
-  
-(** Standalone doc-string. *)
+  (** Standalone doc-string. *)
 end

--- a/test/passing/tests/class_sig.mli
+++ b/test/passing/tests/class_sig.mli
@@ -17,3 +17,8 @@ class c : int -> object end
 class c (* a *) : (* b *) int (* c *) -> (* d *) object (* e *) end (* f *)
 
 class c : object end
+
+class c : object
+  
+(** Standalone doc-string. *)
+end

--- a/test/passing/tests/object.ml
+++ b/test/passing/tests/object.ml
@@ -182,14 +182,13 @@ class a = object end
 and b = object end
 
 class type x = object
-  
-(** floatting1 *)
+  (** floatting1 *)
 
-   (** floatting2 *)
+  (** floatting2 *)
 
-   method x : int
+  method x : int
 
-   (** floatting3 *)
+  (** floatting3 *)
 end
 
 class x =


### PR DESCRIPTION
A floating doc being the first item of a class type would have an extraneous newline before them.

Floating docs in other position would cause the indentation of the class type to be increased by one.