### PR TITLE
Improve compatibility with ocp-indent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Tags:
 
 - Compatible with OCaml 5.1.0 (#2412, @Julow)
   The syntax of let-bindings changed sligthly in this version.
+- Improved ocp-indent compatibility (#2428, @Julow)
 - \* Consistent formatting of arrows in class types (#2422, @Julow)
 
 ### Fixed

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3522,7 +3522,8 @@ and fmt_module_type c ?(rec_ = false) ({ast= mty; _} as xmty) =
               open_hvbox 0 $ fmt_if parens "(" $ pro )
       ; psp
       ; bdy=
-          fmt_if_k (Option.is_none pro) (open_hvbox 2 $ fmt_if parens "(")
+          fmt_if_k (Option.is_none pro)
+            (open_hvbox (Params.Indent.mty_with c.conf) $ fmt_if parens "(")
           $ hvbox 0 bdy
           $ fmt_if_k (Option.is_some epi) esp
           $ fmt_opt epi $ list_fl wcs fmt_cstrs $ fmt_if parens ")"

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4023,13 +4023,17 @@ and fmt_module_expr ?(dock_struct = true) c ({ast= m; _} as xmod) =
       let has_epi =
         Cmts.has_after c.cmts pmod_loc || not (List.is_empty pmod_attributes)
       in
-      { opn= Some (fmt_opt blk_t.opn $ fmt_opt blk_e.opn $ open_hovbox 2)
+      { opn=
+          Some
+            ( fmt_opt blk_t.opn $ fmt_opt blk_e.opn
+            $ open_hovbox (Params.Indent.mod_constraint c.conf ~lhs:me) )
       ; pro= Some (Cmts.fmt_before c pmod_loc $ str "(")
       ; psp= fmt "@,"
       ; bdy=
           hvbox 0
             ( fmt_opt blk_e.pro $ blk_e.psp $ blk_e.bdy $ blk_e.esp
-            $ fmt_opt blk_e.epi $ fmt " :@;<1 2>"
+            $ fmt_opt blk_e.epi $ fmt " :"
+            $ Params.Mod.break_constraint c.conf ~rhs:mt
             $ hvbox 0
                 ( fmt_opt blk_t.pro $ blk_t.psp $ blk_t.bdy $ blk_t.esp
                 $ fmt_opt blk_t.epi ) )

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3317,15 +3317,17 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
   $ hvbox ~name:"constructor_decl" 2
       ( hvbox
           (Params.Indent.constructor_docstring c.conf)
-          ( fmt_or_k first (if_newline "| ") (str "| ")
-          $ hvbox 2
-              ( hovbox ~name:"constructor_decl_name" 2
-                  (Cmts.fmt c loc
-                     (wrap_if
-                        (Std_longident.String_id.is_symbol txt)
-                        "( " " )" (str txt) ) )
-              $ fmt_constructor_arguments_result c ctx pcd_vars pcd_args
-                  pcd_res )
+          ( hvbox 2
+              ( fmt_or_k first (if_newline "| ") (str "| ")
+              $ Cmts.fmt_before c loc
+              $ hvbox 2
+                  ( hovbox ~name:"constructor_decl_name" 2
+                      ( wrap_if
+                          (Std_longident.String_id.is_symbol txt)
+                          "( " " )" (str txt)
+                      $ Cmts.fmt_after c loc )
+                  $ fmt_constructor_arguments_result c ctx pcd_vars pcd_args
+                      pcd_res ) )
           $ fmt_attributes_and_docstrings c pcd_attributes )
       $ Cmts.fmt_after c pcd_loc )
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3315,7 +3315,7 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
   fmt_if_k (not first) (fmt_or (sparse || has_cmt_before) "@;<1000 0>" "@ ")
   $ Cmts.fmt_before ~epi:(break 1000 0) c pcd_loc
   $ hvbox ~name:"constructor_decl" 2
-      ( hvbox
+      ( hovbox
           (Params.Indent.constructor_docstring c.conf)
           ( hvbox 2
               ( fmt_or_k first (if_newline "| ") (str "| ")

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2154,20 +2154,19 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
           Params.Indent.function_ ~default:default_indent c.conf ~parens xexp
         else Params.Indent.fun_ ?eol c.conf
       in
+      let intro =
+        let kw =
+          str "fun"
+          $ fmt_extension_suffix c ext
+          $ str " "
+          $ fmt_attributes c pexp_attributes ~suf:" "
+        and args = fmt_fun_args c xargs in
+        Params.Exp.box_fun_decl_args c.conf ~parens ~kw ~args ~annot:fmt_cstr
+      in
       hvbox_if (box || body_is_function) indent
         (Params.Exp.wrap c.conf ~parens ~disambiguate:true ~fits_breaks:false
            ~offset_closing_paren:(-2)
-           ( hovbox 2
-               ( hovbox 4
-                   ( str "fun"
-                   $ fmt_extension_suffix c ext
-                   $ str " "
-                   $ fmt_attributes c pexp_attributes ~suf:" "
-                   $ hvbox_if
-                       (not c.conf.fmt_opts.wrap_fun_args.v)
-                       0 (fmt_fun_args c xargs)
-                   $ fmt_opt fmt_cstr $ fmt "@ " )
-               $ str "->" $ pre_body )
+           ( hovbox 2 (intro $ fmt "@ " $ str "->" $ pre_body)
            $ fmt "@ " $ body ) )
   | Pexp_function cs ->
       let indent = Params.Indent.function_ c.conf ~parens xexp in

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2169,7 +2169,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       hvbox_if (box || body_is_function) indent
         (Params.Exp.wrap c.conf ~parens ~disambiguate:true ~fits_breaks:false
            ~offset_closing_paren:(-2)
-           ( hovbox 2 (intro $ fmt "@ " $ str "->" $ pre_body)
+           ( hovbox 2 (intro $ str " ->" $ pre_body)
            $ fmt "@ " $ body ) )
   | Pexp_function cs ->
       let indent = Params.Indent.function_ c.conf ~parens xexp in

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2169,8 +2169,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       hvbox_if (box || body_is_function) indent
         (Params.Exp.wrap c.conf ~parens ~disambiguate:true ~fits_breaks:false
            ~offset_closing_paren:(-2)
-           ( hovbox 2 (intro $ str " ->" $ pre_body)
-           $ fmt "@ " $ body ) )
+           (hovbox 2 (intro $ str " ->" $ pre_body) $ fmt "@ " $ body) )
   | Pexp_function cs ->
       let indent = Params.Indent.function_ c.conf ~parens xexp in
       Params.Exp.wrap c.conf ~parens ~disambiguate:true ~fits_breaks:false

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -809,12 +809,17 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
         ~parent_has_parens:parens args fmt_ret_typ
   | Ptyp_constr (lid, []) -> fmt_longident_loc c lid
   | Ptyp_constr (lid, [t1]) ->
-      fmt_core_type c (sub_typ ~ctx t1) $ fmt "@ " $ fmt_longident_loc c lid
+      hvbox
+        (Params.Indent.type_constr c.conf)
+        ( fmt_core_type c (sub_typ ~ctx t1)
+        $ fmt "@ " $ fmt_longident_loc c lid )
   | Ptyp_constr (lid, t1N) ->
-      wrap_fits_breaks c.conf "(" ")"
-        (list t1N (Params.comma_sep c.conf)
-           (sub_typ ~ctx >> fmt_core_type c) )
-      $ fmt "@ " $ fmt_longident_loc c lid
+      hvbox
+        (Params.Indent.type_constr c.conf)
+        ( wrap_fits_breaks c.conf "(" ")"
+            (list t1N (Params.comma_sep c.conf)
+               (sub_typ ~ctx >> fmt_core_type c) )
+        $ fmt "@ " $ fmt_longident_loc c lid )
   | Ptyp_extension ext ->
       hvbox c.conf.fmt_opts.extension_indent.v (fmt_extension c ctx ext)
   | Ptyp_package (id, cnstrs) ->

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4104,9 +4104,10 @@ and fmt_module_expr ?(dock_struct = true) c ({ast= m; _} as xmod) =
             $ after ) }
   | Pmod_unpack (e, ty1, ty2) ->
       let package_type sep (lid, cstrs) =
-        hvbox 0
-          ( hovbox 0 (str sep $ fmt_longident_loc c lid)
-          $ fmt_package_type c ctx cstrs )
+        break 1 (Params.Indent.mod_unpack_annot c.conf)
+        $ hvbox 0
+            ( hovbox 0 (str sep $ fmt_longident_loc c lid)
+            $ fmt_package_type c ctx cstrs )
       in
       { empty with
         opn= Some (open_hvbox 2)
@@ -4117,8 +4118,8 @@ and fmt_module_expr ?(dock_struct = true) c ({ast= m; _} as xmod) =
                 (wrap_fits_breaks ~space:false c.conf "(" ")"
                    ( str "val "
                    $ fmt_expression c (sub_exp ~ctx e)
-                   $ opt ty1 (fun x -> break 1 2 $ package_type ": " x)
-                   $ opt ty2 (fun x -> break 1 2 $ package_type ":> " x) ) )
+                   $ opt ty1 (package_type ": ")
+                   $ opt ty2 (package_type ":> ") ) )
             $ fmt_attributes_and_docstrings c pmod_attributes ) }
   | Pmod_extension x1 ->
       { empty with

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2087,7 +2087,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         c.conf
         (fmt_constant c ?epi const $ fmt_atrs)
   | Pexp_constraint (e, t) ->
-      hvbox 2
+      hvbox
+        (Params.Indent.exp_constraint c.conf)
         ( wrap_fits_breaks ~space:false c.conf "(" ")"
             ( fmt_expression c (sub_exp ~ctx e)
             $ fmt "@ : "

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3273,7 +3273,8 @@ and fmt_label_declaration c ctx ?(last = false) decl =
   in
   hovbox 0
     ( Cmts.fmt_before c pld_loc
-    $ hvbox 4
+    $ hvbox
+        (Params.Indent.record_docstring c.conf)
         ( hvbox 3
             ( hvbox 4
                 ( hvbox 2
@@ -3307,11 +3308,12 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
      eventual comment placed after the previous constructor *)
   fmt_if_k (not first) (fmt_or (sparse || has_cmt_before) "@;<1000 0>" "@ ")
   $ Cmts.fmt_before ~epi:(break 1000 0) c pcd_loc
-  $ fmt_or_k first (if_newline "| ") (str "| ")
-  $ hvbox ~name:"constructor_decl" 0
-      ( hovbox 2
-          ( hvbox 2
-              ( hovbox ~name:"constructor_decl_name" 0
+  $ hvbox ~name:"constructor_decl" 2
+      ( hvbox
+          (Params.Indent.constructor_docstring c.conf)
+          ( fmt_or_k first (if_newline "| ") (str "| ")
+          $ hvbox 2
+              ( hovbox ~name:"constructor_decl_name" 2
                   (Cmts.fmt c loc
                      (wrap_if
                         (Std_longident.String_id.is_symbol txt)

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -693,6 +693,8 @@ module Indent = struct
     if ocp c then match lhs.pmod_desc with Pmod_structure _ -> 0 | _ -> 2
     else 2
 
+  let mod_unpack_annot c = if ocp c then 0 else 2
+
   let mty_with c = if ocp c then 0 else 2
 
   let type_constr c = if ocp c then 2 else 0

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -670,4 +670,11 @@ module Indent = struct
       in
       if Source.begins_line ~ignore_spaces:true source loc then if_breaks
       else 0
+
+  let record_docstring (c : Conf.t) =
+    if ocp c then
+      match c.fmt_opts.break_separators.v with `Before -> -2 | `After -> 0
+    else 4
+
+  let constructor_docstring c = if ocp c then 0 else 4
 end

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -687,6 +687,8 @@ module Indent = struct
 
   let exp_constraint c = if ocp c then 1 else 2
 
+  let assignment_operator_bol c = if ocp c then 0 else 2
+
   let mod_constraint c ~lhs =
     if ocp c then match lhs.pmod_desc with Pmod_structure _ -> 0 | _ -> 2
     else 2

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -677,4 +677,6 @@ module Indent = struct
     else 4
 
   let constructor_docstring c = if ocp c then 0 else 4
+
+  let exp_constraint c = if ocp c then 1 else 2
 end

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -15,7 +15,22 @@ open Asttypes
 open Fmt
 open Ast
 
+(** Shorthand for a commonly used option. *)
 let ocp c = c.Conf.fmt_opts.ocp_indent_compat.v
+
+(** Whether [exp] occurs in [args] as a labelled argument. *)
+let is_labelled_arg args exp =
+  List.exists
+    ~f:(function
+      | Nolabel, _ -> false
+      | Labelled _, x | Optional _, x -> phys_equal x exp )
+    args
+
+(** Like [is_labelled_arg] but look at an expression's context. *)
+let is_labelled_arg' xexp =
+  match xexp.Ast.ctx with
+  | Exp {pexp_desc= Pexp_apply (_, args); _} -> is_labelled_arg args xexp.ast
+  | _ -> false
 
 let parens_if parens (c : Conf.t) ?(disambiguate = false) k =
   if disambiguate && c.fmt_opts.disambiguate_non_breaking_match.v then
@@ -566,11 +581,6 @@ let match_indent ?(default = 0) (c : Conf.t) ~parens ~(ctx : Ast.t) =
       2 (* Match is docked *)
   | _ -> default
 
-let function_indent ?(default = 0) (c : Conf.t) ~(ctx : Ast.t) =
-  match (c.fmt_opts.function_indent_nested.v, ctx) with
-  | `Always, _ | _, (Top | Sig _ | Str _) -> c.fmt_opts.function_indent.v
-  | _ -> default
-
 let comma_sep (c : Conf.t) : Fmt.s =
   match c.fmt_opts.break_separators.v with
   | `Before -> "@,, "
@@ -613,4 +623,51 @@ module Align = struct
       | _ -> parens && not c.fmt_opts.align_symbol_open_paren.v
     in
     hvbox_if align 0 t
+end
+
+module Indent = struct
+  let function_ ?(default = 0) (c : Conf.t) ~parens xexp =
+    match c.fmt_opts.function_indent_nested.v with
+    | `Always -> c.fmt_opts.function_indent.v
+    | _ when ocp c && parens && not (is_labelled_arg' xexp) -> default + 1
+    | _ -> default
+
+  let fun_ ?eol (c : Conf.t) =
+    match c.fmt_opts.function_indent_nested.v with
+    | `Always -> c.fmt_opts.function_indent.v
+    | _ ->
+        if Option.is_none eol then 2
+        else if c.fmt_opts.let_binding_deindent_fun.v then 1
+        else 0
+
+  let fun_type_annot c = if ocp c then 2 else 4
+
+  let fun_args c = if ocp c then 6 else 4
+
+  let docked_function (c : Conf.t) ~parens xexp =
+    if ocp c then if parens then 3 else 2
+    else
+      let default = if c.fmt_opts.wrap_fun_args.v then 2 else 4 in
+      function_ ~default c ~parens:false xexp
+
+  let docked_function_after_fun (c : Conf.t) ~parens ~lbl =
+    if ocp c then if parens && Poly.equal lbl Nolabel then 3 else 2 else 0
+
+  let fun_args_group (c : Conf.t) ~lbl exp =
+    if not (ocp c) then 2
+    else
+      match exp.pexp_desc with
+      | Pexp_function _ -> 2
+      | _ -> ( match lbl with Nolabel -> 3 | _ -> 2 )
+
+  let docked_fun (c : Conf.t) ~source ~loc ~lbl =
+    if not (ocp c) then 2
+    else
+      let loc, if_breaks =
+        match lbl with
+        | Nolabel -> (loc, 3)
+        | Optional x | Labelled x -> (x.loc, 2)
+      in
+      if Source.begins_line ~ignore_spaces:true source loc then if_breaks
+      else 0
 end

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -92,6 +92,13 @@ module Exp = struct
           Fmt.fits_breaks "(" "(" $ k
           $ Fmt.fits_breaks ")" ~hint:(1000, offset_closing_paren) ")"
       | `No -> wrap "(" ")" k
+
+  let box_fun_decl_args c ~parens ~kw ~args ~annot =
+    let box_decl, should_box_args =
+      if ocp c then (hvbox (if parens then 1 else 2), false)
+      else (hovbox 4, not c.fmt_opts.wrap_fun_args.v)
+    in
+    box_decl (kw $ hvbox_if should_box_args 0 args $ fmt_opt annot)
 end
 
 module Mod = struct

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -118,6 +118,13 @@ module Mod = struct
     let arg_psp = if dock then str " " else break 1 psp_indent in
     let align = ocp c in
     {dock; arg_psp; indent; align}
+
+  let break_constraint c ~rhs =
+    if ocp c then
+      match rhs.pmty_desc with
+      | Pmty_signature _ when ocp c -> break 1 0
+      | _ -> break 1 2
+    else break 1 2
 end
 
 let get_or_pattern_sep ?(cmts_before = false) ?(space = false) (c : Conf.t)
@@ -679,4 +686,8 @@ module Indent = struct
   let constructor_docstring c = if ocp c then 0 else 4
 
   let exp_constraint c = if ocp c then 1 else 2
+
+  let mod_constraint c ~lhs =
+    if ocp c then match lhs.pmod_desc with Pmod_structure _ -> 0 | _ -> 2
+    else 2
 end

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -690,4 +690,6 @@ module Indent = struct
   let mod_constraint c ~lhs =
     if ocp c then match lhs.pmod_desc with Pmod_structure _ -> 0 | _ -> 2
     else 2
+
+  let mty_with c = if ocp c then 0 else 2
 end

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -692,4 +692,6 @@ module Indent = struct
     else 2
 
   let mty_with c = if ocp c then 0 else 2
+
+  let type_constr c = if ocp c then 2 else 0
 end

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -194,5 +194,11 @@ module Indent : sig
 
   val exp_constraint : Conf.t -> int
 
+  (** Module expressions *)
+
   val mod_constraint : Conf.t -> lhs:module_expr -> int
+
+  (** Module types *)
+
+  val mty_with : Conf.t -> int
 end

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -184,4 +184,8 @@ module Indent : sig
     Conf.t -> parens:bool -> lbl:arg_label -> int
 
   val fun_args_group : Conf.t -> lbl:arg_label -> expression -> int
+
+  val record_docstring : Conf.t -> int
+
+  val constructor_docstring : Conf.t -> int
 end

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -194,6 +194,8 @@ module Indent : sig
 
   val exp_constraint : Conf.t -> int
 
+  val assignment_operator_bol : Conf.t -> int
+
   (** Module expressions *)
 
   val mod_constraint : Conf.t -> lhs:module_expr -> int

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -201,4 +201,8 @@ module Indent : sig
   (** Module types *)
 
   val mty_with : Conf.t -> int
+
+  (** Types *)
+
+  val type_constr : Conf.t -> int
 end

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -143,12 +143,6 @@ val match_indent : ?default:int -> Conf.t -> parens:bool -> ctx:Ast.t -> int
     option, or using the [default] indentation (0 if not provided) if the
     option does not apply. *)
 
-val function_indent : ?default:int -> Conf.t -> ctx:Ast.t -> int
-(** [function_indent c ~ctx ~default] returns the indentation used for the
-    function in context [ctx], depending on the `function-indent-nested`
-    option, or using the [default] indentation (0 if not provided) if the
-    option does not apply. *)
-
 val comma_sep : Conf.t -> Fmt.s
 (** [comma_sep c] returns the format string used to separate two elements
     with a comma, depending on the `break-separators` option. *)
@@ -162,4 +156,32 @@ module Align : sig
 
   val function_ :
     Conf.t -> parens:bool -> ctx0:Ast.t -> self:expression -> Fmt.t -> Fmt.t
+end
+
+module Indent : sig
+  (** Indentation of various nodes. *)
+
+  (** Expressions *)
+
+  val function_ :
+    ?default:int -> Conf.t -> parens:bool -> expression Ast.xt -> int
+  (** Check the [function-indent-nested] option, or return [default] (0 if
+      not provided) if the option does not apply. *)
+
+  val fun_ : ?eol:Fmt.t -> Conf.t -> int
+  (** Handle [function-indent-nested]. *)
+
+  val fun_args : Conf.t -> int
+
+  val fun_type_annot : Conf.t -> int
+
+  val docked_fun :
+    Conf.t -> source:Source.t -> loc:Location.t -> lbl:arg_label -> int
+
+  val docked_function : Conf.t -> parens:bool -> expression Ast.xt -> int
+
+  val docked_function_after_fun :
+    Conf.t -> parens:bool -> lbl:arg_label -> int
+
+  val fun_args_group : Conf.t -> lbl:arg_label -> expression -> int
 end

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -200,6 +200,8 @@ module Indent : sig
 
   val mod_constraint : Conf.t -> lhs:module_expr -> int
 
+  val mod_unpack_annot : Conf.t -> int
+
   (** Module types *)
 
   val mty_with : Conf.t -> int

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -35,6 +35,16 @@ module Exp : sig
     -> parens:bool
     -> Fmt.t
     -> Fmt.t
+
+  val box_fun_decl_args :
+       Conf.t
+    -> parens:bool
+    -> kw:Fmt.t
+    -> args:Fmt.t
+    -> annot:Fmt.t option
+    -> Fmt.t
+  (** Box and assemble the parts [kw] (up to the arguments), [args] and
+      [annot]. *)
 end
 
 module Mod : sig

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -46,6 +46,9 @@ module Mod : sig
           (** Whether to align argument types inside their parenthesis. *) }
 
   val get_args : Conf.t -> functor_parameter loc list -> args
+
+  val break_constraint : Conf.t -> rhs:module_type -> Fmt.t
+  (** The break after [:] in a [Pmod_constraint]. *)
 end
 
 val get_or_pattern_sep :
@@ -190,4 +193,6 @@ module Indent : sig
   val constructor_docstring : Conf.t -> int
 
   val exp_constraint : Conf.t -> int
+
+  val mod_constraint : Conf.t -> lhs:module_expr -> int
 end

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -188,4 +188,6 @@ module Indent : sig
   val record_docstring : Conf.t -> int
 
   val constructor_docstring : Conf.t -> int
+
+  val exp_constraint : Conf.t -> int
 end

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7692,6 +7692,41 @@ let _ =
     ~h
 ;;
 
+type t
+[@@deriving
+  some_deriver_name
+, another_deriver_name
+, another_deriver_name
+, another_deriver_name
+, yet_another_such_name
+, such_that_they_line_wrap]
+
+type t
+[@@deriving
+  some_deriver_name another_deriver_name another_deriver_name
+    another_deriver_name yet_another_such_name such_that_they_line_wrap]
+
+let pat =
+  String.Search_pattern.create
+    (String.init len ~f:(function
+        | 0 -> '\n'
+        | n when n < len - 1 -> ' '
+        | _ -> '*'))
+;;
+
+type t =
+  { break_separators: [`Before | `After]
+  ; break_sequences: bool
+  ; break_string_literals: [`Auto | `Never]
+        (** How to potentially break string literals into new lines. *)
+  ; break_struct: bool
+  ; cases_exp_indent: int
+  ; cases_matching_exp_indent: [`Normal | `Compact] }
+
+let rec collect_files ~enable_outside_detected_project ~root ~segs ~ignores
+    ~enables ~files =
+  match segs with [] | [""] -> (ignores, enables, files, None)
+
 let _ =
   fooooooooooooooooooooooooooooooooooooooo
     fooooooooooooooooooooooooooooooooooooooo
@@ -7830,7 +7865,18 @@ let _ =
 ;;
 
 let _ =
+  Error
+    (Foooooooooooooooooo
+       (name, Format.sprintf "expecting %S but got %S" Version.version value))
+;;
+
+let _ =
   `Foooooooooooooooooo
+    (name, Format.sprintf "expecting %S but got %S" Version.version value)
+;;
+
+let _ =
+  Foooooooooooooooooo
     (name, Format.sprintf "expecting %S but got %S" Version.version value)
 ;;
 
@@ -7937,6 +7983,50 @@ class x =
       object
         method x = y
       end
+
+module M =
+  [%demo
+    module Foo = Bar
+
+    type t]
+;;
+
+let _ =
+  Some
+    (fun fooooooooooooooooooooooooooooooo
+        fooooooooooooooooooooooooooooooo
+        fooooooooooooooooooooooooooooooo ->
+        foo)
+;;
+
+type t =
+  { xxxxxx :
+      t
+        (* _________________________________________________________________________
+           ____________________________________________________________________
+           ___________ *)
+        XXXXXXX.t
+  }
+
+module Test_gen
+  (For_tests : For_tests_gen)
+  (Tested : S_gen
+            with type 'a src := 'a For_tests.Src.t
+            with type 'a dst := 'a For_tests.Dst.t)
+  (Tested : S_gen
+            with type 'a src := 'a For_tests.Src.t
+            with type 'a dst := 'a For_tests.Dst.t
+            and type 'a dst := 'a For_tests.Dst.t
+            and type 'a dst := 'a For_tests.Dst.t) =
+struct
+  open Tested
+  open For_tests
+end
+
+type t =
+  { xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx : YYYYYYYYYYYYYYYYYYYYY.t
+    (* ____________________________________ *)
+  }
 
 (*{v
 

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -7798,6 +7798,119 @@ let _ =
   | {pexp_desc= Pexp_constraint (e, _); _} -> loop e
   | _ -> false
 
+let _ =
+  let module M = struct
+    include ( val foooooooooooooooooooooooooooooooooooooooo
+                : fooooooooooooooooooooooooooooooooooooooooo )
+  end in
+  ()
+
+type action =
+  | In_out of [ `Impl | `Intf ] input * string option
+  (** Format input file (or [-] for stdin) of given kind to output file,
+      or stdout if None. *)
+  (* foo *)
+  | Inplace of [ `Impl | `Intf ] input list
+  (** Format in-place, overwriting input file(s). *)
+
+let%test_module "semantics" =
+  (module (
+   struct
+     open Core
+     open Appendable_list
+     module Stable = Stable
+   end :
+     S))
+;;
+
+let _ =
+  Error
+    (`Foooooooooooooooooo
+       (name, Format.sprintf "expecting %S but got %S" Version.version value))
+;;
+
+let _ =
+  `Foooooooooooooooooo
+    (name, Format.sprintf "expecting %S but got %S" Version.version value)
+;;
+
+let _ =
+  Foooooooooooooooooo
+    (name, Format.sprintf "expecting %S but got %S" Version.version value)
+;;
+
+let (`Foooooooooooooooooo
+      (foooooooooooooo, foooooooooooooo, foooooooooooooo, foooooooooooooo) )
+    =
+  x
+
+let (Foooooooooooooooooo
+      (foooooooooooooo, foooooooooooooo, foooooooooooooo, foooooooooooooo) )
+    =
+  x
+
+let _ =
+  Foooooooooooooooooooo.foooooooooooooooooooo
+    foooooooooooooooooooo
+    foooooooooooooooooooo
+    (fun x ->
+       function
+       | Foooooooooooooooooooo -> foooooooooooooooooooo
+       | Foooooooooooooooooooo -> foooooooooooooooooooo)
+;;
+
+let _ =
+  Foooooooooooooooooooo.foooooooooooooooooooo
+    foooooooooooooooooooo
+    foooooooooooooooooooo
+    ~x:(fun x ->
+      function
+      | Foooooooooooooooooooo -> foooooooooooooooooooo
+      | Foooooooooooooooooooo -> foooooooooooooooooooo)
+;;
+
+let _ =
+  Foooooooooooooooooooo.foooooooooooooooooooo
+    foooooooooooooooooooo
+    foooooooooooooooooooo
+    (fun x ->
+       match foo with
+       | Foooooooooooooooooooo -> foooooooooooooooooooo
+       | Foooooooooooooooooooo -> foooooooooooooooooooo)
+;;
+
+let _ =
+  Foooooooooooooooooooo.foooooooooooooooooooo
+    foooooooooooooooooooo
+    foooooooooooooooooooo
+    ~x:(fun x ->
+      match foo with
+      | Foooooooooooooooooooo -> foooooooooooooooooooo
+      | Foooooooooooooooooooo -> foooooooooooooooooooo)
+;;
+
+let _ =
+  let x = x in
+  fun foooooooooooooooooo foooooooooooooooooo foooooooooooooooooo foooooooooooooooooo
+      foooooooooooooooooo foooooooooooooooooo ->
+    ()
+;;
+
+module type For_let_syntax_local =
+  For_let_syntax_gen
+    with type ('a, 'b) fn := ('a[@local]) -> 'b
+     and type ('a, 'b) f_labeled_fn := f:('a[@local]) -> 'b
+
+type fooooooooooooooooooooooooooooooo =
+  ( fooooooooooooooooooooooooooooooo
+  , fooooooooooooooooooooooooooooooo )
+    fooooooooooooooooooooooooooooooo
+
+val fooooooooooooooooooooooooooooooo
+  : ( fooooooooooooooooooooooooooooooo
+    , fooooooooooooooooooooooooooooooo )
+      fooooooooooooooooooooooooooooooo
+
 (*
    *)
 

--- a/test/passing/tests/js_source.ml
+++ b/test/passing/tests/js_source.ml
@@ -8167,3 +8167,10 @@ let _ =
 (*    First line is indented more
     .
       . *)
+
+
+module type M = sig
+  val imported_sets_of_closures_table
+    : Simple_value_approx.function_declarations option
+        Set_of_closures_id.Tbl.fooooooooooooooooooooooooo
+end

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,6 +1,5 @@
 Warning: tests/js_source.ml:155 exceeds the margin
 Warning: tests/js_source.ml:9522 exceeds the margin
 Warning: tests/js_source.ml:9625 exceeds the margin
-Warning: tests/js_source.ml:9644 exceeds the margin
 Warning: tests/js_source.ml:9684 exceeds the margin
 Warning: tests/js_source.ml:9766 exceeds the margin

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,5 +1,4 @@
 Warning: tests/js_source.ml:155 exceeds the margin
-Warning: tests/js_source.ml:3556 exceeds the margin
 Warning: tests/js_source.ml:9522 exceeds the margin
 Warning: tests/js_source.ml:9625 exceeds the margin
 Warning: tests/js_source.ml:9644 exceeds the margin

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -10040,6 +10040,128 @@ let _ =
   | _ -> false
 ;;
 
+let _ =
+  let module M = struct
+    include
+      (val foooooooooooooooooooooooooooooooooooooooo
+        : fooooooooooooooooooooooooooooooooooooooooo)
+  end
+  in
+  ()
+;;
+
+type action =
+  | In_out of [ `Impl | `Intf ] input * string option
+  (** Format input file (or [-] for stdin) of given kind to output file,
+      or stdout if None. *)
+  (* foo *)
+  | Inplace of [ `Impl | `Intf ] input list
+  (** Format in-place, overwriting input file(s). *)
+
+let%test_module "semantics" =
+  (module (
+   struct
+     open Core
+     open Appendable_list
+     module Stable = Stable
+   end :
+     S))
+;;
+
+let _ =
+  Error
+    (`Foooooooooooooooooo
+       (name, Format.sprintf "expecting %S but got %S" Version.version value))
+;;
+
+let _ =
+  `Foooooooooooooooooo
+    (name, Format.sprintf "expecting %S but got %S" Version.version value)
+;;
+
+let _ =
+  Foooooooooooooooooo
+    (name, Format.sprintf "expecting %S but got %S" Version.version value)
+;;
+
+let (`Foooooooooooooooooo
+       (foooooooooooooo, foooooooooooooo, foooooooooooooo, foooooooooooooo))
+  =
+  x
+;;
+
+let (Foooooooooooooooooo
+       (foooooooooooooo, foooooooooooooo, foooooooooooooo, foooooooooooooo))
+  =
+  x
+;;
+
+let _ =
+  Foooooooooooooooooooo.foooooooooooooooooooo
+    foooooooooooooooooooo
+    foooooooooooooooooooo
+    (fun x ->
+       function
+       | Foooooooooooooooooooo -> foooooooooooooooooooo
+       | Foooooooooooooooooooo -> foooooooooooooooooooo)
+;;
+
+let _ =
+  Foooooooooooooooooooo.foooooooooooooooooooo
+    foooooooooooooooooooo
+    foooooooooooooooooooo
+    ~x:(fun x ->
+      function
+      | Foooooooooooooooooooo -> foooooooooooooooooooo
+      | Foooooooooooooooooooo -> foooooooooooooooooooo)
+;;
+
+let _ =
+  Foooooooooooooooooooo.foooooooooooooooooooo
+    foooooooooooooooooooo
+    foooooooooooooooooooo
+    (fun x ->
+       match foo with
+       | Foooooooooooooooooooo -> foooooooooooooooooooo
+       | Foooooooooooooooooooo -> foooooooooooooooooooo)
+;;
+
+let _ =
+  Foooooooooooooooooooo.foooooooooooooooooooo
+    foooooooooooooooooooo
+    foooooooooooooooooooo
+    ~x:(fun x ->
+      match foo with
+      | Foooooooooooooooooooo -> foooooooooooooooooooo
+      | Foooooooooooooooooooo -> foooooooooooooooooooo)
+;;
+
+let _ =
+  let x = x in
+  fun foooooooooooooooooo
+    foooooooooooooooooo
+    foooooooooooooooooo
+    foooooooooooooooooo
+    foooooooooooooooooo
+    foooooooooooooooooo ->
+    ()
+;;
+
+module type For_let_syntax_local =
+  For_let_syntax_gen
+  with type ('a, 'b) fn := ('a[@local]) -> 'b
+   and type ('a, 'b) f_labeled_fn := f:('a[@local]) -> 'b
+
+type fooooooooooooooooooooooooooooooo =
+  ( fooooooooooooooooooooooooooooooo
+  , fooooooooooooooooooooooooooooooo )
+    fooooooooooooooooooooooooooooooo
+
+val fooooooooooooooooooooooooooooooo
+  : ( fooooooooooooooooooooooooooooooo
+    , fooooooooooooooooooooooooooooooo )
+      fooooooooooooooooooooooooooooooo
+
 (*
 *)
 

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9913,6 +9913,54 @@ let _ =
     ~h
 ;;
 
+type t
+[@@deriving
+  some_deriver_name
+, another_deriver_name
+, another_deriver_name
+, another_deriver_name
+, yet_another_such_name
+, such_that_they_line_wrap]
+
+type t
+[@@deriving
+  some_deriver_name
+    another_deriver_name
+    another_deriver_name
+    another_deriver_name
+    yet_another_such_name
+    such_that_they_line_wrap]
+
+let pat =
+  String.Search_pattern.create
+    (String.init len ~f:(function
+       | 0 -> '\n'
+       | n when n < len - 1 -> ' '
+       | _ -> '*'))
+;;
+
+type t =
+  { break_separators : [ `Before | `After ]
+  ; break_sequences : bool
+  ; break_string_literals : [ `Auto | `Never ]
+  (** How to potentially break string literals into new lines. *)
+  ; break_struct : bool
+  ; cases_exp_indent : int
+  ; cases_matching_exp_indent : [ `Normal | `Compact ]
+  }
+
+let rec collect_files
+          ~enable_outside_detected_project
+          ~root
+          ~segs
+          ~ignores
+          ~enables
+          ~files
+  =
+  match segs with
+  | [] | [ "" ] -> ignores, enables, files, None
+;;
+
 let _ =
   fooooooooooooooooooooooooooooooooooooooo
     fooooooooooooooooooooooooooooooooooooooo
@@ -10075,7 +10123,18 @@ let _ =
 ;;
 
 let _ =
+  Error
+    (Foooooooooooooooooo
+       (name, Format.sprintf "expecting %S but got %S" Version.version value))
+;;
+
+let _ =
   `Foooooooooooooooooo
+    (name, Format.sprintf "expecting %S but got %S" Version.version value)
+;;
+
+let _ =
+  Foooooooooooooooooo
     (name, Format.sprintf "expecting %S but got %S" Version.version value)
 ;;
 
@@ -10188,6 +10247,50 @@ class x =
   object
     method x = y
   end
+
+module M =
+  [%demo
+    module Foo = Bar
+
+    type t]
+
+let _ =
+  Some
+    (fun fooooooooooooooooooooooooooooooo
+      fooooooooooooooooooooooooooooooo
+      fooooooooooooooooooooooooooooooo ->
+      foo)
+;;
+
+type t =
+  { xxxxxx :
+      t
+        (* _________________________________________________________________________
+           ____________________________________________________________________
+           ___________ *)
+        XXXXXXX.t
+  }
+
+module Test_gen
+    (For_tests : For_tests_gen)
+    (Tested : S_gen
+     with type 'a src := 'a For_tests.Src.t
+     with type 'a dst := 'a For_tests.Dst.t)
+    (Tested : S_gen
+     with type 'a src := 'a For_tests.Src.t
+     with type 'a dst := 'a For_tests.Dst.t
+      and type 'a dst := 'a For_tests.Dst.t
+      and type 'a dst := 'a For_tests.Dst.t) =
+struct
+  open Tested
+  open For_tests
+end
+
+type t =
+  { xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx :
+      YYYYYYYYYYYYYYYYYYYYY.t
+      (* ____________________________________ *)
+  }
 
 (*{v
       foo

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -10423,3 +10423,9 @@ let _ =
 (*    First line is indented more
       .
       . *)
+
+module type M = sig
+  val imported_sets_of_closures_table
+    : Simple_value_approx.function_declarations option
+        Set_of_closures_id.Tbl.fooooooooooooooooooooooooo
+end

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -9699,7 +9699,7 @@ type t =
   (* Here is some verbatim formatted text:
      {v
        starting at column 7
-         v}*)
+     v}*)
   }
 
 module Intro_sort = struct

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -10213,13 +10213,13 @@ module type For_let_syntax_local =
 
 type fooooooooooooooooooooooooooooooo =
   ( fooooooooooooooooooooooooooooooo
-  , fooooooooooooooooooooooooooooooo )
-  fooooooooooooooooooooooooooooooo
+    , fooooooooooooooooooooooooooooooo )
+    fooooooooooooooooooooooooooooooo
 
 val fooooooooooooooooooooooooooooooo
   : ( fooooooooooooooooooooooooooooooo
-    , fooooooooooooooooooooooooooooooo )
-    fooooooooooooooooooooooooooooooo
+      , fooooooooooooooooooooooooooooooo )
+      fooooooooooooooooooooooooooooooo
 
 (*
     *)
@@ -10265,10 +10265,10 @@ let _ =
 type t =
   { xxxxxx :
       t
-      (* _________________________________________________________________________
-         ____________________________________________________________________
-         ___________ *)
-      XXXXXXX.t
+        (* _________________________________________________________________________
+           ____________________________________________________________________
+           ___________ *)
+        XXXXXXX.t
   }
 
 module Test_gen
@@ -10423,3 +10423,9 @@ let _ =
 (*    First line is indented more
       .
       . *)
+
+module type M = sig
+  val imported_sets_of_closures_table
+    : Simple_value_approx.function_declarations option
+        Set_of_closures_id.Tbl.fooooooooooooooooooooooooo
+end

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -10092,7 +10092,7 @@ let _ =
   let module M = struct
     include
       (val foooooooooooooooooooooooooooooooooooooooo
-          : fooooooooooooooooooooooooooooooooooooooooo)
+        : fooooooooooooooooooooooooooooooooooooooooo)
   end
   in
   ()

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9696,10 +9696,10 @@ type t =
 
 type t =
   { field : ty
-      (* Here is some verbatim formatted text:
-         {v
+  (* Here is some verbatim formatted text:
+     {v
        starting at column 7
-         v}*)
+     v}*)
   }
 
 module Intro_sort = struct
@@ -10052,11 +10052,11 @@ let _ =
 
 type action =
   | In_out of [ `Impl | `Intf ] input * string option
-      (** Format input file (or [-] for stdin) of given kind to output file,
-          or stdout if None. *)
+  (** Format input file (or [-] for stdin) of given kind to output file,
+      or stdout if None. *)
   (* foo *)
   | Inplace of [ `Impl | `Intf ] input list
-      (** Format in-place, overwriting input file(s). *)
+  (** Format in-place, overwriting input file(s). *)
 
 let%test_module "semantics" =
   (module (

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -10198,11 +10198,11 @@ let _ =
 let _ =
   let x = x in
   fun foooooooooooooooooo
-      foooooooooooooooooo
-      foooooooooooooooooo
-      foooooooooooooooooo
-      foooooooooooooooooo
-      foooooooooooooooooo ->
+    foooooooooooooooooo
+    foooooooooooooooooo
+    foooooooooooooooooo
+    foooooooooooooooooo
+    foooooooooooooooooo ->
     ()
 ;;
 
@@ -10257,8 +10257,8 @@ module M =
 let _ =
   Some
     (fun fooooooooooooooooooooooooooooooo
-         fooooooooooooooooooooooooooooooo
-         fooooooooooooooooooooooooooooooo ->
+      fooooooooooooooooooooooooooooooo
+      fooooooooooooooooooooooooooooooo ->
       foo)
 ;;
 

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -10149,8 +10149,8 @@ let _ =
 
 module type For_let_syntax_local =
   For_let_syntax_gen
-    with type ('a, 'b) fn := ('a[@local]) -> 'b
-     and type ('a, 'b) f_labeled_fn := f:('a[@local]) -> 'b
+  with type ('a, 'b) fn := ('a[@local]) -> 'b
+   and type ('a, 'b) f_labeled_fn := f:('a[@local]) -> 'b
 
 type fooooooooooooooooooooooooooooooo =
   ( fooooooooooooooooooooooooooooooo

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -3554,7 +3554,7 @@ let ssmap =
    end
    in
    (module S)
-    : (module MapT with type key = string and type data = string and type map = SSMap.map))
+   : (module MapT with type key = string and type data = string and type map = SSMap.map))
 ;;
 
 let ssmap = (module SSMap : MapT with type key = _ and type data = _ and type map = _)
@@ -9888,14 +9888,14 @@ let () =
 
 let () =
   ((one_mississippi, two_mississippi, three_mississippi, four_mississippi)
-    : Mississippi.t * Mississippi.t * Mississippi.t * Mississippi.t)
+   : Mississippi.t * Mississippi.t * Mississippi.t * Mississippi.t)
 ;;
 
 let _ =
   ((match foo with
     | Bar -> bar
     | Baz -> baz)
-    : string)
+   : string)
 ;;
 
 let _ =

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -5462,13 +5462,13 @@ module M2 : sig
   end
 end = (
   M :
-    sig
-      module N : sig
-        val x : int
-      end
+  sig
+    module N : sig
+      val x : int
+    end
 
-      module N' = N
-    end)
+    module N' = N
+  end)
 ;;
 
 M2.N'.x
@@ -5501,13 +5501,13 @@ module M2 : sig
   end
 end = (
   M :
-    sig
-      module C : sig
-        val chr : int -> char
-      end
+  sig
+    module C : sig
+      val chr : int -> char
+    end
 
-      module C' = C
-    end)
+    module C' = C
+  end)
 ;;
 
 M2.C'.chr 66;;
@@ -10060,12 +10060,12 @@ type action =
 
 let%test_module "semantics" =
   (module (
-    struct
-      open Core
-      open Appendable_list
-      module Stable = Stable
-    end :
-      S))
+  struct
+    open Core
+    open Appendable_list
+    module Stable = Stable
+  end :
+    S))
 ;;
 
 let _ =

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9422,8 +9422,8 @@ let foo : type a' b' c' t. a' -> b' -> c' -> t = fun a b c -> assert false
 
 let f x =
   x.contents
-    <- (print_string "coucou";
-        x.contents)
+  <- (print_string "coucou";
+      x.contents)
 ;;
 
 let ( ~$ ) x = Some x
@@ -9642,8 +9642,8 @@ let _ =
 
 let _ =
   aaaaaaa
-    (* __________________________________________________________________________________ *)
-    := bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  (* __________________________________________________________________________________ *)
+  := bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 ;;
 
 let g =

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -1210,7 +1210,7 @@ let rec variantize : type a e. e ty_env -> (a, e) ty -> a -> variant =
       ( tag
       , may_map
           (function
-           | Tdyn (ty, arg) -> variantize e ty arg)
+            | Tdyn (ty, arg) -> variantize e ty arg)
           arg )
 ;;
 
@@ -1302,8 +1302,8 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
     (Sum
        { sum_proj =
            (function
-            | `Nil -> "Nil", None
-            | `Cons p -> "Cons", Some (Tdyn (tcons, p)))
+             | `Nil -> "Nil", None
+             | `Cons p -> "Cons", Some (Tdyn (tcons, p)))
        ; sum_cases = [ "Nil", TCnoarg Thd; "Cons", TCarg (Ttl Thd, tcons) ]
        ; sum_inj =
            (fun (type c) : ((noarg -> a * a vlist -> unit, c) ty_sel * c -> a vlist) ->
@@ -1338,9 +1338,9 @@ let ty_abc : ([ `A of int | `B of string | `C ], 'e) ty =
   (* Could also use [get_case] for proj, but direct definition is shorter *)
   Sum
     ( (function
-       | `A n -> "A", Some (Tdyn (Int, n))
-       | `B s -> "B", Some (Tdyn (String, s))
-       | `C -> "C", None)
+        | `A n -> "A", Some (Tdyn (Int, n))
+        | `B s -> "B", Some (Tdyn (String, s))
+        | `C -> "C", None)
     , function
       | "A", Some (Tdyn (Int, n)) -> `A n
       | "B", Some (Tdyn (String, s)) -> `B s
@@ -1355,8 +1355,8 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
   Rec
     (Sum
        ( (function
-          | `Nil -> "Nil", None
-          | `Cons p -> "Cons", Some (Tdyn (targ, p)))
+           | `Nil -> "Nil", None
+           | `Cons p -> "Cons", Some (Tdyn (targ, p)))
        , function
          | "Nil", None -> `Nil
          | "Cons", Some (Tdyn (Pair (_, Var), (p : a * a vlist))) -> `Cons p ))
@@ -9826,9 +9826,9 @@ let x =
   some_fun________________________________
     some_arg______________________________
     (fun param ->
-      do_something ();
-      do_something_else ();
-      return_this_value)
+       do_something ();
+       do_something_else ();
+       return_this_value)
 ;;
 
 let x =
@@ -10040,6 +10040,128 @@ let _ =
   | _ -> false
 ;;
 
+let _ =
+  let module M = struct
+    include
+      (val foooooooooooooooooooooooooooooooooooooooo
+          : fooooooooooooooooooooooooooooooooooooooooo)
+  end
+  in
+  ()
+;;
+
+type action =
+  | In_out of [ `Impl | `Intf ] input * string option
+      (** Format input file (or [-] for stdin) of given kind to output file,
+          or stdout if None. *)
+  (* foo *)
+  | Inplace of [ `Impl | `Intf ] input list
+      (** Format in-place, overwriting input file(s). *)
+
+let%test_module "semantics" =
+  (module (
+    struct
+      open Core
+      open Appendable_list
+      module Stable = Stable
+    end :
+      S))
+;;
+
+let _ =
+  Error
+    (`Foooooooooooooooooo
+      (name, Format.sprintf "expecting %S but got %S" Version.version value))
+;;
+
+let _ =
+  `Foooooooooooooooooo
+    (name, Format.sprintf "expecting %S but got %S" Version.version value)
+;;
+
+let _ =
+  Foooooooooooooooooo
+    (name, Format.sprintf "expecting %S but got %S" Version.version value)
+;;
+
+let (`Foooooooooooooooooo
+      (foooooooooooooo, foooooooooooooo, foooooooooooooo, foooooooooooooo))
+  =
+  x
+;;
+
+let (Foooooooooooooooooo
+      (foooooooooooooo, foooooooooooooo, foooooooooooooo, foooooooooooooo))
+  =
+  x
+;;
+
+let _ =
+  Foooooooooooooooooooo.foooooooooooooooooooo
+    foooooooooooooooooooo
+    foooooooooooooooooooo
+    (fun x ->
+       function
+       | Foooooooooooooooooooo -> foooooooooooooooooooo
+       | Foooooooooooooooooooo -> foooooooooooooooooooo)
+;;
+
+let _ =
+  Foooooooooooooooooooo.foooooooooooooooooooo
+    foooooooooooooooooooo
+    foooooooooooooooooooo
+    ~x:(fun x ->
+      function
+      | Foooooooooooooooooooo -> foooooooooooooooooooo
+      | Foooooooooooooooooooo -> foooooooooooooooooooo)
+;;
+
+let _ =
+  Foooooooooooooooooooo.foooooooooooooooooooo
+    foooooooooooooooooooo
+    foooooooooooooooooooo
+    (fun x ->
+       match foo with
+       | Foooooooooooooooooooo -> foooooooooooooooooooo
+       | Foooooooooooooooooooo -> foooooooooooooooooooo)
+;;
+
+let _ =
+  Foooooooooooooooooooo.foooooooooooooooooooo
+    foooooooooooooooooooo
+    foooooooooooooooooooo
+    ~x:(fun x ->
+      match foo with
+      | Foooooooooooooooooooo -> foooooooooooooooooooo
+      | Foooooooooooooooooooo -> foooooooooooooooooooo)
+;;
+
+let _ =
+  let x = x in
+  fun foooooooooooooooooo
+      foooooooooooooooooo
+      foooooooooooooooooo
+      foooooooooooooooooo
+      foooooooooooooooooo
+      foooooooooooooooooo ->
+    ()
+;;
+
+module type For_let_syntax_local =
+  For_let_syntax_gen
+    with type ('a, 'b) fn := ('a[@local]) -> 'b
+     and type ('a, 'b) f_labeled_fn := f:('a[@local]) -> 'b
+
+type fooooooooooooooooooooooooooooooo =
+  ( fooooooooooooooooooooooooooooooo
+  , fooooooooooooooooooooooooooooooo )
+  fooooooooooooooooooooooooooooooo
+
+val fooooooooooooooooooooooooooooooo
+  : ( fooooooooooooooooooooooooooooooo
+    , fooooooooooooooooooooooooooooooo )
+    fooooooooooooooooooooooooooooooo
+
 (*
     *)
 
@@ -10160,18 +10282,18 @@ let _ =
        ~fooooooooooooooooooooooooooooooo
        ~fooooooooooooooooooooooooooooooo
        (fun foo ->
-         match bar with
-         | Some _ -> foo
-         | None -> baz)
+          match bar with
+          | Some _ -> foo
+          | None -> baz)
 ;;
 
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooofooooooooooooooooooooooooooooooofoooooooooo
        (fun foo ->
-         match bar with
-         | Some _ -> foo
-         | None -> baz)
+          match bar with
+          | Some _ -> foo
+          | None -> baz)
 ;;
 
 let _ =

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9913,6 +9913,54 @@ let _ =
     ~h
 ;;
 
+type t
+[@@deriving
+  some_deriver_name
+  , another_deriver_name
+  , another_deriver_name
+  , another_deriver_name
+  , yet_another_such_name
+  , such_that_they_line_wrap]
+
+type t
+[@@deriving
+  some_deriver_name
+    another_deriver_name
+    another_deriver_name
+    another_deriver_name
+    yet_another_such_name
+    such_that_they_line_wrap]
+
+let pat =
+  String.Search_pattern.create
+    (String.init len ~f:(function
+      | 0 -> '\n'
+      | n when n < len - 1 -> ' '
+      | _ -> '*'))
+;;
+
+type t =
+  { break_separators : [ `Before | `After ]
+  ; break_sequences : bool
+  ; break_string_literals : [ `Auto | `Never ]
+  (** How to potentially break string literals into new lines. *)
+  ; break_struct : bool
+  ; cases_exp_indent : int
+  ; cases_matching_exp_indent : [ `Normal | `Compact ]
+  }
+
+let rec collect_files
+  ~enable_outside_detected_project
+  ~root
+  ~segs
+  ~ignores
+  ~enables
+  ~files
+  =
+  match segs with
+  | [] | [ "" ] -> ignores, enables, files, None
+;;
+
 let _ =
   fooooooooooooooooooooooooooooooooooooooo
     fooooooooooooooooooooooooooooooooooooooo
@@ -10075,7 +10123,18 @@ let _ =
 ;;
 
 let _ =
+  Error
+    (Foooooooooooooooooo
+       (name, Format.sprintf "expecting %S but got %S" Version.version value))
+;;
+
+let _ =
   `Foooooooooooooooooo
+    (name, Format.sprintf "expecting %S but got %S" Version.version value)
+;;
+
+let _ =
+  Foooooooooooooooooo
     (name, Format.sprintf "expecting %S but got %S" Version.version value)
 ;;
 
@@ -10188,6 +10247,50 @@ class x =
   object
     method x = y
   end
+
+module M =
+  [%demo
+  module Foo = Bar
+
+  type t]
+
+let _ =
+  Some
+    (fun fooooooooooooooooooooooooooooooo
+         fooooooooooooooooooooooooooooooo
+         fooooooooooooooooooooooooooooooo ->
+      foo)
+;;
+
+type t =
+  { xxxxxx :
+      t
+      (* _________________________________________________________________________
+         ____________________________________________________________________
+         ___________ *)
+      XXXXXXX.t
+  }
+
+module Test_gen
+    (For_tests : For_tests_gen)
+    (Tested : S_gen
+              with type 'a src := 'a For_tests.Src.t
+              with type 'a dst := 'a For_tests.Dst.t)
+    (Tested : S_gen
+              with type 'a src := 'a For_tests.Src.t
+              with type 'a dst := 'a For_tests.Dst.t
+               and type 'a dst := 'a For_tests.Dst.t
+               and type 'a dst := 'a For_tests.Dst.t) =
+struct
+  open Tested
+  open For_tests
+end
+
+type t =
+  { xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx :
+      YYYYYYYYYYYYYYYYYYYYY.t
+  (* ____________________________________ *)
+  }
 
 (*{v
       foo

--- a/test/passing/tests/max_indent.ml
+++ b/test/passing/tests/max_indent.ml
@@ -1,8 +1,8 @@
 let () =
   fooooo
   |> List.iter (fun x ->
-       let x = x $ y in
-       fooooooooooo x )
+         let x = x $ y in
+         fooooooooooo x )
 
 let () =
   fooooo
@@ -73,19 +73,19 @@ let foooooooooooooooooooooooooooooooo =
 let x =
   some_fun________________________________
     some_arg______________________________ (fun param ->
-    do_something () ; do_something_else () ; return_this_value )
+      do_something () ; do_something_else () ; return_this_value )
 
 let x =
   some_fun________________________________
     some_arg______________________________ ~f:(fun param ->
-    do_something () ; do_something_else () ; return_this_value )
+      do_something () ; do_something_else () ; return_this_value )
 
 let x =
   some_value
   |> some_fun (fun x ->
-       do_something () ; do_something_else () ; return_this_value )
+         do_something () ; do_something_else () ; return_this_value )
 
 let x =
   some_value
   ^ some_fun (fun x ->
-      do_something () ; do_something_else () ; return_this_value )
+        do_something () ; do_something_else () ; return_this_value )

--- a/test/passing/tests/ocp_indent_compat.ml
+++ b/test/passing/tests/ocp_indent_compat.ml
@@ -25,7 +25,7 @@ module type M = sig
 
   val imported_sets_of_closures_table
     : Simple_value_approx.function_declarations option
-      Set_of_closures_id.Tbl.t
+        Set_of_closures_id.Tbl.t
 
   type 'a option_decl =
     names:string list

--- a/test/passing/tests/types-compact-space_around-docked.ml.ref
+++ b/test/passing/tests/types-compact-space_around-docked.ml.ref
@@ -215,3 +215,8 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = { a: ' a'. ' a' t' }
+
+type t =
+  | Foo
+  | (* Redirect (None, lib) looks up lib in the same database *)
+    Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-compact-space_around-docked.ml.ref
+++ b/test/passing/tests/types-compact-space_around-docked.ml.ref
@@ -220,3 +220,8 @@ type t =
   | Foo
   | (* Redirect (None, lib) looks up lib in the same database *)
     Redirect of db option * (Loc.t * Lib_name.t)
+
+type t =
+  | Foo
+  | Store of { exp1: Exp.t; typ: Typ.t option; exp2: Exp.t; loc: Location.t }
+      (** *exp1 <- exp2 with exp2:typ *)

--- a/test/passing/tests/types-compact-space_around.ml.ref
+++ b/test/passing/tests/types-compact-space_around.ml.ref
@@ -213,3 +213,8 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = { a: ' a'. ' a' t' }
+
+type t =
+  | Foo
+  | (* Redirect (None, lib) looks up lib in the same database *)
+    Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-compact-space_around.ml.ref
+++ b/test/passing/tests/types-compact-space_around.ml.ref
@@ -218,3 +218,8 @@ type t =
   | Foo
   | (* Redirect (None, lib) looks up lib in the same database *)
     Redirect of db option * (Loc.t * Lib_name.t)
+
+type t =
+  | Foo
+  | Store of { exp1: Exp.t; typ: Typ.t option; exp2: Exp.t; loc: Location.t }
+      (** *exp1 <- exp2 with exp2:typ *)

--- a/test/passing/tests/types-compact.ml.ref
+++ b/test/passing/tests/types-compact.ml.ref
@@ -211,3 +211,8 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = {a: ' a'. ' a' t'}
+
+type t =
+  | Foo
+  | (* Redirect (None, lib) looks up lib in the same database *)
+    Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-compact.ml.ref
+++ b/test/passing/tests/types-compact.ml.ref
@@ -216,3 +216,8 @@ type t =
   | Foo
   | (* Redirect (None, lib) looks up lib in the same database *)
     Redirect of db option * (Loc.t * Lib_name.t)
+
+type t =
+  | Foo
+  | Store of {exp1: Exp.t; typ: Typ.t option; exp2: Exp.t; loc: Location.t}
+      (** *exp1 <- exp2 with exp2:typ *)

--- a/test/passing/tests/types-indent.ml.ref
+++ b/test/passing/tests/types-indent.ml.ref
@@ -216,3 +216,9 @@ type t =
       | Foo
       | (* Redirect (None, lib) looks up lib in the same database *)
         Redirect of db option * (Loc.t * Lib_name.t)
+
+type t =
+      | Foo
+      | Store of
+          {exp1: Exp.t; typ: Typ.t option; exp2: Exp.t; loc: Location.t}
+          (** *exp1 <- exp2 with exp2:typ *)

--- a/test/passing/tests/types-indent.ml.ref
+++ b/test/passing/tests/types-indent.ml.ref
@@ -211,3 +211,8 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = {a: ' a'. ' a' t'}
+
+type t =
+      | Foo
+      | (* Redirect (None, lib) looks up lib in the same database *)
+        Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-sparse-space_around.ml.ref
+++ b/test/passing/tests/types-sparse-space_around.ml.ref
@@ -259,3 +259,8 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = { a: ' a'. ' a' t' }
+
+type t =
+  | Foo
+  | (* Redirect (None, lib) looks up lib in the same database *)
+    Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-sparse-space_around.ml.ref
+++ b/test/passing/tests/types-sparse-space_around.ml.ref
@@ -264,3 +264,12 @@ type t =
   | Foo
   | (* Redirect (None, lib) looks up lib in the same database *)
     Redirect of db option * (Loc.t * Lib_name.t)
+
+type t =
+  | Foo
+  | Store of
+      { exp1: Exp.t
+      ; typ: Typ.t option
+      ; exp2: Exp.t
+      ; loc: Location.t
+      }  (** *exp1 <- exp2 with exp2:typ *)

--- a/test/passing/tests/types-sparse.ml.ref
+++ b/test/passing/tests/types-sparse.ml.ref
@@ -240,3 +240,8 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = {a: ' a'. ' a' t'}
+
+type t =
+  | Foo
+  | (* Redirect (None, lib) looks up lib in the same database *)
+    Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-sparse.ml.ref
+++ b/test/passing/tests/types-sparse.ml.ref
@@ -245,3 +245,11 @@ type t =
   | Foo
   | (* Redirect (None, lib) looks up lib in the same database *)
     Redirect of db option * (Loc.t * Lib_name.t)
+
+type t =
+  | Foo
+  | Store of
+      { exp1: Exp.t
+      ; typ: Typ.t option
+      ; exp2: Exp.t
+      ; loc: Location.t }  (** *exp1 <- exp2 with exp2:typ *)

--- a/test/passing/tests/types.ml
+++ b/test/passing/tests/types.ml
@@ -211,3 +211,8 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = {a: ' a'. ' a' t'}
+
+type t =
+  | Foo
+  | (* Redirect (None, lib) looks up lib in the same database *)
+    Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types.ml
+++ b/test/passing/tests/types.ml
@@ -216,3 +216,8 @@ type t =
   | Foo
   | (* Redirect (None, lib) looks up lib in the same database *)
     Redirect of db option * (Loc.t * Lib_name.t)
+
+type t =
+  | Foo
+  | Store of {exp1: Exp.t; typ: Typ.t option; exp2: Exp.t; loc: Location.t}
+      (** *exp1 <- exp2 with exp2:typ *)


### PR DESCRIPTION
These are changes from https://github.com/ocaml-ppx/ocamlformat/pull/2314 that I extracted and polished a bit.

This is a work-in-progress, the goal is to cause no regressions on the default profile.