### PR TITLE
Consistent formatting for arrow class types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Items marked with an asterisk (`*`) are changes that are likely to format
+Items marked with an asterisk (\*) are changes that are likely to format
 existing code differently from the previous release when using the default
 profile. This started with version 0.26.0.
 
@@ -16,6 +16,10 @@ Tags:
 -->
 
 ## unreleased
+
+### Changed
+
+- \* Consistent formatting of arrows in class types (#2422, @Julow)
 
 ### Fixed
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2801,14 +2801,16 @@ and fmt_class_type ?(pro = noop) c ({ast= typ; _} as xtyp) =
           @@ Params.parens_if parens c.conf
                (fmt_extension c ctx ext $ fmt_attributes c atrs) )
   | Pcty_open (popen, cl) ->
-      hvbox 2
-        ( pro
-        $ Cmts.fmt c pcty_loc
-          @@ Params.parens_if parens c.conf
-          @@ ( fmt_open_description c ~keyword:"let open" ~kw_attributes:atrs
-                 popen
-             $ fmt " in@;<1000 0>"
-             $ fmt_class_type c (sub_cty ~ctx cl) ) )
+      let pro =
+        hvbox 2
+          ( pro
+          $ Cmts.fmt c pcty_loc
+            @@ Params.parens_if parens c.conf
+            @@ ( fmt_open_description c ~keyword:"let open"
+                   ~kw_attributes:atrs popen
+               $ fmt " in@;<1000 0>" ) )
+      in
+      fmt_class_type c ~pro (sub_cty ~ctx cl)
       $ fmt_docstring c ~pro:(fmt "@ ") doc
 
 and fmt_class_expr c ({ast= exp; ctx= ctx0} as xexp) =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -719,7 +719,7 @@ and fmt_arrow_param c ctx {pap_label= lI; pap_loc= locI; pap_type= tI} =
     be aligned to. [parent_has_parens] is used to align arrows to
     parentheses. *)
 and fmt_arrow_type c ~ctx ?separator_len ~parens ~parent_has_parens args
-    ret_typ =
+    fmt_ret_typ =
   let indent =
     match separator_len with
     | Some separator_len when c.conf.fmt_opts.ocp_indent_compat.v ->
@@ -740,7 +740,7 @@ and fmt_arrow_type c ~ctx ?separator_len ~parens ~parent_has_parens args
           (arrow_sep c ~parens:parent_has_parens)
           (fmt_arrow_param c ctx)
       $ fmt (arrow_sep c ~parens:parent_has_parens)
-      $ fmt_core_type c (sub_typ ~ctx ret_typ) )
+      $ fmt_ret_typ )
 
 (* The context of [xtyp] refers to the RHS of the expression (namely
    Pexp_constraint) and does not give a relevant information as to whether
@@ -798,8 +798,9 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
       Cmts.relocate c.cmts ~src:ptyp_loc
         ~before:(List.hd_exn args).pap_type.ptyp_loc ~after:ret_typ.ptyp_loc ;
       let separator_len = Option.map ~f:String.length pro in
+      let fmt_ret_typ = fmt_core_type c (sub_typ ~ctx ret_typ) in
       fmt_arrow_type c ~ctx ?separator_len ~parens:parenze_constraint_ctx
-        ~parent_has_parens:parens args ret_typ
+        ~parent_has_parens:parens args fmt_ret_typ
   | Ptyp_constr (lid, []) -> fmt_longident_loc c lid
   | Ptyp_constr (lid, [t1]) ->
       fmt_core_type c (sub_typ ~ctx t1) $ fmt "@ " $ fmt_longident_loc c lid
@@ -2719,7 +2720,7 @@ and fmt_class_structure c ~ctx ?ext self_ fields =
   $ fmt_or (List.is_empty fields) "@ " "@;<1000 0>"
   $ str "end"
 
-and fmt_class_signature c ~ctx ~parens ?ext self_ fields =
+and fmt_class_signature c ~ctx ~parens ~loc ?(pro = noop) ?ext self_ fields =
   let update_config c i =
     match i.pctf_desc with
     | Pctf_attribute atr -> update_config c [atr]
@@ -2736,53 +2737,73 @@ and fmt_class_signature c ~ctx ~parens ?ext self_ fields =
     fmt_class_type_field c (sub_ctf ~ctx i)
   in
   let ast x = Ctf x in
-  Params.parens_if parens c.conf
-    ( str "object"
-    $ fmt_extension_suffix c ext
-    $ self_ $ fmt "@ "
-    $ hvbox 0
-        ( fmt_if_k (List.is_empty fields)
-            (Cmts.fmt_within ~pro:noop c (Ast.location ctx))
-        $ fmt_item_list c ctx update_config ast fmt_item fields )
+  let cmts_within =
+    if List.is_empty fields then
+      (* Side effect order is important. *)
+      Cmts.fmt_within ~pro:noop c (Ast.location ctx)
+    else noop
+  in
+  hvbox 2
+    ( hvbox 2
+        ( pro
+        $ ( fmt_if parens "(" $ Cmts.fmt_before c loc $ str "object"
+          $ fmt_extension_suffix c ext
+          $ self_ ) )
+    $ fmt "@ " $ cmts_within
+    $ fmt_item_list c ctx update_config ast fmt_item fields
     $ fmt_if (not (List.is_empty fields)) "@;<1000 -2>"
-    $ str "end" )
+    $ hvbox 0 (str "end" $ Cmts.fmt_after c loc $ fmt_if parens ")") )
 
-and fmt_class_type c ({ast= typ; _} as xtyp) =
+and fmt_class_type ?(pro = noop) c ({ast= typ; _} as xtyp) =
   protect c (Cty typ)
   @@
   let {pcty_desc; pcty_loc; pcty_attributes} = typ in
   update_config_maybe_disabled c pcty_loc pcty_attributes
   @@ fun c ->
   let doc, atrs = doc_atrs pcty_attributes in
-  Cmts.fmt c pcty_loc
-  @@
   let parens = parenze_cty xtyp in
-  ( Params.parens_if parens c.conf
-  @@
   let ctx = Cty typ in
   match pcty_desc with
   | Pcty_constr (name, params) ->
       let params = List.map params ~f:(fun x -> (x, [])) in
-      fmt_class_params c ctx params
-      $ fmt_longident_loc c name $ fmt_attributes c atrs
+      hvbox 2
+        ( pro
+        $ hovbox 0
+            (wrap_if parens "(" ")"
+               ( Cmts.fmt c pcty_loc @@ fmt_class_params c ctx params
+               $ fmt_longident_loc c name $ fmt_attributes c atrs ) ) )
   | Pcty_signature {pcsig_self; pcsig_fields} ->
-      fmt_class_signature c ~ctx ~parens pcsig_self pcsig_fields
+      fmt_class_signature c ~ctx ~parens ~loc:pcty_loc ~pro pcsig_self
+        pcsig_fields
       $ fmt_attributes c atrs
-  | Pcty_arrow (ctl, ct2) ->
+  | Pcty_arrow (args, ret_typ) ->
       Cmts.relocate c.cmts ~src:pcty_loc
-        ~before:(List.hd_exn ctl).pap_type.ptyp_loc ~after:ct2.pcty_loc ;
-      let xct2 = sub_cty ~ctx ct2 in
-      list ctl (arrow_sep c ~parens) (fmt_arrow_param c ctx)
-      $ fmt (arrow_sep c ~parens)
-      $ (Cmts.fmt_before c ct2.pcty_loc $ fmt_class_type c xct2)
-      $ fmt_attributes c atrs
-  | Pcty_extension ext -> fmt_extension c ctx ext $ fmt_attributes c atrs
+        ~before:(List.hd_exn args).pap_type.ptyp_loc ~after:ret_typ.pcty_loc ;
+      let pro =
+        pro
+        $ ( fmt_if parens "("
+          $ Cmts.fmt_before c pcty_loc
+          $ fmt_arrow_type c ~ctx ~parens:false ~parent_has_parens:parens
+              args noop )
+      in
+      fmt_class_type c ~pro (sub_cty ~ctx ret_typ)
+      $ fmt_attributes c atrs $ Cmts.fmt_after c pcty_loc $ fmt_if parens ")"
+  | Pcty_extension ext ->
+      hvbox 2
+        ( pro
+        $ Cmts.fmt c pcty_loc
+          @@ Params.parens_if parens c.conf
+               (fmt_extension c ctx ext $ fmt_attributes c atrs) )
   | Pcty_open (popen, cl) ->
-      hvbox 0
-        ( fmt_open_description c ~keyword:"let open" ~kw_attributes:atrs popen
-        $ fmt " in@;<1000 0>"
-        $ fmt_class_type c (sub_cty ~ctx cl) ) )
-  $ fmt_docstring c ~pro:(fmt "@ ") doc
+      hvbox 2
+        ( pro
+        $ Cmts.fmt c pcty_loc
+          @@ Params.parens_if parens c.conf
+          @@ ( fmt_open_description c ~keyword:"let open" ~kw_attributes:atrs
+                 popen
+             $ fmt " in@;<1000 0>"
+             $ fmt_class_type c (sub_cty ~ctx cl) ) )
+      $ fmt_docstring c ~pro:(fmt "@ ") doc
 
 and fmt_class_expr c ({ast= exp; ctx= ctx0} as xexp) =
   protect c (Cl exp)
@@ -2847,7 +2868,7 @@ and fmt_class_expr c ({ast= exp; ctx= ctx0} as xexp) =
       hvbox 2
         (wrap_fits_breaks ~space:false c.conf "(" ")"
            ( fmt_class_expr c (sub_cl ~ctx e)
-           $ fmt "@ : "
+           $ fmt " :@ "
            $ fmt_class_type c (sub_cty ~ctx t) ) )
       $ fmt_atrs
   | Pcl_extension ext -> fmt_extension c ctx ext $ fmt_atrs
@@ -3630,16 +3651,18 @@ and fmt_class_types ?ext c ctx ~pre ~sep cls =
         fmt_docstring_around_item ~force_before c cl.pci_attributes
       in
       let class_types =
+        let pro =
+          hovbox 2
+            ( str (if first then pre else "and")
+            $ fmt_if_k first (fmt_extension_suffix c ext)
+            $ fmt_virtual_flag c cl.pci_virt
+            $ fmt "@ "
+            $ fmt_class_params c ctx cl.pci_params
+            $ fmt_str_loc c cl.pci_name $ fmt " " $ str sep )
+          $ fmt "@ "
+        in
         hovbox 2
-          ( hvbox 2
-              ( str (if first then pre else "and")
-              $ fmt_if_k first (fmt_extension_suffix c ext)
-              $ fmt_virtual_flag c cl.pci_virt
-              $ fmt "@ "
-              $ fmt_class_params c ctx cl.pci_params
-              $ fmt_str_loc c cl.pci_name $ fmt "@ " $ str sep )
-          $ fmt "@;"
-          $ fmt_class_type c (sub_cty ~ctx cl.pci_expr)
+          ( fmt_class_type c ~pro (sub_cty ~ctx cl.pci_expr)
           $ fmt_item_attributes c ~pre:(Break (1, 0)) atrs )
       in
       fmt_if (not first) "\n@;<1000 0>"
@@ -3668,22 +3691,27 @@ and fmt_class_exprs ?ext c ctx cls =
            fmt_docstring_around_item ~force_before c cl.pci_attributes
          in
          let class_exprs =
+           let pro =
+             box_fun_decl_args c 2
+               ( hovbox 2
+                   ( str (if first then "class" else "and")
+                   $ fmt_if_k first (fmt_extension_suffix c ext)
+                   $ fmt_virtual_flag c cl.pci_virt
+                   $ fmt "@ "
+                   $ fmt_class_params c ctx cl.pci_params
+                   $ fmt_str_loc c cl.pci_name )
+               $ fmt_if (not (List.is_empty xargs)) "@ "
+               $ wrap_fun_decl_args c (fmt_fun_args c xargs) )
+           in
+           let intro =
+             match ty with
+             | Some ty ->
+                 let pro = pro $ fmt " :@ " in
+                 fmt_class_type c ~pro (sub_cty ~ctx ty)
+             | None -> pro
+           in
            hovbox 2
-             ( hovbox 2
-                 ( box_fun_decl_args c 2
-                     ( hovbox 2
-                         ( str (if first then "class" else "and")
-                         $ fmt_if_k first (fmt_extension_suffix c ext)
-                         $ fmt_virtual_flag c cl.pci_virt
-                         $ fmt "@ "
-                         $ fmt_class_params c ctx cl.pci_params
-                         $ fmt_str_loc c cl.pci_name )
-                     $ fmt_if (not (List.is_empty xargs)) "@ "
-                     $ wrap_fun_decl_args c (fmt_fun_args c xargs) )
-                 $ opt ty (fun t ->
-                       fmt " :@ " $ fmt_class_type c (sub_cty ~ctx t) )
-                 $ fmt "@ =" )
-             $ fmt "@;" $ fmt_class_expr c e )
+             (hovbox 2 (intro $ fmt "@ =") $ fmt "@;" $ fmt_class_expr c e)
            $ fmt_item_attributes c ~pre:(Break (1, 0)) atrs
          in
          fmt_if (not first) "\n@;<1000 0>"

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -915,6 +915,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to class_sig-after.mli.stdout
+   (with-stderr-to class_sig-after.mli.stderr
+     (run %{bin:ocamlformat} --margin-check --break-separators=after %{dep:tests/class_sig.mli})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/class_sig-after.mli.ref class_sig-after.mli.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/class_sig-after.mli.err class_sig-after.mli.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to class_sig.mli.stdout
    (with-stderr-to class_sig.mli.stderr
      (run %{bin:ocamlformat} --margin-check %{dep:tests/class_sig.mli})))))
@@ -922,7 +940,7 @@
 (rule
  (alias runtest)
  (package ocamlformat)
- (action (diff tests/class_sig.mli class_sig.mli.stdout)))
+ (action (diff tests/class_sig.mli.ref class_sig.mli.stdout)))
 
 (rule
  (alias runtest)

--- a/test/passing/tests/class_sig-after.mli.opts
+++ b/test/passing/tests/class_sig-after.mli.opts
@@ -1,0 +1,1 @@
+--break-separators=after

--- a/test/passing/tests/class_sig-after.mli.ref
+++ b/test/passing/tests/class_sig-after.mli.ref
@@ -22,22 +22,10 @@ class c : object
   (** Standalone doc-string. *)
 end
 
-class unix_mockup :
-     foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> bar
+class unix_mockup : foooo:string -> foooo:string -> foooo:string ->
+  foooo:string -> foooo:string -> foooo:string -> bar
 
-class unix_mockup :
-     foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> object
+class unix_mockup : foooo:string -> foooo:string -> foooo:string ->
+  foooo:string -> foooo:string -> foooo:string -> object
   method foo : string
 end

--- a/test/passing/tests/class_sig-after.mli.ref
+++ b/test/passing/tests/class_sig-after.mli.ref
@@ -22,10 +22,22 @@ class c : object
   (** Standalone doc-string. *)
 end
 
-class unix_mockup : foooo:string -> foooo:string -> foooo:string ->
-  foooo:string -> foooo:string -> foooo:string -> bar
+class unix_mockup :
+  foooo:string ->
+  foooo:string ->
+  foooo:string ->
+  foooo:string ->
+  foooo:string ->
+  foooo:string ->
+  bar
 
-class unix_mockup : foooo:string -> foooo:string -> foooo:string ->
-  foooo:string -> foooo:string -> foooo:string -> object
+class unix_mockup :
+  foooo:string ->
+  foooo:string ->
+  foooo:string ->
+  foooo:string ->
+  foooo:string ->
+  foooo:string ->
+  object
   method foo : string
 end

--- a/test/passing/tests/class_sig.mli.ref
+++ b/test/passing/tests/class_sig.mli.ref
@@ -22,10 +22,22 @@ class c : object
   (** Standalone doc-string. *)
 end
 
-class unix_mockup : foooo:string -> foooo:string -> foooo:string
-  -> foooo:string -> foooo:string -> foooo:string -> bar
+class unix_mockup :
+     foooo:string
+  -> foooo:string
+  -> foooo:string
+  -> foooo:string
+  -> foooo:string
+  -> foooo:string
+  -> bar
 
-class unix_mockup : foooo:string -> foooo:string -> foooo:string
-  -> foooo:string -> foooo:string -> foooo:string -> object
+class unix_mockup :
+     foooo:string
+  -> foooo:string
+  -> foooo:string
+  -> foooo:string
+  -> foooo:string
+  -> foooo:string
+  -> object
   method foo : string
 end

--- a/test/passing/tests/class_sig.mli.ref
+++ b/test/passing/tests/class_sig.mli.ref
@@ -22,22 +22,10 @@ class c : object
   (** Standalone doc-string. *)
 end
 
-class unix_mockup :
-     foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> bar
+class unix_mockup : foooo:string -> foooo:string -> foooo:string
+  -> foooo:string -> foooo:string -> foooo:string -> bar
 
-class unix_mockup :
-     foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> foooo:string
-  -> object
+class unix_mockup : foooo:string -> foooo:string -> foooo:string
+  -> foooo:string -> foooo:string -> foooo:string -> object
   method foo : string
 end

--- a/test/passing/tests/class_type.ml.ref
+++ b/test/passing/tests/class_type.ml.ref
@@ -1,13 +1,15 @@
 class c : x -> y -> z = object end
 
-class c : (* fooooooooooooo foooooooooo *) xxxxxxxxxxxxxx
+class c :
+     (* fooooooooooooo foooooooooo *) xxxxxxxxxxxxxx
   -> (* fooooooooo foooooooooo *) yyyyyyyyyyyyyy
   -> (* fooooooooooooo fooooooooooo *) zzzzzzzzzzzzzzzzzz = object end
 
-class c : (* fooooooooooooo foooooooooo *) xxxxxxxxxxxxxx (* fooooooooooo *)
+class c :
+     (* fooooooooooooo foooooooooo *) xxxxxxxxxxxxxx (* fooooooooooo *)
   -> (* fooooooooo foooooooooo *) yyyyyyyyyyyyyy (* foooooooooooooo *)
   -> (* fooooooooooooo fooooooooooo *) zzzzzzzzzzzzzzzzzz
-  (* fooooooooooooooooo *) = object end
+     (* fooooooooooooooooo *) = object end
 
 class c : (a -> b) -> x = object end
 

--- a/test/passing/tests/comment_in_empty.ml
+++ b/test/passing/tests/comment_in_empty.ml
@@ -6,7 +6,7 @@ module type M = sig
   (* this module type is empty *)
 end
 
-class type m = object (* this class type is empty *) end
+class type m = object end (* this class type is empty *)
 
 let x = object (* this object is empty *) end
 

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9481,8 +9481,8 @@ class c =
 class type ct =
   let open M in
   object
-  method f : t
-end
+    method f : t
+  end
 
 (* M.(::) notation *)
 module Exotic_list = struct

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9481,8 +9481,8 @@ class c =
 class type ct =
   let open M in
   object
-    method f : t
-  end
+  method f : t
+end
 
 (* M.(::) notation *)
 module Exotic_list = struct

--- a/test/passing/tests/object.ml
+++ b/test/passing/tests/object.ml
@@ -91,7 +91,9 @@ module type A = sig
     method xxxxxxxxxxxxxxxxxxxxxxxxxxx : int
   end
 
-  class tttttttttttt : aaaaaaaaaaaaaaaaaa:int -> bbbbbbbbbbbbbbbbbbbbb:float
+  class tttttttttttt :
+       aaaaaaaaaaaaaaaaaa:int
+    -> bbbbbbbbbbbbbbbbbbbbb:float
     -> cccccccccccccccccccc
 
   class c : object
@@ -116,20 +118,20 @@ end
 class type mapper =
   let open Modl1 in
   object
-  method expression : Javascript.expression -> Javascript.expression
+    method expression : Javascript.expression -> Javascript.expression
 
-  method expression_o :
-    Javascript.expression option -> Javascript.expression option
+    method expression_o :
+      Javascript.expression option -> Javascript.expression option
 
-  method switch_case :
-       Javascript.expression
-    -> Javascript.expression
-    -> a
-    -> b
-    -> ccccccccccc
-    -> d
-    -> e
-end
+    method switch_case :
+         Javascript.expression
+      -> Javascript.expression
+      -> a
+      -> b
+      -> ccccccccccc
+      -> d
+      -> e
+  end
 
 class tttttttttttttttttttttttttt ~aaaaaaaaaaaaaaaaaaaaaaaaaaaa
   bbbbbbbbbbbbbbbbbbbbb =

--- a/test/passing/tests/object.ml
+++ b/test/passing/tests/object.ml
@@ -118,20 +118,20 @@ end
 class type mapper =
   let open Modl1 in
   object
-    method expression : Javascript.expression -> Javascript.expression
+  method expression : Javascript.expression -> Javascript.expression
 
-    method expression_o :
-      Javascript.expression option -> Javascript.expression option
+  method expression_o :
+    Javascript.expression option -> Javascript.expression option
 
-    method switch_case :
-         Javascript.expression
-      -> Javascript.expression
-      -> a
-      -> b
-      -> ccccccccccc
-      -> d
-      -> e
-  end
+  method switch_case :
+       Javascript.expression
+    -> Javascript.expression
+    -> a
+    -> b
+    -> ccccccccccc
+    -> d
+    -> e
+end
 
 class tttttttttttttttttttttttttt ~aaaaaaaaaaaaaaaaaaaaaaaaaaaa
   bbbbbbbbbbbbbbbbbbbbb =

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -9093,8 +9093,8 @@ class c =
 class type ct =
   let open M in
   object
-    method f : t
-  end
+  method f : t
+end
 
 (* M.(::) notation *)
 module Exotic_list = struct

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -5942,7 +5942,7 @@ class type ['a] cursor = object
   method is_last : bool
 end
 
-class type ['a] storage = object ('self )
+class type ['a] storage = object ('self)
   method first : 'a cursor
 
   method len : int
@@ -6209,7 +6209,7 @@ and argument (func, ty) =
 
 let f (x : #M.foo) = 0
 
-class type ['e] t = object ('s )
+class type ['e] t = object ('s)
   method update : 'e -> 's
 end
 
@@ -9093,8 +9093,8 @@ class c =
 class type ct =
   let open M in
   object
-  method f : t
-end
+    method f : t
+  end
 
 (* M.(::) notation *)
 module Exotic_list = struct


### PR DESCRIPTION
Use the same indentation and breaks for arrows in class types as for
arrows in core types.
The main challenge is that class types contain class signatures, which
are docked after an arrow.

The `fmt_class_type` is rewritten in the "pro" style, which also
changes:

- Remove unecessary space in object poly types
- Indented `object .. end` after a `let open .. in`
