### PR TITLE
Avoid alignment in if-then-else

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ profile. This started with version 0.26.0.
 - \* Fix the indentation of tuples in attributes and extensions (#2488, @Julow)
 - Fix unstable comment around docked functor argument (#2506, @Julow)
 - \* Fix unwanted alignment after comment (#2507, @Julow)
+- \* Fix unwanted alignment in if-then-else (#2511, @Julow)
 
 ## 0.26.1 (2023-09-15)
 

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -608,7 +608,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
             ~wrap_breaks:
               (get_parens_breaks ~opn_hint_indent:0
                  ~cls_hint:((1, 0), (1000, -2)) )
-      ; box_expr= Some false
+      ; box_expr= None
       ; expr_pro= None
       ; expr_eol= None
       ; branch_expr

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -598,9 +598,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
                 ( fmt_or_k first
                     (str "if" $ fmt_opt fmt_extension_suffix)
                     (str "else if")
-                $ fmt_attributes
-                $ fmt_or (Option.is_some fmt_extension_suffix) "@ " " "
-                $ fmt_cond xcnd )
+                $ fmt_attributes $ fmt "@ " $ fmt_cond xcnd )
               $ fmt "@ " )
       ; box_keyword_and_expr=
           (fun k -> hvbox 2 (fmt_or (Option.is_some xcond) "then" "else" $ k))

--- a/test/passing/tests/exp_grouping.ml.ref
+++ b/test/passing/tests/exp_grouping.ml.ref
@@ -279,8 +279,8 @@ let _ =
 
 let () =
   if a
-  then begin b
-    (* asd *)
+  then begin
+    b (* asd *)
   end
 
 [@@@ocamlformat "if-then-else=k-r"]

--- a/test/passing/tests/ite-kw_first.ml.ref
+++ b/test/passing/tests/ite-kw_first.ml.ref
@@ -45,8 +45,9 @@ f
 ;;
 
 f
-  ( if and_ even
-         loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  ( if
+      and_ even
+        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
     then ()
     else () )
 
@@ -164,10 +165,12 @@ let _ =
     xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
 
 let _ =
-  if (* foo *)
-     foo
+  if
+    (* foo *)
+    foo
   then 0
-  else if (* bar *)
-          bar
+  else if
+    (* bar *)
+    bar
   then 1
   else 2

--- a/test/passing/tests/ite-kw_first.ml.ref
+++ b/test/passing/tests/ite-kw_first.ml.ref
@@ -159,10 +159,10 @@ let _ =
   if x
   then
     fun xxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyyy zzzzzzzzzzz ->
-    xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
+      xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
   else
     fun xxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyyy zzzzzzzzzzz ->
-    xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
+      xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
 
 let _ =
   if

--- a/test/passing/tests/ite-kw_first_closing.ml.ref
+++ b/test/passing/tests/ite-kw_first_closing.ml.ref
@@ -174,10 +174,10 @@ let _ =
   if x
   then
     fun xxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyyy zzzzzzzzzzz ->
-    xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
+      xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
   else
     fun xxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyyy zzzzzzzzzzz ->
-    xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
+      xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
 
 let _ =
   if

--- a/test/passing/tests/ite-kw_first_closing.ml.ref
+++ b/test/passing/tests/ite-kw_first_closing.ml.ref
@@ -52,8 +52,9 @@ f
 ;;
 
 f
-  ( if and_ even
-         loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  ( if
+      and_ even
+        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
     then ()
     else ()
   )
@@ -179,10 +180,12 @@ let _ =
     xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
 
 let _ =
-  if (* foo *)
-     foo
+  if
+    (* foo *)
+    foo
   then 0
-  else if (* bar *)
-          bar
+  else if
+    (* bar *)
+    bar
   then 1
   else 2

--- a/test/passing/tests/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/tests/ite-kw_first_no_indicate.ml.ref
@@ -158,10 +158,10 @@ let _ =
   if x
   then
     fun xxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyyy zzzzzzzzzzz ->
-    xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
+      xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
   else
     fun xxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyyy zzzzzzzzzzz ->
-    xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
+      xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
 
 let _ =
   if

--- a/test/passing/tests/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/tests/ite-kw_first_no_indicate.ml.ref
@@ -45,8 +45,9 @@ f
 ;;
 
 f
-  (if and_ even
-        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  (if
+     and_ even
+       loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
    then ()
    else ())
 
@@ -163,10 +164,12 @@ let _ =
     xxxxxxxxx yyyyyyyyyy zzzzzzzzzzzz
 
 let _ =
-  if (* foo *)
-     foo
+  if
+    (* foo *)
+    foo
   then 0
-  else if (* bar *)
-          bar
+  else if
+    (* bar *)
+    bar
   then 1
   else 2


### PR DESCRIPTION
These are some commits made by @gpetiot on top of https://github.com/ocaml-ppx/ocamlformat/pull/2507

This avoids alignment in if-then-else that were not introduced in #2507 but are now more noticeable. For example:

```ocaml
f
  ( if and_ even
         loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
    then ()
    else () )
```

```ocaml
let _ =
  if (* foo *)
     foo
  then 0
  else ...
```
