### PR TITLE
WIP: fix conflict over the Ocaml_common library

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -28,7 +28,7 @@
   (backend bisect_ppx))
  (libraries
   format_
-  ocaml_common
+  ocamlformat-lib._ocaml-common
   parser_standard
   parser_extended
   ocamlformat_stdlib

--- a/test/install/ocamlformat-lib/dune
+++ b/test/install/ocamlformat-lib/dune
@@ -1,0 +1,9 @@
+(executable
+ (name foo)
+ (libraries ocamlformat-lib ppxlib))
+
+(rule
+ (alias runtest)
+ (deps ./foo.exe)
+ (action
+  (run %{deps})))

--- a/test/install/ocamlformat-lib/foo.ml
+++ b/test/install/ocamlformat-lib/foo.ml
@@ -1,0 +1,3 @@
+let _ = Ocamlformat_lib.Translation_unit.parse_and_format
+
+type t = Ppxlib_ast.Parsetree.structure

--- a/vendor/ocaml-common/dune
+++ b/vendor/ocaml-common/dune
@@ -1,6 +1,6 @@
 (library
  (name ocaml_common)
- (public_name ocamlformat-lib.ocaml_common)
+ (public_name ocamlformat-lib._ocaml-common)
  (flags
   (:standard -w -9 -open Parser_shims))
  (libraries parser_shims))

--- a/vendor/ocamlformat-stdlib/dune
+++ b/vendor/ocamlformat-stdlib/dune
@@ -3,4 +3,4 @@
  (public_name ocamlformat-lib.ocamlformat_stdlib)
  (flags
   (:standard -open Ocaml_common))
- (libraries base cmdliner ocaml_common fpath stdio))
+ (libraries base cmdliner ocamlformat-lib._ocaml-common fpath stdio))

--- a/vendor/parser-extended/dune
+++ b/vendor/parser-extended/dune
@@ -3,7 +3,11 @@
  (public_name ocamlformat-lib.parser_extended)
  (flags
   (:standard -w -9 -open Parser_shims -open Ocaml_common))
- (libraries compiler-libs.common menhirLib parser_shims ocaml_common))
+ (libraries
+  compiler-libs.common
+  menhirLib
+  parser_shims
+  ocamlformat-lib._ocaml-common))
 
 (ocamllex lexer)
 

--- a/vendor/parser-standard/dune
+++ b/vendor/parser-standard/dune
@@ -3,7 +3,11 @@
  (public_name ocamlformat-lib.parser_standard)
  (flags
   (:standard -w -9 -open Parser_shims -open Ocaml_common))
- (libraries compiler-libs.common menhirLib parser_shims ocaml_common))
+ (libraries
+  compiler-libs.common
+  menhirLib
+  parser_shims
+  ocamlformat-lib._ocaml-common))
 
 (ocamllex lexer)
 


### PR DESCRIPTION
Will fix #2441 (not yet)

I tried to change the public name of the `ocaml-common` library vendored in ocamlformat, no success so far, I added a test showing that.

