### PR TITLE
Stabilize comment around functor type arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ profile. This started with version 0.26.0.
 
 ### Bug fixes
 
+- Fix non-stabilizing comments before a functor type argument (#2420, @Julow)
 - Fix crash caused by module types with nested `with module` (#2419, @Julow)
 
 ## 0.26.0 (2023-07-18)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3406,11 +3406,12 @@ and fmt_functor_param c ctx {loc; txt= arg} =
   | Unit -> Cmts.fmt c loc (wrap "(" ")" (Cmts.fmt_within c loc))
   | Named (name, mt) ->
       let xmt = sub_mty ~ctx mt in
-      Cmts.fmt c loc
-        (wrap "(" ")"
-           (hovbox 0
-              ( hovbox 0 (fmt_str_loc_opt c name $ fmt "@ : ")
-              $ compose_module (fmt_module_type c xmt) ~f:Fn.id ) ) )
+      hvbox 0
+        (Cmts.fmt c loc
+           (wrap "(" ")"
+              (hovbox 0
+                 ( hovbox 0 (fmt_str_loc_opt c name $ fmt "@ : ")
+                 $ compose_module (fmt_module_type c xmt) ~f:Fn.id ) ) ) )
 
 and fmt_module_type c ?(rec_ = false) ({ast= mty; _} as xmty) =
   let ctx = Mty mty in

--- a/test/passing/tests/module_type.ml
+++ b/test/passing/tests/module_type.ml
@@ -108,3 +108,9 @@ let foo (type foooo fooo_ooooo)
          Fooooo_ooooooo_oooooo.Foooo_fooooooooo_fooooo.t )
     (Fooo.Fooo.T (foo, bar)) xxxx =
   ()
+
+module type Grammar = functor
+  (Nonterm : Nonterminal)
+  (* Set of nonterminals *)
+  (Attr : Attribute)
+  -> sig end


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/2415