### PR TITLE
Add type constraint to binding_op

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1905,16 +1905,23 @@ end = struct
     | Fp {pparam_desc= Pparam_val (_, _, _); _}, Ppat_cons _ -> true
     | Pat {ppat_desc= Ppat_construct _; _}, Ppat_cons _ -> true
     | _, Ppat_constraint (_, {ptyp_desc= Ptyp_poly _; _}) -> false
-    | ( (Exp {pexp_desc= Pexp_letop _; _} | Bo {pbop_typ= Some _; _})
+    | ( Exp {pexp_desc= Pexp_letop _; _}
       , ( Ppat_construct (_, Some _)
         | Ppat_cons _
         | Ppat_variant (_, Some _)
-        | Ppat_or _ | Ppat_alias _ | Ppat_tuple _
+        | Ppat_or _ | Ppat_alias _
         | Ppat_constraint ({ppat_desc= Ppat_any; _}, _) ) ) ->
         true
-    | ( (Exp {pexp_desc= Pexp_letop _; _} | Bo {pbop_typ= Some _; _})
+    | ( Exp {pexp_desc= Pexp_letop _; _}
       , Ppat_constraint ({ppat_desc= Ppat_tuple _; _}, _) ) ->
         false
+    | ( Bo {pbop_typ= None; _}
+      , ( Ppat_construct (_, Some _)
+        | Ppat_cons _
+        | Ppat_variant (_, Some _)
+        | Ppat_or _ | Ppat_alias _ ) ) ->
+        true
+    | Bo {pbop_typ= Some _; _}, (Ppat_any | Ppat_tuple _) -> true
     | _, Ppat_constraint _
      |_, Ppat_unpack _
      |( Pat

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1003,7 +1003,7 @@ end = struct
     | Fp _ -> assert false
     | Vc c -> assert (check_value_constraint c)
     | Lb _ -> assert false
-    | Bo ctx -> assert (Option.exists ctx.pbop_typ ~f:check_value_constraint)
+    | Bo _ -> assert false
     | Mb _ -> assert false
     | Md _ -> assert false
     | Cl {pcl_desc; _} ->

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -641,6 +641,7 @@ module T = struct
     | Fp of function_param
     | Vc of value_constraint
     | Lb of value_binding
+    | Bo of binding_op
     | Mb of module_binding
     | Md of module_declaration
     | Cl of class_expr
@@ -663,6 +664,7 @@ module T = struct
     | Fp p -> Format.fprintf fs "Fp:@\n%a" Printast.function_param p
     | Vc c -> Format.fprintf fs "Vc:@\n%a" Printast.value_constraint c
     | Lb b -> Format.fprintf fs "Lb:@\n%a" Printast.value_binding b
+    | Bo b -> Format.fprintf fs "Bo:@\n%a" Printast.binding_op b
     | Mb m -> Format.fprintf fs "Mb:@\n%a" Printast.module_binding m
     | Md m -> Format.fprintf fs "Md:@\n%a" Printast.module_declaration m
     | Cl cl -> Format.fprintf fs "Cl:@\n%a" Printast.class_expr cl
@@ -697,6 +699,7 @@ let attributes = function
   | Fp _ -> []
   | Vc _ -> []
   | Lb x -> x.pvb_attributes
+  | Bo _ -> []
   | Mb x -> attrs_of_ext_attrs x.pmb_ext_attrs
   | Md x -> attrs_of_ext_attrs x.pmd_ext_attrs
   | Cl x -> x.pcl_attributes
@@ -720,6 +723,7 @@ let location = function
   | Fp x -> x.pparam_loc
   | Vc _ -> Location.none
   | Lb x -> x.pvb_loc
+  | Bo x -> x.pbop_loc
   | Mb x -> x.pmb_loc
   | Md x -> x.pmd_loc
   | Cl x -> x.pcl_loc
@@ -999,6 +1003,7 @@ end = struct
     | Fp _ -> assert false
     | Vc c -> assert (check_value_constraint c)
     | Lb _ -> assert false
+    | Bo ctx -> assert (Option.exists ctx.pbop_typ ~f:check_value_constraint)
     | Mb _ -> assert false
     | Md _ -> assert false
     | Cl {pcl_desc; _} ->
@@ -1108,6 +1113,7 @@ end = struct
     | Fp _ -> assert false
     | Vc _ -> assert false
     | Lb _ -> assert false
+    | Bo _ -> assert false
     | Mb _ -> assert false
     | Md _ -> assert false
     | Pld _ -> assert false
@@ -1177,6 +1183,7 @@ end = struct
     | Fp _ -> assert false
     | Vc _ -> assert false
     | Lb _ -> assert false
+    | Bo _ -> assert false
     | Mb _ -> assert false
     | Md _ -> assert false
     | Pld _ -> assert false
@@ -1303,6 +1310,7 @@ end = struct
     | Fp ctx -> assert (check_function_param ctx)
     | Vc _ -> assert false
     | Lb x -> assert (x.pvb_pat == pat)
+    | Bo x -> assert (x.pbop_pat == pat)
     | Mb _ -> assert false
     | Md _ -> assert false
     | Cl ctx ->
@@ -1434,6 +1442,7 @@ end = struct
     | Fp ctx -> assert (check_function_param ctx)
     | Vc _ -> assert false
     | Lb x -> assert (x.pvb_expr == exp)
+    | Bo x -> assert (x.pbop_exp == exp)
     | Mb _ -> assert false
     | Md _ -> assert false
     | Str str -> (
@@ -1689,6 +1698,8 @@ end = struct
      |{ctx= _; ast= Vc _}
      |{ctx= Lb _; ast= _}
      |{ctx= _; ast= Lb _}
+     |{ctx= Bo _; ast= _}
+     |{ctx= _; ast= Bo _}
      |{ctx= Td _; ast= _}
      |{ctx= _; ast= Td _}
      |{ ctx= Cl _
@@ -1773,6 +1784,7 @@ end = struct
     | Fp _ -> None
     | Vc _ -> None
     | Lb _ -> None
+    | Bo _ -> None
     | Cl c -> (
       match c.pcl_desc with
       | Pcl_apply _ -> Some Apply
@@ -1893,14 +1905,14 @@ end = struct
     | Fp {pparam_desc= Pparam_val (_, _, _); _}, Ppat_cons _ -> true
     | Pat {ppat_desc= Ppat_construct _; _}, Ppat_cons _ -> true
     | _, Ppat_constraint (_, {ptyp_desc= Ptyp_poly _; _}) -> false
-    | ( Exp {pexp_desc= Pexp_letop _; _}
+    | ( (Exp {pexp_desc= Pexp_letop _; _} | Bo {pbop_typ= Some _; _})
       , ( Ppat_construct (_, Some _)
         | Ppat_cons _
         | Ppat_variant (_, Some _)
-        | Ppat_or _ | Ppat_alias _
+        | Ppat_or _ | Ppat_alias _ | Ppat_tuple _
         | Ppat_constraint ({ppat_desc= Ppat_any; _}, _) ) ) ->
         true
-    | ( Exp {pexp_desc= Pexp_letop _; _}
+    | ( (Exp {pexp_desc= Pexp_letop _; _} | Bo {pbop_typ= Some _; _})
       , Ppat_constraint ({ppat_desc= Ppat_tuple _; _}, _) ) ->
         false
     | _, Ppat_constraint _
@@ -1938,7 +1950,7 @@ end = struct
      |Cl {pcl_desc= Pcl_fun _; _}, Ppat_construct _
      |Cl {pcl_desc= Pcl_fun _; _}, Ppat_alias _
      |Cl {pcl_desc= Pcl_fun _; _}, Ppat_lazy _
-     |Exp {pexp_desc= Pexp_letop _; _}, Ppat_exception _
+     |(Exp {pexp_desc= Pexp_letop _; _} | Bo _), Ppat_exception _
      |( Exp {pexp_desc= Pexp_fun _; _}
       , ( Ppat_construct _ | Ppat_cons _ | Ppat_lazy _ | Ppat_tuple _
         | Ppat_variant _ ) ) ->

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -113,6 +113,7 @@ type t =
   | Fp of function_param
   | Vc of value_constraint
   | Lb of value_binding
+  | Bo of binding_op
   | Mb of module_binding
   | Md of module_declaration
   | Cl of class_expr

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2305,7 +2305,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       $ fmt_let_bindings c ?ext ~parens ~fmt_atrs ~fmt_expr ~has_attr
           lbs.pvbs_rec bindings body
   | Pexp_letop {let_; ands; body} ->
-      let bd = Sugar.Let_binding.of_binding_ops c.cmts ~ctx (let_ :: ands) in
+      let bd = Sugar.Let_binding.of_binding_ops c.cmts (let_ :: ands) in
       let fmt_expr = fmt_expression c (sub_exp ~ctx body) in
       pro
       $ fmt_let_bindings c ?ext ~parens ~fmt_atrs ~fmt_expr ~has_attr

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -70,5 +70,5 @@ module Let_binding : sig
 
   val of_let_bindings : Cmts.t -> ctx:Ast.t -> value_binding list -> t list
 
-  val of_binding_ops : Cmts.t -> ctx:Ast.t -> binding_op list -> t list
+  val of_binding_ops : Cmts.t -> binding_op list -> t list
 end

--- a/test/passing/tests/monadic_binding.ml
+++ b/test/passing/tests/monadic_binding.ml
@@ -32,4 +32,6 @@ let _ =
   let* (args, _) : bar = () in
   let* (arg : bar) = () in
   let* (_ : foo) = () in
+  let* _ as t = xxx in
+  let+ Ok x = xxx in
   ()

--- a/test/passing/tests/monadic_binding.ml
+++ b/test/passing/tests/monadic_binding.ml
@@ -32,6 +32,6 @@ let _ =
   let* (args, _) : bar = () in
   let* (arg : bar) = () in
   let* (_ : foo) = () in
-  let* _ as t = xxx in
-  let+ Ok x = xxx in
+  let* (_ as t) = xxx in
+  let+ (Ok x) = xxx in
   ()

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -175,10 +175,11 @@ module Exp = struct
      pc_rhs = rhs;
     }
 
-  let binding_op op pat exp pun loc =
+  let binding_op op pat typ exp pun loc =
     {
       pbop_op = op;
       pbop_pat = pat;
+      pbop_typ = typ;
       pbop_exp = exp;
       pbop_is_pun = pun;
       pbop_loc = loc;

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -2231,10 +2231,10 @@ expr:
   | let_bindings(ext) IN seq_expr
       { expr_of_let_bindings ~loc:$sloc $1 $3 }
   | pbop_op = mkrhs(LETOP) bindings = letop_bindings IN body = seq_expr
-      { let (pbop_pat, pbop_exp, pbop_is_pun, rev_ands) = bindings in
+      { let (pbop_pat, pbop_typ, pbop_exp, pbop_is_pun, rev_ands) = bindings in
         let ands = List.rev rev_ands in
         let pbop_loc = make_loc $sloc in
-        let let_ = {pbop_op; pbop_pat; pbop_exp; pbop_is_pun; pbop_loc} in
+        let let_ = {pbop_op; pbop_pat; pbop_typ; pbop_exp; pbop_is_pun; pbop_loc} in
         mkexp ~loc:$sloc (Pexp_letop{ let_; ands; body}) }
   | expr COLONCOLON e = expr
       { match e.pexp_desc, e.pexp_attributes with
@@ -2548,26 +2548,25 @@ and_let_binding:
 ;
 letop_binding_body:
     pat = let_ident exp = strict_binding
-      { (pat, exp, false) }
+      { (pat, None, exp, false) }
   | val_ident
       (* Let-punning *)
-      { (mkpatvar ~loc:$loc $1, mkexpvar ~loc:$loc $1, true) }
+      { (mkpatvar ~loc:$loc $1, None, mkexpvar ~loc:$loc $1, true) }
   | pat = simple_pattern COLON typ = core_type EQUAL exp = seq_expr
-      { let loc = ($startpos(pat), $endpos(typ)) in
-        (ghpat ~loc (Ppat_constraint(pat, typ)), exp, false) }
+      { (pat, Some (Pvc_constraint { locally_abstract_univars = []; typ }), exp, false) }
   | pat = pattern_no_exn EQUAL exp = seq_expr
-      { (pat, exp, false) }
+      { (pat, None, exp, false) }
 ;
 letop_bindings:
     body = letop_binding_body
-      { let let_pat, let_exp, let_is_pun = body in
-        let_pat, let_exp, let_is_pun, [] }
+      { let let_pat, let_typ, let_exp, let_is_pun = body in
+        let_pat, let_typ, let_exp, let_is_pun, [] }
   | bindings = letop_bindings pbop_op = mkrhs(ANDOP) body = letop_binding_body
-      { let let_pat, let_exp, let_is_pun, rev_ands = bindings in
-        let pbop_pat, pbop_exp, pbop_is_pun = body in
+      { let let_pat, let_typ, let_exp, let_is_pun, rev_ands = bindings in
+        let pbop_pat, pbop_typ, pbop_exp, pbop_is_pun = body in
         let pbop_loc = make_loc $sloc in
-        let and_ = {pbop_op; pbop_pat; pbop_exp; pbop_is_pun; pbop_loc} in
-        let_pat, let_exp, let_is_pun, and_ :: rev_ands }
+        let and_ = {pbop_op; pbop_pat; pbop_typ; pbop_exp; pbop_is_pun; pbop_loc} in
+        let_pat, let_typ, let_exp, let_is_pun, and_ :: rev_ands }
 ;
 fun_binding:
     strict_binding

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -482,6 +482,7 @@ and binding_op =
   {
     pbop_op : string loc;
     pbop_pat : pattern;
+    pbop_typ : value_constraint option;
     pbop_exp : expression;
     pbop_is_pun: bool;
     pbop_loc : Location.t;

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -1233,3 +1233,5 @@ let signature_item ppf x = signature_item 0 ppf x
 let function_param ppf x = function_param 0 ppf x
 
 let value_constraint ppf x = value_constraint 0 ppf x
+
+let binding_op ppf x = binding_op 0 ppf x


### PR DESCRIPTION
Contributing to #2401 

The main positive is removing `Sugar.type_cstr` (all this code is inconvenient for the polynewtypes shenanigans) by doing this work in the parser.

A minor side effect is that we don't add useless parentheses around:
 - `let* ({ state; server; pool } as t) = xxx`
 - `let+ (Ok x) = xxx`

It's a fix, but not important enough to add a line in the changelog.