### PR TITLE
Add args to binding_ops

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2318,7 +2318,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       $ fmt_let_bindings c ?ext ~parens ~fmt_atrs ~fmt_expr ~has_attr
           lbs.pvbs_rec bindings body
   | Pexp_letop {let_; ands; body} ->
-      let bd = Sugar.Let_binding.of_binding_ops c.cmts (let_ :: ands) in
+      let bd = Sugar.Let_binding.of_binding_ops (let_ :: ands) in
       let fmt_expr = fmt_expression c (sub_exp ~ctx body) in
       pro
       $ fmt_let_bindings c ?ext ~parens ~fmt_atrs ~fmt_expr ~has_attr

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -226,16 +226,14 @@ module Let_binding = struct
   let of_let_bindings cmts ~ctx =
     List.mapi ~f:(fun i -> of_let_binding cmts ~ctx ~first:(i = 0))
 
-  let of_binding_ops cmts bos =
+  let of_binding_ops bos =
     List.map bos ~f:(fun bo ->
         let ctx = Bo bo in
-        let xbody = sub_exp ~ctx bo.pbop_exp in
-        let xargs, xbody = fun_ cmts ~will_keep_first_ast_node:false xbody in
         { lb_op= bo.pbop_op
         ; lb_pat= sub_pat ~ctx bo.pbop_pat
-        ; lb_args= xargs
+        ; lb_args= bo.pbop_args
         ; lb_typ= bo.pbop_typ
-        ; lb_exp= xbody
+        ; lb_exp= sub_exp ~ctx bo.pbop_exp
         ; lb_pun= bo.pbop_is_pun
         ; lb_attrs= []
         ; lb_loc= bo.pbop_loc } )

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -61,5 +61,5 @@ module Let_binding : sig
 
   val of_let_bindings : Cmts.t -> ctx:Ast.t -> value_binding list -> t list
 
-  val of_binding_ops : Cmts.t -> binding_op list -> t list
+  val of_binding_ops : binding_op list -> t list
 end

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -175,10 +175,11 @@ module Exp = struct
      pc_rhs = rhs;
     }
 
-  let binding_op op pat typ exp pun loc =
+  let binding_op op pat args typ exp pun loc =
     {
       pbop_op = op;
       pbop_pat = pat;
+      pbop_args = args;
       pbop_typ = typ;
       pbop_exp = exp;
       pbop_is_pun = pun;

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -620,14 +620,15 @@ module E = struct
     | Pexp_infix (op, e1, e2) ->
         infix ~loc ~attrs (map_loc sub op) (sub.expr sub e1) (sub.expr sub e2)
 
-  let map_binding_op sub {pbop_op; pbop_pat; pbop_typ; pbop_exp; pbop_is_pun; pbop_loc} =
+  let map_binding_op sub {pbop_op; pbop_pat; pbop_args; pbop_typ; pbop_exp; pbop_is_pun; pbop_loc} =
     let open Exp in
     let op = map_loc sub pbop_op in
     let pat = sub.pat sub pbop_pat in
+    let args = List.map (FP.map sub FP.map_expr) pbop_args in
     let typ = map_opt (map_value_constraint sub) pbop_typ in
     let exp = sub.expr sub pbop_exp in
     let loc = sub.location sub pbop_loc in
-    binding_op op pat typ exp pbop_is_pun loc
+    binding_op op pat args typ exp pbop_is_pun loc
 
 end
 

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -482,6 +482,7 @@ and binding_op =
   {
     pbop_op : string loc;
     pbop_pat : pattern;
+    pbop_args : expr_function_param list;
     pbop_typ : value_constraint option;
     pbop_exp : expression;
     pbop_is_pun: bool;


### PR DESCRIPTION
Needed for #2401, removing one call to `Sugar.fun_`