### PR TITLE
Break around comments following an infix operator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ profile. This started with version 0.26.0.
 - Fixed bug with attributes on sub-expressions of infix operators (#2459, @tdelvecchio-jsc)
 - \* Fix cinaps comment formatting to not change multiline string contents (#2463, @tdelvecchio-jsc)
 - Fix position of comments around function parameters (#2471, @gpetiot)
+- \* Force a break around comments following an infix operator (fix non-stabilizing comments) (#2478, @gpetiot)
 
 ## 0.26.1 (2023-09-15)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -262,9 +262,10 @@ let fmt_constant c ?epi {pconst_desc; pconst_loc= loc} =
   | Pconst_char (_, s) -> wrap "'" "'" @@ str s
   | Pconst_string (s, loc', Some delim) ->
       Cmts.fmt c loc'
-      @@ (* If a multiline string has newlines in it, the configuration might
-            specify it should get treated as a "long" box element. To do so,
-            we pretend it is 1000 characters long. *)
+      @@
+      (* If a multiline string has newlines in it, the configuration might
+         specify it should get treated as a "long" box element. To do so, we
+         pretend it is 1000 characters long. *)
       ( if
           c.conf.fmt_opts.break_around_multiline_strings.v
           && String.mem s '\n'
@@ -1650,7 +1651,7 @@ and fmt_infix_op_args c ~parens xexp op_args =
                else fmt_if (not very_first) " "
              in
              match cmts_after with
-             | Some c -> (noop, op $ break $ c)
+             | Some c -> (noop, hovbox 0 (op $ fmt "@;" $ c))
              | None -> (op $ break, noop)
            in
            fmt_opt cmts_before $ before_arg
@@ -1939,8 +1940,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                     || Cmts.has_before c.cmts arg.ast.pexp_loc
                   then
                     Some
-                      ( Cmts.fmt_after c op.loc
-                      $ Cmts.fmt_before ~adj c arg.ast.pexp_loc )
+                      ( Cmts.fmt_after c ~epi:adj op.loc
+                      $ Cmts.fmt_before ~adj ~epi:adj c arg.ast.pexp_loc )
                   else None
                 in
                 let fmt_op = fmt_str_loc c op in

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -2395,7 +2395,7 @@
 (rule
  (alias runtest)
  (package ocamlformat)
- (action (diff tests/infix_arg_grouping.ml infix_arg_grouping.ml.stdout)))
+ (action (diff tests/infix_arg_grouping.ml.ref infix_arg_grouping.ml.stdout)))
 
 (rule
  (alias runtest)
@@ -2408,7 +2408,7 @@
  (action
   (with-stdout-to infix_bind-break.ml.stdout
    (with-stderr-to infix_bind-break.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --break-infix=wrap --break-infix-before-func %{dep:tests/infix_bind.ml})))))
+     (run %{bin:ocamlformat} --margin-check --break-infix=wrap --break-infix-before-func --max-iters=3 %{dep:tests/infix_bind.ml})))))
 
 (rule
  (alias runtest)
@@ -2426,7 +2426,7 @@
  (action
   (with-stdout-to infix_bind-fit_or_vertical-break.ml.stdout
    (with-stderr-to infix_bind-fit_or_vertical-break.ml.stderr
-     (run %{bin:ocamlformat} --margin-check --break-infix=fit-or-vertical --break-infix-before-func %{dep:tests/infix_bind.ml})))))
+     (run %{bin:ocamlformat} --margin-check --break-infix=fit-or-vertical --break-infix-before-func --max-iters=3 %{dep:tests/infix_bind.ml})))))
 
 (rule
  (alias runtest)

--- a/test/passing/tests/comments-no-wrap.ml.err
+++ b/test/passing/tests/comments-no-wrap.ml.err
@@ -1,5 +1,4 @@
 Warning: tests/comments.ml:186 exceeds the margin
 Warning: tests/comments.ml:190 exceeds the margin
-Warning: tests/comments.ml:248 exceeds the margin
-Warning: tests/comments.ml:383 exceeds the margin
-Warning: tests/comments.ml:415 exceeds the margin
+Warning: tests/comments.ml:250 exceeds the margin
+Warning: tests/comments.ml:430 exceeds the margin

--- a/test/passing/tests/comments-no-wrap.ml.ref
+++ b/test/passing/tests/comments-no-wrap.ml.ref
@@ -194,12 +194,14 @@ type t =
 
 let () =
   xxxxxxxxxx
-  || (* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx *)
+  ||
+  (* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx *)
   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 let () =
   xxxxxxxxxx
-  land (* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx *)
+  land
+  (* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx *)
   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 let rec fooooooooooo = function
@@ -354,34 +356,47 @@ let a =
 
 let _ =
   1
-  + (* foooooooooooooooooooooooo fooooooooooooooo fooooooooooooooooo *)
+  +
+  (* foooooooooooooooooooooooo fooooooooooooooo fooooooooooooooooo *)
   fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-  - (* fooooooooooooo foooooooooooooooooooooo foooooooooooooooooooo *)
+  -
+  (* fooooooooooooo foooooooooooooooooooooo foooooooooooooooooooo *)
   foooooooooooooo foooooooooooooo foooooooooooooooooo fooooooooo
-  % (* foooooooooooooooo foooooooooooo foooooooooooooooooo *)
+  %
+  (* foooooooooooooooo foooooooooooo foooooooooooooooooo *)
   fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-  / (* foooooooooooooooooooooooo fooooooooooooooo fooooooooooooooooo *)
+  /
+  (* foooooooooooooooooooooooo fooooooooooooooo fooooooooooooooooo *)
   barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr
-  * (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  *
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  $ (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  $
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  & (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  &
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  = (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  =
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  > (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  >
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  < (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  <
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
   (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   @ foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  ^ (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  ^
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  || (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  ||
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo
     fooooooooooooooo
-    #= (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+    #=
+    (* convert from foos to bars blah blah blah blah blah blah blah blah *)
     foooooooooooooooooooooooo
     foooooooooooooooo fooooooooooooooo
 

--- a/test/passing/tests/comments.ml.err
+++ b/test/passing/tests/comments.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/comments.ml:250 exceeds the margin
+Warning: tests/comments.ml:252 exceeds the margin

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -196,12 +196,14 @@ type t =
 
 let () =
   xxxxxxxxxx
-  || (* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx *)
+  ||
+  (* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx *)
   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 let () =
   xxxxxxxxxx
-  land (* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx *)
+  land
+  (* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx *)
   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 let rec fooooooooooo = function
@@ -356,35 +358,47 @@ let a =
 
 let _ =
   1
-  + (* foooooooooooooooooooooooo fooooooooooooooo fooooooooooooooooo *)
+  +
+  (* foooooooooooooooooooooooo fooooooooooooooo fooooooooooooooooo *)
   fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-  - (* fooooooooooooo foooooooooooooooooooooo foooooooooooooooooooo *)
+  -
+  (* fooooooooooooo foooooooooooooooooooooo foooooooooooooooooooo *)
   foooooooooooooo foooooooooooooo foooooooooooooooooo fooooooooo
-  % (* foooooooooooooooo foooooooooooo foooooooooooooooooo *)
+  %
+  (* foooooooooooooooo foooooooooooo foooooooooooooooooo *)
   fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-  / (* foooooooooooooooooooooooo fooooooooooooooo fooooooooooooooooo *)
+  /
+  (* foooooooooooooooooooooooo fooooooooooooooo fooooooooooooooooo *)
   barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr
-  * (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  *
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  $ (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  $
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  & (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  &
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  = (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  =
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  > (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  >
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  < (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  <
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
   (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   @ foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  ^ (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  ^
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo fooooooooooooooo
-  || (* convert from foos to bars blah blah blah blah blah blah blah blah *)
+  ||
+  (* convert from foos to bars blah blah blah blah blah blah blah blah *)
   foooooooooooooooooooooooo foooooooooooooooo
     fooooooooooooooo
-    #= (* convert from foos to bars blah blah blah blah blah blah blah
-          blah *)
+    #=
+    (* convert from foos to bars blah blah blah blah blah blah blah blah *)
     foooooooooooooooooooooooo
     foooooooooooooooo fooooooooooooooo
 

--- a/test/passing/tests/infix_arg_grouping.ml.ref
+++ b/test/passing/tests/infix_arg_grouping.ml.ref
@@ -93,7 +93,8 @@ let sigma_seed =
 
 match
   "\"" ^ line ^ " \""
-  |> (* split by whitespace *)
+  |>
+  (* split by whitespace *)
   Str.split (Str.regexp_string "\" \"")
 with
 | prog :: args -> fooooooooooooooooooooo
@@ -101,9 +102,11 @@ with
 let () =
   (* Open the repo *)
   initialise
-  >>= (* Perform a subsequent action *)
+  >>=
+  (* Perform a subsequent action *)
   subsequent_action
-  >|= (* Keep going... *)
+  >|=
+  (* Keep going... *)
   another_action
   |> fun t ->
   (* And finally do this *)
@@ -121,21 +124,21 @@ let () =
 
 let _ =
   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  - (* ___________________________________ *)
+  -
+  (* ___________________________________ *)
   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 let _ =
   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  >= (* ___________________________________ *)
+  >=
+  (* ___________________________________ *)
   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 let _ =
-    List.filter
-      (fun s ->
-         ((* 3.1. the sid of the authenticated user *)
-           foooooooooooooooooooooooooooooo
-           || (* 3.2. any sids of the group that authenticated the user *)
-           (* TODO: better to look up the membership closure *)
-           fooooooooooooooooooooooooooo
-         )
-      )
+  List.filter (fun s ->
+      (* 3.1. the sid of the authenticated user *)
+      foooooooooooooooooooooooooooooo
+      ||
+      (* 3.2. any sids of the group that authenticated the user *)
+      (* TODO: better to look up the membership closure *)
+      fooooooooooooooooooooooooooo )

--- a/test/passing/tests/infix_bind-break.ml.opts
+++ b/test/passing/tests/infix_bind-break.ml.opts
@@ -1,2 +1,3 @@
 --break-infix=wrap
 --break-infix-before-func
+--max-iters=3

--- a/test/passing/tests/infix_bind-break.ml.ref
+++ b/test/passing/tests/infix_bind-break.ml.ref
@@ -171,32 +171,43 @@ let _ =
   >>= fun (* foo before *) [@warning "-4"] (* foo after *) x ->
   fooooooooooooooooooooooo
 
-let f = Ok () >>= (* *) fun _ -> Ok ()
+let f =
+  Ok ()
+  >>=
+  (* *)
+  fun _ -> Ok ()
 
 let f =
   (* fooooooooooooooo foooooooooooooooo *)
   Ok ()
-  >>= (* *) fun _ -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
+  >>=
+  (* *)
+  fun _ -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
-let f = Ok () >>= (* *) function Foo -> Ok ()
+let f =
+  Ok ()
+  >>=
+  (* *)
+  function Foo -> Ok ()
 
 let f =
   (* fooooooooooooooo foooooooooooooooo *)
   Ok ()
-  >>= (* *)
+  >>=
+  (* *)
   function Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 let f =
   Ok ()
-  >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo
-         foooooooooooooooo *)
+  >>=
+  (* fooooooooooooooo fooooooooooooooo fooooooooooooooo foooooooooooooooo *)
   fun foooooo fooooo foooo foooooo ->
   Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 let f =
   Ok ()
-  >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo
-         foooooooooooooooo *)
+  >>=
+  (* fooooooooooooooo fooooooooooooooo fooooooooooooooo foooooooooooooooo *)
   function Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 (** The tests below are testing a dropped comment with

--- a/test/passing/tests/infix_bind-fit_or_vertical-break.ml.opts
+++ b/test/passing/tests/infix_bind-fit_or_vertical-break.ml.opts
@@ -1,2 +1,3 @@
 --break-infix=fit-or-vertical
 --break-infix-before-func
+--max-iters=3

--- a/test/passing/tests/infix_bind-fit_or_vertical-break.ml.ref
+++ b/test/passing/tests/infix_bind-fit_or_vertical-break.ml.ref
@@ -176,32 +176,43 @@ let _ =
   >>= fun (* foo before *) [@warning "-4"] (* foo after *) x ->
   fooooooooooooooooooooooo
 
-let f = Ok () >>= (* *) fun _ -> Ok ()
+let f =
+  Ok ()
+  >>=
+  (* *)
+  fun _ -> Ok ()
 
 let f =
   (* fooooooooooooooo foooooooooooooooo *)
   Ok ()
-  >>= (* *) fun _ -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
+  >>=
+  (* *)
+  fun _ -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
-let f = Ok () >>= (* *) function Foo -> Ok ()
+let f =
+  Ok ()
+  >>=
+  (* *)
+  function Foo -> Ok ()
 
 let f =
   (* fooooooooooooooo foooooooooooooooo *)
   Ok ()
-  >>= (* *)
+  >>=
+  (* *)
   function Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 let f =
   Ok ()
-  >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo
-         foooooooooooooooo *)
+  >>=
+  (* fooooooooooooooo fooooooooooooooo fooooooooooooooo foooooooooooooooo *)
   fun foooooo fooooo foooo foooooo ->
   Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 let f =
   Ok ()
-  >>= (* fooooooooooooooo fooooooooooooooo fooooooooooooooo
-         foooooooooooooooo *)
+  >>=
+  (* fooooooooooooooo fooooooooooooooo fooooooooooooooo foooooooooooooooo *)
   function Foo -> Ok foooooooooooooooooooooooooooooooooooooooooooooooooo
 
 (** The tests below are testing a dropped comment with


### PR DESCRIPTION
Fix #2057

I'm opening this PR to get feedback on the new output. The ambiguity of where to place comments here is annoying, the solution is drastic, but I find the result easier to read.
