### PR TITLE
Fix unstable comment around docked functor arg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ profile. This started with version 0.26.0.
 - Fix position of comments around function parameters (#2471, @gpetiot)
 - \* Force a break around comments following an infix operator (fix non-stabilizing comments) (#2478, @gpetiot)
 - \* Fix the indentation of tuples in attributes and extensions (#2488, @Julow)
+- Fix unstable comment around docked functor argument (#2506, @Julow)
 
 ## 0.26.1 (2023-09-15)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3828,8 +3828,10 @@ and fmt_module c ctx ?rec_ ?epi ?(can_sparse = false) keyword ?(eqty = "=")
       if args_p.align then (open_hvbox 0, close_box) else (noop, noop)
     in
     let pro =
-      pro $ Cmts.fmt_before c loc $ str "(" $ align_opn
-      $ fmt_str_loc_opt c name $ str " :"
+      hovbox 1
+        ( pro
+        $ Cmts.fmt_before c ~epi:(fmt "@ ") loc
+        $ str "(" $ align_opn $ fmt_str_loc_opt c name $ str " :" )
       $ fmt_or_k (Option.is_some blk.pro) (str " ") (break 1 2)
     and epi = str ")" $ Cmts.fmt_after c loc $ align_cls in
     compose_module' ~box:false ~pro ~epi blk

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -2190,6 +2190,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to functor.mli.stdout
+   (with-stderr-to functor.mli.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/functor.mli})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/functor.mli functor.mli.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/functor.mli.err functor.mli.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to funsig.ml.stdout
    (with-stderr-to funsig.ml.stderr
      (run %{bin:ocamlformat} --margin-check %{dep:tests/funsig.ml})))))

--- a/test/passing/tests/functor.mli
+++ b/test/passing/tests/functor.mli
@@ -1,0 +1,3 @@
+module F (* test *) (M : sig
+  type t
+end) : S

--- a/test/passing/tests/wrapping_functor_args.ml
+++ b/test/passing/tests/wrapping_functor_args.ml
@@ -38,3 +38,7 @@ module F3
       val x : int
     end) =
 struct end
+
+module F (* test *) (M : sig
+  type t
+end) : S = struct end


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/2504