### PR TITLE
Fix formatting of type vars in GADT constructors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@ profile. This started with version 0.26.0.
 - \* Fix unwanted alignment in if-then-else (#2511, @Julow)
 - Fix position of comments around and within `(type ...)` function arguments (#2503, @gpetiot)
 - Fix missing parentheses around constraint expressions with attributes (#2513, @alanechang)
+- Fix formatting of type vars in GADT constructors (#2518, @Julow)
 
 ## 0.26.1 (2023-09-15)
 

--- a/test/passing/tests/gadt.ml
+++ b/test/passing/tests/gadt.ml
@@ -17,3 +17,5 @@ type _ t = ..
 type _ t += A : int | B : int -> int
 
 type t = A : (int -> int) -> int
+
+type _ g = MkG : 'a. 'a g


### PR DESCRIPTION
Fix: https://github.com/ocaml-ppx/ocamlformat/issues/2517

The formatting of type variables was short circuited when the constructor contained no argument.