### PR TITLE
Fix ';;' formatting between  doc-comments and toplevel directives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,7 @@ Tags:
 - Fix dropped attributes on a begin-end in a match case (#2421, @Julow)
 - Fix non-stabilizing comments before a functor type argument (#2420, @Julow)
 - Fix crash caused by module types with nested `with module` (#2419, @Julow)
-- Fix ';;' formatting between  doc-comments and toplevel directives (#<PR_NUMBER>, @gpetiot)
+- Fix ';;' formatting between  doc-comments and toplevel directives (#2432, @gpetiot)
 
 ## 0.26.0 (2023-07-18)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,7 @@ Tags:
 - Fix dropped attributes on a begin-end in a match case (#2421, @Julow)
 - Fix non-stabilizing comments before a functor type argument (#2420, @Julow)
 - Fix crash caused by module types with nested `with module` (#2419, @Julow)
-- Fix ';;' formatting between  doc-comments and toplevel directives (#2432, @gpetiot)
+- Fix ';;' formatting between doc-comments and toplevel directives (#2432, @gpetiot)
 
 ## 0.26.0 (2023-07-18)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ Tags:
 - Fix dropped attributes on a begin-end in a match case (#2421, @Julow)
 - Fix non-stabilizing comments before a functor type argument (#2420, @Julow)
 - Fix crash caused by module types with nested `with module` (#2419, @Julow)
+- Fix ';;' formatting between  doc-comments and toplevel directives (#<PR_NUMBER>, @gpetiot)
 
 ## 0.26.0 (2023-07-18)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4448,7 +4448,11 @@ let fmt_toplevel ?(force_semisemi = false) c ctx itms =
     let last = Option.is_none next in
     let semisemi =
       match (itm, next) with
+      | `Item {pstr_desc= Pstr_attribute _; _}, _ -> false
       | _, Some (`Item {pstr_desc= Pstr_eval _; _}, _) -> true
+      | ( `Item {pstr_desc= Pstr_eval _; _}
+        , Some (`Item {pstr_desc= Pstr_attribute _; _}, _) ) ->
+          true
       | `Item _, Some (`Directive _, _) -> true
       | _ -> force_semisemi && last
     in

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4448,8 +4448,8 @@ let fmt_toplevel ?(force_semisemi = false) c ctx itms =
     let last = Option.is_none next in
     let semisemi =
       match (itm, next) with
-      | `Item {pstr_desc= Pstr_attribute _; _}, _ -> false
       | _, Some (`Item {pstr_desc= Pstr_eval _; _}, _) -> true
+      | `Item {pstr_desc= Pstr_attribute _; _}, _ -> false
       | `Item _, Some (`Directive _, _) -> true
       | _ -> force_semisemi && last
     in

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4450,9 +4450,6 @@ let fmt_toplevel ?(force_semisemi = false) c ctx itms =
       match (itm, next) with
       | `Item {pstr_desc= Pstr_attribute _; _}, _ -> false
       | _, Some (`Item {pstr_desc= Pstr_eval _; _}, _) -> true
-      | ( `Item {pstr_desc= Pstr_eval _; _}
-        , Some (`Item {pstr_desc= Pstr_attribute _; _}, _) ) ->
-          true
       | `Item _, Some (`Directive _, _) -> true
       | _ -> force_semisemi && last
     in

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1590,6 +1590,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to docstrings_toplevel_directives.mlt.stdout
+   (with-stderr-to docstrings_toplevel_directives.mlt.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/docstrings_toplevel_directives.mlt})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/docstrings_toplevel_directives.mlt docstrings_toplevel_directives.mlt.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/docstrings_toplevel_directives.mlt.err docstrings_toplevel_directives.mlt.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to eliom_ext.eliom.stdout
    (with-stderr-to eliom_ext.eliom.stderr
      (run %{bin:ocamlformat} --margin-check %{dep:tests/eliom_ext.eliom})))))

--- a/test/passing/tests/docstrings_toplevel_directives.mlt
+++ b/test/passing/tests/docstrings_toplevel_directives.mlt
@@ -1,0 +1,5 @@
+(** Header *)
+
+#use "something"
+
+let two = 2

--- a/test/passing/tests/docstrings_toplevel_directives.mlt
+++ b/test/passing/tests/docstrings_toplevel_directives.mlt
@@ -3,3 +3,9 @@
 #use "something"
 
 let two = 2
+
+[@@@warning "-labels-omitted"] ;;
+
+Clflags.strict_sequence := false
+
+let f () = x

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -9132,7 +9132,7 @@ end
 
 type t = | ;;
 
-M.(Some x) [@foo]
+M.(Some x) [@foo] ;;
 
 [@@@foo:]
 

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -9132,7 +9132,7 @@ end
 
 type t = | ;;
 
-M.(Some x) [@foo] ;;
+M.(Some x) [@foo]
 
 [@@@foo:]
 


### PR DESCRIPTION
Fix #2407