### PR TITLE
Align variant arguments indentation inside parentheses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ profile. This started with version 0.26.0.
   Use the option `parse-docstrings = false` to disable.
 - \* Janestreet profile: do not break `fun _ -> function` (#2460, @tdelvecchio-jsc)
 - \* Reduce the indentation of (polytype) type constraints (#2437, @gpetiot)
+- \* Consistent indentation of polymorphic variant arguments (#2427, @Julow)
 
 ### Fixed
 

--- a/lib-rpc/ocamlformat_rpc_lib.ml
+++ b/lib-rpc/ocamlformat_rpc_lib.ml
@@ -120,9 +120,9 @@ module Make (IO : IO) = struct
               return
                 (Error
                    (`Msg
-                     "OCamlFormat-RPC did not respond. Check that a \
-                      compatible version of the OCamlFormat RPC server \
-                      (ocamlformat-rpc >= 0.18.0) is installed." ) ) )
+                      "OCamlFormat-RPC did not respond. Check that a \
+                       compatible version of the OCamlFormat RPC server \
+                       (ocamlformat-rpc >= 0.18.0) is installed." ) ) )
     in
     aux versions
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1537,8 +1537,8 @@ let parse_attr {attr_name= {txt; loc= _}; attr_payload; _} =
   | _ when String.is_prefix ~prefix:"ocamlformat." txt ->
       Error
         (`Msg
-          (Format.sprintf "Invalid format: Unknown suffix %S"
-             (String.chop_prefix_exn ~prefix:"ocamlformat." txt) ) )
+           (Format.sprintf "Invalid format: Unknown suffix %S"
+              (String.chop_prefix_exn ~prefix:"ocamlformat." txt) ) )
   | _ -> Error `Ignore
 
 let update ?(quiet = false) c ({attr_name= {txt; loc}; _} as attr) =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1060,8 +1060,8 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
       Cmts.fmt c ppat_loc
         (hvbox 0 (fmt_pat_cons c ~parens (List.map lp ~f:(sub_pat ~ctx))))
   | Ppat_construct (lid, Some (exists, pat)) ->
-      cbox 2
-        (Params.parens_if parens c.conf
+      Params.parens_if parens c.conf
+        (cbox 2
            ( fmt_longident_loc c lid $ fmt "@ "
            $ ( match exists with
              | [] -> noop
@@ -1073,8 +1073,8 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
            $ fmt_pattern c (sub_pat ~ctx pat) ) )
   | Ppat_variant (lbl, None) -> variant_var c lbl
   | Ppat_variant (lbl, Some pat) ->
-      cbox 2
-        (Params.parens_if parens c.conf
+      Params.parens_if parens c.conf
+        (cbox 2
            (variant_var c lbl $ fmt "@ " $ fmt_pattern c (sub_pat ~ctx pat)) )
   | Ppat_record (flds, closed_flag) ->
       let fmt_field (lid, typ1, pat) =
@@ -2178,8 +2178,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
           $ fmt_atrs )
   | Pexp_variant (s, arg) ->
       pro
-      $ hvbox 2
-          (Params.parens_if parens c.conf
+      $ Params.parens_if parens c.conf
+          (hvbox 2
              ( variant_var c s
              $ opt arg (fmt "@ " >$ (sub_exp ~ctx >> fmt_expression c))
              $ fmt_atrs ) )

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1060,22 +1060,25 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
       Cmts.fmt c ppat_loc
         (hvbox 0 (fmt_pat_cons c ~parens (List.map lp ~f:(sub_pat ~ctx))))
   | Ppat_construct (lid, Some (exists, pat)) ->
-      Params.parens_if parens c.conf
-        (cbox 2
-           ( fmt_longident_loc c lid $ fmt "@ "
-           $ ( match exists with
-             | [] -> noop
-             | names ->
-                 hvbox 0
-                   (Params.parens c.conf
-                      (str "type " $ list names "@ " (fmt_str_loc c)) )
-                 $ fmt "@ " )
-           $ fmt_pattern c (sub_pat ~ctx pat) ) )
+      cbox 0
+        (Params.parens_if parens c.conf
+           (hvbox 2
+              ( fmt_longident_loc c lid $ fmt "@ "
+              $ ( match exists with
+                | [] -> noop
+                | names ->
+                    hvbox 0
+                      (Params.parens c.conf
+                         (str "type " $ list names "@ " (fmt_str_loc c)) )
+                    $ fmt "@ " )
+              $ fmt_pattern c (sub_pat ~ctx pat) ) ) )
   | Ppat_variant (lbl, None) -> variant_var c lbl
   | Ppat_variant (lbl, Some pat) ->
-      Params.parens_if parens c.conf
-        (cbox 2
-           (variant_var c lbl $ fmt "@ " $ fmt_pattern c (sub_pat ~ctx pat)) )
+      cbox 0
+        (Params.parens_if parens c.conf
+           (hvbox 2
+              ( variant_var c lbl $ fmt "@ "
+              $ fmt_pattern c (sub_pat ~ctx pat) ) ) )
   | Ppat_record (flds, closed_flag) ->
       let fmt_field (lid, typ1, pat) =
         let typ1 = Option.map typ1 ~f:(sub_typ ~ctx) in

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -10134,7 +10134,7 @@ let%test_module "semantics" =
 let _ =
   Error
     (`Foooooooooooooooooo
-      (name, Format.sprintf "expecting %S but got %S" Version.version value))
+       (name, Format.sprintf "expecting %S but got %S" Version.version value))
 ;;
 
 let _ =
@@ -10159,13 +10159,13 @@ let _ =
 ;;
 
 let (`Foooooooooooooooooo
-      (foooooooooooooo, foooooooooooooo, foooooooooooooo, foooooooooooooo))
+       (foooooooooooooo, foooooooooooooo, foooooooooooooo, foooooooooooooo))
   =
   x
 ;;
 
 let (Foooooooooooooooooo
-      (foooooooooooooo, foooooooooooooo, foooooooooooooo, foooooooooooooo))
+       (foooooooooooooo, foooooooooooooo, foooooooooooooo, foooooooooooooo))
   =
   x
 ;;

--- a/test/rpc/rpc_test.ml
+++ b/test/rpc/rpc_test.ml
@@ -70,9 +70,9 @@ let start ?versions () =
   | exception _ ->
       Error
         (`Msg
-          "OCamlFormat-RPC did not respond. Check that a compatible version \
-           of the OCamlFormat RPC server (ocamlformat-rpc >= 0.18.0) is \
-           installed." )
+           "OCamlFormat-RPC did not respond. Check that a compatible \
+            version of the OCamlFormat RPC server (ocamlformat-rpc >= \
+            0.18.0) is installed." )
   | x -> x )
   |> Result.map_error ~f:(fun (`Msg msg) ->
          state := Errored ;

--- a/test/rpc/rpc_test_fail.ml
+++ b/test/rpc/rpc_test_fail.ml
@@ -68,9 +68,9 @@ let start () =
   | exception _ ->
       Error
         (`Msg
-          "OCamlFormat-RPC did not respond. Check that a compatible version \
-           of the OCamlFormat RPC server (ocamlformat-rpc >= 0.18.0) is \
-           installed." )
+           "OCamlFormat-RPC did not respond. Check that a compatible \
+            version of the OCamlFormat RPC server (ocamlformat-rpc >= \
+            0.18.0) is installed." )
   | x -> x )
   |> Result.map_error ~f:(fun (`Msg msg) ->
          state := Errored ;


### PR DESCRIPTION
Parenthesed variants are aligned inside their parentheses, which increases the indentation of its arguments. This is consistent with non-polymorphic variant constructors.

Previously:

    (`Foo
      ...
      )

Now:

    (`Foo
       ...
    )