### PR TITLE
Backport dead code in vendored parsers

### DIFF
--- a/test/failing/tests/unit_lex.ml.broken-ref
+++ b/test/failing/tests/unit_lex.ml.broken-ref
@@ -3,6 +3,7 @@ File "tests/unit_lex.ml", line 18, characters 4-10:
          ^^^^^^
 Alert deprecated: ISO-Latin1 characters in identifiers
 ocamlformat: ignoring "tests/unit_lex.ml" (syntax error)
+
 File "tests/unit_lex.ml", line 55, characters 2-8:
 55 |   '\999'; (* wrong, but yet... *)
        ^^^^^^

--- a/test/failing/tests/unit_values.ml.broken-ref
+++ b/test/failing/tests/unit_values.ml.broken-ref
@@ -3,6 +3,7 @@ File "tests/unit_values.ml", line 6, characters 10-11:
               ^
 Alert deprecated: ISO-Latin1 characters in identifiers
 ocamlformat: ignoring "tests/unit_values.ml" (syntax error)
+
 File "tests/unit_values.ml", line 6, characters 11-12:
 6 | let i32 = −1073741824, 1073741823
                ^

--- a/test/passing/tests/error3.ml.err
+++ b/test/passing/tests/error3.ml.err
@@ -3,6 +3,7 @@ File "tests/error3.ml", line 2, characters 0-13:
 2 | (** a or b *)
     ^^^^^^^^^^^^^
 Warning 50 [unexpected-docstring]: ambiguous documentation comment
+
 File "tests/error3.ml", line 3, characters 8-16:
 3 | let b = (** ? *) ()          
             ^^^^^^^^

--- a/test/passing/tests/error4.ml.err
+++ b/test/passing/tests/error4.ml.err
@@ -2,6 +2,7 @@ File "tests/error4.ml", line 2, characters 0-13:
 2 | (** a or b *)
     ^^^^^^^^^^^^^
 Warning 50 [unexpected-docstring]: ambiguous documentation comment
+
 File "tests/error4.ml", line 3, characters 8-16:
 3 | let b = (** ? *) ()          
             ^^^^^^^^

--- a/test/passing/tests/option.ml.err
+++ b/test/passing/tests/option.ml.err
@@ -3,21 +3,25 @@ File "tests/option.ml", line 63, characters 17-28:
                       ^^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'ocamlformat'.
 margin not allowed here
+
 File "tests/option.ml", line 13, characters 3-19:
 13 | [@@ocamlformat.typo "if-then-else=keyword-first"]
         ^^^^^^^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'ocamlformat.typo'.
 Invalid format: Unknown suffix "typo"
+
 File "tests/option.ml", line 21, characters 3-14:
 21 | [@@ocamlformat 1, "if-then-else=keyword-first"]
         ^^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'ocamlformat'.
 Invalid format: String expected
+
 File "tests/option.ml", line 28, characters 3-14:
 28 | [@@ocamlformat "if-then-else=bad"]
         ^^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'ocamlformat'.
 For option "if-then-else": invalid value 'bad', expected one of 'compact', 'fit-or-vertical', 'vertical', 'keyword-first' or 'k-r'
+
 File "tests/option.ml", line 39, characters 14-25:
 39 |            [@@ocamlformat "if-then-else=bad"]
                    ^^^^^^^^^^^

--- a/test/unit/test_translation_unit.ml
+++ b/test/unit/test_translation_unit.ml
@@ -65,6 +65,7 @@ let test_parse_and_format_module_type =
       ~expected:
         (Error
            {|test_unit: ignoring "<test>" (syntax error)
+
 File "<test>", line 1, characters 3-3:
 Error: Syntax error: 'end' expected
 File "<test>", line 1, characters 0-3:

--- a/vendor/ocaml-common/location.ml
+++ b/vendor/ocaml-common/location.ml
@@ -95,8 +95,19 @@ let setup_terminal () =
    input in the terminal. This would not be possible without this information,
    since printing several warnings/errors adds text between the user input and
    the bottom of the terminal.
+
+   We also use for {!is_first_report}, see below.
 *)
 let num_loc_lines = ref 0
+
+(* We use [num_loc_lines] to determine if the report about to be
+   printed is the first or a follow-up report of the current
+   "batch" -- contiguous reports without user input in between, for
+   example for the current toplevel phrase. We use this to print
+   a blank line between messages of the same batch.
+*)
+let is_first_message () =
+  !num_loc_lines = 0
 
 (* This is used by the toplevel to reset [num_loc_lines] before each phrase *)
 let reset () =
@@ -106,6 +117,13 @@ let reset () =
 let echo_eof () =
   print_newline ();
   incr num_loc_lines
+
+(* This is used by the toplevel and the report printers below. *)
+let separate_new_message ppf =
+  if not (is_first_message ()) then begin
+    Format.pp_print_newline ppf ();
+    incr num_loc_lines
+  end
 
 (* Code printing errors and warnings must be wrapped using this function, in
    order to update [num_loc_lines].
@@ -459,20 +477,28 @@ let highlight_quote ppf
         (* Single-line error *)
         Format.fprintf ppf "%s | %s@," line_nb line;
         Format.fprintf ppf "%*s   " (String.length line_nb) "";
-        String.iteri (fun i c ->
+        (* Iterate up to [rightmost], which can be larger than the length of
+           the line because we may point to a location after the end of the
+           last token on the line, for instance:
+           {[
+             token
+                       ^
+             Did you forget ...
+           ]} *)
+        for i = 0 to rightmost.pos_cnum - line_start_cnum - 1 do
           let pos = line_start_cnum + i in
           if ISet.is_start iset ~pos <> None then
             Format.fprintf ppf "@{<%s>" highlight_tag;
           if ISet.mem iset ~pos then Format.pp_print_char ppf '^'
-          else if pos < rightmost.pos_cnum then begin
+          else if i < String.length line then begin
             (* For alignment purposes, align using a tab for each tab in the
                source code *)
-            if c = '\t' then Format.pp_print_char ppf '\t'
+            if line.[i] = '\t' then Format.pp_print_char ppf '\t'
             else Format.pp_print_char ppf ' '
           end;
           if ISet.is_end iset ~pos <> None then
             Format.fprintf ppf "@}"
-        ) line;
+        done;
         Format.fprintf ppf "@}@,"
     | _ ->
         (* Multi-line error *)
@@ -722,6 +748,7 @@ let batch_mode_printer : report_printer =
   let pp_txt ppf txt = Format.fprintf ppf "@[%t@]" txt in
   let pp self ppf report =
     setup_colors ();
+    separate_new_message ppf;
     (* Make sure we keep [num_loc_lines] updated.
        The tabulation box is here to give submessage the option
        to be aligned with the main message box
@@ -894,6 +921,32 @@ let alert ?(def = none) ?(use = none) ~kind loc message =
 
 let deprecated ?def ?use loc message =
   alert ?def ?use ~kind:"deprecated" loc message
+
+let auto_include_alert lib =
+  let message = Printf.sprintf "\
+    OCaml's lib directory layout changed in 5.0. The %s subdirectory has been \
+    automatically added to the search path, but you should add -I +%s to the \
+    command-line to silence this alert (e.g. by adding %s to the list of \
+    libraries in your dune file, or adding use_%s to your _tags file for \
+    ocamlbuild, or using -package %s for ocamlfind)." lib lib lib lib lib in
+  let alert =
+    {Warnings.kind="ocaml_deprecated_auto_include"; use=none; def=none;
+     message = Format.asprintf "@[@\n%a@]" Format.pp_print_text message}
+  in
+  prerr_alert none alert
+
+let deprecated_script_alert program =
+  let message = Printf.sprintf "\
+    Running %s where the first argument is an implicit basename with no \
+    extension (e.g. %s script-file) is deprecated. Either rename the script \
+    (%s script-file.ml) or qualify the basename (%s ./script-file)"
+    program program program program
+  in
+  let alert =
+    {Warnings.kind="ocaml_deprecated_cli"; use=none; def=none;
+     message = Format.asprintf "@[@\n%a@]" Format.pp_print_text message}
+  in
+  prerr_alert none alert
 
 (******************************************************************************)
 (* Reporting errors on exceptions *)

--- a/vendor/ocaml-common/location.mli
+++ b/vendor/ocaml-common/location.mli
@@ -88,10 +88,11 @@ val input_phrase_buffer: Buffer.t option ref
 (** {1 Toplevel-specific functions} *)
 
 val echo_eof: unit -> unit
+val separate_new_message: formatter -> unit
 val reset: unit -> unit
 
 
-(** {1 Printing locations} *)
+(** {1 Rewriting path } *)
 
 val rewrite_absolute_path: string -> string
     (** rewrite absolute path to honor the BUILD_PATH_PREFIX_MAP
@@ -99,6 +100,13 @@ val rewrite_absolute_path: string -> string
         if it is set. *)
 
 val absolute_path: string -> string
+ (** [absolute_path path] first makes an absolute path, [s] from [path],
+     prepending the current working directory if [path] was relative.
+     Then [s] is rewritten using [rewrite_absolute_path].
+     Finally the result is normalized by eliminating instances of
+     ['.'] or ['..']. *)
+
+(** {1 Printing locations} *)
 
 val show_filename: string -> string
     (** In -absname mode, return the absolute path for this filename.
@@ -243,6 +251,13 @@ val deprecated: ?def:t -> ?use:t -> t -> string -> unit
 val alert: ?def:t -> ?use:t -> kind:string -> t -> string -> unit
 (** Prints an arbitrary alert. *)
 
+val auto_include_alert: string -> unit
+(** Prints an alert that -I +lib has been automatically added to the load
+    path *)
+
+val deprecated_script_alert: string -> unit
+(** [deprecated_script_alert command] prints an alert that [command foo] has
+    been deprecated in favour of [command ./foo] *)
 
 (** {1 Reporting errors} *)
 

--- a/vendor/parser-shims/parser_shims.ml
+++ b/vendor/parser-shims/parser_shims.ml
@@ -49,4 +49,14 @@ module Clflags = struct
   let color = ref None                    (* -color *)
   let error_style = ref None              (* -error-style *)
   let unboxed_types = ref false
+  let no_std_include = ref false
+end
+
+module Load_path = struct
+  type dir
+  type auto_include_callback =
+    (dir -> string -> string option) -> string -> string
+  let init ~auto_include:_ _ = ()
+  let get_paths () = []
+  let auto_include_otherlibs _ _ s = s
 end

--- a/vendor/parser-shims/parser_shims.mli
+++ b/vendor/parser-shims/parser_shims.mli
@@ -49,4 +49,14 @@ module Clflags : sig
   val color : Misc.Color.setting option ref
   val error_style : Misc.Error_style.setting option ref
   val unboxed_types : bool ref
+  val no_std_include : bool ref
+end
+
+module Load_path : sig
+  type dir
+  type auto_include_callback =
+    (dir -> string -> string option) -> string -> string
+  val init : auto_include:auto_include_callback -> string list -> unit
+  val get_paths : unit -> string list
+  val auto_include_otherlibs : (string -> unit) -> auto_include_callback
 end

--- a/vendor/parser-standard/ast_mapper.ml
+++ b/vendor/parser-standard/ast_mapper.ml
@@ -924,7 +924,16 @@ module PpxContext = struct
       | "include_dirs" ->
           Clflags.include_dirs := get_list get_string payload
       | "load_path" ->
-          ()
+          (* Duplicates Compmisc.auto_include, since we can't reference Compmisc
+             from this module. *)
+          let auto_include find_in_dir fn =
+            if !Clflags.no_std_include then
+              raise Not_found
+            else
+              let alert = Location.auto_include_alert in
+              Load_path.auto_include_otherlibs alert find_in_dir fn
+          in
+          Load_path.init ~auto_include (get_list get_string payload)
       | "open_modules" ->
           Clflags.open_modules := get_list get_string payload
       | "for_package" ->

--- a/vendor/parser-standard/parser.mly
+++ b/vendor/parser-standard/parser.mly
@@ -2305,7 +2305,7 @@ expr:
   | expr attribute
       { Exp.attr $1 $2 }
 /* BEGIN AVOID */
-  (*
+  (* Allowed in exprs. Commented-out to reduce diffs with upstream.
   | UNDERSCORE
      { not_expecting $loc($1) "wildcard \"_\"" }
   *)
@@ -3643,6 +3643,7 @@ label_longident:
 ;
 type_longident:
     mk_longident(mod_ext_longident, LIDENT)  { $1 }
+  (* Allow identifiers like [t/42]. *)
   | LIDENT SLASH TYPE_DISAMBIGUATOR          { Lident ($1 ^ "/" ^ $3) }
 ;
 mod_longident:


### PR DESCRIPTION
Commented-out dead code is useful to differentiate new code while backporting and reduce the textual diff with upstream.
The second commit backports some 5.1 changes that do not affect formatting code.
This is meant to reduce the diff of https://github.com/ocaml-ppx/ocamlformat/pull/2412