### PR TITLE
Restore indentation of `->`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
 - Consistent indentation of `@@ let+ x = ...` (#2315, #2396, @Julow)
 - Remove double parenthesis around tuple in a match (#2308, @Julow)
 - Consistent indentation of `fun (type a) ->` that follow `fun x ->` (#2294, @Julow)
-- Avoid adding breaks inside `~label:(fun` and base the indentation on the label. (#2271, #2291, #2293, #2298, @Julow)
+- Improve indentation of `~label:(fun` (#2271, #2291, #2293, #2298, #2398, @Julow)
 - Fix non-stabilizing comments attached to private/virtual/mutable keywords (#2272, #2307, @gpetiot, @Julow)
 - Fix formatting of comments in "disable" chunks (#2279, @gpetiot)
 - Fix indentation of trailing double-semicolons (#2295, @gpetiot)

--- a/lib/Conf_decl.ml
+++ b/lib/Conf_decl.ml
@@ -436,7 +436,8 @@ let removed_option ~names ~since ~msg =
 let update store ~config ~from:new_from ~name ~value ~inline =
   List.find_map store
     ~f:(fun
-      (Pack {names; parse; update; allow_inline; get_value; to_string; _}) ->
+        (Pack {names; parse; update; allow_inline; get_value; to_string; _})
+      ->
       if List.exists names ~f:(String.equal name) then
         if inline && not allow_inline then
           Some (Error (Error.Misplaced (name, value)))

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1352,12 +1352,12 @@ and fmt_fun ?force_closing_paren
     else noop
   in
   let (label_sep : s), break_fun =
-    (* Break between the label and the fun to avoid ocp-indent's
-       alignment. *)
+    (* Break between the label and the fun to avoid ocp-indent's alignment.
+       If a label is present, arguments should be indented more than the
+       arrow and the eventually breaking [fun] keyword. *)
     if c.conf.fmt_opts.ocp_indent_compat.v then (":@,", fmt "@;<1 2>")
-    else (":", fmt "@ ")
+    else (":", if has_label then fmt "@;<1 2>" else fmt "@ ")
   in
-  let break_arrow = if has_label then fmt "@ " else fmt "@;<1 -2>" in
   hovbox_if box 2
     ( wrap_intro
         (hvbox_if has_cmts_outer 0
@@ -1367,8 +1367,8 @@ and fmt_fun ?force_closing_paren
                $ fmt "fun" $ break_fun
                $ hvbox 0
                    ( fmt_attributes c ast.pexp_attributes ~suf:" "
-                   $ fmt_fun_args c xargs $ fmt_opt fmt_cstr $ break_arrow
-                   $ fmt "->" ) ) ) )
+                   $ fmt_fun_args c xargs $ fmt_opt fmt_cstr
+                   $ fmt "@;<1 -2>->" ) ) ) )
     $ body $ closing
     $ Cmts.fmt_after c ast.pexp_loc )
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1357,6 +1357,7 @@ and fmt_fun ?force_closing_paren
     if c.conf.fmt_opts.ocp_indent_compat.v then (":@,", fmt "@;<1 2>")
     else (":", fmt "@ ")
   in
+  let break_arrow = if has_label then fmt "@ " else fmt "@;<1 -2>" in
   hovbox_if box 2
     ( wrap_intro
         (hvbox_if has_cmts_outer 0
@@ -1366,8 +1367,8 @@ and fmt_fun ?force_closing_paren
                $ fmt "fun" $ break_fun
                $ hvbox 0
                    ( fmt_attributes c ast.pexp_attributes ~suf:" "
-                   $ fmt_fun_args c xargs $ fmt_opt fmt_cstr $ fmt "@ ->" )
-               ) ) )
+                   $ fmt_fun_args c xargs $ fmt_opt fmt_cstr $ break_arrow
+                   $ fmt "->" ) ) ) )
     $ body $ closing
     $ Cmts.fmt_after c ast.pexp_loc )
 

--- a/test/passing/tests/break_fun_decl-fit_or_vertical.ml.ref
+++ b/test/passing/tests/break_fun_decl-fit_or_vertical.ml.ref
@@ -127,7 +127,7 @@ let _ =
     (fun
       (module Store : Irmin.Generic_key.S with type repo = repo)
       (module Store : Irmin.Generic_key.S with type repo = repo)
-      -> body )
+    -> body )
 
 let f
     (module Store : Irmin.Generic_key.S with type repo = repo)

--- a/test/passing/tests/break_fun_decl-fit_or_vertical.ml.ref
+++ b/test/passing/tests/break_fun_decl-fit_or_vertical.ml.ref
@@ -116,3 +116,20 @@ class type ffffffffffffffffffff = object
     -> cccccccccccccccccccccc
     -> dddddddddddddddddddddd
 end
+
+let _ =
+ fun (module Store : Irmin.Generic_key.S with type repo = repo)
+     (module Store : Irmin.Generic_key.S with type repo = repo) ->
+  body
+
+let _ =
+  f
+    (fun
+      (module Store : Irmin.Generic_key.S with type repo = repo)
+      (module Store : Irmin.Generic_key.S with type repo = repo)
+      -> body )
+
+let f
+    (module Store : Irmin.Generic_key.S with type repo = repo)
+    (module Store : Irmin.Generic_key.S with type repo = repo) =
+  body

--- a/test/passing/tests/break_fun_decl-smart.ml.ref
+++ b/test/passing/tests/break_fun_decl-smart.ml.ref
@@ -121,7 +121,7 @@ let _ =
     (fun
       (module Store : Irmin.Generic_key.S with type repo = repo)
       (module Store : Irmin.Generic_key.S with type repo = repo)
-      -> body )
+    -> body )
 
 let f
     (module Store : Irmin.Generic_key.S with type repo = repo)

--- a/test/passing/tests/break_fun_decl-smart.ml.ref
+++ b/test/passing/tests/break_fun_decl-smart.ml.ref
@@ -110,3 +110,20 @@ class type ffffffffffffffffffff = object
     -> cccccccccccccccccccccc
     -> dddddddddddddddddddddd
 end
+
+let _ =
+ fun (module Store : Irmin.Generic_key.S with type repo = repo)
+     (module Store : Irmin.Generic_key.S with type repo = repo) ->
+  body
+
+let _ =
+  f
+    (fun
+      (module Store : Irmin.Generic_key.S with type repo = repo)
+      (module Store : Irmin.Generic_key.S with type repo = repo)
+      -> body )
+
+let f
+    (module Store : Irmin.Generic_key.S with type repo = repo)
+    (module Store : Irmin.Generic_key.S with type repo = repo) =
+  body

--- a/test/passing/tests/break_fun_decl-wrap.ml.ref
+++ b/test/passing/tests/break_fun_decl-wrap.ml.ref
@@ -92,3 +92,19 @@ class type ffffffffffffffffffff = object
     -> cccccccccccccccccccccc
     -> dddddddddddddddddddddd
 end
+
+let _ =
+ fun (module Store : Irmin.Generic_key.S with type repo = repo)
+     (module Store : Irmin.Generic_key.S with type repo = repo) ->
+  body
+
+let _ =
+  f
+    (fun
+      (module Store : Irmin.Generic_key.S with type repo = repo)
+      (module Store : Irmin.Generic_key.S with type repo = repo)
+      -> body )
+
+let f (module Store : Irmin.Generic_key.S with type repo = repo)
+    (module Store : Irmin.Generic_key.S with type repo = repo) =
+  body

--- a/test/passing/tests/break_fun_decl-wrap.ml.ref
+++ b/test/passing/tests/break_fun_decl-wrap.ml.ref
@@ -103,7 +103,7 @@ let _ =
     (fun
       (module Store : Irmin.Generic_key.S with type repo = repo)
       (module Store : Irmin.Generic_key.S with type repo = repo)
-      -> body )
+    -> body )
 
 let f (module Store : Irmin.Generic_key.S with type repo = repo)
     (module Store : Irmin.Generic_key.S with type repo = repo) =

--- a/test/passing/tests/break_fun_decl.ml
+++ b/test/passing/tests/break_fun_decl.ml
@@ -92,3 +92,19 @@ class type ffffffffffffffffffff = object
     -> cccccccccccccccccccccc
     -> dddddddddddddddddddddd
 end
+
+let _ =
+ fun (module Store : Irmin.Generic_key.S with type repo = repo)
+     (module Store : Irmin.Generic_key.S with type repo = repo) ->
+  body
+
+let _ =
+  f
+    (fun
+      (module Store : Irmin.Generic_key.S with type repo = repo)
+      (module Store : Irmin.Generic_key.S with type repo = repo)
+      -> body )
+
+let f (module Store : Irmin.Generic_key.S with type repo = repo)
+    (module Store : Irmin.Generic_key.S with type repo = repo) =
+  body

--- a/test/passing/tests/break_fun_decl.ml
+++ b/test/passing/tests/break_fun_decl.ml
@@ -103,7 +103,7 @@ let _ =
     (fun
       (module Store : Irmin.Generic_key.S with type repo = repo)
       (module Store : Irmin.Generic_key.S with type repo = repo)
-      -> body )
+    -> body )
 
 let f (module Store : Irmin.Generic_key.S with type repo = repo)
     (module Store : Irmin.Generic_key.S with type repo = repo) =

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9883,7 +9883,7 @@ let () =
         very_long_argument_name_one
         very_long_argument_name_two
         very_long_argument_name_three
-        -> ())
+      -> ())
 ;;
 
 let () =

--- a/test/passing/tests/labelled_args-414.ml.ref
+++ b/test/passing/tests/labelled_args-414.ml.ref
@@ -5,16 +5,16 @@ let _ =
 let () =
   very_long_function_name
     ~very_long_argument_label:(fun
-      very_long_argument_name_one
-      very_long_argument_name_two
-      very_long_argument_name_three
+        very_long_argument_name_one
+        very_long_argument_name_two
+        very_long_argument_name_three
       -> () )
 
 let () =
   very_long_function_name
     ~very_long_argument_label:(* foo *)
       (fun
-      very_long_argument_name_one
-      very_long_argument_name_two
-      very_long_argument_name_three
+        very_long_argument_name_one
+        very_long_argument_name_two
+        very_long_argument_name_three
       -> () )

--- a/test/passing/tests/labelled_args.ml
+++ b/test/passing/tests/labelled_args.ml
@@ -5,16 +5,16 @@ let _ =
 let () =
   very_long_function_name
     ~very_long_argument_label:(fun
-      very_long_argument_name_one
-      very_long_argument_name_two
-      very_long_argument_name_three
+        very_long_argument_name_one
+        very_long_argument_name_two
+        very_long_argument_name_three
       -> () )
 
 let () =
   very_long_function_name
     ~very_long_argument_label:(* foo *)
       (fun
-      very_long_argument_name_one
-      very_long_argument_name_two
-      very_long_argument_name_three
+        very_long_argument_name_one
+        very_long_argument_name_two
+        very_long_argument_name_three
       -> () )


### PR DESCRIPTION
The second commit restore the indentation of `->` as it was in 0.25.1.
The third commit fixes a bug in the formatting of `fun` after a label.