### PR TITLE
Consistent spacing between items with extension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ profile. This started with version 0.26.0.
 ### Fixed
 
 - Remove trailing space inside a wrapping empty signature (#2443, @Julow)
+- Fix extension-point spacing in structures (#2450, @Julow)
 
 ## 0.26.1 (2023-09-15)
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -388,6 +388,7 @@ module Structure_item = struct
       | ( Pstr_extension ((_, PStr [n1]), _attrs1)
         , Pstr_extension ((_, PStr [n2]), _attrs2) ) ->
           allow_adjacent (n1, cI) (n2, cJ)
+      | Pstr_extension _, Pstr_extension _ -> true
       | _ -> false )
     | _ -> true
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -366,7 +366,7 @@ module Structure_item = struct
           longident_is_simple c i.txt
       | _ -> false )
 
-  let allow_adjacent (itmI, cI) (itmJ, cJ) =
+  let rec allow_adjacent (itmI, cI) (itmJ, cJ) =
     match
       Conf.
         (cI.fmt_opts.module_item_spacing.v, cJ.fmt_opts.module_item_spacing.v)
@@ -383,9 +383,11 @@ module Structure_item = struct
        |Pstr_modtype _, Pstr_modtype _
        |Pstr_class _, Pstr_class _
        |Pstr_class_type _, Pstr_class_type _
-       |Pstr_attribute _, Pstr_attribute _
-       |Pstr_extension _, Pstr_extension _ ->
+       |Pstr_attribute _, Pstr_attribute _ ->
           true
+      | ( Pstr_extension ((_, PStr [n1]), _attrs1)
+        , Pstr_extension ((_, PStr [n2]), _attrs2) ) ->
+          allow_adjacent (n1, cI) (n2, cJ)
       | _ -> false )
     | _ -> true
 

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,5 +1,5 @@
-Warning: tests/js_source.ml:156 exceeds the margin
-Warning: tests/js_source.ml:9529 exceeds the margin
-Warning: tests/js_source.ml:9632 exceeds the margin
-Warning: tests/js_source.ml:9691 exceeds the margin
-Warning: tests/js_source.ml:9773 exceeds the margin
+Warning: tests/js_source.ml:155 exceeds the margin
+Warning: tests/js_source.ml:9528 exceeds the margin
+Warning: tests/js_source.ml:9631 exceeds the margin
+Warning: tests/js_source.ml:9690 exceeds the margin
+Warning: tests/js_source.ml:9772 exceeds the margin

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,5 +1,5 @@
-Warning: tests/js_source.ml:155 exceeds the margin
-Warning: tests/js_source.ml:9522 exceeds the margin
-Warning: tests/js_source.ml:9625 exceeds the margin
-Warning: tests/js_source.ml:9684 exceeds the margin
-Warning: tests/js_source.ml:9766 exceeds the margin
+Warning: tests/js_source.ml:156 exceeds the margin
+Warning: tests/js_source.ml:9529 exceeds the margin
+Warning: tests/js_source.ml:9632 exceeds the margin
+Warning: tests/js_source.ml:9691 exceeds the margin
+Warning: tests/js_source.ml:9773 exceeds the margin

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -47,6 +47,7 @@ let [%foo let () = ()] : [%foo type t = t] = [%foo class c = object end]
 let [%foo: [ `Foo ]] : [%foo: t -> t] = [%foo: < foo : t > ]
 
 [%%foo? _]
+
 [%%foo? Some y when y > 0]
 
 let [%foo? Bar x | Baz x] : [%foo? #bar] = [%foo? { x }]
@@ -176,16 +177,22 @@ type%foo t = int [@@foo]
 and t = int [@@foo]
 
 type%foo t += T [@@foo]
+
 class%foo x = x [@@foo]
+
 class type%foo x = x [@@foo]
+
 external%foo x : _ = "" [@@foo]
+
 exception%foo X [@foo]
+
 module%foo M = M [@@foo]
 
 module%foo rec M : S = M [@@foo]
 and M : S = M [@@foo]
 
 module type%foo S = S [@@foo]
+
 include%foo M [@@foo]
 open%foo M [@@foo]
 

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -47,7 +47,6 @@ let [%foo let () = ()] : [%foo type t = t] = [%foo class c = object end]
 let [%foo: [ `Foo ]] : [%foo: t -> t] = [%foo: < foo : t > ]
 
 [%%foo? _]
-
 [%%foo? Some y when y > 0]
 
 let [%foo? Bar x | Baz x] : [%foo? #bar] = [%foo? { x }]

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -47,6 +47,7 @@ let [%foo let () = ()] : [%foo type t = t] = [%foo class c = object end]
 let [%foo: [ `Foo ]] : [%foo: t -> t] = [%foo: < foo : t > ]
 
 [%%foo? _]
+
 [%%foo? Some y when y > 0]
 
 let [%foo? Bar x | Baz x] : [%foo? #bar] = [%foo? { x }]
@@ -176,16 +177,22 @@ type%foo t = int [@@foo]
 and t = int [@@foo]
 
 type%foo t += T [@@foo]
+
 class%foo x = x [@@foo]
+
 class type%foo x = x [@@foo]
+
 external%foo x : _ = "" [@@foo]
+
 exception%foo X [@foo]
+
 module%foo M = M [@@foo]
 
 module%foo rec M : S = M [@@foo]
 and M : S = M [@@foo]
 
 module type%foo S = S [@@foo]
+
 include%foo M [@@foo]
 open%foo M [@@foo]
 

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -47,7 +47,6 @@ let [%foo let () = ()] : [%foo type t = t] = [%foo class c = object end]
 let [%foo: [ `Foo ]] : [%foo: t -> t] = [%foo: < foo : t > ]
 
 [%%foo? _]
-
 [%%foo? Some y when y > 0]
 
 let [%foo? Bar x | Baz x] : [%foo? #bar] = [%foo? { x }]


### PR DESCRIPTION
Structure items with an extension were formatted in a compact way when `module-item-spacing=compact` even though the similar items without an extension would not.

```ocaml
exception%foo X
module%foo M = M
module type%foo S = S
include%foo M

exception X

module M = M

module type S = S

include M
```

This is a problem in future work where the `Pstr_extension` node is no longer used.

