### PR TITLE
Fix cinaps comment formatting to not change multiline string contents.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ profile. This started with version 0.26.0.
 - Fix extension-point spacing in structures (#2450, @Julow)
 - \* Consistent break after string constant argument (#2453, @Julow)
 - Fix invalid syntax generated with `ocp-indent-compat` (#2445, @Julow)
+- \* Fix cinaps comment formatting to not change multiline string contents (#2463, @tdelvecchio-jsc)
 
 ## 0.26.1 (2023-09-15)
 

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -547,16 +547,7 @@ module Cinaps = struct
 
   (** Comments enclosed in [(*$], [$*)] are formatted as code. *)
   let fmt ~cls code =
-    let wrap k = hvbox 2 (fmt "(*$" $ k $ fmt cls) in
-    match String.split_lines code with
-    | [] | [""] -> wrap (str " ")
-    | [line] -> wrap (fmt "@ " $ str line $ fmt "@;<1 -2>")
-    | lines ->
-        let fmt_line = function
-          | "" -> fmt "\n"
-          | line -> fmt "@\n" $ str line
-        in
-        wrap (list lines "" fmt_line $ fmt "@;<1000 -2>")
+    hvbox 0 (fmt "(*$" $ hvbox (-1) (fmt "@;" $ code) $ fmt "@;" $ fmt cls)
 end
 
 module Ocp_indent_compat = struct
@@ -608,12 +599,7 @@ let fmt_cmt (conf : Conf.t) cmt ~fmt_code pos =
         let len = String.length str - if dollar_suf then 2 else 1 in
         let offset = offset + 1 in
         let source = String.sub ~pos:1 ~len str in
-        let source =
-          String.split_lines source
-          |> Cmt.unindent_lines ~offset
-          |> String.concat ~sep:"\n"
-        in
-        match fmt_code conf ~offset source with
+        match fmt_code conf ~offset ~set_margin:false source with
         | Ok formatted -> `Code (formatted, cls)
         | Error (`Msg _) -> `Unwrapped (str, None) )
     | txt when Char.equal txt.[0] '=' -> `Verbatim txt

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4598,7 +4598,7 @@ let fmt_parse_result conf ~debug ast_kind ast source comments
   let cmts = Cmts.init ast_kind ~debug source ast comments in
   let ctx = Top in
   let code =
-    (if set_margin_p then set_margin conf.Conf.fmt_opts.margin.v else noop)
+    fmt_if_k set_margin_p (set_margin conf.Conf.fmt_opts.margin.v)
     $ fmt_file ~ctx ~debug ast_kind source cmts conf ast ~fmt_code
   in
   Ok code

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -14,7 +14,11 @@ open Odoc_parser.Ast
 module Loc = Odoc_parser.Loc
 
 type fmt_code =
-  Conf.t -> offset:int -> string -> (string, [`Msg of string]) Result.t
+     Conf.t
+  -> offset:int
+  -> set_margin:bool
+  -> string
+  -> (Fmt.t, [`Msg of string]) Result.t
 
 type c = {fmt_code: fmt_code; conf: Conf.t}
 
@@ -119,8 +123,8 @@ let fmt_code_block c s1 s2 =
   match s1 with
   | Some ({value= "ocaml"; _}, _) | None -> (
     (* [offset] doesn't take into account code blocks nested into lists. *)
-    match c.fmt_code c.conf ~offset:2 original with
-    | Ok formatted -> fmt_code formatted
+    match c.fmt_code c.conf ~offset:2 ~set_margin:true original with
+    | Ok formatted -> formatted |> Format_.asprintf "%a" Fmt.eval |> fmt_code
     | Error (`Msg message) ->
         ( match message with
         | "" -> ()
@@ -356,8 +360,8 @@ let fmt_parsed (conf : Conf.t) ~fmt_code ~input ~offset parsed =
   let begin_offset = beginning_offset conf input in
   (* The offset is used to adjust the margin when formatting code blocks. *)
   let offset = offset + begin_offset in
-  let fmt_code conf ~offset:offset' input =
-    fmt_code conf ~offset:(offset + offset') input
+  let fmt_code conf ~offset:offset' ~set_margin input =
+    fmt_code conf ~offset:(offset + offset') ~set_margin input
   in
   let fmt_parsed parsed =
     str (String.make begin_offset ' ')

--- a/lib/Fmt_odoc.mli
+++ b/lib/Fmt_odoc.mli
@@ -12,7 +12,11 @@
 (** [offset] is the column at which the content of the comment begins. It is
     used to adjust the margin. *)
 type fmt_code =
-  Conf.t -> offset:int -> string -> (string, [`Msg of string]) Result.t
+     Conf.t
+  -> offset:int
+  -> set_margin:bool
+  -> string
+  -> (Fmt.t, [`Msg of string]) Result.t
 
 val fmt_ast : Conf.t -> fmt_code:fmt_code -> Odoc_parser.Ast.t -> Fmt.t
 

--- a/test/passing/tests/cinaps.ml.err
+++ b/test/passing/tests/cinaps.ml.err
@@ -1,0 +1,1 @@
+Warning: tests/cinaps.ml:24 exceeds the margin

--- a/test/passing/tests/cinaps.ml.ref
+++ b/test/passing/tests/cinaps.ml.ref
@@ -22,7 +22,7 @@ let y = 2
   #use "import.cinaps" ;;
 
   List.iter all_fields ~f:(fun (name, type_) ->
-      printf "\nexternal get_%s\n: unit -> %s = \"get_%s\"" name type_ name )
+      printf "\nexternal get_%s\n  : unit -> %s = \"get_%s\"" name type_ name )
 *)
 external get_name : unit -> string = "get_name"
 

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -10323,15 +10323,13 @@ let _ =
 
 (*$
   [%string {| xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  zzzzzzzzzzzzzzzzzzzzzzzzzzzz
-      |}]
+zzzzzzzzzzzzzzzzzzzzzzzzzzzz
+    |}]
 *)
 (*$*)
 
-(*$
-  {|
-        f|}
-*)
+(*$ {|
+         f|} *)
 
 let () =
   match () with

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -10323,15 +10323,13 @@ let _ =
 
 (*$
   [%string {| xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  zzzzzzzzzzzzzzzzzzzzzzzzzzzz
-      |}]
+zzzzzzzzzzzzzzzzzzzzzzzzzzzz
+    |}]
 *)
 (*$*)
 
-(*$
-  {|
-        f|}
-*)
+(*$ {|
+         f|} *)
 
 let () =
   match () with


### PR DESCRIPTION
Fixes #2462.

Rather than formatting comment code blocks into a string, and then converting that string back into an `Fmt.t`, we instead just generate the `Fmt.t` directly, which allows the styling to know about current indentation without needing to manually indent/unindent the formatted text.

This change has some rough edges to it (with the addition of `set_margin` as an argument to `fmt_code`, in particular), so any feedback would be greatly appreciated!