### PR TITLE
Fix: Ast_mapper.map_function_param should call arg_label

### DIFF
--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -473,7 +473,7 @@ module E = struct
       match desc with
       | Pparam_val (lab, def, p) ->
           Pparam_val
-            (lab,
+            (sub.arg_label sub lab,
              map_opt (sub.expr sub) def,
              sub.pat sub p)
       | Pparam_newtype ty ->


### PR DESCRIPTION
This caused a bug on `test-extra/code/base/src/map_intf.ml` caught by the CI of #2472, but introduced on main in #2471 (code was copied from the compiler in #2466).

edit: the code in the compiler doesn't contain a function to map arg_labels, so nothing to fix on the compiler.