### PR TITLE
Fix indentation of tuples in payloads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ profile. This started with version 0.26.0.
 - Fixed bug with attributes on sub-expressions of infix operators (#2459, @tdelvecchio-jsc)
 - \* Fix cinaps comment formatting to not change multiline string contents (#2463, @tdelvecchio-jsc)
 - Fix position of comments around function parameters (#2471, @gpetiot)
+- \* Fix the indentation of tuples in attributes and extensions (#2488, @Julow)
 
 ## 0.26.1 (2023-09-15)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1047,7 +1047,7 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
       in
       hvbox 0
         (Params.wrap_tuple ~parens ~no_parens_if_break:false c.conf
-           (list pats (Params.comma_sep c.conf)
+           (list_k pats (Params.tuple_sep c.conf)
               (sub_pat ~ctx >> fmt_pattern c) ) )
   | Ppat_construct ({txt= Lident (("()" | "[]") as txt); loc}, None) ->
       let opn = txt.[0] and cls = txt.[1] in
@@ -2584,7 +2584,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
              ( hvbox 0
                  (Params.wrap_tuple ~parens:inner_wrap ~no_parens_if_break
                     c.conf
-                    (list es (Params.comma_sep c.conf)
+                    (list_k es (Params.tuple_sep c.conf)
                        (sub_exp ~ctx >> fmt_expression c) ) )
              $ fmt_atrs ) )
   | Pexp_lazy e ->

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1047,8 +1047,7 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
       in
       hvbox 0
         (Params.wrap_tuple ~parens ~no_parens_if_break:false c.conf
-           (list_k pats (Params.tuple_sep c.conf)
-              (sub_pat ~ctx >> fmt_pattern c) ) )
+           (List.map pats ~f:(sub_pat ~ctx >> fmt_pattern c)) )
   | Ppat_construct ({txt= Lident (("()" | "[]") as txt); loc}, None) ->
       let opn = txt.[0] and cls = txt.[1] in
       Cmts.fmt c loc
@@ -2584,8 +2583,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
              ( hvbox 0
                  (Params.wrap_tuple ~parens:inner_wrap ~no_parens_if_break
                     c.conf
-                    (list_k es (Params.tuple_sep c.conf)
-                       (sub_exp ~ctx >> fmt_expression c) ) )
+                    (List.map es ~f:(sub_exp ~ctx >> fmt_expression c)) )
              $ fmt_atrs ) )
   | Pexp_lazy e ->
       pro

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -300,15 +300,16 @@ let wrap_collec c ~space_around opn cls =
 let wrap_record (c : Conf.t) =
   wrap_collec c ~space_around:c.fmt_opts.space_around_records.v "{" "}"
 
-let wrap_tuple (c : Conf.t) ~parens ~no_parens_if_break k =
+let wrap_tuple (c : Conf.t) ~parens ~no_parens_if_break items =
+  let tuple_sep =
+    match c.fmt_opts.break_separators.v with
+    | `Before -> fits_breaks ", " ~hint:(1000, -2) ", "
+    | `After -> fmt ",@ "
+  in
+  let k = list_k items tuple_sep Fn.id in
   if parens then wrap_fits_breaks c "(" ")" (hvbox 0 k)
   else if no_parens_if_break then k
   else fits_breaks "" "( " $ hvbox 0 k $ fits_breaks "" ~hint:(1, 0) ")"
-
-let tuple_sep (c : Conf.t) =
-  match c.fmt_opts.break_separators.v with
-  | `Before -> fits_breaks ", " ~hint:(1000, -2) ", "
-  | `After -> fmt ",@ "
 
 type record_type =
   { docked_before: Fmt.t

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -300,10 +300,15 @@ let wrap_collec c ~space_around opn cls =
 let wrap_record (c : Conf.t) =
   wrap_collec c ~space_around:c.fmt_opts.space_around_records.v "{" "}"
 
-let wrap_tuple (c : Conf.t) ~parens ~no_parens_if_break =
-  if parens then wrap_fits_breaks c "(" ")"
-  else if no_parens_if_break then Fn.id
-  else wrap_k (fits_breaks "" "( ") (fits_breaks "" ~hint:(1, 0) ")")
+let wrap_tuple (c : Conf.t) ~parens ~no_parens_if_break k =
+  if parens then wrap_fits_breaks c "(" ")" (hvbox 0 k)
+  else if no_parens_if_break then k
+  else fits_breaks "" "( " $ hvbox 0 k $ fits_breaks "" ~hint:(1, 0) ")"
+
+let tuple_sep (c : Conf.t) =
+  match c.fmt_opts.break_separators.v with
+  | `Before -> fits_breaks ", " ~hint:(1000, -2) ", "
+  | `After -> fmt ",@ "
 
 type record_type =
   { docked_before: Fmt.t

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -92,9 +92,8 @@ val get_cases :
   -> cases
 
 val wrap_tuple :
-  Conf.t -> parens:bool -> no_parens_if_break:bool -> Fmt.t -> Fmt.t
-
-val tuple_sep : Conf.t -> Fmt.t
+  Conf.t -> parens:bool -> no_parens_if_break:bool -> Fmt.t list -> Fmt.t
+(** Format a tuple given a list of items. *)
 
 type record_type =
   { docked_before: Fmt.t

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -94,6 +94,8 @@ val get_cases :
 val wrap_tuple :
   Conf.t -> parens:bool -> no_parens_if_break:bool -> Fmt.t -> Fmt.t
 
+val tuple_sep : Conf.t -> Fmt.t
+
 type record_type =
   { docked_before: Fmt.t
   ; break_before: Fmt.t

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -9931,11 +9931,11 @@ let _ =
 type t
 [@@deriving
   some_deriver_name
-  , another_deriver_name
-  , another_deriver_name
-  , another_deriver_name
-  , yet_another_such_name
-  , such_that_they_line_wrap]
+, another_deriver_name
+, another_deriver_name
+, another_deriver_name
+, yet_another_such_name
+, such_that_they_line_wrap]
 
 type t
 [@@deriving

--- a/test/passing/tests/string.ml.ref
+++ b/test/passing/tests/string.ml.ref
@@ -4,7 +4,7 @@ let f = function
         [%sexp
           "Xxxx \036 \036 \036 \036 \036 \036 \036 xxx xxxx xx xxxxxx xx \
            xxx xxxxxxx xxxxxx, xxxxxxx xxxxxxxxxx xx xxxx.  Xxxx."
-          , 0]
+        , 0]
 
 let _ = "\010\xFFa\o123\n\\\u{12345}aa🐪🐪🐪🐪🐪\n"
 

--- a/test/passing/tests/tuple.ml
+++ b/test/passing/tests/tuple.ml
@@ -14,16 +14,16 @@ let _ = [%ext 1, 2, 3]
 let _ =
   [%ext
     loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
-    , 2
-    , 3]
+  , 2
+  , 3]
 
 type t = int [@@deriving 1, 2, 3]
 
 type t = int
 [@@deriving
   sexp
-  , compare
-  , loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong]
+, compare
+, loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong]
 
 let _ =
   ( 1

--- a/test/passing/tests/tuple_less_parens.ml
+++ b/test/passing/tests/tuple_less_parens.ml
@@ -14,16 +14,16 @@ let _ = [%ext 1, 2, 3]
 let _ =
   [%ext
     loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
-    , 2
-    , 3]
+  , 2
+  , 3]
 
 type t = int [@@deriving 1, 2, 3]
 
 type t = int
 [@@deriving
   sexp
-  , compare
-  , loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong]
+, compare
+, loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong]
 
 let _ =
   ( 1


### PR DESCRIPTION
Extracted from https://github.com/ocaml-ppx/ocamlformat/pull/2314 as it changes the default profile.