### PR TITLE
Undo let-bindings normalizations, carry out the args to remove the sugaring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ profile. This started with version 0.26.0.
 - \* Consistent indentation of polymorphic variant arguments (#2427, @Julow)
 - \* Don't align breaking module arguments (#2505, @Julow)
 - Improvements to ocp-indent-compat and the Janestreet profile (#2314, @Julow)
+- \* Undo let-bindings normalizations (#2523, @gpetiot)
 
 ### Fixed
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2311,7 +2311,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
           $ fmt_atrs )
   | Pexp_let (lbs, body) ->
       let bindings =
-        Sugar.Let_binding.of_let_bindings c.cmts ~ctx lbs.pvbs_bindings
+        Sugar.Let_binding.of_let_bindings ~ctx lbs.pvbs_bindings
       in
       let fmt_expr = fmt_expression c (sub_exp ~ctx body) in
       let ext = lbs.pvbs_extension in
@@ -2971,7 +2971,7 @@ and fmt_class_expr c ({ast= exp; ctx= ctx0} as xexp) =
         | _ -> c.conf.fmt_opts.indent_after_in.v
       in
       let bindings =
-        Sugar.Let_binding.of_let_bindings c.cmts ~ctx lbs.pvbs_bindings
+        Sugar.Let_binding.of_let_bindings ~ctx lbs.pvbs_bindings
       in
       let fmt_expr = fmt_class_expr c (sub_cl ~ctx body) in
       let has_attr = not (List.is_empty pcl_attributes) in
@@ -4340,7 +4340,7 @@ and fmt_structure_item c ~last:last_item ?ext ~semisemi
       let fmt_item c ctx ~prev ~next b =
         let first = Option.is_none prev in
         let last = Option.is_none next in
-        let b = Sugar.Let_binding.of_let_binding c.cmts ~ctx ~first b in
+        let b = Sugar.Let_binding.of_let_binding ~ctx ~first b in
         let epi =
           match c.conf.fmt_opts.let_binding_spacing.v with
           | `Compact -> None

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -56,10 +56,9 @@ module Let_binding : sig
     ; lb_attrs: attribute list
     ; lb_loc: Location.t }
 
-  val of_let_binding :
-    Cmts.t -> ctx:Ast.t -> first:bool -> value_binding -> t
+  val of_let_binding : ctx:Ast.t -> first:bool -> value_binding -> t
 
-  val of_let_bindings : Cmts.t -> ctx:Ast.t -> value_binding list -> t list
+  val of_let_bindings : ctx:Ast.t -> value_binding list -> t list
 
   val of_binding_ops : binding_op list -> t list
 end

--- a/test/passing/tests/comments-no-wrap.ml.ref
+++ b/test/passing/tests/comments-no-wrap.ml.ref
@@ -114,7 +114,7 @@ end
 
 let f = (* comment *) function x -> x
 
-let foo x : z = (* comment *) y
+let foo x = (* comment *) (y : z)
 
 let _ =
   (*a*)
@@ -455,8 +455,4 @@ let _ =
 *)
   ()
 
-let vexpr (*aa*)
-    (type (*bb*) a
-    (*cc*)
-    (*dd*) b ) : _ -> _ =
-  (*ee*) k
+let vexpr (*aa*) (type (*bb*) a) (*cc*) (type (*dd*) b) (*ee*) : _ -> _ = k

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -114,7 +114,7 @@ end
 
 let f = (* comment *) function x -> x
 
-let foo x : z = (* comment *) y
+let foo x = (* comment *) (y : z)
 
 let _ =
   (*a*)
@@ -454,8 +454,4 @@ let _ =
   (* indentation not preserved *)
   ()
 
-let vexpr (*aa*)
-    (type (*bb*) a
-    (*cc*)
-    (*dd*) b ) : _ -> _ =
-  (*ee*) k
+let vexpr (*aa*) (type (*bb*) a) (*cc*) (type (*dd*) b) (*ee*) : _ -> _ = k

--- a/test/passing/tests/js_args.ml.ref
+++ b/test/passing/tests/js_args.ml.ref
@@ -9,7 +9,7 @@ let should_check_can_sell_and_marking regulatory_regime =
 let should_check_can_sell_and_marking regulatory_regime =
   match z with `foo -> some_function argument
 
-let f x = ghi x
+let f = fun x -> ghi x
 
 (* common *)
 let x = try x with a -> b | c -> d

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,6 +1,6 @@
 Warning: tests/js_source.ml:162 exceeds the margin
-Warning: tests/js_source.ml:9546 exceeds the margin
-Warning: tests/js_source.ml:9650 exceeds the margin
-Warning: tests/js_source.ml:9709 exceeds the margin
-Warning: tests/js_source.ml:9791 exceeds the margin
-Warning: tests/js_source.ml:10290 exceeds the margin
+Warning: tests/js_source.ml:9552 exceeds the margin
+Warning: tests/js_source.ml:9656 exceeds the margin
+Warning: tests/js_source.ml:9715 exceeds the margin
+Warning: tests/js_source.ml:9797 exceeds the margin
+Warning: tests/js_source.ml:10296 exceeds the margin

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -812,7 +812,7 @@ open Typ
 let int = Int TypEq.refl
 let str = String TypEq.refl
 
-let pair (type s1 s2) t1 t2 =
+let pair (type s1) (type s2) t1 t2 =
   let module P = struct
     type t = s1 * s2
     type t1 = s1
@@ -2418,7 +2418,13 @@ type (_, _, _) binop =
   | Leq : ('a, 'a, bool) binop
   | Add : (int, int, int) binop
 
-let eval (type a b c) (bop : (a, b, c) binop) (x : a constant) (y : b constant)
+let eval
+      (type a)
+      (type b)
+      (type c)
+      (bop : (a, b, c) binop)
+      (x : a constant)
+      (y : b constant)
   : c constant
   =
   match bop, x, y with
@@ -2663,7 +2669,7 @@ let vexpr (type visit_action) : ('a, 'result, visit_action) context -> 'a -> vis
     | Global -> fun _ -> raise Exit
 ;;
 
-let vexpr (type result visit_action)
+let vexpr (type result) (type visit_action)
   : (unit, result, visit_action) context -> unit -> visit_action
   = function
     | Local -> fun _ -> raise Exit
@@ -3500,7 +3506,7 @@ end =
 let int = Typ.Int TypEq.refl
 let str = Typ.String TypEq.refl
 
-let pair (type s1 s2) t1 t2 =
+let pair (type s1) (type s2) t1 t2 =
   let module P = struct
     type t = s1 * s2
     type t1 = s1
@@ -3540,7 +3546,7 @@ end
 type ('k, 'd, 'm) map =
   (module MapT with type key = 'k and type data = 'd and type map = 'm)
 
-let add (type k d m) (m : (k, d, m) map) x y s =
+let add (type k) (type d) (type m) (m : (k, d, m) map) x y s =
   let module M = (val m : MapT with type key = k and type data = d and type map = m) in
   M.of_t (M.add x y (M.to_t s))
 ;;
@@ -4572,7 +4578,7 @@ type foo =
 
 type bar = { x : int }
 
-let f (r : bar) : foo = { r with z = 3 }
+let f (r : bar) = ({ r with z = 3 } : foo)
 
 type foo = { x : int }
 
@@ -4626,8 +4632,8 @@ module Hash2 : sig
 end =
   Hash
 
-let f1 (x : (_, _) Hash1.t) : (_, _) Hashtbl.t = x
-let f2 (x : (_, _) Hash2.t) : (_, _) Hashtbl.t = x
+let f1 (x : (_, _) Hash1.t) = (x : (_, _) Hashtbl.t)
+let f2 (x : (_, _) Hash2.t) = (x : (_, _) Hashtbl.t)
 
 (* Another case, not using include *)
 
@@ -4640,7 +4646,7 @@ end
 module Std' = Std2
 module M' : module type of Std'.M = Std2.M
 
-let f3 (x : M'.t) : Std2.M.t = x
+let f3 (x : M'.t) = (x : Std2.M.t)
 
 (* original report required Core_kernel:
    module type S = sig
@@ -5040,7 +5046,7 @@ module Fix (F : sig
 struct
   type 'a fix = ('a, 'a F.f) eq
 
-  let uniq (type a b) (Eq : a fix) (Eq : b fix) : (a, b) eq = Eq
+  let uniq (type a) (type b) (Eq : a fix) (Eq : b fix) : (a, b) eq = Eq
 end
 
 (* This would allow:
@@ -5569,7 +5575,7 @@ module S = String
 module StringSet = Set.Make (String)
 module SSet = Set.Make (S)
 
-let f (x : StringSet.t) : SSet.t = x
+let f (x : StringSet.t) = (x : SSet.t)
 
 (* Also using include (cf. Leo's mail 2013-11-16) *)
 module F (M : sig end) : sig
@@ -5925,7 +5931,7 @@ end
 
 (* ok to convert between structurally equal signatures, and parameters
    are inferred *)
-let f (x : (module S with type t = 'a and type u = 'b)) : (module S') = x
+let f (x : (module S with type t = 'a and type u = 'b)) = (x : (module S'))
 let g x = (x : (module S with type t = 'a and type u = 'b) :> (module S'))
 
 (* with subtyping it is also ok to forget some types *)
@@ -5937,10 +5943,10 @@ end
 
 let g2 x = (x : (module S2 with type t = 'a and type u = 'b) :> (module S'))
 let h x = (x : (module S2 with type t = 'a) :> (module S with type t = 'a))
-let f2 (x : (module S2 with type t = 'a and type u = 'b)) : (module S') = x
+let f2 (x : (module S2 with type t = 'a and type u = 'b)) = (x : (module S'))
 
 (* fail *)
-let k (x : (module S2 with type t = 'a)) : (module S with type t = 'a) = x
+let k (x : (module S2 with type t = 'a)) = (x : (module S with type t = 'a))
 
 (* fail *)
 
@@ -6485,7 +6491,7 @@ type refer1 = < poly : 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 type refer2 = < poly : 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 
 (* Actually this should succeed ... *)
-let f (x : refer1) : refer2 = x
+let f (x : refer1) = (x : refer2)
 
 module Classdef = struct
   class virtual ['a, 'b, 'c] cl0 =
@@ -6519,7 +6525,7 @@ end
 open Pr3918b
 
 let f x = (x : 'a vlist :> 'b vlist)
-let f (x : 'a vlist) : 'b vlist = x
+let f (x : 'a vlist) = (x : 'b vlist)
 
 module type Poly = sig
   type 'a t = 'a constraint 'a = [> ]
@@ -6730,13 +6736,13 @@ module F0 : sig
 end =
   Foobar
 
-let f (x : F0.t) : Foobar.t = x
+let f (x : F0.t) = (x : Foobar.t)
 
 (* fails *)
 
 module F = Foobar
 
-let f (x : F.t) : Foobar.t = x
+let f (x : F.t) = (x : Foobar.t)
 
 module M = struct
   type t = < m : int >
@@ -6803,7 +6809,7 @@ module Bar : sig
 end = struct
   type t = int
 
-  let f (x : int) : t = x
+  let f (x : int) = (x : t)
 end
 
 (* must fail *)
@@ -6904,7 +6910,7 @@ end
 
 module Test2 : module type of Test with type t = Test.t = Test
 
-let f (x : Test.t) : Test2.t = x
+let f (x : Test.t) = (x : Test2.t)
 let f Test2.A = ()
 let a = Test2.A
 
@@ -7240,7 +7246,7 @@ module PR_4758 = struct
     type t
   end
 
-  let f (x : F(C).t) : F(C').t = x
+  let f (x : F(C).t) = (x : F(C').t)
 end
 
 (* PR 4557 *)
@@ -7268,7 +7274,7 @@ module PR_4557 = struct
       type elt = X.t
       type t = XSet.t XMap.t
 
-      let compare x y = 0
+      let compare = fun x y -> 0
     end
 
     and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
@@ -7298,7 +7304,7 @@ module F (X : Set.OrderedType) = struct
     type elt = X.t
     type t = XSet.t XMap.t
 
-    let compare x y = 0
+    let compare = fun x y -> 0
   end
 
   and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
@@ -9360,7 +9366,7 @@ let g = function
   | { l1 = x; l2 = y; _ } -> ()
 ;;
 
-let h ?l:(p = 1) ?y:u ?(x = 3) = 2
+let h = fun ?l:(p = 1) ?y:u ?(x = 3) -> 2
 
 let _ = function
   | a, s, ba1, ba2, ba3, bg ->

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -812,7 +812,7 @@ open Typ
 let int = Int TypEq.refl
 let str = String TypEq.refl
 
-let pair (type s1 s2) t1 t2 =
+let pair (type s1) (type s2) t1 t2 =
   let module P = struct
     type t = s1 * s2
     type t1 = s1
@@ -2418,7 +2418,13 @@ type (_, _, _) binop =
   | Leq : ('a, 'a, bool) binop
   | Add : (int, int, int) binop
 
-let eval (type a b c) (bop : (a, b, c) binop) (x : a constant) (y : b constant)
+let eval
+      (type a)
+      (type b)
+      (type c)
+      (bop : (a, b, c) binop)
+      (x : a constant)
+      (y : b constant)
   : c constant
   =
   match bop, x, y with
@@ -2663,7 +2669,7 @@ let vexpr (type visit_action) : ('a, 'result, visit_action) context -> 'a -> vis
   | Global -> fun _ -> raise Exit
 ;;
 
-let vexpr (type result visit_action)
+let vexpr (type result) (type visit_action)
   : (unit, result, visit_action) context -> unit -> visit_action
   = function
   | Local -> fun _ -> raise Exit
@@ -3500,7 +3506,7 @@ end =
 let int = Typ.Int TypEq.refl
 let str = Typ.String TypEq.refl
 
-let pair (type s1 s2) t1 t2 =
+let pair (type s1) (type s2) t1 t2 =
   let module P = struct
     type t = s1 * s2
     type t1 = s1
@@ -3540,7 +3546,7 @@ end
 type ('k, 'd, 'm) map =
   (module MapT with type key = 'k and type data = 'd and type map = 'm)
 
-let add (type k d m) (m : (k, d, m) map) x y s =
+let add (type k) (type d) (type m) (m : (k, d, m) map) x y s =
   let module M = (val m : MapT with type key = k and type data = d and type map = m) in
   M.of_t (M.add x y (M.to_t s))
 ;;
@@ -4572,7 +4578,7 @@ type foo =
 
 type bar = { x : int }
 
-let f (r : bar) : foo = { r with z = 3 }
+let f (r : bar) = ({ r with z = 3 } : foo)
 
 type foo = { x : int }
 
@@ -4626,8 +4632,8 @@ module Hash2 : sig
 end =
   Hash
 
-let f1 (x : (_, _) Hash1.t) : (_, _) Hashtbl.t = x
-let f2 (x : (_, _) Hash2.t) : (_, _) Hashtbl.t = x
+let f1 (x : (_, _) Hash1.t) = (x : (_, _) Hashtbl.t)
+let f2 (x : (_, _) Hash2.t) = (x : (_, _) Hashtbl.t)
 
 (* Another case, not using include *)
 
@@ -4640,7 +4646,7 @@ end
 module Std' = Std2
 module M' : module type of Std'.M = Std2.M
 
-let f3 (x : M'.t) : Std2.M.t = x
+let f3 (x : M'.t) = (x : Std2.M.t)
 
 (* original report required Core_kernel:
 module type S = sig
@@ -5040,7 +5046,7 @@ module Fix (F : sig
 struct
   type 'a fix = ('a, 'a F.f) eq
 
-  let uniq (type a b) (Eq : a fix) (Eq : b fix) : (a, b) eq = Eq
+  let uniq (type a) (type b) (Eq : a fix) (Eq : b fix) : (a, b) eq = Eq
 end
 
 (* This would allow:
@@ -5569,7 +5575,7 @@ module S = String
 module StringSet = Set.Make (String)
 module SSet = Set.Make (S)
 
-let f (x : StringSet.t) : SSet.t = x
+let f (x : StringSet.t) = (x : SSet.t)
 
 (* Also using include (cf. Leo's mail 2013-11-16) *)
 module F (M : sig end) : sig
@@ -5925,7 +5931,7 @@ end
 
 (* ok to convert between structurally equal signatures, and parameters
    are inferred *)
-let f (x : (module S with type t = 'a and type u = 'b)) : (module S') = x
+let f (x : (module S with type t = 'a and type u = 'b)) = (x : (module S'))
 let g x = (x : (module S with type t = 'a and type u = 'b) :> (module S'))
 
 (* with subtyping it is also ok to forget some types *)
@@ -5937,10 +5943,10 @@ end
 
 let g2 x = (x : (module S2 with type t = 'a and type u = 'b) :> (module S'))
 let h x = (x : (module S2 with type t = 'a) :> (module S with type t = 'a))
-let f2 (x : (module S2 with type t = 'a and type u = 'b)) : (module S') = x
+let f2 (x : (module S2 with type t = 'a and type u = 'b)) = (x : (module S'))
 
 (* fail *)
-let k (x : (module S2 with type t = 'a)) : (module S with type t = 'a) = x
+let k (x : (module S2 with type t = 'a)) = (x : (module S with type t = 'a))
 
 (* fail *)
 
@@ -6485,7 +6491,7 @@ type refer1 = < poly : 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 type refer2 = < poly : 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 
 (* Actually this should succeed ... *)
-let f (x : refer1) : refer2 = x
+let f (x : refer1) = (x : refer2)
 
 module Classdef = struct
   class virtual ['a, 'b, 'c] cl0 =
@@ -6519,7 +6525,7 @@ end
 open Pr3918b
 
 let f x = (x : 'a vlist :> 'b vlist)
-let f (x : 'a vlist) : 'b vlist = x
+let f (x : 'a vlist) = (x : 'b vlist)
 
 module type Poly = sig
   type 'a t = 'a constraint 'a = [> ]
@@ -6730,13 +6736,13 @@ module F0 : sig
 end =
   Foobar
 
-let f (x : F0.t) : Foobar.t = x
+let f (x : F0.t) = (x : Foobar.t)
 
 (* fails *)
 
 module F = Foobar
 
-let f (x : F.t) : Foobar.t = x
+let f (x : F.t) = (x : Foobar.t)
 
 module M = struct
   type t = < m : int >
@@ -6803,7 +6809,7 @@ module Bar : sig
 end = struct
   type t = int
 
-  let f (x : int) : t = x
+  let f (x : int) = (x : t)
 end
 
 (* must fail *)
@@ -6904,7 +6910,7 @@ end
 
 module Test2 : module type of Test with type t = Test.t = Test
 
-let f (x : Test.t) : Test2.t = x
+let f (x : Test.t) = (x : Test2.t)
 let f Test2.A = ()
 let a = Test2.A
 
@@ -7240,7 +7246,7 @@ module PR_4758 = struct
     type t
   end
 
-  let f (x : F(C).t) : F(C').t = x
+  let f (x : F(C).t) = (x : F(C').t)
 end
 
 (* PR 4557 *)
@@ -7268,7 +7274,7 @@ module PR_4557 = struct
       type elt = X.t
       type t = XSet.t XMap.t
 
-      let compare x y = 0
+      let compare = fun x y -> 0
     end
 
     and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
@@ -7298,7 +7304,7 @@ module F (X : Set.OrderedType) = struct
     type elt = X.t
     type t = XSet.t XMap.t
 
-    let compare x y = 0
+    let compare = fun x y -> 0
   end
 
   and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
@@ -9360,7 +9366,7 @@ let g = function
   | { l1 = x; l2 = y; _ } -> ()
 ;;
 
-let h ?l:(p = 1) ?y:u ?(x = 3) = 2
+let h = fun ?l:(p = 1) ?y:u ?(x = 3) -> 2
 
 let _ = function
   | a, s, ba1, ba2, ba3, bg ->

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -899,7 +899,7 @@ let int = Int TypEq.refl
 
 let str = String TypEq.refl
 
-let pair (type s1 s2) t1 t2 =
+let pair (type s1) (type s2) t1 t2 =
   let module P = struct
     type t = s1 * s2
 
@@ -2372,7 +2372,7 @@ type (_, _, _) binop =
   | Leq : ('a, 'a, bool) binop
   | Add : (int, int, int) binop
 
-let eval (type a b c) (bop : (a, b, c) binop) (x : a constant)
+let eval (type a) (type b) (type c) (bop : (a, b, c) binop) (x : a constant)
     (y : b constant) : c constant =
   match (bop, x, y) with
   | Eq, Bool x, Bool y -> Bool (if x then y else not y)
@@ -2571,7 +2571,7 @@ let vexpr (type visit_action) :
   | Local -> fun _ -> raise Exit
   | Global -> fun _ -> raise Exit
 
-let vexpr (type result visit_action) :
+let vexpr (type result) (type visit_action) :
     (unit, result, visit_action) context -> unit -> visit_action = function
   | Local -> fun _ -> raise Exit
   | Global -> fun _ -> raise Exit
@@ -3345,7 +3345,7 @@ let int = Typ.Int TypEq.refl
 
 let str = Typ.String TypEq.refl
 
-let pair (type s1 s2) t1 t2 =
+let pair (type s1) (type s2) t1 t2 =
   let module P = struct
     type t = s1 * s2
 
@@ -3388,7 +3388,7 @@ end
 type ('k, 'd, 'm) map =
   (module MapT with type key = 'k and type data = 'd and type map = 'm)
 
-let add (type k d m) (m : (k, d, m) map) x y s =
+let add (type k) (type d) (type m) (m : (k, d, m) map) x y s =
   let module M =
     (val m : MapT with type key = k and type data = d and type map = m)
   in
@@ -4311,7 +4311,7 @@ type foo = {y: int; z: int}
 
 type bar = {x: int}
 
-let f (r : bar) : foo = {r with z= 3}
+let f (r : bar) = ({r with z= 3} : foo)
 
 type foo = {x: int}
 
@@ -4362,9 +4362,9 @@ module Hash2 : sig
 end =
   Hash
 
-let f1 (x : (_, _) Hash1.t) : (_, _) Hashtbl.t = x
+let f1 (x : (_, _) Hash1.t) = (x : (_, _) Hashtbl.t)
 
-let f2 (x : (_, _) Hash2.t) : (_, _) Hashtbl.t = x
+let f2 (x : (_, _) Hash2.t) = (x : (_, _) Hashtbl.t)
 
 (* Another case, not using include *)
 
@@ -4378,7 +4378,7 @@ module Std' = Std2
 
 module M' : module type of Std'.M = Std2.M
 
-let f3 (x : M'.t) : Std2.M.t = x
+let f3 (x : M'.t) = (x : Std2.M.t)
 
 (* original report required Core_kernel: module type S = sig open
    Core_kernel.Std
@@ -4778,7 +4778,7 @@ end) =
 struct
   type 'a fix = ('a, 'a F.f) eq
 
-  let uniq (type a b) (Eq : a fix) (Eq : b fix) : (a, b) eq = Eq
+  let uniq (type a) (type b) (Eq : a fix) (Eq : b fix) : (a, b) eq = Eq
 end
 
 (* This would allow: module FixId = Fix (struct type 'a f = 'a end) let bad :
@@ -5314,7 +5314,7 @@ module S = String
 module StringSet = Set.Make (String)
 module SSet = Set.Make (S)
 
-let f (x : StringSet.t) : SSet.t = x
+let f (x : StringSet.t) = (x : SSet.t)
 
 (* Also using include (cf. Leo's mail 2013-11-16) *)
 module F (M : sig end) : sig
@@ -5672,7 +5672,7 @@ end
 
 (* ok to convert between structurally equal signatures, and parameters are
    inferred *)
-let f (x : (module S with type t = 'a and type u = 'b)) : (module S') = x
+let f (x : (module S with type t = 'a and type u = 'b)) = (x : (module S'))
 
 let g x = (x : (module S with type t = 'a and type u = 'b) :> (module S'))
 
@@ -5689,10 +5689,10 @@ let g2 x = (x : (module S2 with type t = 'a and type u = 'b) :> (module S'))
 
 let h x = (x : (module S2 with type t = 'a) :> (module S with type t = 'a))
 
-let f2 (x : (module S2 with type t = 'a and type u = 'b)) : (module S') = x
+let f2 (x : (module S2 with type t = 'a and type u = 'b)) = (x : (module S'))
 
 (* fail *)
-let k (x : (module S2 with type t = 'a)) : (module S with type t = 'a) = x
+let k (x : (module S2 with type t = 'a)) = (x : (module S with type t = 'a))
 
 (* fail *)
 
@@ -6272,7 +6272,7 @@ type refer1 = < poly: 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 type refer2 = < poly: 'a 'b 'c. (('b, 'c) #Classdef.cl2 as 'a) >
 
 (* Actually this should succeed ... *)
-let f (x : refer1) : refer2 = x
+let f (x : refer1) = (x : refer2)
 
 module Classdef = struct
   class virtual ['a, 'b, 'c] cl0 =
@@ -6305,7 +6305,7 @@ open Pr3918b
 
 let f x = (x : 'a vlist :> 'b vlist)
 
-let f (x : 'a vlist) : 'b vlist = x
+let f (x : 'a vlist) = (x : 'b vlist)
 
 module type Poly = sig
   type 'a t = 'a constraint 'a = [> ]
@@ -6487,13 +6487,13 @@ module F0 : sig
 end =
   Foobar
 
-let f (x : F0.t) : Foobar.t = x
+let f (x : F0.t) = (x : Foobar.t)
 
 (* fails *)
 
 module F = Foobar
 
-let f (x : F.t) : Foobar.t = x
+let f (x : F.t) = (x : Foobar.t)
 
 module M = struct
   type t = < m: int >
@@ -6561,7 +6561,7 @@ module Bar : sig
 end = struct
   type t = int
 
-  let f (x : int) : t = x
+  let f (x : int) = (x : t)
 end
 
 (* must fail *)
@@ -6664,7 +6664,7 @@ end
 
 module Test2 : module type of Test with type t = Test.t = Test
 
-let f (x : Test.t) : Test2.t = x
+let f (x : Test.t) = (x : Test2.t)
 
 let f Test2.A = ()
 
@@ -7006,7 +7006,7 @@ module PR_4758 = struct
     type t
   end
 
-  let f (x : F(C).t) : F(C').t = x
+  let f (x : F(C).t) = (x : F(C').t)
 end
 
 (* PR 4557 *)
@@ -7038,7 +7038,7 @@ module PR_4557 = struct
 
       type t = XSet.t XMap.t
 
-      let compare x y = 0
+      let compare = fun x y -> 0
     end
 
     and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
@@ -7072,7 +7072,7 @@ module F (X : Set.OrderedType) = struct
 
     type t = XSet.t XMap.t
 
-    let compare x y = 0
+    let compare = fun x y -> 0
   end
 
   and ModSet : (Set.S with type elt = Mod.t) = Set.Make (Mod)
@@ -8966,7 +8966,7 @@ let g = function
   | ({l1= x; l2= y} [@foo]) -> ()
   | {l1= x; l2= y; _} -> ()
 
-let h ?l:(p = 1) ?y:u ?(x = 3) = 2
+let h = fun ?l:(p = 1) ?y:u ?(x = 3) -> 2
 
 let _ = function
   | a, s, ba1, ba2, ba3, bg ->

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -440,9 +440,10 @@ end
 
 module Vb = struct
   let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs)
-        ?(text = []) ?value_constraint ~is_pun pat expr =
+        ?(text = []) ?value_constraint ~is_pun pat args expr =
     {
      pvb_pat = pat;
+     pvb_args = args;
      pvb_expr = expr;
      pvb_constraint=value_constraint;
      pvb_is_pun = is_pun;

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -875,9 +875,10 @@ let default_mapper =
       );
 
     value_binding =
-      (fun this {pvb_pat; pvb_expr; pvb_constraint; pvb_is_pun; pvb_attributes; pvb_loc} ->
+      (fun this {pvb_pat; pvb_args; pvb_expr; pvb_constraint; pvb_is_pun; pvb_attributes; pvb_loc} ->
          Vb.mk
            (this.pat this pvb_pat)
+           (List.map (FP.map this FP.map_expr) pvb_args)
            (this.expr this pvb_expr)
            ?value_constraint:(Option.map (map_value_constraint this) pvb_constraint)
            ~is_pun:pvb_is_pun

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -1100,6 +1100,7 @@ and value_constraint =
 and value_binding =
   {
     pvb_pat: pattern;
+    pvb_args: expr_function_param list;
     pvb_expr: expression;
     pvb_constraint: value_constraint option;
     pvb_is_pun: bool;


### PR DESCRIPTION
This PR adds a `lb_args: expr_function_param list;` field to let-bindings to get this info from the parser, reducing the amount of work done in `Sugar.ml`. But it is too cumbersome to also maintain the normalizations that were done in this code.
So as a result you can see the code now preserves the original shape of the let-bindings, e.g. `let x = fun y -> ...` is no longer rewritten as `let x y = ...`, same for constraints.

This removes a lot of hard-to-maintain code and makes the work on #2401 much easier.