### PR TITLE
Add class_infos to Ast.t

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -636,6 +636,8 @@ module T = struct
     | Typ of core_type
     | Td of type_declaration
     | Cty of class_type
+    | Cd of class_declaration
+    | Ctd of class_type_declaration
     | Pat of pattern
     | Exp of expression
     | Fp of function_param
@@ -670,6 +672,9 @@ module T = struct
     | Cl cl -> Format.fprintf fs "Cl:@\n%a" Printast.class_expr cl
     | Mty mt -> Format.fprintf fs "Mty:@\n%a" Printast.module_type mt
     | Cty cty -> Format.fprintf fs "Cty:@\n%a" Printast.class_type cty
+    | Cd cd -> Format.fprintf fs "Cd:@\n%a" Printast.class_declaration cd
+    | Ctd ctd ->
+        Format.fprintf fs "Ctd:@\n%a" Printast.class_type_declaration ctd
     | Mod m -> Format.fprintf fs "Mod:@\n%a" Printast.module_expr m
     | Sig s -> Format.fprintf fs "Sig:@\n%a" Printast.signature_item s
     | Str s | Tli (`Item s) ->
@@ -703,6 +708,8 @@ let attributes = function
   | Mb x -> attrs_of_ext_attrs x.pmb_ext_attrs
   | Md x -> attrs_of_ext_attrs x.pmd_ext_attrs
   | Cl x -> x.pcl_attributes
+  | Cd x -> x.pci_attributes
+  | Ctd x -> x.pci_attributes
   | Mty x -> x.pmty_attributes
   | Mod x -> x.pmod_attributes
   | Sig _ -> []
@@ -727,6 +734,8 @@ let location = function
   | Mb x -> x.pmb_loc
   | Md x -> x.pmd_loc
   | Cl x -> x.pcl_loc
+  | Cd x -> x.pci_loc
+  | Ctd x -> x.pci_loc
   | Mty x -> x.pmty_loc
   | Mod x -> x.pmod_loc
   | Sig x -> x.psig_loc
@@ -906,15 +915,20 @@ end = struct
     let check_typexn {ptyexn_constructor; _} =
       check_ext ptyexn_constructor
     in
-    let check_class_type l =
-      List.exists l ~f:(fun {pci_expr= {pcty_desc; _}; pci_params; _} ->
-          List.exists pci_params ~f:(fun (t, _) -> t == typ)
-          ||
-          match pcty_desc with
-          | Pcty_constr (_, l) -> List.exists l ~f:(fun x -> x == typ)
-          | Pcty_arrow (t, _) ->
-              List.exists t ~f:(fun x -> x.pap_type == typ)
-          | _ -> false )
+    let check_class_type {pci_expr= {pcty_desc; _}; pci_params; _} =
+      List.exists pci_params ~f:(fun (t, _) -> t == typ)
+      ||
+      match pcty_desc with
+      | Pcty_constr (_, l) -> List.exists l ~f:(fun x -> x == typ)
+      | Pcty_arrow (t, _) -> List.exists t ~f:(fun x -> x.pap_type == typ)
+      | _ -> false
+    in
+    let check_class_expr {pci_expr= {pcl_desc; _}; pci_params; _} =
+      List.exists pci_params ~f:(fun (t, _) -> t == typ)
+      ||
+      match pcl_desc with
+      | Pcl_constr (_, l) -> List.exists l ~f:(fun x -> x == typ)
+      | _ -> false
     in
     let check_value_constraint = function
       | Pvc_constraint {typ= typ'; _} -> typ' == typ
@@ -1017,6 +1031,8 @@ end = struct
           | Pcl_open _ -> false
           | Pcl_extension _ -> false
           | Pcl_structure _ -> false )
+    | Cd ctx -> assert (check_class_expr ctx)
+    | Ctd ctx -> assert (check_class_type ctx)
     | Mty _ -> assert false
     | Mod ctx -> (
       match ctx.pmod_desc with
@@ -1031,8 +1047,6 @@ end = struct
       | Psig_typesubst _ -> assert false
       | Psig_typext typext -> assert (check_typext typext)
       | Psig_exception ext -> assert (check_typexn ext)
-      | Psig_class_type l -> assert (check_class_type l)
-      | Psig_class l -> assert (check_class_type l)
       | _ -> assert false )
     | Str ctx -> (
       match ctx.pstr_desc with
@@ -1040,15 +1054,6 @@ end = struct
       | Pstr_type (_, _) -> assert false
       | Pstr_typext typext -> assert (check_typext typext)
       | Pstr_exception ext -> assert (check_typexn ext)
-      | Pstr_class l ->
-          assert (
-            List.exists l ~f:(fun {pci_expr= {pcl_desc; _}; pci_params; _} ->
-                List.exists pci_params ~f:(fun (t, _) -> t == typ)
-                ||
-                match pcl_desc with
-                | Pcl_constr (_, l) -> List.exists l ~f:(fun x -> x == typ)
-                | _ -> false ) )
-      | Pstr_class_type l -> assert (check_class_type l)
       | Pstr_extension ((_, PTyp t), _) -> assert (t == typ)
       | Pstr_extension (_, _) -> assert false
       | Pstr_value {pvbs_bindings; _} ->
@@ -1099,15 +1104,6 @@ end = struct
     assert_no_raise ~f:check_typ ~dump xtyp
 
   let check_cty {ctx; ast= cty} =
-    let check_class_type l =
-      List.exists l ~f:(fun {pci_expr; _} ->
-          let rec loop x =
-            x == cty
-            ||
-            match x.pcty_desc with Pcty_arrow (_, x) -> loop x | _ -> false
-          in
-          loop pci_expr )
-    in
     match (ctx : t) with
     | Exp _ -> assert false
     | Fp _ -> assert false
@@ -1117,25 +1113,8 @@ end = struct
     | Mb _ -> assert false
     | Md _ -> assert false
     | Pld _ -> assert false
-    | Str ctx -> (
-      match ctx.pstr_desc with
-      | Pstr_class_type l -> assert (check_class_type l)
-      | Pstr_class l ->
-          assert (
-            List.exists l ~f:(fun {pci_expr; _} ->
-                let rec loop x =
-                  match x.pcl_desc with
-                  | Pcl_fun (_, x) -> loop x
-                  | Pcl_constraint (_, x) -> x == cty
-                  | _ -> false
-                in
-                loop pci_expr ) )
-      | _ -> assert false )
-    | Sig ctx -> (
-      match ctx.psig_desc with
-      | Psig_class_type l -> assert (check_class_type l)
-      | Psig_class l -> assert (check_class_type l)
-      | _ -> assert false )
+    | Str _ -> assert false
+    | Sig _ -> assert false
     | Cty {pcty_desc; _} -> (
       match pcty_desc with
       | Pcty_arrow (_, t) -> assert (t == cty)
@@ -1159,6 +1138,8 @@ end = struct
           | Pcl_constraint (_, x) -> x == cty
           | Pcl_extension _ -> false
           | Pcl_open _ -> false )
+    | Cd _ -> assert false
+    | Ctd ctx -> assert (ctx.pci_expr == cty)
     | Clf _ -> assert false
     | Ctf {pctf_desc; _} ->
         assert (
@@ -1187,21 +1168,7 @@ end = struct
     | Mb _ -> assert false
     | Md _ -> assert false
     | Pld _ -> assert false
-    | Str ctx -> (
-      match ctx.pstr_desc with
-      | Pstr_class l ->
-          assert (
-            List.exists l ~f:(fun {pci_expr; _} ->
-                let rec loop x =
-                  cl == x
-                  ||
-                  match x.pcl_desc with
-                  | Pcl_fun (_, x) -> loop x
-                  | Pcl_constraint (x, _) -> loop x
-                  | _ -> false
-                in
-                loop pci_expr ) )
-      | _ -> assert false )
+    | Str _ -> assert false
     | Sig _ -> assert false
     | Cty _ -> assert false
     | Top -> assert false
@@ -1220,6 +1187,8 @@ end = struct
           | Pcl_open (_, x) -> x == cl
           | Pcl_constr _ -> false
           | Pcl_extension _ -> false )
+    | Cd ctx -> assert (ctx.pci_expr == cl)
+    | Ctd _ -> assert false
     | Clf {pcf_desc; _} ->
         assert (
           match pcf_desc with Pcf_inherit (_, x, _) -> x == cl | _ -> false )
@@ -1327,6 +1296,8 @@ end = struct
           | Pcl_extension (_, ext) -> check_extensions ext
           | Pcl_open _ -> false )
     | Cty _ -> assert false
+    | Cd _ -> assert false
+    | Ctd _ -> assert false
     | Mty _ | Mod _ | Sig _ -> assert false
     | Str str -> (
       match str.pstr_desc with
@@ -1477,6 +1448,8 @@ end = struct
         in
         assert (loop ctx)
     | Cty _ -> assert false
+    | Cd _ -> assert false
+    | Ctd _ -> assert false
     | Ctf _ -> assert false
     | Clf {pcf_desc; _} ->
         assert (
@@ -1703,6 +1676,10 @@ end = struct
      |{ctx= _; ast= Bo _}
      |{ctx= Td _; ast= _}
      |{ctx= _; ast= Td _}
+     |{ctx= Cd _; ast= _}
+     |{ctx= _; ast= Cd _}
+     |{ctx= Ctd _; ast= _}
+     |{ctx= _; ast= Ctd _}
      |{ ctx= Cl _
       ; ast=
           ( Pld _ | Top | Tli _ | Pat _ | Mty _ | Mod _ | Sig _ | Str _
@@ -1792,7 +1769,7 @@ end = struct
       | Pcl_structure _ -> Some Apply
       | _ -> None )
     | Top | Pat _ | Mty _ | Mod _ | Sig _ | Str _ | Tli _ | Clf _ | Ctf _
-     |Rep | Mb _ | Md _ ->
+     |Rep | Mb _ | Md _ | Cd _ | Ctd _ ->
         None
 
   (** [ambig_prec {ctx; ast}] holds when [ast] is ambiguous in its context

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -108,6 +108,8 @@ type t =
   | Typ of core_type
   | Td of type_declaration
   | Cty of class_type
+  | Cd of class_declaration
+  | Ctd of class_type_declaration
   | Pat of pattern
   | Exp of expression
   | Fp of function_param

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -1214,3 +1214,7 @@ let function_param ppf x = function_param 0 ppf x
 let value_constraint ppf x = value_constraint 0 ppf x
 
 let binding_op ppf x = binding_op 0 ppf x
+
+let class_declaration ppf x = class_declaration 0 ppf x
+
+let class_type_declaration ppf x = class_type_declaration 0 ppf x


### PR DESCRIPTION
Simplification of Ast.ml, and it makes the modification of class_infos type easier.