### PR TITLE
Remove extra break in constructor decl after a comment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Tags:
 
 - Compatible with OCaml 5.1.0 (#2412, @Julow)
   The syntax of let-bindings changed sligthly in this version.
+- \* Removed extra break in constructor declaration with comment (#2429, @Julow)
 - \* Consistent formatting of arrows in class types (#2422, @Julow)
 
 ### Fixed

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3317,14 +3317,16 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
   $ fmt_or_k first (if_newline "| ") (str "| ")
   $ hvbox ~name:"constructor_decl" 0
       ( hovbox 2
-          ( hvbox 2
-              ( hovbox ~name:"constructor_decl_name" 0
-                  (Cmts.fmt c loc
-                     (wrap_if
-                        (Std_longident.String_id.is_symbol txt)
-                        "( " " )" (str txt) ) )
-              $ fmt_constructor_arguments_result c ctx pcd_vars pcd_args
-                  pcd_res )
+          ( hvbox 0
+              ( Cmts.fmt_before c loc
+              $ hvbox 2
+                  ( hovbox ~name:"constructor_decl_name" 0
+                      ( wrap_if
+                          (Std_longident.String_id.is_symbol txt)
+                          "( " " )" (str txt)
+                      $ Cmts.fmt_after c loc )
+                  $ fmt_constructor_arguments_result c ctx pcd_vars pcd_args
+                      pcd_res ) )
           $ fmt_attributes_and_docstrings c pcd_attributes )
       $ Cmts.fmt_after c pcd_loc )
 

--- a/test/passing/tests/types-compact-space_around-docked.ml.ref
+++ b/test/passing/tests/types-compact-space_around-docked.ml.ref
@@ -219,5 +219,4 @@ type t = { a: ' a'. ' a' t' }
 type t =
   | Foo
   | (* Redirect (None, lib) looks up lib in the same database *)
-    Redirect of
-      db option * (Loc.t * Lib_name.t)
+    Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-compact-space_around-docked.ml.ref
+++ b/test/passing/tests/types-compact-space_around-docked.ml.ref
@@ -215,3 +215,9 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = { a: ' a'. ' a' t' }
+
+type t =
+  | Foo
+  | (* Redirect (None, lib) looks up lib in the same database *)
+    Redirect of
+      db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-compact-space_around.ml.ref
+++ b/test/passing/tests/types-compact-space_around.ml.ref
@@ -213,3 +213,9 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = { a: ' a'. ' a' t' }
+
+type t =
+  | Foo
+  | (* Redirect (None, lib) looks up lib in the same database *)
+    Redirect of
+      db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-compact-space_around.ml.ref
+++ b/test/passing/tests/types-compact-space_around.ml.ref
@@ -217,5 +217,4 @@ type t = { a: ' a'. ' a' t' }
 type t =
   | Foo
   | (* Redirect (None, lib) looks up lib in the same database *)
-    Redirect of
-      db option * (Loc.t * Lib_name.t)
+    Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-compact.ml.ref
+++ b/test/passing/tests/types-compact.ml.ref
@@ -215,5 +215,4 @@ type t = {a: ' a'. ' a' t'}
 type t =
   | Foo
   | (* Redirect (None, lib) looks up lib in the same database *)
-    Redirect of
-      db option * (Loc.t * Lib_name.t)
+    Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-compact.ml.ref
+++ b/test/passing/tests/types-compact.ml.ref
@@ -211,3 +211,9 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = {a: ' a'. ' a' t'}
+
+type t =
+  | Foo
+  | (* Redirect (None, lib) looks up lib in the same database *)
+    Redirect of
+      db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-indent.ml.ref
+++ b/test/passing/tests/types-indent.ml.ref
@@ -211,3 +211,9 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = {a: ' a'. ' a' t'}
+
+type t =
+      | Foo
+      | (* Redirect (None, lib) looks up lib in the same database *)
+        Redirect of
+          db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-indent.ml.ref
+++ b/test/passing/tests/types-indent.ml.ref
@@ -215,5 +215,4 @@ type t = {a: ' a'. ' a' t'}
 type t =
       | Foo
       | (* Redirect (None, lib) looks up lib in the same database *)
-        Redirect of
-          db option * (Loc.t * Lib_name.t)
+        Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-sparse-space_around.ml.ref
+++ b/test/passing/tests/types-sparse-space_around.ml.ref
@@ -259,3 +259,9 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = { a: ' a'. ' a' t' }
+
+type t =
+  | Foo
+  | (* Redirect (None, lib) looks up lib in the same database *)
+    Redirect of
+      db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-sparse-space_around.ml.ref
+++ b/test/passing/tests/types-sparse-space_around.ml.ref
@@ -263,5 +263,4 @@ type t = { a: ' a'. ' a' t' }
 type t =
   | Foo
   | (* Redirect (None, lib) looks up lib in the same database *)
-    Redirect of
-      db option * (Loc.t * Lib_name.t)
+    Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-sparse.ml.ref
+++ b/test/passing/tests/types-sparse.ml.ref
@@ -240,3 +240,9 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = {a: ' a'. ' a' t'}
+
+type t =
+  | Foo
+  | (* Redirect (None, lib) looks up lib in the same database *)
+    Redirect of
+      db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types-sparse.ml.ref
+++ b/test/passing/tests/types-sparse.ml.ref
@@ -244,5 +244,4 @@ type t = {a: ' a'. ' a' t'}
 type t =
   | Foo
   | (* Redirect (None, lib) looks up lib in the same database *)
-    Redirect of
-      db option * (Loc.t * Lib_name.t)
+    Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types.ml
+++ b/test/passing/tests/types.ml
@@ -215,5 +215,4 @@ type t = {a: ' a'. ' a' t'}
 type t =
   | Foo
   | (* Redirect (None, lib) looks up lib in the same database *)
-    Redirect of
-      db option * (Loc.t * Lib_name.t)
+    Redirect of db option * (Loc.t * Lib_name.t)

--- a/test/passing/tests/types.ml
+++ b/test/passing/tests/types.ml
@@ -211,3 +211,9 @@ type ' a' t = ' a' option
 type ' a' t = int as ' a'
 
 type t = {a: ' a'. ' a' t'}
+
+type t =
+  | Foo
+  | (* Redirect (None, lib) looks up lib in the same database *)
+    Redirect of
+      db option * (Loc.t * Lib_name.t)


### PR DESCRIPTION
A comment just before a constructor in a type declaration was causing
the argument of the constructor to be formatted in vertical style.

The constructor is now formatted the same as if there were no comment.