### PR TITLE
ocp-indent-compat: Don't unindent unwrapped docstrings

### DIFF
--- a/lib/Cmt.ml
+++ b/lib/Cmt.ml
@@ -100,18 +100,16 @@ end
 type pos = Before | Within | After
 
 let unindent_lines ~offset first_line tl_lines =
-  let indent_of_line s =
-    (* index of first non-whitespace is indentation, None means white line *)
-    String.lfindi s ~f:(fun _ c -> not (Char.is_whitespace c))
-  in
   (* The indentation of the first line must account for the location of the
      comment opening *)
-  let fl_spaces = Option.value ~default:0 (indent_of_line first_line) in
+  let fl_spaces =
+    Option.value ~default:0 (String.indent_of_line first_line)
+  in
   let fl_indent = fl_spaces + offset in
   let min_indent =
     List.fold_left ~init:fl_indent
       ~f:(fun acc s ->
-        Option.value_map ~default:acc ~f:(min acc) (indent_of_line s) )
+        Option.value_map ~default:acc ~f:(min acc) (String.indent_of_line s) )
       tl_lines
   in
   (* Completely trim the first line *)

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7956,3 +7956,11 @@ let _ =
 
 (** xxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx
     xxxx] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx] *)
+
+(*    Hand-aligned comment
+        .
+      . *)
+
+(*    First line is indented more
+    .
+      . *)

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -2865,8 +2865,8 @@ let rec pre_subst f = function
 ;;
 
 let comp_subst f g (x : 'a fin) = pre_subst f (g x)
-(* val comp_subst :
-   ('b fin -> 'c term) -> ('a fin -> 'b term) -> 'a fin -> 'c term *)
+(*  val comp_subst :
+    ('b fin -> 'c term) -> ('a fin -> 'b term) -> 'a fin -> 'c term *)
 
 (* 4 The Occur-Check, through thick and thin *)
 
@@ -2961,7 +2961,7 @@ let rec sub' : type m. m ealist -> m fin -> m term = function
 ;;
 
 let subst' d = pre_subst (sub' d)
-(* val subst' : 'a ealist -> 'a term -> 'a term *)
+(*  val subst' : 'a ealist -> 'a term -> 'a term *)
 
 (* 6 First-Order Unification *)
 
@@ -10043,7 +10043,7 @@ let _ =
 (*
 *)
 
-(** xxx *)
+(**    xxx *)
 include S1
 (** @inline *)
 
@@ -10190,3 +10190,11 @@ let _ =
 
 (** xxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx
     xxxx] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx] *)
+
+(*    Hand-aligned comment
+      .
+      . *)
+
+(*    First line is indented more
+      .
+      . *)

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -2865,8 +2865,8 @@ let rec pre_subst f = function
 ;;
 
 let comp_subst f g (x : 'a fin) = pre_subst f (g x)
-(* val comp_subst :
-   ('b fin -> 'c term) -> ('a fin -> 'b term) -> 'a fin -> 'c term *)
+(*  val comp_subst :
+    ('b fin -> 'c term) -> ('a fin -> 'b term) -> 'a fin -> 'c term *)
 
 (* 4 The Occur-Check, through thick and thin *)
 
@@ -2961,7 +2961,7 @@ let rec sub' : type m. m ealist -> m fin -> m term = function
 ;;
 
 let subst' d = pre_subst (sub' d)
-(* val subst' : 'a ealist -> 'a term -> 'a term *)
+(*  val subst' : 'a ealist -> 'a term -> 'a term *)
 
 (* 6 First-Order Unification *)
 
@@ -10041,9 +10041,9 @@ let _ =
 ;;
 
 (*
-   *)
+    *)
 
-(** xxx *)
+(**    xxx *)
 include S1
 (** @inline *)
 
@@ -10190,3 +10190,11 @@ let _ =
 
 (** xxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx
     xxxx] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx [xxxxxxx] *)
+
+(*    Hand-aligned comment
+      .
+      . *)
+
+(*    First line is indented more
+      .
+      . *)

--- a/vendor/ocamlformat-stdlib/string_ext.ml
+++ b/vendor/ocamlformat-stdlib/string_ext.ml
@@ -5,3 +5,5 @@ let starts_with_whitespace s = (not (is_empty s)) && Char.is_whitespace s.[0]
 
 let ends_with_whitespace s =
   (not (is_empty s)) && Char.is_whitespace s.[length s - 1]
+
+let indent_of_line s = String.lfindi s ~f:(fun _ c -> not (Char.is_whitespace c))

--- a/vendor/ocamlformat-stdlib/string_ext.mli
+++ b/vendor/ocamlformat-stdlib/string_ext.mli
@@ -7,3 +7,7 @@ val starts_with_whitespace : string -> bool
 val ends_with_whitespace : string -> bool
 (** [ends_with_whitespace s] holds if [s] is non empty and ends with a
     whitespace character. *)
+
+val indent_of_line : string -> int option
+(** [indent_of_line s] is the number of whitespace at the beginning of [s].
+    Returns [None] if the string is only whitespaces or is empty. *)


### PR DESCRIPTION
In ocp-indent-compat mode, the indentation of unwrapped docstrings is based on the indentation of the first line.

This applies to the janestreet profile.