### PR TITLE
Fixed bug with attributes on sub-expressions of infix operators.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ profile. This started with version 0.26.0.
 - Fix extension-point spacing in structures (#2450, @Julow)
 - \* Consistent break after string constant argument (#2453, @Julow)
 - Fix invalid syntax generated with `ocp-indent-compat` (#2445, @Julow)
+- Fixed bug with attributes on sub-expressions of infix operators (#2459, @tdelvecchio-jsc)
 
 ## 0.26.1 (2023-09-15)
 

--- a/test/passing/tests/comments.ml
+++ b/test/passing/tests/comments.ml
@@ -311,3 +311,7 @@ type a = b (* a *) as (* b *) 'c (* c *)
 type t = { (* comment before mutable *) mutable
  (* really long comment that doesn't fit on the same line as other stuff *)
  x : int }
+
+let _ = (x + y) [@attr] + z
+
+let _ = x ^ (y ^ z) [@attr]

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -420,3 +420,7 @@ type t =
          stuff *)
       x:
       int }
+
+let _ = (x + y) [@attr] + z
+
+let _ = x ^ (y ^ z) [@attr]


### PR DESCRIPTION
Fixes #2458.

The issue is that sugaring of n-ary infix operators doesn't keep the original sub-expression around, which carries the attribute with it. This fix just prevents sugaring of n-ary infix operations if an attribute is reached.