### PR TITLE
Better ignore doc comment

### DIFF
--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -152,10 +152,50 @@ let make_mapper conf ~ignore_doc_comments =
     let typ = {typ with ptyp_loc_stack= []} in
     Ast_mapper.default_mapper.typ m typ
   in
+  let structure =
+    if ignore_doc_comments then fun (m : Ast_mapper.mapper) l ->
+      List.filter l ~f:(function
+        | {pstr_desc= Pstr_attribute a; _} -> not (is_doc a)
+        | _ -> true )
+      |> Ast_mapper.default_mapper.structure m
+    else Ast_mapper.default_mapper.structure
+  in
+  let signature =
+    if ignore_doc_comments then fun (m : Ast_mapper.mapper) l ->
+      List.filter l ~f:(function
+        | {psig_desc= Psig_attribute a; _} -> not (is_doc a)
+        | _ -> true )
+      |> Ast_mapper.default_mapper.signature m
+    else Ast_mapper.default_mapper.signature
+  in
+  let class_structure =
+    if ignore_doc_comments then fun (m : Ast_mapper.mapper) x ->
+      let pcstr_fields =
+        List.filter x.pcstr_fields ~f:(function
+          | {pcf_desc= Pcf_attribute a; _} -> not (is_doc a)
+          | _ -> true )
+      in
+      Ast_mapper.default_mapper.class_structure m {x with pcstr_fields}
+    else Ast_mapper.default_mapper.class_structure
+  in
+  let class_signature =
+    if ignore_doc_comments then fun (m : Ast_mapper.mapper) x ->
+      let pcsig_fields =
+        List.filter x.pcsig_fields ~f:(function
+          | {pctf_desc= Pctf_attribute a; _} -> not (is_doc a)
+          | _ -> true )
+      in
+      Ast_mapper.default_mapper.class_signature m {x with pcsig_fields}
+    else Ast_mapper.default_mapper.class_signature
+  in
   { Ast_mapper.default_mapper with
     location
   ; attribute
   ; attributes
+  ; structure
+  ; signature
+  ; class_signature
+  ; class_structure
   ; expr
   ; pat
   ; typ }

--- a/lib/Std_ast.ml
+++ b/lib/Std_ast.ml
@@ -43,7 +43,12 @@ let map (type a) (x : a t) (m : Ast_mapper.mapper) : a -> a =
   match x with
   | Structure -> m.structure m
   | Signature -> m.signature m
-  | Use_file -> List.map ~f:(m.toplevel_phrase m)
+  | Use_file ->
+      List.filter_map ~f:(fun x ->
+          match m.toplevel_phrase m x with
+          | Ptop_def [] -> None
+          | Ptop_def _ as x -> Some x
+          | Ptop_dir _ as x -> Some x )
   | Core_type -> m.typ m
   | Module_type -> m.module_type m
   | Expression -> m.expr m

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -5403,6 +5403,24 @@
 
 (rule
  (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to w50.ml.stdout
+   (with-stderr-to w50.ml.stderr
+     (run %{bin:ocamlformat} --margin-check --no-comment-check -q --max-iters=3 %{dep:tests/w50.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/w50.ml.ref w50.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/w50.ml.err w50.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
  (enabled_if (<> %{os_type} Win32))
  (package ocamlformat)
  (action

--- a/test/passing/tests/w50.ml
+++ b/test/passing/tests/w50.ml
@@ -1,0 +1,20 @@
+(* When using [--no-comment-check] (to format code despite warning 50),
+   We should not complain if doc-comments start appearing in the AST.
+*)
+
+module type T = sig
+val test_raises_some_exc : ('a -> 'b) -> 'a -> bool;;
+(** AAAA *)
+
+val test_raises_this_exc : exn -> ('a -> 'b) -> 'a -> bool;;
+(** BBBB *)
+end
+
+module T = struct
+
+let test_raises_some_exc = 2;;
+(** CCCC *)
+
+let test_raises_this_exc = 3;;
+(** DDDD *)
+end

--- a/test/passing/tests/w50.ml.opts
+++ b/test/passing/tests/w50.ml.opts
@@ -1,0 +1,1 @@
+--no-comment-check -q --max-iters=3

--- a/test/passing/tests/w50.ml.ref
+++ b/test/passing/tests/w50.ml.ref
@@ -1,0 +1,20 @@
+(* When using [--no-comment-check] (to format code despite warning 50), We
+   should not complain if doc-comments start appearing in the AST. *)
+
+module type T = sig
+  val test_raises_some_exc : ('a -> 'b) -> 'a -> bool
+
+  (** AAAA *)
+
+  val test_raises_this_exc : exn -> ('a -> 'b) -> 'a -> bool
+  (** BBBB *)
+end
+
+module T = struct
+  let test_raises_some_exc = 2
+
+  (** CCCC *)
+
+  (** DDDD *)
+  let test_raises_this_exc = 3
+end


### PR DESCRIPTION
Fix #2408
Floating doc comment were not ignored when using `--no-comment-check`, only attached doc-comment were.

This change can result in empty `Ptop_def []` which are now ignored while mapping.

For the record, I've tested this PR on the all sources inside opam-respository
```
find ../all-sources -name "*.ml" -type f -o -name "*.mli" -type f | parallel --progress _build/default/bin/ocamlformat/main.exe --enable-outside-detected-project -q --no-comment-check --no-version-check --ignore-invalid-option > /dev/null
```

I don't see any `Ast changed` bug anymore 