### PR TITLE
use `force_break` value instead of `fmt "@;<1000 0>"`

### DIFF
--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -94,6 +94,8 @@ let break n o =
       Box_debug.break fs n o ;
       Format_.pp_print_break fs n o )
 
+let force_break = break 1000 0
+
 let cbreak ~fits ~breaks =
   with_pp (fun fs ->
       Box_debug.cbreak fs ~fits ~breaks ;

--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -54,6 +54,9 @@ val protect : t -> on_error:(exn -> unit) -> t
 val break : int -> int -> t
 (** Format a break hint. *)
 
+val force_break : t
+(** [force_break] forces a break with indentation 0. *)
+
 val cbreak : fits:string * int * string -> breaks:string * int * string -> t
 (** Format a custom break.
 

--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -55,7 +55,7 @@ val break : int -> int -> t
 (** Format a break hint. *)
 
 val force_break : t
-(** [force_break] forces a break with indentation 0. *)
+(** [force_break] forces a break with indentation 0. Equivalent to [break 1000 0].*)
 
 val cbreak : fits:string * int * string -> breaks:string * int * string -> t
 (** Format a custom break.

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1381,7 +1381,7 @@ and fmt_body c ?ext ({ast= body; _} as xbody) =
       , update_config_maybe_disabled c pexp_loc pexp_attributes
         @@ fun c ->
         fmt_cases c ctx cs $ fmt_if parens ")" $ Cmts.fmt_after c pexp_loc )
-  | _ -> (noop, fmt_expression c ~eol:(force_break) xbody)
+  | _ -> (noop, fmt_expression c ~eol:force_break xbody)
 
 and fmt_indexop_access c ctx ~fmt_atrs ~has_attr ~parens x =
   let {pia_lhs; pia_kind; pia_paren; pia_rhs} = x in
@@ -2783,8 +2783,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       let wrap_beginend k =
         let opn = str "begin" $ fmt_extension_suffix c ext
         and cls = str "end" in
-        hvbox 0
-          (wrap_k opn cls (wrap_k (break 1 2) (force_break) k) $ fmt_atrs)
+        hvbox 0 (wrap_k opn cls (wrap_k (break 1 2) force_break k) $ fmt_atrs)
       in
       pro
       $ wrap_beginend
@@ -2839,7 +2838,7 @@ and fmt_class_structure c ~ctx ?ext self_ fields =
       | _ -> noop )
     $ fmt_or_k (List.is_empty fields)
         (Cmts.fmt_within ~epi:noop c (Ast.location ctx))
-        (force_break)
+        force_break
     $ fmt_item_list c ctx update_config ast fmt_item fields )
   $ fmt_or (List.is_empty fields) "@ " "@;<1000 0>"
   $ str "end"
@@ -3195,9 +3194,7 @@ and fmt_case c ctx ~first ~last case =
     | _ -> parenze_pat xlhs
   in
   let eol =
-    Option.some_if
-      (Cmts.has_before c.cmts pc_rhs.pexp_loc)
-      (force_break)
+    Option.some_if (Cmts.has_before c.cmts pc_rhs.pexp_loc) force_break
   in
   let p = Params.get_cases c.conf ~ctx ~first ~last ~xbch:xrhs in
   p.leading_space $ leading_cmt
@@ -3433,7 +3430,7 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
   (* Force break if comment before pcd_loc, it would interfere with an
      eventual comment placed after the previous constructor *)
   fmt_if_k (not first) (fmt_or (sparse || has_cmt_before) "@;<1000 0>" "@ ")
-  $ Cmts.fmt_before ~epi:(force_break) c pcd_loc
+  $ Cmts.fmt_before ~epi:force_break c pcd_loc
   $ hvbox ~name:"constructor_decl" 2
       ( hovbox
           (Params.Indent.constructor_docstring c.conf)
@@ -4495,7 +4492,7 @@ and fmt_value_binding c ~rec_flag ?ext ?in_ ?epi
         , fmt_item_attributes c ~pre:(Break (1, 2)) at_at_attrs $ in_ indent
         , fmt_opt epi
         , Cmts.fmt_before c lb_loc
-        , Cmts.fmt_after c lb_loc ~pro:(break 1000 0) )
+        , Cmts.fmt_after c lb_loc ~pro:force_break )
     | None ->
         let epi =
           fmt_item_attributes c ~pre:(Break (1, 0)) at_at_attrs $ fmt_opt epi
@@ -4540,8 +4537,7 @@ and fmt_value_binding c ~rec_flag ?ext ?in_ ?epi
                   $ fmt_if_k (not lb_pun) body )
               $ cmts_after
               $ opt loc_in
-                  (Cmts.fmt_before c ~pro:(break 1000 0) ~epi:noop ~eol:noop)
-              )
+                  (Cmts.fmt_before c ~pro:force_break ~epi:noop ~eol:noop) )
           $ in_ )
       $ opt loc_in (Cmts.fmt_after ~pro:(fmt "@;<1000 0>") c)
       $ epi )

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -218,7 +218,7 @@ let fmt_item_list c ctx update_config ast fmt_item items =
   $ opt next (fun (i_n, c_n) ->
         fmt_or_k
           (break_between c (ast itm, c.conf) (ast i_n, c_n.conf))
-          (fmt "\n" $ force_break)
+          (str "\n" $ force_break)
           (fmt_or_k break_struct force_break (fmt "@ ")) )
 
 let fmt_recmodule c ctx items fmt_item ast sub =
@@ -896,7 +896,7 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
               ( if
                   in_type_declaration
                   && Poly.(c.conf.fmt_opts.type_decl.v = `Sparse)
-                then force_break $ fmt "| "
+                then force_break $ str "| "
                 else fmt "@ | " )
               (fmt_row_field c ctx)
       in
@@ -1552,7 +1552,7 @@ and fmt_sequence c ?ext ~has_attr parens width xexp fmt_atrs =
   let fmt_sep c ?(force_break = false) xe1 ext xe2 =
     let break =
       let l1 = xe1.ast.pexp_loc and l2 = xe2.ast.pexp_loc in
-      if sequence_blank_line c l1 l2 then fmt "\n" $ Fmt.force_break
+      if sequence_blank_line c l1 l2 then str "\n" $ Fmt.force_break
       else if c.conf.fmt_opts.break_sequences.v || force_break then
         Fmt.force_break
       else if parens && Poly.(c.conf.fmt_opts.sequence_style.v = `Before)
@@ -1780,7 +1780,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                         $ fmt "@ ->" )
                     $ fmt "@ " $ fmt_expression c xbody ) )
              $ fmt "@ ;@ "
-             $ list_k grps (fmt " ;" $ force_break) fmt_grp ) )
+             $ list_k grps (str " ;" $ force_break) fmt_grp ) )
   | Pexp_infix
       ( {txt= "|>"; loc}
       , e0
@@ -3804,7 +3804,7 @@ and fmt_class_types ?ext c ~pre ~sep cls =
           ( fmt_class_type c ~pro (sub_cty ~ctx cl.pci_expr)
           $ fmt_item_attributes c ~pre:(Break (1, 0)) atrs )
       in
-      fmt_if_k (not first) (fmt "\n" $ force_break)
+      fmt_if_k (not first) (str "\n" $ force_break)
       $ hovbox 0
         @@ Cmts.fmt c cl.pci_loc (doc_before $ class_types $ doc_after) )
 
@@ -3844,7 +3844,7 @@ and fmt_class_exprs ?ext c cls =
              $ fmt_class_expr c (sub_cl ~ctx cl.pci_expr) )
            $ fmt_item_attributes c ~pre:(Break (1, 0)) atrs
          in
-         fmt_if_k (not first) (fmt "\n" $ force_break)
+         fmt_if_k (not first) (str "\n" $ force_break)
          $ hovbox 0
            @@ Cmts.fmt c cl.pci_loc (doc_before $ class_expr $ doc_after) )
 
@@ -4646,8 +4646,8 @@ module Chunk = struct
               let output =
                 output
                 $ Cmts.fmt_before c chunk.attr_loc
-                    ~eol:(fmt "\n" $ force_break)
-                $ fmt_if_k (i > 0) (fmt "\n" $ force_break)
+                    ~eol:(str "\n" $ force_break)
+                $ fmt_if_k (i > 0) (str "\n" $ force_break)
                 $ str
                     (String.strip
                        (Source.string_at c.source chunk.chunk_loc) )


### PR DESCRIPTION
I thought the constant occurances of random values like "1000" in the code looked bad, so I replaced every occurence that I could by a new `force_break` value that is equal to `break 1000 0`.

I replaced `break 1000 0` and `fmt "@;<1000 0>"` by `force_break`.

I could not use `force_break` when used in function that expect a format string and not an Fmt.t like `fmt_or`. I am sure it is possible to do, but I wanted this Pr to be the easiest possible to review and merge.