### PR TITLE
tools/printast: Option for using standard parser

### DIFF
--- a/lib/Std_ast.ml
+++ b/lib/Std_ast.ml
@@ -25,7 +25,17 @@ type 'a t =
   | Repl_file : unit t
   | Documentation : unit t
 
-type any_t = Any : 'a t -> any_t
+type any_t = Any : 'a t -> any_t [@@unboxed]
+
+let of_syntax = function
+  | Syntax.Structure -> Any Structure
+  | Signature -> Any Signature
+  | Use_file -> Any Use_file
+  | Core_type -> Any Core_type
+  | Module_type -> Any Module_type
+  | Expression -> Any Expression
+  | Repl_file -> Any Repl_file
+  | Documentation -> Any Documentation
 
 let equal (type a) (_ : a t) : a -> a -> bool = Poly.equal
 

--- a/lib/Std_ast.mli
+++ b/lib/Std_ast.mli
@@ -28,7 +28,9 @@ type 'a t =
   | Repl_file : unit t
   | Documentation : unit t
 
-type any_t = Any : 'a t -> any_t
+type any_t = Any : 'a t -> any_t [@@unboxed]
+
+val of_syntax : Syntax.t -> any_t
 
 module Parse : sig
   val ast : 'a t -> input_name:string -> string -> 'a

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -396,17 +396,7 @@ let parse_and_format (type a b) (fg : a Extended_ast.t)
   in
   Ok (Eol_compat.normalize_eol ~exclude_locs:strlocs ~line_endings formatted)
 
-let std_of_extended (type a) : a Extended_ast.t -> Std_ast.any_t = function
-  | Extended_ast.Structure -> Std_ast.Any Std_ast.Structure
-  | Signature -> Any Signature
-  | Use_file -> Any Use_file
-  | Core_type -> Any Core_type
-  | Module_type -> Any Module_type
-  | Expression -> Any Expression
-  | Repl_file -> Any Repl_file
-  | Documentation -> Any Documentation
-
 let parse_and_format syntax =
   let (Extended_ast.Any ext) = Extended_ast.of_syntax syntax in
-  let (Std_ast.Any std) = std_of_extended ext in
+  let (Std_ast.Any std) = Std_ast.of_syntax syntax in
   parse_and_format ext std

--- a/tools/printast/printast.ml
+++ b/tools/printast/printast.ml
@@ -1,24 +1,38 @@
 open! Stdio
 open Ocamlformat_lib
-module E = Extended_ast
+
+let ocaml_version = Ocaml_version.sys_version
+
+let extended_ast ppf syntax ~input_name content =
+  let open Extended_ast in
+  let (Any kind) = of_syntax syntax in
+  Parse.ast kind ~ocaml_version ~preserve_beginend:true ~input_name content
+  |> Printast.ast kind ppf
+
+let std_ast ppf syntax ~input_name content =
+  let open Std_ast in
+  let (Any kind) = of_syntax syntax in
+  Parse.ast kind ~input_name content |> Printast.ast kind ppf
 
 let get_arg () =
-  if Array.length Sys.argv < 2 then (
-    Printf.eprintf "Not enough argument\n" ;
-    exit 2 )
-  else Sys.argv.(1)
+  let std = ref false and input = ref None in
+  let opts = [("-std", Arg.Set std, "Use the standard parser")] in
+  let usage = "printast [-std] <file>" in
+  Arg.parse opts (fun inp -> input := Some inp) usage ;
+  let input =
+    match !input with
+    | Some inp -> inp
+    | None ->
+        Printf.eprintf "Not enough argument\n" ;
+        exit 2
+  and parse_and_print = if !std then std_ast else extended_ast in
+  (parse_and_print, input)
 
 let () =
-  let inputf = get_arg () in
+  let parse_and_print, inputf = get_arg () in
   let syntax =
     Option.value ~default:Syntax.Use_file (Syntax.of_fname inputf)
   in
-  let (E.Any kind) = E.of_syntax syntax in
   Printf.printf "Reading %S\n" inputf ;
   let content = In_channel.read_all inputf in
-  let ocaml_version = Ocaml_version.sys_version in
-  let ast =
-    E.Parse.ast kind ~ocaml_version ~preserve_beginend:true
-      ~input_name:inputf content
-  in
-  E.Printast.ast kind Format.std_formatter ast
+  parse_and_print Format.std_formatter syntax ~input_name:inputf content


### PR DESCRIPTION
instead of the extended parser (the default).