### PR TITLE
Parenthese nested module with-constraints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@ Items marked with an asterisk (`*`) are changes that are likely to format
 existing code differently from the previous release when using the default
 profile. This started with version 0.26.0.
 
+## unreleased
+
+### Bug fixes
+
+- Fix crash caused by module types with nested `with module` (#2419, @Julow)
+
 ## 0.26.0 (2023-07-18)
 
 ### Removed

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1781,7 +1781,12 @@ end = struct
 
   (** [parenze_mty {ctx; ast}] holds when module type [ast] should be
       parenthesized in context [ctx]. *)
-  let parenze_mty {ctx= _; ast= mty} = Mty.has_trailing_attributes mty
+  let parenze_mty {ctx; ast= mty} =
+    Mty.has_trailing_attributes mty
+    ||
+    match (ctx, mty.pmty_desc) with
+    | Mty {pmty_desc= Pmty_with _; _}, Pmty_with _ -> true
+    | _ -> false
 
   (** [parenze_mod {ctx; ast}] holds when module expr [ast] should be
       parenthesized in context [ctx]. *)

--- a/test/passing/tests/module_type.ml
+++ b/test/passing/tests/module_type.ml
@@ -108,3 +108,5 @@ let foo (type foooo fooo_ooooo)
          Fooooo_ooooooo_oooooo.Foooo_fooooooooo_fooooo.t )
     (Fooo.Fooo.T (foo, bar)) xxxx =
   ()
+
+module N : S with module type T = (U with module M = M) = struct end


### PR DESCRIPTION
Fix: https://github.com/ocaml-ppx/ocamlformat/issues/2416

This was a missing AST rule.