### PR TITLE
Fixes a bug in class type when trying to disable ocamlformat.

### DIFF
--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -1332,6 +1332,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to disable_class_type.ml.stdout
+   (with-stderr-to disable_class_type.ml.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/disable_class_type.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/disable_class_type.ml disable_class_type.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/disable_class_type.ml.err disable_class_type.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to disable_conf_attrs.ml.stdout
    (with-stderr-to disable_conf_attrs.ml.stderr
      (run %{bin:ocamlformat} --margin-check --disable-conf-attrs %{dep:tests/disable_conf_attrs.ml})))))

--- a/test/passing/tests/disable_class_type.ml
+++ b/test/passing/tests/disable_class_type.ml
@@ -1,0 +1,3 @@
+class type c = let open [@ocamlformat "disable"] Z
+  in
+  z


### PR DESCRIPTION
Currently then following snippet:
```ocaml
class type c = let open [@ocamlformat "disable"] Z
  in
  z
```
is printed as:
```ocaml
let open [@ocamlformat "disable"] Z
  in
  z
```

This PR fixes that. My implementation is a bit hackish, doing something better will require effort to ensure that we do not break the formatting in the absence of @disable.