### PR TITLE
Fix AST changed on let coercion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 
+- Fix crash due to `let f (type a) :> a M.u = ..` (#2399, @Julow)
 - Fix crash due to `module T = (val (x : (module S)))` (#2370, @Julow)
 - Fix invalid formatting of `then begin end` (#2369, @Julow)
 - Protect match after `fun _ : _ ->` (#2352, @Julow)

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -62,11 +62,12 @@ module Let_binding : sig
   type t =
     { lb_op: string loc
     ; lb_pat: pattern Ast.xt
+    ; lb_args: arg_kind list
     ; lb_typ:
         [ `Polynewtype of label loc list * core_type Ast.xt
         | `Coerce of core_type Ast.xt option * core_type Ast.xt
-        | `Other of arg_kind list * core_type Ast.xt
-        | `None of arg_kind list ]
+        | `Other of core_type Ast.xt
+        | `None ]
     ; lb_exp: expression Ast.xt
     ; lb_pun: bool
     ; lb_attrs: attribute list

--- a/test/passing/tests/coerce.ml
+++ b/test/passing/tests/coerce.ml
@@ -23,3 +23,7 @@ class c =
   let a = (v : x :> y) in
   let a : x :> y = (v : x :> y) in
   object end
+
+let f (type a) :> a M.u = function z -> z
+
+let f x (type a) :> a M.u = function z -> z


### PR DESCRIPTION
A let-binding can have a newtype and a coercion at the same time. This is fixed by removing the coupling between the two.