### PR TITLE
`enable_outside_detected_project=true` for rpc

### DIFF
--- a/lib-rpc-server/ocamlformat_rpc.ml
+++ b/lib-rpc-server/ocamlformat_rpc.ml
@@ -64,7 +64,7 @@ let run_config conf c =
 
 let run_path path =
   match
-    Bin_conf.build_config ~enable_outside_detected_project:false ~root:None
+    Bin_conf.build_config ~enable_outside_detected_project:true ~root:None
       ~file:path ~is_stdin:false
   with
   | Ok _ as ok -> ok


### PR DESCRIPTION
The rpc api doesn't allow for enabling `ocamlformat` outside detected project. 
In situations where we want the editor (`ocaml-lsp`) to respect the global config (in `~/.config/.ocamlformat`), it is useful to enable formatting without having a `.ocamlformat` in the project

This change enables it for `rpc`, with the assumption that if a client is triggering the `rpc` explicitly for formatting, they expect it to be picked up 

Related to https://github.com/ocaml-ppx/ocamlformat/issues/2092