### PR TITLE
Uncomment test in test/passing/tests/record.ml

### DIFF
--- a/test/passing/tests/record-402.ml.ref
+++ b/test/passing/tests/record-402.ml.ref
@@ -38,8 +38,7 @@ let f ~l:{f; g} = e
 
 let f ?l:({f; g}) = e
 
-(* TODO: let _ = {a; b = ((match b with `A -> A | `B -> B | `C -> C) : c);
-   c} *)
+let _ = {a; b= (match b with `A -> A | `B -> B | `C -> C : c); c}
 
 let a () = A {A.a= (a : t)}
 

--- a/test/passing/tests/record-loose.ml.ref
+++ b/test/passing/tests/record-loose.ml.ref
@@ -38,8 +38,7 @@ let f ~l:{f; g} = e
 
 let f ?l:({f; g}) = e
 
-(* TODO: let _ = {a; b = ((match b with `A -> A | `B -> B | `C -> C) : c);
-   c} *)
+let _ = {a; b = (match b with `A -> A | `B -> B | `C -> C : c); c}
 
 let a () = A {A.a : t}
 

--- a/test/passing/tests/record-tight_decl.ml.ref
+++ b/test/passing/tests/record-tight_decl.ml.ref
@@ -38,8 +38,7 @@ let f ~l:{f; g} = e
 
 let f ?l:({f; g}) = e
 
-(* TODO: let _ = {a; b = ((match b with `A -> A | `B -> B | `C -> C) : c);
-   c} *)
+let _ = {a; b = (match b with `A -> A | `B -> B | `C -> C : c); c}
 
 let a () = A {A.a : t}
 

--- a/test/passing/tests/record.ml
+++ b/test/passing/tests/record.ml
@@ -38,7 +38,7 @@ let f ~l:{f; g} = e
 
 let f ?l:({f; g}) = e
 
-(* TODO: let _ = {a; b = ((match b with `A -> A | `B -> B | `C -> C) : c); c} *)
+let _ = {a; b = ((match b with `A -> A | `B -> B | `C -> C) : c); c}
 
 let a () = A {A.a = (a : t)}
 

--- a/test/passing/tests/record.ml.ref
+++ b/test/passing/tests/record.ml.ref
@@ -38,8 +38,7 @@ let f ~l:{f; g} = e
 
 let f ?l:({f; g}) = e
 
-(* TODO: let _ = {a; b = ((match b with `A -> A | `B -> B | `C -> C) : c);
-   c} *)
+let _ = {a; b= (match b with `A -> A | `B -> B | `C -> C : c); c}
 
 let a () = A {A.a: t}
 


### PR DESCRIPTION
This test is surprisingly passing. I commented it in https://github.com/ocaml-ppx/ocamlformat/pull/2388 as I added the `.ref` file thinking it would crash.