### PR TITLE
Removes format syntax

### DIFF
--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -492,7 +492,8 @@ module Wrapped = struct
              fmt_if_k (not first) (str "\n" $ force_newline)
              $ hovbox 0
                  (list_fl group (fun ~first ~last x ->
-                      fmt_if_k (not first) space_break $ fmt_line x
+                      fmt_if_k (not first) space_break
+                      $ fmt_line x
                       $ fmt_if_k (last_group && last) (str suffix $ epi) ) ) )
         )
 end
@@ -501,7 +502,8 @@ module Asterisk_prefixed = struct
   open Fmt
 
   let fmt_line ~first:_ ~last s =
-    if last && is_only_whitespaces s then cut_break else cut_break $ str "*" $ str s
+    if last && is_only_whitespaces s then cut_break
+    else cut_break $ str "*" $ str s
 
   let fmt ~pro ~epi = function
     | hd :: tl -> vbox 1 (pro $ str hd $ list_fl tl fmt_line $ epi)
@@ -536,7 +538,8 @@ module Cinaps = struct
   let fmt ~pro ~epi ~fmt_code conf ~offset code =
     match fmt_code conf ~offset ~set_margin:false code with
     | Ok formatted ->
-        hvbox 0 (pro $ hvbox (-1) (space_break $ formatted) $ space_break $ epi)
+        hvbox 0
+          (pro $ hvbox (-1) (space_break $ formatted) $ space_break $ epi)
     | Error _ -> Verbatim.fmt ~pro ~epi code
 end
 
@@ -664,7 +667,8 @@ module Toplevel = struct
               if Source.begins_line t.source first_loc then
                 fmt_or_k
                   (Source.empty_line_before t.source first_loc)
-                  (str "\n" $ force_break) force_newline
+                  (str "\n" $ force_break)
+                  force_newline
               else break 1 0
         in
         let epi =
@@ -674,7 +678,8 @@ module Toplevel = struct
               if Source.ends_line t.source last_loc then
                 fmt_or_k
                   (Source.empty_line_after t.source last_loc)
-                  (str "\n" $ force_break) force_newline
+                  (str "\n" $ force_break)
+                  force_newline
               else break 1 0
           | After -> noop
         in

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -475,7 +475,7 @@ module Wrapped = struct
           (String.split_on_chars line
              ~on:['\t'; '\n'; '\011'; '\012'; '\r'; ' '] )
       in
-      list words "@ " str
+      list_k words space_break str
     in
     let lines =
       List.remove_consecutive_duplicates
@@ -489,10 +489,10 @@ module Wrapped = struct
     $ hovbox 0
         (list_fl groups (fun ~first ~last:last_group group ->
              let group = List.filter group ~f:(Fn.non is_only_whitespaces) in
-             fmt_if (not first) "\n@\n"
+             fmt_if_k (not first) (str "\n" $ force_newline)
              $ hovbox 0
                  (list_fl group (fun ~first ~last x ->
-                      fmt_if (not first) "@ " $ fmt_line x
+                      fmt_if_k (not first) space_break $ fmt_line x
                       $ fmt_if_k (last_group && last) (str suffix $ epi) ) ) )
         )
 end
@@ -501,7 +501,7 @@ module Asterisk_prefixed = struct
   open Fmt
 
   let fmt_line ~first:_ ~last s =
-    if last && is_only_whitespaces s then fmt "@," else fmt "@,*" $ str s
+    if last && is_only_whitespaces s then cut_break else cut_break $ str "*" $ str s
 
   let fmt ~pro ~epi = function
     | hd :: tl -> vbox 1 (pro $ str hd $ list_fl tl fmt_line $ epi)
@@ -536,7 +536,7 @@ module Cinaps = struct
   let fmt ~pro ~epi ~fmt_code conf ~offset code =
     match fmt_code conf ~offset ~set_margin:false code with
     | Ok formatted ->
-        hvbox 0 (pro $ hvbox (-1) (fmt "@;" $ formatted) $ fmt "@;" $ epi)
+        hvbox 0 (pro $ hvbox (-1) (space_break $ formatted) $ space_break $ epi)
     | Error _ -> Verbatim.fmt ~pro ~epi code
 end
 
@@ -561,9 +561,9 @@ module Doc = struct
     let open Fmt in
     hvbox 2
       ( pro
-      $ fmt_if pre_nl "@;<1000 1>"
+      $ fmt_if_k pre_nl (break 1000 1)
       $ doc
-      $ fmt_if trail_nl "@;<1000 -2>"
+      $ fmt_if_k trail_nl (break 1000 (-2))
       $ epi )
 end
 
@@ -602,20 +602,20 @@ let fmt_cmts_aux t (conf : Conf.t) cmts ~fmt_code pos =
              in
              break $ fmt_cmt conf cmt ~fmt_code
          | group ->
-             list group "@;<1000 0>" (fun cmt ->
-                 wrap "(*" "*)" (str (Cmt.txt cmt)) ) )
+             list_k group force_break (fun cmt ->
+                 wrap_k (str "(*") (str "*)") (str (Cmt.txt cmt)) ) )
          $
          match next with
          | Some (next :: _) ->
              let last = List.last_exn group in
-             fmt_if
+             fmt_if_k
                (Location.line_difference (Cmt.loc last) (Cmt.loc next) > 1)
-               "\n"
-             $ fmt "@ "
+               (str "\n")
+             $ space_break
          | _ -> noop ) )
 
 (** Format comments for loc. *)
-let fmt_cmts t conf ~fmt_code ?pro ?epi ?(eol = Fmt.fmt "@;<1000 0>")
+let fmt_cmts t conf ~fmt_code ?pro ?epi ?(eol = Fmt.break 1000 0)
     ?(adj = eol) found loc pos =
   let open Fmt in
   match found with
@@ -662,9 +662,9 @@ module Toplevel = struct
           | Before -> noop
           | Within | After ->
               if Source.begins_line t.source first_loc then
-                fmt_or
+                fmt_or_k
                   (Source.empty_line_before t.source first_loc)
-                  "\n@;<1000 0>" "@\n"
+                  (str "\n" $ force_break) force_newline
               else break 1 0
         in
         let epi =
@@ -672,9 +672,9 @@ module Toplevel = struct
           match pos with
           | Before | Within ->
               if Source.ends_line t.source last_loc then
-                fmt_or
+                fmt_or_k
                   (Source.empty_line_after t.source last_loc)
-                  "\n@;<1000 0>" "@\n"
+                  (str "\n" $ force_break) force_newline
               else break 1 0
           | After -> noop
         in

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -475,7 +475,7 @@ module Wrapped = struct
           (String.split_on_chars line
              ~on:['\t'; '\n'; '\011'; '\012'; '\r'; ' '] )
       in
-      list_k words space_break str
+      list words space_break str
     in
     let lines =
       List.remove_consecutive_duplicates
@@ -489,12 +489,12 @@ module Wrapped = struct
     $ hovbox 0
         (list_fl groups (fun ~first ~last:last_group group ->
              let group = List.filter group ~f:(Fn.non is_only_whitespaces) in
-             fmt_if_k (not first) (str "\n" $ force_newline)
+             fmt_if (not first) (str "\n" $ force_newline)
              $ hovbox 0
                  (list_fl group (fun ~first ~last x ->
-                      fmt_if_k (not first) space_break
+                      fmt_if (not first) space_break
                       $ fmt_line x
-                      $ fmt_if_k (last_group && last) (str suffix $ epi) ) ) )
+                      $ fmt_if (last_group && last) (str suffix $ epi) ) ) )
         )
 end
 
@@ -564,9 +564,9 @@ module Doc = struct
     let open Fmt in
     hvbox 2
       ( pro
-      $ fmt_if_k pre_nl (break 1000 1)
+      $ fmt_if pre_nl (break 1000 1)
       $ doc
-      $ fmt_if_k trail_nl (break 1000 (-2))
+      $ fmt_if trail_nl (break 1000 (-2))
       $ epi )
 end
 
@@ -597,7 +597,7 @@ let fmt_cmts_aux t (conf : Conf.t) cmts ~fmt_code pos =
          | [] -> impossible "previous match"
          | [cmt] ->
              let break =
-               fmt_if_k
+               fmt_if
                  ( conf.fmt_opts.ocp_indent_compat.v
                  && Poly.(pos = Cmt.After)
                  && String.contains (Cmt.txt cmt) '\n' )
@@ -605,13 +605,13 @@ let fmt_cmts_aux t (conf : Conf.t) cmts ~fmt_code pos =
              in
              break $ fmt_cmt conf cmt ~fmt_code
          | group ->
-             list_k group force_break (fun cmt ->
-                 wrap_k (str "(*") (str "*)") (str (Cmt.txt cmt)) ) )
+             list group force_break (fun cmt ->
+                 wrap (str "(*") (str "*)") (str (Cmt.txt cmt)) ) )
          $
          match next with
          | Some (next :: _) ->
              let last = List.last_exn group in
-             fmt_if_k
+             fmt_if
                (Location.line_difference (Cmt.loc last) (Cmt.loc next) > 1)
                (str "\n")
              $ space_break
@@ -628,7 +628,7 @@ let fmt_cmts t conf ~fmt_code ?pro ?epi ?(eol = Fmt.break 1000 0)
         let last_loc = Cmt.loc (List.last_exn cmts) in
         let eol_cmt = Source.ends_line t.source last_loc in
         let adj_cmt = eol_cmt && Location.line_difference last_loc loc = 1 in
-        fmt_or_k eol_cmt (fmt_or_k adj_cmt adj eol) (fmt_opt epi)
+        fmt_or eol_cmt (fmt_or adj_cmt adj eol) (fmt_opt epi)
       in
       fmt_opt pro $ fmt_cmts_aux t conf cmts ~fmt_code pos $ epi
 
@@ -665,7 +665,7 @@ module Toplevel = struct
           | Before -> noop
           | Within | After ->
               if Source.begins_line t.source first_loc then
-                fmt_or_k
+                fmt_or
                   (Source.empty_line_before t.source first_loc)
                   (str "\n" $ force_break)
                   force_newline
@@ -676,7 +676,7 @@ module Toplevel = struct
           match pos with
           | Before | Within ->
               if Source.ends_line t.source last_loc then
-                fmt_or_k
+                fmt_or
                   (Source.empty_line_after t.source last_loc)
                   (str "\n" $ force_break)
                   force_newline

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -165,14 +165,14 @@ let list_fl xs pp =
   list_pn xs (fun ~prev x ~next ->
       pp ~first:(Option.is_none prev) ~last:(Option.is_none next) x )
 
-let list_k l sep f =
+let list l sep f =
   list_fl l (fun ~first:_ ~last x -> f x $ if last then noop else sep)
 
 (** Conditional formatting ----------------------------------------------*)
 
-let fmt_if_k cnd x = if cnd then x else noop
+let fmt_if cnd x = if cnd then x else noop
 
-let fmt_or_k cnd t f = if cnd then t else f
+let fmt_or cnd t f = if cnd then t else f
 
 let fmt_opt o = Option.value o ~default:noop
 
@@ -202,25 +202,25 @@ let fits_breaks ?force ?(hint = (0, Int.min_value)) ?(level = 0) fits breaks
   let nspaces, offset = hint in
   match force with
   | Some Fit -> str fits
-  | Some Break -> fmt_if_k (offset >= 0) (break nspaces offset) $ str breaks
+  | Some Break -> fmt_if (offset >= 0) (break nspaces offset) $ str breaks
   | None -> fits_or_breaks ~level fits nspaces offset breaks
 
 let fits_breaks_if ?force ?hint ?level cnd fits breaks =
-  fmt_if_k cnd (fits_breaks ?force ?hint ?level fits breaks)
+  fmt_if cnd (fits_breaks ?force ?hint ?level fits breaks)
 
 (** Wrapping ------------------------------------------------------------*)
 
-let wrap_if_k cnd pre suf k = fmt_if_k cnd pre $ k $ fmt_if_k cnd suf
+let wrap_if cnd pre suf k = fmt_if cnd pre $ k $ fmt_if cnd suf
 
-let wrap_k x = wrap_if_k true x
+let wrap x = wrap_if true x
 
 let wrap_if_fits_or cnd pre suf k =
-  if cnd then wrap_k (str pre) (str suf) k
+  if cnd then wrap (str pre) (str suf) k
   else fits_breaks pre "" $ k $ fits_breaks suf ""
 
 let wrap_fits_breaks_if ?(space = true) (c : Conf.t) cnd pre suf k =
   match (c.fmt_opts.indicate_multiline_delimiters.v, space) with
-  | `No, false -> wrap_if_k cnd (str pre) (str suf) k
+  | `No, false -> wrap_if cnd (str pre) (str suf) k
   | `Space, _ | `No, true ->
       fits_breaks_if cnd pre (pre ^ " ")
       $ k
@@ -268,18 +268,18 @@ and close_box =
 
 (** Wrapping boxes ------------------------------------------------------*)
 
-let cbox ?name n = wrap_k (open_box ?name n) close_box
+let cbox ?name n = wrap (open_box ?name n) close_box
 
-and vbox ?name n = wrap_k (open_vbox ?name n) close_box
+and vbox ?name n = wrap (open_vbox ?name n) close_box
 
-and hvbox ?name n = wrap_k (open_hvbox ?name n) close_box
+and hvbox ?name n = wrap (open_hvbox ?name n) close_box
 
-and hovbox ?name n = wrap_k (open_hovbox ?name n) close_box
+and hovbox ?name n = wrap (open_hovbox ?name n) close_box
 
-and cbox_if ?name cnd n = wrap_if_k cnd (open_box ?name n) close_box
+and cbox_if ?name cnd n = wrap_if cnd (open_box ?name n) close_box
 
-and vbox_if ?name cnd n = wrap_if_k cnd (open_vbox ?name n) close_box
+and vbox_if ?name cnd n = wrap_if cnd (open_vbox ?name n) close_box
 
-and hvbox_if ?name cnd n = wrap_if_k cnd (open_hvbox ?name n) close_box
+and hvbox_if ?name cnd n = wrap_if cnd (open_hvbox ?name n) close_box
 
-and hovbox_if ?name cnd n = wrap_if_k cnd (open_hovbox ?name n) close_box
+and hovbox_if ?name cnd n = wrap_if cnd (open_hovbox ?name n) close_box

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -98,8 +98,6 @@ let space_break = with_pp (fun fs -> Format_.pp_print_space fs ())
 
 let cut_break = with_pp (fun fs -> Format_.pp_print_cut fs ())
 
-let flush_newline = with_pp (fun fs -> Format_.pp_print_newline fs ())
-
 let force_newline = with_pp (fun fs -> Format_.pp_force_newline fs ())
 
 let cbreak ~fits ~breaks =

--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -94,18 +94,13 @@ let break n o =
 
 let force_break = break 1000 0
 
-let space_break =
-  with_pp (fun fs -> Format_.pp_print_space fs () )
+let space_break = with_pp (fun fs -> Format_.pp_print_space fs ())
 
+let cut_break = with_pp (fun fs -> Format_.pp_print_cut fs ())
 
-  let cut_break =
-    with_pp (fun fs -> Format_.pp_print_cut fs () )
+let flush_newline = with_pp (fun fs -> Format_.pp_print_newline fs ())
 
-let flush_newline =
-    with_pp (fun fs -> Format_.pp_print_newline fs () )
-
-let force_newline =
-  with_pp (fun fs -> Format_.pp_force_newline fs () )
+let force_newline = with_pp (fun fs -> Format_.pp_force_newline fs ())
 
 let cbreak ~fits ~breaks =
   with_pp (fun fs ->
@@ -126,7 +121,6 @@ let sequence l =
         go a a_len $ go b b_len
   in
   go l (List.length l)
-
 
 (** Primitive types -----------------------------------------------------*)
 

--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -11,9 +11,6 @@
 
 (** Formatting combinators *)
 
-(** Format strings that accept no arguments. *)
-type s = (unit, Format_.formatter, unit) format
-
 (** Format thunks. *)
 type t
 
@@ -57,6 +54,18 @@ val break : int -> int -> t
 val force_break : t
 (** [force_break] forces a break with indentation 0. Equivalent to [break 1000 0].*)
 
+val space_break: t
+(** fmt "@ " *)
+
+val cut_break: t
+(** fmt "@," *)
+
+val flush_newline: t
+(** fmt "@." *)
+
+val force_newline: t
+(** force_newline *)
+
 val cbreak : fits:string * int * string -> breaks:string * int * string -> t
 (** Format a custom break.
 
@@ -67,9 +76,6 @@ val cbreak : fits:string * int * string -> breaks:string * int * string -> t
 
 val noop : t
 (** Format nothing. *)
-
-val fmt : s -> t
-(** Format a format string. *)
 
 (** Primitive types -----------------------------------------------------*)
 
@@ -87,10 +93,6 @@ val str_as : int -> string -> t
 val opt : 'a option -> ('a -> t) -> t
 (** Format an option using provided formatter for the element. *)
 
-val list : 'a list -> s -> ('a -> t) -> t
-(** Format a list separated by a format string using provided function for
-    the elements. *)
-
 val list_fl : 'a list -> (first:bool -> last:bool -> 'a -> t) -> t
 (** Format a list using provided function for the elements, which is passed
     the flags indicating if the element is the first or last. *)
@@ -104,14 +106,8 @@ val list_k : 'a list -> t -> ('a -> t) -> t
 
 (** Conditional formatting ----------------------------------------------*)
 
-val fmt_if : bool -> s -> t
-(** Conditionally format. *)
-
 val fmt_if_k : bool -> t -> t
 (** Conditionally format thunk. *)
-
-val fmt_or : bool -> s -> s -> t
-(** Conditionally select between two format strings. *)
 
 val fmt_or_k : bool -> t -> t -> t
 (** Conditionally select between two format thunks. *)
@@ -151,15 +147,9 @@ val fits_breaks_if :
 
 (** Wrapping ------------------------------------------------------------*)
 
-val wrap : s -> s -> t -> t
-(** [wrap prologue epilogue body] formats [prologue] then [body] then
-    [epilogue]. *)
 
 val wrap_k : t -> t -> t -> t
 (** As [wrap], but prologue and epilogue may be arbitrary format thunks. *)
-
-val wrap_if : bool -> s -> s -> t -> t
-(** As [wrap], but prologue and epilogue are only formatted conditionally. *)
 
 val wrap_if_k : bool -> t -> t -> t -> t
 (** As [wrap_if], but prologue and epilogue may be arbitrary format thunks. *)

--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -55,16 +55,24 @@ val force_break : t
 (** [force_break] forces a break with indentation 0. Equivalent to [break 1000 0].*)
 
 val space_break : t
-(** fmt "@ " *)
+(** [space_break] is either a single space or a newline.
+    See {!Stdlib.Format.print_space_break}.
+    Equivalement to format syntax ["@ "].*)
 
 val cut_break : t
-(** fmt "@," *)
+(** [cut_break] is either a newline or a {!noop}.
+    See {!Stdlib.Format.print_cut}.
+    Equivalement to format syntax ["@,"].*)
 
 val flush_newline : t
-(** fmt "@." *)
+(** [flush_newline] flushes (finishes pretty printing) and output a newline.
+    See {!Stdlib.Format.print_newline}
+    Equivalement to format syntax ["@."].*)
 
 val force_newline : t
-(** force_newline *)
+(** [force_newline] force a new line in the current pretty-printing box.
+    See {!Stdlib.Format.force_newline}.
+    Equivalement to format syntax ["@\n"].*)
 
 val cbreak : fits:string * int * string -> breaks:string * int * string -> t
 (** Format a custom break.

--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -54,16 +54,16 @@ val break : int -> int -> t
 val force_break : t
 (** [force_break] forces a break with indentation 0. Equivalent to [break 1000 0].*)
 
-val space_break: t
+val space_break : t
 (** fmt "@ " *)
 
-val cut_break: t
+val cut_break : t
 (** fmt "@," *)
 
-val flush_newline: t
+val flush_newline : t
 (** fmt "@." *)
 
-val force_newline: t
+val force_newline : t
 (** force_newline *)
 
 val cbreak : fits:string * int * string -> breaks:string * int * string -> t
@@ -146,7 +146,6 @@ val fits_breaks_if :
 (** As [fits_breaks], but conditional. *)
 
 (** Wrapping ------------------------------------------------------------*)
-
 
 val wrap_k : t -> t -> t -> t
 (** As [wrap], but prologue and epilogue may be arbitrary format thunks. *)

--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -109,15 +109,15 @@ val list_pn : 'a list -> (prev:'a option -> 'a -> next:'a option -> t) -> t
 (** Format a list using provided function for the elements, which is passed
     the previous and next elements, if any. *)
 
-val list_k : 'a list -> t -> ('a -> t) -> t
+val list : 'a list -> t -> ('a -> t) -> t
 (** Format a list using the format thunk for the separators between elements. *)
 
 (** Conditional formatting ----------------------------------------------*)
 
-val fmt_if_k : bool -> t -> t
+val fmt_if : bool -> t -> t
 (** Conditionally format thunk. *)
 
-val fmt_or_k : bool -> t -> t -> t
+val fmt_or : bool -> t -> t -> t
 (** Conditionally select between two format thunks. *)
 
 val fmt_opt : t option -> t
@@ -155,10 +155,10 @@ val fits_breaks_if :
 
 (** Wrapping ------------------------------------------------------------*)
 
-val wrap_k : t -> t -> t -> t
+val wrap : t -> t -> t -> t
 (** As [wrap], but prologue and epilogue may be arbitrary format thunks. *)
 
-val wrap_if_k : bool -> t -> t -> t -> t
+val wrap_if : bool -> t -> t -> t -> t
 (** As [wrap_if], but prologue and epilogue may be arbitrary format thunks. *)
 
 val wrap_if_fits_or : bool -> string -> string -> t -> t

--- a/lib/Fmt.mli
+++ b/lib/Fmt.mli
@@ -64,11 +64,6 @@ val cut_break : t
     See {!Stdlib.Format.print_cut}.
     Equivalement to format syntax ["@,"].*)
 
-val flush_newline : t
-(** [flush_newline] flushes (finishes pretty printing) and output a newline.
-    See {!Stdlib.Format.print_newline}
-    Equivalement to format syntax ["@."].*)
-
 val force_newline : t
 (** [force_newline] force a new line in the current pretty-printing box.
     See {!Stdlib.Format.force_newline}.

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -203,8 +203,8 @@ let box_semisemi c ~parent_ctx b k =
   let space = Poly.(c.conf.fmt_opts.sequence_style.v = `Separator) in
   match parent_ctx with
   | _ when not b -> k
-  | Rep -> k $ fmt_if space " " $ str ";;"
-  | _ -> hvbox 0 (k $ fmt_or space "@;" "@," $ str ";;")
+  | Rep -> k $ fmt_if_k space (str " ") $ str ";;"
+  | _ -> hvbox 0 (k $ fmt_or_k space (space_break) cut_break $ str ";;")
 
 let fmt_hole () = str "_"
 
@@ -219,7 +219,7 @@ let fmt_item_list c ctx update_config ast fmt_item items =
         fmt_or_k
           (break_between c (ast itm, c.conf) (ast i_n, c_n.conf))
           (str "\n" $ force_break)
-          (fmt_or_k break_struct force_break (fmt "@ ")) )
+          (fmt_or_k break_struct force_break (space_break)) )
 
 let fmt_recmodule c ctx items fmt_item ast sub =
   let update_config c i = update_config c (Ast.attributes (ast i)) in
@@ -235,13 +235,13 @@ let fmt_recmodule c ctx items fmt_item ast sub =
 
 let rec fmt_longident (li : Longident.t) =
   let fmt_id id =
-    wrap_if (Std_longident.String_id.is_symbol id) "( " " )" (str id)
+    wrap_if_k (Std_longident.String_id.is_symbol id) (str "( ") (str " )") (str id)
   in
   match li with
   | Lident id -> fmt_id id
-  | Ldot (li, id) -> hvbox 0 (fmt_longident li $ fmt "@,." $ fmt_id id)
+  | Ldot (li, id) -> hvbox 0 (fmt_longident li $ cut_break $ str "." $ fmt_id id)
   | Lapply (li1, li2) ->
-      hvbox 2 (fmt_longident li1 $ wrap "@,(" ")" (fmt_longident li2))
+      hvbox 2 (fmt_longident li1 $ wrap_k (cut_break $ str "(") (str ")") (fmt_longident li2))
 
 let fmt_longident_loc c ?pre {txt; loc} =
   Cmts.fmt c loc (opt pre str $ fmt_longident txt)
@@ -263,7 +263,7 @@ let fmt_constant c ?epi {pconst_desc; pconst_loc= loc} =
   match pconst_desc with
   | Pconst_integer (lit, suf) | Pconst_float (lit, suf) ->
       str lit $ opt suf char
-  | Pconst_char (_, s) -> wrap "'" "'" @@ str s
+  | Pconst_char (_, s) -> wrap_k (str "'") (str "'") @@ str s
   | Pconst_string (s, loc', Some delim) ->
       Cmts.fmt c loc'
       @@
@@ -343,28 +343,28 @@ let fmt_constant c ?epi {pconst_desc; pconst_loc= loc} =
           List.fold_left delim ~init:s ~f:break_on_pp_commands
           |> fmt_string_auto ~break_on_newlines:true
       | `Auto -> fmt_string_auto ~break_on_newlines:false s
-      | `Never -> wrap "\"" "\"" (str s) )
+      | `Never -> wrap_k (str "\"") (str "\"") (str s) )
 
-let fmt_variance_injectivity c vc = hvbox 0 (list vc "" (fmt_str_loc c))
+let fmt_variance_injectivity c vc = hvbox 0 (list_k vc noop (fmt_str_loc c))
 
 let fmt_label lbl sep =
   (* No comment can be attached here. *)
   match lbl with
   | Nolabel -> noop
-  | Labelled l -> str "~" $ str l.txt $ fmt sep
-  | Optional l -> str "?" $ str l.txt $ fmt sep
+  | Labelled l -> str "~" $ str l.txt $ sep
+  | Optional l -> str "?" $ str l.txt $ sep
 
 let fmt_direction_flag = function
-  | Upto -> fmt "@ to "
-  | Downto -> fmt "@ downto "
+  | Upto -> space_break $ str "to "
+  | Downto -> space_break $ str "downto "
 
-let fmt_private ?(pro = fmt "@ ") c loc =
+let fmt_private ?(pro = space_break) c loc =
   pro $ hvbox 0 @@ Cmts.fmt c loc @@ str "private"
 
-let fmt_virtual ?(pro = fmt "@ ") c loc =
+let fmt_virtual ?(pro = space_break) c loc =
   pro $ hvbox 0 @@ Cmts.fmt c loc @@ str "virtual"
 
-let fmt_mutable ?(pro = fmt "@ ") ?(epi = noop) c loc =
+let fmt_mutable ?(pro = space_break) ?(epi = noop) c loc =
   pro $ hvbox 0 (Cmts.fmt c loc (str "mutable")) $ epi
 
 let fmt_private_flag c = function
@@ -404,10 +404,10 @@ let fmt_parsed_docstring c ~loc ?pro ~epi input parsed =
   and fmt_code = c.fmt_code in
   let doc = Fmt_odoc.fmt_parsed c.conf ~fmt_code ~offset ~input parsed in
   Cmts.fmt c loc
-  @@ vbox_if (Option.is_none pro) 0 (fmt_opt pro $ wrap "(**" "*)" doc $ epi)
+  @@ vbox_if (Option.is_none pro) 0 (fmt_opt pro $ wrap_k (str "(**") (str "*)") doc $ epi)
 
 let docstring_epi ~standalone ~next ~epi ~floating =
-  let epi = if Option.is_some next then fmt "@\n" else fmt_opt epi in
+  let epi = if Option.is_some next then force_newline else fmt_opt epi in
   match next with
   | (None | Some (_, false)) when floating && not standalone ->
       str "\n" $ epi
@@ -423,8 +423,8 @@ let fmt_docstring_around_item' ?(is_val = false) ?(force_before = false)
     ?(fit = false) c doc1 doc2 =
   match (doc1, doc2) with
   | Some _, Some _ ->
-      ( fmt_docstring c ~epi:(fmt "@\n") doc1
-      , fmt_docstring c ~pro:(fmt "@\n") doc2 )
+      ( fmt_docstring c ~epi:(force_newline) doc1
+      , fmt_docstring c ~pro:(force_newline) doc2 )
   | None, None -> (noop, noop)
   | None, Some doc | Some doc, None -> (
       let is_tag_only =
@@ -460,10 +460,10 @@ let fmt_docstring_around_item' ?(is_val = false) ?(force_before = false)
           in
           conf
       in
-      let floating_doc = fmt_doc ~epi:(fmt "@\n") floating_doc in
+      let floating_doc = fmt_doc ~epi:(force_newline) floating_doc in
       match placement with
-      | `Before -> (floating_doc $ fmt_doc ~epi:(fmt "@\n") doc, noop)
-      | `After -> (floating_doc, fmt_doc ~pro:(fmt "@\n") doc)
+      | `Before -> (floating_doc $ fmt_doc ~epi:(force_newline) doc, noop)
+      | `After -> (floating_doc, fmt_doc ~pro:(force_newline) doc)
       | `Fit ->
           ( floating_doc
           , fmt_doc ~pro:(break c.conf.fmt_opts.doc_comments_padding.v 0) doc
@@ -499,13 +499,13 @@ let is_arrow_or_poly = function
 let fmt_assign_arrow c =
   match c.conf.fmt_opts.assignment_operator.v with
   | `Begin_line ->
-      break 1 (Params.Indent.assignment_operator_bol c.conf) $ fmt "<- "
-  | `End_line -> fmt " <-@;<1 2>"
+      break 1 (Params.Indent.assignment_operator_bol c.conf) $ str "<- "
+  | `End_line -> str " <-" $ break 1 2
 
-let arrow_sep c ~parens : Fmt.s =
+let arrow_sep c ~parens : Fmt.t =
   match c.conf.fmt_opts.break_separators.v with
-  | `Before -> if parens then "@;<1 1>-> " else "@ -> "
-  | `After -> " ->@;<1 0>"
+  | `Before -> if parens then break 1 1 $ str "-> " else space_break $ str "-> "
+  | `After -> str " ->" $ break 1 0
 
 let fmt_docstring_padded c doc =
   fmt_docstring c ~pro:(break c.conf.fmt_opts.doc_comments_padding.v 0) doc
@@ -544,7 +544,7 @@ let fmt_type_var s =
   str "'"
   (* [' a'] is a valid type variable, the space is required to not lex as a
      char. https://github.com/ocaml/ocaml/pull/2034 *)
-  $ fmt_if (String.length s > 1 && Char.equal s.[1] '\'') " "
+  $ fmt_if_k (String.length s > 1 && Char.equal s.[1] '\'') (str" ")
   $ str s
 
 let rec fmt_extension_aux c ctx ~key (ext, pld) =
@@ -592,11 +592,11 @@ let rec fmt_extension_aux c ctx ~key (ext, pld) =
         else Fn.id
       in
       box
-        (wrap "[" "]"
+        (wrap_k (str "[") (str "]")
            ( str (Ext.Key.to_string key)
            $ fmt_str_loc c ext
            $ fmt_payload c (Pld pld) pld
-           $ fmt_if (Exposed.Right.payload pld) " " ) )
+           $ fmt_if_k (Exposed.Right.payload pld) (str" ") ) )
 
 and fmt_extension = fmt_extension_aux ~key:Ext.Key.Regular
 
@@ -617,8 +617,8 @@ and fmt_attribute c ~key {attr_name; attr_payload; attr_loc} =
                   ; _ }
                 , [] )
           ; _ } ] ) ->
-      fmt_or (String.equal txt "ocaml.text") "@ " " "
-      $ wrap "(**" "*)" (str doc)
+      fmt_or_k (String.equal txt "ocaml.text") space_break (str" ")
+      $ wrap_k (str "(**") (str "*)") (str doc)
   | name, pld ->
       let indent =
         match (pld, key) with
@@ -627,18 +627,18 @@ and fmt_attribute c ~key {attr_name; attr_payload; attr_loc} =
         | _ -> c.conf.fmt_opts.extension_indent.v
       in
       hvbox indent
-        (wrap "[" "]"
+        (wrap_k (str "[") (str "]")
            ( str (Attr.Key.to_string key)
            $ fmt_str_loc c name
            $ fmt_payload c (Pld pld) pld
-           $ fmt_if (Exposed.Right.payload pld) " " ) )
+           $ fmt_if_k (Exposed.Right.payload pld) (str" ") ) )
 
 and fmt_attributes_aux c ?pre ?suf ~key attrs =
   let num = List.length attrs in
   fmt_if_k (num > 0)
     ( opt pre sp
     $ hvbox_if (num > 1) 0
-        (hvbox 0 (list attrs "@ " (fmt_attribute c ~key)) $ opt suf str) )
+        (hvbox 0 (list_k attrs space_break (fmt_attribute c ~key)) $ opt suf str) )
 
 and fmt_attributes = fmt_attributes_aux ~key:Attr.Key.Regular
 
@@ -670,7 +670,7 @@ and fmt_attributes_and_docstrings_aux c ~key attrs =
         fmt_docstring c ~standalone ~pro (Some [({txt; loc}, standalone)])
     | attr -> space $ fmt_attribute c ~key attr
   in
-  list attrs "" aux
+  list_k attrs noop aux
 
 and fmt_attributes_and_docstrings =
   fmt_attributes_and_docstrings_aux ~key:Attr.Key.Regular
@@ -683,17 +683,17 @@ and fmt_payload c ctx pld =
   @@
   match pld with
   | PStr mex ->
-      fmt_if (not (List.is_empty mex)) "@ " $ fmt_structure c ctx mex
+      fmt_if_k (not (List.is_empty mex)) space_break $ fmt_structure c ctx mex
   | PSig mty ->
       str ":"
-      $ fmt_if (not (List.is_empty mty)) "@ "
+      $ fmt_if_k (not (List.is_empty mty)) space_break
       $ fmt_signature c ctx mty
-  | PTyp typ -> fmt ":@ " $ fmt_core_type c (sub_typ ~ctx typ)
+  | PTyp typ -> str ":" $ space_break $ fmt_core_type c (sub_typ ~ctx typ)
   | PPat (pat, exp) ->
       let fmt_when exp =
         str " when " $ fmt_expression c (sub_exp ~ctx exp)
       in
-      fmt "?@ " $ fmt_pattern c (sub_pat ~ctx pat) $ opt exp fmt_when
+      str "?" $ space_break $ fmt_pattern c (sub_pat ~ctx pat) $ opt exp fmt_when
 
 and fmt_record_field c ?typ1 ?typ2 ?rhs lid1 =
   let field_space =
@@ -701,13 +701,13 @@ and fmt_record_field c ?typ1 ?typ2 ?rhs lid1 =
     | `Loose | `Tight_decl -> str " "
     | `Tight -> noop
   in
-  let t1 = Option.map typ1 ~f:(fun x -> fmt ": " $ fmt_core_type c x) in
-  let t2 = Option.map typ2 ~f:(fun x -> fmt ":> " $ fmt_core_type c x) in
-  let r = Option.map rhs ~f:(fun x -> fmt "=@;<1 2>" $ cbox 0 x) in
+  let t1 = Option.map typ1 ~f:(fun x -> str ": " $ fmt_core_type c x) in
+  let t2 = Option.map typ2 ~f:(fun x -> str ":> " $ fmt_core_type c x) in
+  let r = Option.map rhs ~f:(fun x -> str "=" $ break 1 2 $ cbox 0 x) in
   let fmt_type_rhs =
     match List.filter_opt [t1; t2; r] with
     | [] -> noop
-    | l -> field_space $ list l "@ " Fn.id
+    | l -> field_space $ list_k l space_break Fn.id
   in
   Cmts.fmt_before c lid1.loc
   $ cbox 0
@@ -715,7 +715,7 @@ and fmt_record_field c ?typ1 ?typ2 ?rhs lid1 =
 
 and fmt_type_cstr c ?constraint_ctx xtyp =
   let colon_before = Poly.(c.conf.fmt_opts.break_colon.v = `Before) in
-  fmt_or_k colon_before (fits_breaks " " ~hint:(1000, 0) "") (fmt "@;<0 -1>")
+  fmt_or_k colon_before (fits_breaks " " ~hint:(1000, 0) "") (break 0 (-1))
   $ cbox_if colon_before 0
       (fmt_core_type c ~pro:":" ?constraint_ctx ~pro_space:(not colon_before)
          ~box:(not colon_before) xtyp )
@@ -743,8 +743,8 @@ and fmt_arrow_param c ctx {pap_label= lI; pap_loc= locI; pap_type= tI} =
   let arg_label lbl =
     match lbl with
     | Nolabel -> None
-    | Labelled l -> Some (str l.txt $ fmt ":@,")
-    | Optional l -> Some (str "?" $ str l.txt $ fmt ":@,")
+    | Labelled l -> Some (str l.txt $ str ":" $ cut_break)
+    | Optional l -> Some (str "?" $ str l.txt $ str ":" $ cut_break)
   in
   let xtI = sub_typ ~ctx tI in
   let arg =
@@ -769,12 +769,12 @@ and fmt_arrow_type c ~ctx ?indent ~parens ~parent_has_parens args fmt_ret_typ
              (fits_breaks "" "   ") )
   and ret_typ =
     match fmt_ret_typ with
-    | Some k -> fmt (arrow_sep c ~parens:parent_has_parens) $ k
+    | Some k -> (arrow_sep c ~parens:parent_has_parens) $ k
     | None -> noop
   in
   indent
-  $ wrap_if parens "(" ")"
-      ( list args
+  $ wrap_if_k parens (str "(") (str ")")
+      ( list_k args
           (arrow_sep c ~parens:parent_has_parens)
           (fmt_arrow_param c ctx)
       $ ret_typ )
@@ -794,13 +794,13 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
   ( match pro with
   | Some pro -> (
     match c.conf.fmt_opts.break_colon.v with
-    | `Before -> fmt_if pro_space "@;" $ str pro $ str " "
-    | `After -> fmt_if pro_space " " $ str pro $ fmt "@ " )
+    | `Before -> fmt_if_k pro_space space_break $ str pro $ str " "
+    | `After -> fmt_if_k pro_space (str " ") $ str pro $ space_break )
   | None -> noop )
   $
   let doc, atrs = doc_atrs ptyp_attributes in
   Cmts.fmt c ptyp_loc
-  @@ (fun k -> k $ fmt_docstring c ~pro:(fmt "@ ") doc)
+  @@ (fun k -> k $ fmt_docstring c ~pro:(space_break) doc)
   @@ ( if List.is_empty atrs then Fn.id
        else fun k ->
          hvbox 0 (Params.parens c.conf (k $ fmt_attributes c ~pre:Cut atrs))
@@ -826,9 +826,9 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
   match ptyp_desc with
   | Ptyp_alias (typ, str) ->
       hvbox 0
-        (wrap_if parenze_constraint_ctx "(" ")"
+        (wrap_if_k parenze_constraint_ctx (Fmt.str "(") (Fmt.str ")")
            ( fmt_core_type c (sub_typ ~ctx typ)
-           $ fmt "@ as@ "
+           $ space_break $ (Fmt.str "as") $ space_break
            $ Cmts.fmt c str.loc @@ fmt_type_var str.txt ) )
   | Ptyp_any -> str "_"
   | Ptyp_arrow (args, ret_typ) ->
@@ -854,38 +854,38 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
       hvbox
         (Params.Indent.type_constr c.conf)
         ( fmt_core_type c (sub_typ ~ctx t1)
-        $ fmt "@ " $ fmt_longident_loc c lid )
+        $ space_break $ fmt_longident_loc c lid )
   | Ptyp_constr (lid, t1N) ->
       hvbox
         (Params.Indent.type_constr c.conf)
         ( wrap_fits_breaks c.conf "(" ")"
-            (list t1N (Params.comma_sep c.conf)
+            (list_k t1N (Params.comma_sep c.conf)
                (sub_typ ~ctx >> fmt_core_type c) )
-        $ fmt "@ " $ fmt_longident_loc c lid )
+        $ space_break $ fmt_longident_loc c lid )
   | Ptyp_extension ext ->
       hvbox c.conf.fmt_opts.extension_indent.v (fmt_extension c ctx ext)
   | Ptyp_package (id, cnstrs) ->
       hvbox 2
-        ( hovbox 0 (fmt "module@ " $ fmt_longident_loc c id)
+        ( hovbox 0 (str "module" $ space_break $ fmt_longident_loc c id)
         $ fmt_package_type c ctx cnstrs )
   | Ptyp_open (lid, typ) ->
       hvbox 2
-        ( hvbox 0 (fmt_longident_loc c lid $ fmt ".(")
-        $ fmt "@;<0 0>"
+        ( hvbox 0 (fmt_longident_loc c lid $ str ".(")
+        $ break 0 0
         $ fmt_core_type c (sub_typ ~ctx typ)
-        $ fmt ")" )
+        $ str ")" )
   | Ptyp_poly ([], _) ->
       impossible "produced by the parser, handled elsewhere"
   | Ptyp_poly (a1N, t) ->
       hovbox_if box 0
-        ( list a1N "@ " (fun {txt; _} -> fmt_type_var txt)
-        $ fmt ".@ "
+        ( list_k a1N space_break (fun {txt; _} -> fmt_type_var txt)
+        $ str "." $ space_break
         $ fmt_core_type c ~box:true (sub_typ ~ctx t) )
   | Ptyp_tuple typs ->
       hvbox 0
-        (wrap_if parenze_constraint_ctx "(" ")"
+        (wrap_if_k parenze_constraint_ctx (str "(") (str ")")
            (wrap_fits_breaks_if ~space:false c.conf parens "(" ")"
-              (list typs "@ * " (sub_typ ~ctx >> fmt_core_type c)) ) )
+              (list_k typs (space_break $ str "* ") (sub_typ ~ctx >> fmt_core_type c)) ) )
   | Ptyp_var s -> fmt_type_var s
   | Ptyp_variant (rfs, flag, lbls) ->
       let row_fields rfs =
@@ -897,7 +897,7 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
                   in_type_declaration
                   && Poly.(c.conf.fmt_opts.type_decl.v = `Sparse)
                 then force_break $ str "| "
-                else fmt "@ | " )
+                else space_break $ str "| " )
               (fmt_row_field c ctx)
       in
       let protect_token = Exposed.Right.(list ~elt:row_field) rfs in
@@ -926,14 +926,14 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
         | Closed, Some [], _ -> str "[< " $ row_fields rfs $ closing
         | Closed, Some ls, _ ->
             str "[< " $ row_fields rfs $ str " > "
-            $ list ls "@ " (variant_var c)
+            $ list_k ls space_break (variant_var c)
             $ closing
         | Open, Some _, _ -> impossible "not produced by parser" )
   | Ptyp_object ([], closed_flag) ->
-      wrap "<@ " ">"
+      wrap_k (str "<" $ space_break) (str ">")
         ( match closed_flag with
         | OClosed -> Cmts.fmt_within c ~pro:noop ~epi:(str " ") ptyp_loc
-        | OOpen loc -> Cmts.fmt c loc (str "..") $ fmt "@ " )
+        | OOpen loc -> Cmts.fmt c loc (str "..") $ space_break )
   | Ptyp_object (fields, closed_flag) ->
       let fmt_field {pof_desc; pof_attributes; pof_loc} =
         let fmt_field =
@@ -945,7 +945,7 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
                 | `Loose | `Tight_decl -> true
                 | `Tight -> false
               in
-              fmt_str_loc c lab_loc $ fmt_if field_loose " " $ fmt ":@ "
+              fmt_str_loc c lab_loc $ fmt_if_k field_loose (str " ") $ str ":" $ space_break
               $ fmt_core_type c (sub_typ ~ctx typ)
           | Oinherit typ -> fmt_core_type c (sub_typ ~ctx typ)
         in
@@ -955,30 +955,30 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
              $ fmt_attributes_and_docstrings c pof_attributes )
       in
       hvbox 0
-        (wrap "< " " >"
-           ( list fields "@ ; " fmt_field
+        (wrap_k (str "< ") (str " >")
+           ( list_k fields (space_break $ str "; ") fmt_field
            $
            match closed_flag with
            | OClosed -> noop
-           | OOpen loc -> fmt "@ ; " $ Cmts.fmt c loc @@ str ".." ) )
+           | OOpen loc -> space_break $ str "; " $ Cmts.fmt c loc @@ str ".." ) )
   | Ptyp_class (lid, []) -> fmt_longident_loc c ~pre:"#" lid
   | Ptyp_class (lid, [t1]) ->
       fmt_core_type c (sub_typ ~ctx t1)
-      $ fmt "@ "
+      $ space_break
       $ fmt_longident_loc c ~pre:"#" lid
   | Ptyp_class (lid, t1N) ->
       wrap_fits_breaks c.conf "(" ")"
-        (list t1N (Params.comma_sep c.conf)
+        (list_k t1N (Params.comma_sep c.conf)
            (sub_typ ~ctx >> fmt_core_type c) )
-      $ fmt "@ "
+      $ space_break
       $ fmt_longident_loc c ~pre:"#" lid
 
 and fmt_package_type c ctx cnstrs =
   let fmt_cstr ~first ~last:_ (lid, typ) =
-    fmt_or first "@;<1 0>" "@;<1 1>"
+    fmt_or_k first (break 1 0) (break 1 1)
     $ hvbox 2
-        ( fmt_or first "with type " "and type "
-        $ fmt_longident_loc c lid $ fmt " =@ "
+        ( fmt_or_k first (str "with type ") (str "and type ")
+        $ fmt_longident_loc c lid $ str " =" $ space_break
         $ fmt_core_type c (sub_typ ~ctx typ) )
   in
   list_fl cnstrs fmt_cstr
@@ -989,9 +989,9 @@ and fmt_row_field c ctx {prf_desc; prf_attributes; prf_loc} =
     match prf_desc with
     | Rtag (name, const, typs) ->
         variant_var c name
-        $ fmt_if (not (const && List.is_empty typs)) " of@ "
-        $ fmt_if (const && not (List.is_empty typs)) " & "
-        $ list typs "@ & " (sub_typ ~ctx >> fmt_core_type c)
+        $ fmt_if_k (not (const && List.is_empty typs)) (str " of" $ space_break)
+        $ fmt_if_k (const && not (List.is_empty typs)) (str" & ")
+        $ list_k typs (space_break $ str "& ") (sub_typ ~ctx >> fmt_core_type c)
     | Rinherit typ -> fmt_core_type c (sub_typ ~ctx typ)
   in
   hvbox 0
@@ -1040,7 +1040,7 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
   | Ppat_any -> str "_"
   | Ppat_var {txt; loc} ->
       Cmts.fmt c loc
-      @@ wrap_if (Std_longident.String_id.is_symbol txt) "( " " )" (str txt)
+      @@ wrap_if_k (Std_longident.String_id.is_symbol txt) (str "( ") (str " )") (str txt)
   | Ppat_alias (pat, {txt; loc}) ->
       let paren_pat =
         match pat.ppat_desc with
@@ -1051,11 +1051,11 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
         (wrap_fits_breaks_if ~space:false c.conf parens "(" ")"
            (hovbox 0
               ( fmt_pattern c ?parens:paren_pat (sub_pat ~ctx pat)
-              $ fmt "@ as@ "
+              $ space_break $ str "as" $ space_break
               $ Cmts.fmt c loc
-                  (wrap_if
+                  (wrap_if_k
                      (Std_longident.String_id.is_symbol txt)
-                     "( " " )" (str txt) ) ) ) )
+                     (str "( ") (str " )") (str txt) ) ) ) )
   | Ppat_constant const -> fmt_constant c const
   | Ppat_interval (l, u) -> fmt_constant c l $ str " .. " $ fmt_constant c u
   | Ppat_tuple pats ->
@@ -1080,14 +1080,14 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
         (Params.Indent.variant c.conf ~parens)
         (Params.parens_if parens c.conf
            (hvbox 2
-              ( fmt_longident_loc c lid $ fmt "@ "
+              ( fmt_longident_loc c lid $ space_break
               $ ( match exists with
                 | [] -> noop
                 | names ->
                     hvbox 0
                       (Params.parens c.conf
-                         (str "type " $ list names "@ " (fmt_str_loc c)) )
-                    $ fmt "@ " )
+                         (str "type " $ list_k names space_break (fmt_str_loc c)) )
+                    $ space_break )
               $ fmt_pattern c (sub_pat ~ctx pat) ) ) )
   | Ppat_variant (lbl, None) -> variant_var c lbl
   | Ppat_variant (lbl, Some pat) ->
@@ -1095,7 +1095,7 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
         (Params.Indent.variant c.conf ~parens)
         (Params.parens_if parens c.conf
            (hvbox 2
-              ( variant_var c lbl $ fmt "@ "
+              ( variant_var c lbl $ space_break
               $ fmt_pattern c (sub_pat ~ctx pat) ) ) )
   | Ppat_record (flds, closed_flag) ->
       let fmt_field (lid, typ1, pat) =
@@ -1179,8 +1179,8 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
                   let cmts_before = Cmts.has_before c.cmts loc in
                   let leading_cmt =
                     let pro, adj =
-                      if first_grp && first then (noop, fmt "@ ")
-                      else (fmt "@ ", noop)
+                      if first_grp && first then (noop, space_break)
+                      else (space_break, noop)
                     in
                     Cmts.fmt_before ~pro c loc ~adj ~eol:noop
                   in
@@ -1208,8 +1208,8 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
         (Params.parens_if parens c.conf
            ( fmt_pattern c (sub_pat ~ctx pat)
            $ ( match ctx0 with
-             | Exp {pexp_desc= Pexp_let _; _} -> fmt "@ : "
-             | _ -> fmt " :@ " )
+             | Exp {pexp_desc= Pexp_let _; _} -> space_break $ str ": "
+             | _ -> str " :" $ space_break )
            $ fmt_core_type c (sub_typ ~ctx typ) ) )
   | Ppat_type lid -> fmt_longident_loc c ~pre:"#" lid
   | Ppat_lazy pat ->
@@ -1217,7 +1217,7 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
         (Params.parens_if parens c.conf
            ( str "lazy"
            $ fmt_extension_suffix c ext
-           $ fmt "@ "
+           $ space_break
            $ fmt_pattern c (sub_pat ~ctx pat) ) )
   | Ppat_unpack (name, pt) ->
       let fmt_constraint_opt pt k =
@@ -1226,7 +1226,7 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
             hovbox 0
               (Params.parens_if parens c.conf
                  (hvbox 1
-                    ( hovbox 0 (k $ fmt "@ : " $ fmt_longident_loc c id)
+                    ( hovbox 0 (k $ space_break $ str ": " $ fmt_longident_loc c id)
                     $ fmt_package_type c ctx cnstrs ) ) )
         | None -> wrap_fits_breaks_if ~space:false c.conf parens "(" ")" k
       in
@@ -1237,9 +1237,9 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
   | Ppat_exception pat ->
       cbox 2
         (Params.parens_if parens c.conf
-           ( fmt "exception"
+           ( str "exception"
            $ fmt_extension_suffix c ext
-           $ fmt "@ "
+           $ space_break
            $ fmt_pattern c (sub_pat ~ctx pat) ) )
   | Ppat_extension
       ( ext
@@ -1266,7 +1266,7 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
       cbox 0
         ( fmt_longident_loc c lid
         $ wrap_k (str opn) (str cls)
-            (fmt "@;<0 2>" $ fmt_pattern c (sub_pat ~ctx pat)) )
+            (break 0 2 $ fmt_pattern c (sub_pat ~ctx pat)) )
 
 and fmt_param_val c ctx : param_val -> _ = function
   | ( ((Labelled l | Optional l) as lbl)
@@ -1294,13 +1294,13 @@ and fmt_param_val c ctx : param_val -> _ = function
         | _ -> (not has_attr, false)
       in
       cbox 2
-        ( fmt_label lbl ":@,"
+        ( fmt_label lbl (str ":" $ cut_break)
         $ hovbox 0
           @@ Params.parens_if outer_parens c.conf
                (fmt_pattern ~parens:inner_parens c xpat) )
   | ((Labelled _ | Nolabel) as lbl), None, pat ->
       let xpat = sub_pat ~ctx pat in
-      cbox 2 (fmt_label lbl ":@," $ fmt_pattern c xpat)
+      cbox 2 (fmt_label lbl (str ":" $ cut_break) $ fmt_pattern c xpat)
   | ( Optional l
     , Some exp
     , ({ppat_desc= Ppat_var {txt; loc= _}; ppat_attributes= []; _} as pat) )
@@ -1308,9 +1308,9 @@ and fmt_param_val c ctx : param_val -> _ = function
       let xexp = sub_exp ~ctx exp in
       let xpat = sub_pat ~ctx pat in
       cbox 0
-        (wrap "?(" ")"
+        (wrap_k (str "?(") (str ")")
            ( fmt_pattern c ~box:true xpat
-           $ fmt " =@;<1 2>"
+           $ str " =" $ break 1 2
            $ hovbox 2 (fmt_expression c xexp) ) )
   | ( Optional l
     , Some exp
@@ -1322,9 +1322,9 @@ and fmt_param_val c ctx : param_val -> _ = function
       let xexp = sub_exp ~ctx exp in
       let xpat = sub_pat ~ctx pat in
       cbox 0
-        (wrap "?(" ")"
+        (wrap_k (str "?(") (str ")")
            ( fmt_pattern c ~parens:false ~box:true xpat
-           $ fmt " =@;<1 2>" $ fmt_expression c xexp ) )
+           $ str " =" $ break 1 2 $ fmt_expression c xexp ) )
   | Optional l, Some exp, pat ->
       let xexp = sub_exp ~ctx exp in
       let xpat = sub_pat ~ctx pat in
@@ -1335,9 +1335,9 @@ and fmt_param_val c ctx : param_val -> _ = function
       in
       cbox 2
         ( str "?" $ str l.txt
-        $ wrap_k (fmt ":@,(") (str ")")
+        $ wrap_k (str ":" $ cut_break $ str "(") (str ")")
             ( fmt_pattern c ?parens ~box:true xpat
-            $ fmt " =@;<1 2>" $ fmt_expression c xexp ) )
+            $ str " =" $ break 1 2 $ fmt_expression c xexp ) )
   | (Labelled _ | Nolabel), Some _, _ -> impossible "not accepted by parser"
 
 and fmt_param_newtype c : param_newtype -> _ = function
@@ -1345,7 +1345,7 @@ and fmt_param_newtype c : param_newtype -> _ = function
   | names ->
       cbox 0
         (Params.parens c.conf
-           (str "type " $ list names "@ " (fmt_str_loc c)) )
+           (str "type " $ list_k names space_break (fmt_str_loc c)) )
 
 and fmt_expr_fun_arg c fp =
   let ctx = Fpe fp in
@@ -1359,9 +1359,9 @@ and fmt_class_fun_arg c fp =
   let ctx = Fpc fp in
   Cmts.fmt c fp.pparam_loc @@ fmt_param_val c ctx fp.pparam_desc
 
-and fmt_expr_fun_args c args = list args "@;" (fmt_expr_fun_arg c)
+and fmt_expr_fun_args c args = list_k args space_break (fmt_expr_fun_arg c)
 
-and fmt_class_fun_args c args = list args "@;" (fmt_class_fun_arg c)
+and fmt_class_fun_args c args = list_k args space_break (fmt_class_fun_arg c)
 
 (** The second returned value of [fmt_body] belongs to a box of level N-1 if
     the first returned value belongs to a box of level N. *)
@@ -1372,23 +1372,23 @@ and fmt_body c ?ext ({ast= body; _} as xbody) =
   | {pexp_desc= Pexp_function cs; pexp_attributes; pexp_loc; _} ->
       ( ( update_config_maybe_disabled c pexp_loc pexp_attributes
         @@ fun c ->
-        fmt "@ "
+        space_break
         $ Cmts.fmt_before c pexp_loc
-        $ fmt_if parens "(" $ str "function"
+        $ fmt_if_k parens (str"(") $ str "function"
         $ fmt_extension_suffix c ext
         $ fmt_attributes c pexp_attributes )
       , update_config_maybe_disabled c pexp_loc pexp_attributes
         @@ fun c ->
-        fmt_cases c ctx cs $ fmt_if parens ")" $ Cmts.fmt_after c pexp_loc )
+        fmt_cases c ctx cs $ fmt_if_k parens (str ")") $ Cmts.fmt_after c pexp_loc )
   | _ -> (noop, fmt_expression c ~eol:force_break xbody)
 
 and fmt_indexop_access c ctx ~fmt_atrs ~has_attr ~parens x =
   let {pia_lhs; pia_kind; pia_paren; pia_rhs} = x in
   let wrap_paren =
     match pia_paren with
-    | Paren -> wrap "(" ")"
-    | Bracket -> wrap "[" "]"
-    | Brace -> wrap "{" "}"
+    | Paren -> wrap_k (str "(") (str ")")
+    | Bracket -> wrap_k (str "[") (str "]")
+    | Brace -> wrap_k (str "{") (str "}")
   in
   let inner_wrap = has_attr && Option.is_some pia_rhs in
   Params.parens_if parens c.conf
@@ -1407,7 +1407,7 @@ and fmt_indexop_access c ctx ~fmt_atrs ~has_attr ~parens x =
                  opt path (fun x -> fmt_longident_loc c x $ str ".")
                  $ str op
                  $ wrap_paren
-                     (list idx ";@ " (sub_exp ~ctx >> fmt_expression c)) )
+                     (list_k idx (str ";" $ space_break) (sub_exp ~ctx >> fmt_expression c)) )
            $ opt pia_rhs (fun e ->
                  fmt_assign_arrow c $ fmt_expression c (sub_exp ~ctx e) ) )
        $ fmt_atrs ) )
@@ -1415,14 +1415,14 @@ and fmt_indexop_access c ctx ~fmt_atrs ~has_attr ~parens x =
 (** Format [Pexp_fun] or [Pexp_newtype]. [wrap_intro] wraps up to after the
     [->] and is responsible for breaking. *)
 and fmt_fun ?force_closing_paren
-    ?(wrap_intro = fun x -> hvbox 2 x $ fmt "@ ") ?(box = true) ~label
+    ?(wrap_intro = fun x -> hvbox 2 x $ space_break) ?(box = true) ~label
     ?(parens = false) c ({ast; _} as xast) =
   let has_label = match label with Nolabel -> false | _ -> true in
   (* Make sure the comment is placed after the eventual label but not into
      the inner box if no label is present. Side effects of Cmts.fmt c.cmts
      before Sugar.fun_ is important. *)
   let has_cmts_outer, cmts_outer, cmts_inner =
-    let eol = if has_label then Some (fmt "@,") else None in
+    let eol = if has_label then Some (cut_break) else None in
     let has_cmts = Cmts.has_before c.cmts ast.pexp_loc in
     let cmts = Cmts.fmt_before ?eol c ast.pexp_loc in
     if has_label then (false, noop, cmts) else (has_cmts, cmts, noop)
@@ -1440,24 +1440,24 @@ and fmt_fun ?force_closing_paren
     if parens then closing_paren c ?force:force_closing_paren ~offset:(-2)
     else noop
   in
-  let (label_sep : s), break_fun =
+  let (label_sep : t), break_fun =
     (* Break between the label and the fun to avoid ocp-indent's alignment.
        If a label is present, arguments should be indented more than the
        arrow and the eventually breaking [fun] keyword. *)
-    if c.conf.fmt_opts.ocp_indent_compat.v then (":@,", fmt "@;<1 2>")
-    else (":", if has_label then fmt "@;<1 2>" else fmt "@ ")
+    if c.conf.fmt_opts.ocp_indent_compat.v then (str ":" $ cut_break, break 1 2)
+    else (str ":", if has_label then break 1 2 else space_break)
   in
   hovbox_if box 2
     ( wrap_intro
         (hvbox_if has_cmts_outer 0
            ( cmts_outer
            $ hvbox 2
-               ( fmt_label label label_sep $ cmts_inner $ fmt_if parens "("
-               $ fmt "fun" $ break_fun
+               ( fmt_label label label_sep $ cmts_inner $ fmt_if_k parens (str"(")
+               $ str "fun" $ break_fun
                $ hvbox 0
                    ( fmt_attributes c ast.pexp_attributes ~suf:" "
                    $ fmt_expr_fun_args c xargs $ fmt_opt fmt_cstr
-                   $ fmt "@;<1 -2>->" ) ) ) )
+                   $ break 1 (-2) $ str  "->" ) ) ) )
     $ body $ closing
     $ Cmts.fmt_after c ast.pexp_loc )
 
@@ -1465,7 +1465,7 @@ and fmt_label_arg ?(box = true) ?eol c (lbl, ({ast= arg; _} as xarg)) =
   match (lbl, arg.pexp_desc) with
   | (Labelled l | Optional l), Pexp_ident {txt= Lident i; loc}
     when String.equal l.txt i && List.is_empty arg.pexp_attributes ->
-      Cmts.fmt c loc @@ Cmts.fmt c ?eol arg.pexp_loc @@ fmt_label lbl ""
+      Cmts.fmt c loc @@ Cmts.fmt c ?eol arg.pexp_loc @@ fmt_label lbl noop
   | ( (Labelled l | Optional l)
     , Pexp_constraint ({pexp_desc= Pexp_ident {txt= Lident i; _}; _}, _) )
     when String.equal l.txt i
@@ -1485,13 +1485,13 @@ and fmt_label_arg ?(box = true) ?eol c (lbl, ({ast= arg; _} as xarg)) =
       let cmts_after = Cmts.fmt_after c xarg.ast.pexp_loc in
       hvbox_if box 2
         ( hvbox_if box 0
-            (fmt_expression c ~pro:(fmt_label lbl ":@;<0 2>") ~box xarg)
+            (fmt_expression c ~pro:(fmt_label lbl (str ":" $ break 0 2)) ~box xarg)
         $ cmts_after )
   | (Labelled _ | Optional _), (Pexp_fun _ | Pexp_newtype _) ->
       fmt_fun ~box ~label:lbl ~parens:true c xarg
   | _ ->
-      let label_sep : s =
-        if box || c.conf.fmt_opts.wrap_fun_args.v then ":@," else ":"
+      let label_sep : t =
+        if box || c.conf.fmt_opts.wrap_fun_args.v then (str ":" $ cut_break) else str ":"
       in
       fmt_label lbl label_sep $ fmt_expression c ~box xarg
 
@@ -1556,15 +1556,15 @@ and fmt_sequence c ?ext ~has_attr parens width xexp fmt_atrs =
       else if c.conf.fmt_opts.break_sequences.v || force_break then
         Fmt.force_break
       else if parens && Poly.(c.conf.fmt_opts.sequence_style.v = `Before)
-      then fmt "@;<1 -2>"
-      else fmt "@;<1 0>"
+      then (break 1 (-2))
+      else break 1 0
     in
     match c.conf.fmt_opts.sequence_style.v with
     | `Before ->
         break $ str ";"
         $ fmt_extension_suffix c ext
         $ fmt_or_k (Option.is_some ext)
-            (fmt_or parens "@ " "@;<1 2>")
+            (fmt_or_k parens space_break (Fmt.break 1 2))
             (str " ")
     | `Separator -> str " ;" $ fmt_extension_suffix c ext $ break
     | `Terminator -> str ";" $ fmt_extension_suffix c ext $ break
@@ -1668,11 +1668,11 @@ and fmt_infix_op_args c ~parens xexp op_args =
            let very_last = last_grp && last in
            let pro, before_arg =
              let break =
-               if very_last && is_not_indented xarg then fmt "@ "
-               else fmt_if (not very_first) " "
+               if very_last && is_not_indented xarg then space_break
+               else fmt_if_k (not very_first) (str " ")
              in
              match cmts_after with
-             | Some c -> (noop, hovbox 0 (op $ fmt "@;" $ c))
+             | Some c -> (noop, hovbox 0 (op $ space_break $ c))
              | None -> (op $ break, noop)
            in
            fmt_opt cmts_before $ before_arg
@@ -1702,7 +1702,7 @@ and fmt_pat_cons c ~parens args =
            let very_first = first_grp && first in
            let very_last = last_grp && last in
            hvbox 0
-             ( fmt_if (not very_first) ":: "
+             ( fmt_if_k (not very_first) (str":: ")
              $ hovbox_if (not very_last) 2 (fmt_pattern c ~box:true xarg) )
            $ fmt_if_k (not last) (break 1 0) ) )
     $ fmt_if_k (not last_grp) (break 1 0)
@@ -1721,10 +1721,10 @@ and fmt_match c ?pro ~parens ?ext ctx xexp cs e0 keyword =
              ( str keyword
              $ fmt_extension_suffix c ext
              $ fmt_attributes c xexp.ast.pexp_attributes
-             $ fmt "@;<1 2>"
+             $ break 1 2
              $ fmt_expression c (sub_exp ~ctx e0)
-             $ fmt "@ with" )
-         $ fmt "@ " $ fmt_cases c ctx cs ) )
+             $ space_break $ str "with" )
+         $ space_break $ fmt_cases c ctx cs ) )
 
 and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
     ?(indent_wrap = 0) ?ext ({ast= exp; ctx= ctx0} as xexp) =
@@ -1766,20 +1766,20 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
           (List.map ~f:snd (Sugar.sequence c.cmts (sub_exp ~ctx e2)))
           ~break
       in
-      let fmt_grp grp = list grp " ;@ " (fmt_expression c) in
+      let fmt_grp grp = list_k grp (str " ;" $ space_break) (fmt_expression c) in
       pro
       $ hvbox 0
           (Params.parens_if parens c.conf
              ( hvbox c.conf.fmt_opts.extension_indent.v
-                 (wrap "[" "]"
+                 (wrap_k (str "[") (str "]")
                     ( str "%"
                     $ hovbox 2
                         ( fmt_str_loc c name $ str " fun "
                         $ fmt_attributes c ~suf:" " call.pexp_attributes
                         $ fmt_expr_fun_args c xargs $ fmt_opt fmt_cstr
-                        $ fmt "@ ->" )
-                    $ fmt "@ " $ fmt_expression c xbody ) )
-             $ fmt "@ ;@ "
+                        $ space_break $ str "->" )
+                    $ space_break $ fmt_expression c xbody ) )
+             $ space_break $ str ";" $ space_break
              $ list_k grps (str " ;" $ force_break) fmt_grp ) )
   | Pexp_infix
       ( {txt= "|>"; loc}
@@ -1798,17 +1798,17 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       $ hvbox 0
           (Params.Exp.wrap c.conf ~parens
              ( fmt_expression c (sub_exp ~ctx e0)
-             $ fmt "@\n"
-             $ Cmts.fmt c loc (fmt "|>@\n")
+             $ force_newline
+             $ Cmts.fmt c loc (str "|>" $ force_newline)
              $ hvbox c.conf.fmt_opts.extension_indent.v
-                 (wrap "[" "]"
+                 (wrap_k (str "[") (str "]")
                     ( str "%"
                     $ hovbox 2
                         ( fmt_str_loc c name $ str " fun "
                         $ fmt_attributes c ~suf:" " retn.pexp_attributes
                         $ fmt_expr_fun_args c xargs $ fmt_opt fmt_cstr
-                        $ fmt "@ ->" )
-                    $ fmt "@ " $ fmt_expression c xbody ) ) ) )
+                        $ space_break $ str "->" )
+                    $ space_break $ fmt_expression c xbody ) ) ) )
   | Pexp_infix ({txt= ":="; loc}, r, v)
     when is_simple c.conf (expression_width c) (sub_exp ~ctx r) ->
       let bol_indent = Params.Indent.assignment_operator_bol c.conf in
@@ -1818,7 +1818,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
              according to indentation. *)
           match c.conf.fmt_opts.assignment_operator.v with
           | `Begin_line -> (bol_indent, noop)
-          | `End_line -> (2, fmt "@,")
+          | `End_line -> (2, cut_break)
         in
         Cmts.fmt_before c loc ~pro:(break 1 indent) ~epi:adj ~adj
       in
@@ -1829,13 +1829,13 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
              ( match c.conf.fmt_opts.assignment_operator.v with
              | `Begin_line ->
                  hvbox 0 (fmt_expression c (sub_exp ~ctx r) $ cmts_before)
-                 $ break 1 bol_indent $ fmt ":= " $ cmts_after
+                 $ break 1 bol_indent $ str ":= " $ cmts_after
                  $ hvbox 2 (fmt_expression c (sub_exp ~ctx v))
              | `End_line ->
                  hvbox 0
                    ( hvbox 0 (fmt_expression c (sub_exp ~ctx r) $ cmts_before)
                    $ str " :=" )
-                 $ fmt "@;<1 2>" $ cmts_after
+                 $ break 1 2 $ cmts_after
                  $ hvbox 2 (fmt_expression c (sub_exp ~ctx v)) ) )
   | Pexp_prefix ({txt= ("~-" | "~-." | "~+" | "~+.") as op; loc}, e1) ->
       let op =
@@ -1843,7 +1843,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
           String.sub op ~pos:1 ~len:(String.length op - 1)
         else op
       in
-      let spc = fmt_if (Exp.exposed_left e1) "@ " in
+      let spc = fmt_if_k (Exp.exposed_left e1)space_break in
       pro
       $ Params.parens_if parens c.conf
           ( Cmts.fmt c pexp_loc
@@ -1877,25 +1877,25 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       pro
       $ wrap_fits_breaks_if c.conf parens "(" ")"
           ( hovbox 0
-              (wrap_if has_attr "(" ")"
+              (wrap_if_k has_attr (str "(") (str ")")
                  ( hvbox 2
                      ( hvbox indent_wrap
                          ( fmt_expression ~indent_wrap c (sub_exp ~ctx l)
-                         $ fmt "@;"
+                         $ space_break
                          $ hovbox 2
                              ( hvbox 0
-                                 ( fmt_str_loc c op $ fmt "@ " $ cmts_before
-                                 $ fmt_if parens_r "(" $ str "fun " )
+                                 ( fmt_str_loc c op $ space_break $ cmts_before
+                                 $ fmt_if_k parens_r (str"(") $ str "fun " )
                              $ fmt_attributes c pexp_attributes ~suf:" "
                              $ hvbox_if
                                  (not c.conf.fmt_opts.wrap_fun_args.v)
                                  4
                                  ( fmt_expr_fun_args c xargs
                                  $ fmt_opt fmt_cstr )
-                             $ fmt "@ ->" ) )
+                             $ space_break $ str "->" ) )
                      $ pre_body )
-                 $ fmt_or_k followed_by_infix_op force_break (fmt "@ ")
-                 $ body $ fmt_if parens_r ")" $ cmts_after ) )
+                 $ fmt_or_k followed_by_infix_op force_break (space_break)
+                 $ body $ fmt_if_k parens_r (str ")") $ cmts_after ) )
           $ fmt_atrs )
   | Pexp_infix
       ( op
@@ -1912,14 +1912,14 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
           (hvbox indent
              ( hvbox 0
                  ( fmt_expression c (sub_exp ~ctx l)
-                 $ fmt "@;"
+                 $ space_break
                  $ hovbox 2
                      ( hvbox 0
-                         ( fmt_str_loc c op $ fmt "@ " $ cmts_before
-                         $ fmt_if parens_r "( " $ str "function"
+                         ( fmt_str_loc c op $ space_break $ cmts_before
+                         $ fmt_if_k parens_r (str"( ") $ str "function"
                          $ fmt_extension_suffix c ext )
                      $ fmt_attributes c pexp_attributes ) )
-             $ fmt "@ " $ fmt_cases c (Exp r) cs $ fmt_if parens_r " )"
+             $ space_break $ fmt_cases c (Exp r) cs $ fmt_if_k parens_r (str" )")
              $ cmts_after ) )
   | Pexp_infix _ ->
       let op_args = Sugar.Exp.infix c.cmts (prec_ast (Exp exp)) xexp in
@@ -1981,7 +1981,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       pro
       $ hvbox 2
           (Params.Exp.wrap c.conf ~parens
-             ( fmt_str_loc c op $ fmt_if has_cmts "@,"
+             ( fmt_str_loc c op $ fmt_if_k has_cmts cut_break
              $ fmt_expression c ~box (sub_exp ~ctx e)
              $ fmt_atrs ) )
   | Pexp_apply (e0, e1N1) -> (
@@ -2026,7 +2026,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
               wrap
                 ( intro_epi
                 $ fmt_args_grouped e0 args_before
-                $ fmt "@ " $ hvbox 0 x )
+                $ space_break $ hvbox 0 x )
               $ break_body
             in
             let force_closing_paren =
@@ -2060,17 +2060,17 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                     ( wrap
                         ( intro_epi
                         $ fmt_args_grouped e0 args_before
-                        $ fmt "@ "
+                        $ space_break
                         $ Cmts.fmt_before c last_arg.pexp_loc
-                        $ fmt_label lbl ":" $ str "(function"
+                        $ fmt_label lbl (str ":") $ str "(function"
                         $ fmt_attributes c ~pre:Blank
                             last_arg.pexp_attributes )
-                    $ fmt "@ " $ leading_cmt
+                    $ space_break $ leading_cmt
                     $ hvbox 0
                         ( fmt_pattern c ~pro:(if_newline "| ")
                             (sub_pat ~ctx pc_lhs)
-                        $ fmt "@ ->" )
-                    $ fmt "@ "
+                        $ space_break $ str "->" )
+                    $ space_break
                     $ cbox 0 (fmt_expression c (sub_exp ~ctx pc_rhs))
                     $ closing_paren c ~force
                     $ Cmts.fmt_after c last_arg.pexp_loc )
@@ -2090,11 +2090,11 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                 ( wrap
                     ( intro_epi
                     $ fmt_args_grouped e0 args_before
-                    $ fmt "@ "
+                    $ space_break
                     $ Cmts.fmt_before c last_arg.pexp_loc
-                    $ fmt_label lbl ":" $ str "(function"
+                    $ fmt_label lbl (str ":") $ str "(function"
                     $ fmt_attributes c ~pre:Blank last_arg.pexp_attributes )
-                $ fmt "@ " $ fmt_cases c ctx'' cs $ closing_paren c
+                $ space_break $ fmt_cases c ctx'' cs $ closing_paren c
                 $ Cmts.fmt_after c last_arg.pexp_loc
                 $ fmt_atrs ) )
       | _ ->
@@ -2106,7 +2106,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
               Fit
             else Break
           in
-          pro $ fmt_if parens "("
+          pro $ fmt_if_k parens (str "(")
           $ hvbox 2
               ( fmt_args_grouped ~epi:fmt_atrs e0 e1N1
               $ fmt_if_k parens (closing_paren c ~force ~offset:(-3)) ) )
@@ -2155,7 +2155,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                 ( hvbox 2
                     ( str "assert"
                     $ fmt_extension_suffix c ext
-                    $ fmt_or paren_body " (@," "@ "
+                    $ fmt_or_k paren_body (str " (" $ cut_break) space_break
                     $ fmt_expression c ~parens:false (sub_exp ~ctx e0) )
                 $ fmt_if_k paren_body (closing_paren c)
                 $ fmt_atrs ) ) )
@@ -2172,7 +2172,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
           (Params.parens_if parens c.conf
              ( wrap_fits_breaks ~space:false c.conf "(" ")"
                  ( fmt_expression c (sub_exp ~ctx e)
-                 $ fmt "@ : "
+                 $ space_break $ str ": "
                  $ fmt_core_type c (sub_typ ~ctx t) )
              $ fmt_atrs ) )
   | Pexp_construct ({txt= Lident (("()" | "[]") as txt); loc}, None) ->
@@ -2193,14 +2193,14 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
           ( hvbox indent_wrap
               (fmt_infix_op_args c ~parens xexp
                  (List.mapi l ~f:(fun i e ->
-                      (None, None, (fmt_if (i > 0) "::", sub_exp ~ctx e)) )
+                      (None, None, (fmt_if_k (i > 0) (str "::"), sub_exp ~ctx e)) )
                  ) )
           $ fmt_atrs )
   | Pexp_construct (lid, Some arg) ->
       pro
       $ Params.parens_if parens c.conf
           ( hvbox 2
-              ( fmt_longident_loc c lid $ fmt "@ "
+              ( fmt_longident_loc c lid $ space_break
               $ fmt_expression c (sub_exp ~ctx arg) )
           $ fmt_atrs )
   | Pexp_variant (s, arg) ->
@@ -2209,14 +2209,14 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
           (hvbox
              (Params.Indent.variant c.conf ~parens)
              ( variant_var c s
-             $ opt arg (fmt "@ " >$ (sub_exp ~ctx >> fmt_expression c))
+             $ opt arg (space_break >$ (sub_exp ~ctx >> fmt_expression c))
              $ fmt_atrs ) )
   | Pexp_field (exp, lid) ->
       pro
       $ hvbox 2
           (Params.parens_if parens c.conf
              ( fmt_expression c (sub_exp ~ctx exp)
-             $ fmt "@,." $ fmt_longident_loc c lid $ fmt_atrs ) )
+             $ cut_break $ str "." $ fmt_longident_loc c lid $ fmt_atrs ) )
   | Pexp_newtype _ | Pexp_fun _ ->
       let xargs, xbody = Sugar.fun_ c.cmts xexp in
       let fmt_cstr, xbody = type_constr_and_body c xbody in
@@ -2247,7 +2247,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       $ hvbox_if (box || body_is_function) indent
           (Params.Exp.wrap c.conf ~parens ~disambiguate:true
              ~fits_breaks:false ~offset_closing_paren:(-2)
-             (hovbox 2 (intro $ str " ->" $ pre_body) $ fmt "@ " $ body) )
+             (hovbox 2 (intro $ str " ->" $ pre_body) $ space_break $ body) )
   | Pexp_function cs ->
       let indent = Params.Indent.function_ c.conf ~parens xexp in
       pro
@@ -2263,7 +2263,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       let outer_parens = has_attr && parens in
       pro
       $ Cmts.fmt c loc
-        @@ wrap_if outer_parens "(" ")"
+        @@ wrap_if_k outer_parens (str "(") (str ")")
         @@ (fmt_longident txt $ Cmts.fmt_within c loc $ fmt_atrs)
   | Pexp_ifthenelse (if_branches, else_) ->
       let last_loc =
@@ -2336,7 +2336,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
           Nonrecursive bd body
   | Pexp_letexception (ext_cstr, exp) ->
       let pre =
-        str "let exception" $ fmt_extension_suffix c ext $ fmt "@ "
+        str "let exception" $ fmt_extension_suffix c ext $ space_break
       in
       pro
       $ hvbox 0
@@ -2347,7 +2347,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                   ( hvbox 2
                       (hvbox 2
                          (pre $ fmt_extension_constructor c ctx ext_cstr) )
-                  $ fmt "@ in" )
+                  $ space_break $ str "in" )
               $ force_break
               $ fmt_expression c (sub_exp ~ctx exp) )
           $ fmt_atrs )
@@ -2403,8 +2403,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
              ( hvbox 0
                  ( hvbox 0
                      ( fmt_longident_loc c lid $ str "."
-                     $ fmt_if inner_parens "(" )
-                 $ fmt "@;<0 2>"
+                     $ fmt_if_k inner_parens (str "(") )
+                 $ break 0 2
                  $ fmt_expression c (sub_exp ~ctx e0)
                  $ fmt_if_k inner_parens (closing_paren c) )
              $ fmt_atrs ) )
@@ -2430,8 +2430,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                                  ( hvbox 0
                                      ( str "let" $ break 1 0
                                      $ Cmts.fmt_before c popen_loc
-                                     $ fmt_or override "open!" "open"
-                                     $ opt ext (fun _ -> fmt_if override " ")
+                                     $ fmt_or_k override (str"open!") (str"open")
+                                     $ opt ext (fun _ -> fmt_if_k override (str " "))
                                      $ fmt_extension_suffix c ext )
                                  $ break 1 0 )
                                (sub_mod ~ctx popen_expr)
@@ -2459,27 +2459,27 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                  ( str "try"
                  $ fmt_extension_suffix c ext
                  $ fmt_attributes c pexp_attributes
-                 $ fmt "@;<1 2>"
+                 $ break 1 2
                  $ fmt_expression c (sub_exp ~ctx e0) )
              $ break 1 (-2)
              $ hvbox 0
                  ( hvbox 0
-                     ( fmt "with@ " $ leading_cmt
+                     ( str "with" $ space_break $ leading_cmt
                      $ hvbox 0
                          ( fmt_pattern c ~pro:(if_newline "| ")
                              (sub_pat ~ctx pc_lhs)
                          $ opt pc_guard (fun g ->
-                               fmt "@ when "
+                               space_break $ str "when "
                                $ fmt_expression c (sub_exp ~ctx g) )
-                         $ fmt "@ ->" $ fmt_if parens_here " (" ) )
-                 $ fmt "@;<1 2>"
+                         $ space_break $ str "->" $ fmt_if_k parens_here (str" (") ) )
+                 $ break 1 2
                  $ cbox 0 (fmt_expression c ?parens:parens_for_exp xpc_rhs)
                  )
-             $ fmt_if parens_here
+             $ fmt_if_k parens_here
                  ( match c.conf.fmt_opts.indicate_multiline_delimiters.v with
-                 | `No -> ")"
-                 | `Space -> " )"
-                 | `Closing_on_separate_line -> "@;<1000 -2>)" ) ) )
+                 | `No -> str ")"
+                 | `Space -> str " )"
+                 | `Closing_on_separate_line -> break 1000 (-2) ) ) )
   | Pexp_match (e0, cs) ->
       fmt_match c ~pro ~parens ?ext ctx xexp cs e0 "match"
   | Pexp_try (e0, cs) -> fmt_match c ~pro ~parens ?ext ctx xexp cs e0 "try"
@@ -2509,7 +2509,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
         match pt with
         | Some (id, cnstrs) ->
             hvbox 2
-              ( hovbox 0 (m $ fmt "@ : " $ fmt_longident_loc c id)
+              ( hovbox 0 (m $ space_break $ str ": " $ fmt_longident_loc c id)
               $ fmt_package_type c ctx cnstrs )
         | None -> m
       in
@@ -2551,7 +2551,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
           ( p1.box
               ( opt default (fun d ->
                     hvbox 2
-                      (fmt_expression c (sub_exp ~ctx d) $ fmt "@;<1 -2>")
+                      (fmt_expression c (sub_exp ~ctx d) $ (break 1 (-2)))
                     $ str "with" $ p2.break_after_with )
               $ fmt_fields )
           $ fmt_atrs )
@@ -2619,7 +2619,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
           (Params.Exp.wrap c.conf ~parens
              ( str "lazy"
              $ fmt_extension_suffix c ext
-             $ fmt "@ "
+             $ space_break
              $ fmt_expression c (sub_exp ~ctx e)
              $ fmt_atrs ) )
   | Pexp_extension
@@ -2680,17 +2680,17 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                      ( hvbox 0
                          ( str "for"
                          $ fmt_extension_suffix c ext
-                         $ fmt "@;<1 2>"
+                         $ break 1 2
                          $ hovbox 0
                              ( fmt_pattern c (sub_pat ~ctx p1)
-                             $ fmt "@ =@;<1 2>"
+                             $ space_break $ str "=" $ break 1 2
                              $ fmt_expression c (sub_exp ~ctx e1)
                              $ fmt_direction_flag dir
                              $ fmt_expression c (sub_exp ~ctx e2) )
-                         $ fmt "@;do" )
+                         $ space_break $ str "do" )
                      $ force_break
                      $ fmt_expression c (sub_exp ~ctx e3) )
-                 $ force_break $ fmt "done" )
+                 $ force_break $ str "done" )
              $ fmt_atrs ) )
   | Pexp_coerce (e1, t1, t2) ->
       pro
@@ -2698,8 +2698,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
           (Params.parens_if (parens && has_attr) c.conf
              ( wrap_fits_breaks ~space:false c.conf "(" ")"
                  ( fmt_expression c (sub_exp ~ctx e1)
-                 $ opt t1 (fmt "@ : " >$ (sub_typ ~ctx >> fmt_core_type c))
-                 $ fmt "@ :> "
+                 $ opt t1 (space_break $ str ": " >$ (sub_typ ~ctx >> fmt_core_type c))
+                 $ space_break $ str ":> "
                  $ fmt_core_type c (sub_typ ~ctx t2) )
              $ fmt_atrs ) )
   | Pexp_while (e1, e2) ->
@@ -2711,12 +2711,12 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                      ( hvbox 0
                          ( str "while"
                          $ fmt_extension_suffix c ext
-                         $ fmt "@;<1 2>"
+                         $ break 1 2
                          $ fmt_expression c (sub_exp ~ctx e1)
-                         $ fmt "@;do" )
+                         $ space_break $ str "do" )
                      $ force_break
                      $ fmt_expression c (sub_exp ~ctx e2) )
-                 $ force_break $ fmt "done" )
+                 $ force_break $ str "done" )
              $ fmt_atrs ) )
   | Pexp_unreachable -> pro $ str "."
   | Pexp_send (exp, meth) ->
@@ -2724,7 +2724,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       $ hvbox 2
           (Params.parens_if parens c.conf
              ( fmt_expression c (sub_exp ~ctx exp)
-             $ fmt "@,#" $ fmt_str_loc c meth $ fmt_atrs ) )
+             $ cut_break $ str "#" $ fmt_str_loc c meth $ fmt_atrs ) )
   | Pexp_new {txt; loc} ->
       pro
       $ Cmts.fmt c loc
@@ -2732,7 +2732,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
              (Params.parens_if parens c.conf
                 ( str "new"
                 $ fmt_extension_suffix c ext
-                $ fmt "@ " $ fmt_longident txt $ fmt_atrs ) )
+                $ space_break $ fmt_longident txt $ fmt_atrs ) )
   | Pexp_object {pcstr_self; pcstr_fields} ->
       pro
       $ hvbox 0
@@ -2741,7 +2741,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
              $ fmt_atrs ) )
   | Pexp_override l -> (
       let fmt_field ({txt; loc}, f) =
-        let eol = fmt "@;<1 3>" in
+        let eol = break 1 3 in
         let txt = Longident.lident txt in
         match f.pexp_desc with
         | Pexp_ident {txt= txt'; loc}
@@ -2757,13 +2757,13 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       | [] ->
           pro
           $ Params.parens_if parens c.conf
-              (wrap "{<" ">}" (Cmts.fmt_within c pexp_loc) $ fmt_atrs)
+              (wrap_k (str "{<") (str ">}") (Cmts.fmt_within c pexp_loc) $ fmt_atrs)
       | _ ->
           pro
           $ hvbox 0
               (Params.parens_if parens c.conf
                  ( wrap_fits_breaks ~space:false c.conf "{<" ">}"
-                     (list l "@;<0 1>; " fmt_field)
+                     (list_k l (break 0 1 $ str "; ") fmt_field)
                  $ fmt_atrs ) ) )
   | Pexp_setinstvar (name, expr) ->
       pro
@@ -2824,7 +2824,7 @@ and fmt_class_structure c ~ctx ?ext self_ fields =
   in
   let self_ =
     opt self_ (fun self_ ->
-        fmt "@;"
+        space_break
         $ Params.parens c.conf
             (fmt_pattern c ~parens:false (sub_pat ~ctx self_)) )
   in
@@ -2839,7 +2839,7 @@ and fmt_class_structure c ~ctx ?ext self_ fields =
         (Cmts.fmt_within ~epi:noop c (Ast.location ctx))
         force_break
     $ fmt_item_list c ctx update_config ast fmt_item fields )
-  $ fmt_or_k (List.is_empty fields) (fmt "@ ") force_break
+  $ fmt_or_k (List.is_empty fields) (space_break) force_break
   $ str "end"
 
 (** [epi] is a function to ensure ordered access to comments. *)
@@ -2852,7 +2852,7 @@ and fmt_class_signature c ~ctx ~pro ~epi ?ext self_ fields =
   let self_ =
     opt self_ (fun self_ ->
         let no_attr typ = List.is_empty typ.ptyp_attributes in
-        fmt "@;"
+        space_break
         $ Params.parens_if (no_attr self_) c.conf
             (fmt_core_type c (sub_typ ~ctx self_)) )
   in
@@ -2868,9 +2868,9 @@ and fmt_class_signature c ~ctx ~pro ~epi ?ext self_ fields =
   in
   hvbox 2
     ( hvbox 2 (pro $ str "object" $ fmt_extension_suffix c ext $ self_)
-    $ fmt "@ " $ cmts_within
+    $ space_break $ cmts_within
     $ fmt_item_list c ctx update_config ast fmt_item fields
-    $ fmt_if (not (List.is_empty fields)) "@;<1000 -2>"
+    $ fmt_if_k (not (List.is_empty fields)) (break 1000 (-2))
     $ hvbox 0 (str "end" $ epi ()) )
 
 and fmt_class_type ?(pro = noop) c ({ast= typ; _} as xtyp) =
@@ -2886,12 +2886,12 @@ and fmt_class_type ?(pro = noop) c ({ast= typ; _} as xtyp) =
   let pro ~cmt =
     pro
     $ (if cmt then Cmts.fmt_before c pcty_loc else noop)
-    $ fmt_if parens "("
+    $ fmt_if_k parens (str "(")
   and epi ~attrs =
-    fmt_if parens ")"
+    fmt_if_k parens (str ")")
     $ (if attrs then fmt_attributes c atrs else noop)
     $ Cmts.fmt_after c pcty_loc
-    $ fmt_docstring c ~pro:(fmt "@ ") doc
+    $ fmt_docstring c ~pro:(space_break) doc
   in
   match pcty_desc with
   | Pcty_constr (name, params) ->
@@ -2938,7 +2938,7 @@ and fmt_class_expr c ({ast= exp; ctx= ctx0} as xexp) =
   let ctx = Cl exp in
   let fmt_args_grouped e0 a1N =
     (* TODO: consider [e0] when grouping *)
-    fmt_class_expr c (sub_cl ~ctx e0) $ fmt "@ " $ fmt_args_grouped c ctx a1N
+    fmt_class_expr c (sub_cl ~ctx e0) $ space_break $ fmt_args_grouped c ctx a1N
   in
   let fmt_cmts = Cmts.fmt c pcl_loc in
   let fmt_atrs = fmt_attributes c ~pre:Space pcl_attributes in
@@ -2967,9 +2967,9 @@ and fmt_class_expr c ({ast= exp; ctx= ctx0} as xexp) =
                    ( str "fun "
                    $ fmt_attributes c pcl_attributes ~suf:" "
                    $ wrap_fun_decl_args c (fmt_class_fun_args c xargs)
-                   $ fmt "@ " )
+                   $ space_break )
                $ str "->" )
-           $ fmt "@ "
+           $ space_break
            $ fmt_class_expr c (sub_cl ~ctx body) ) )
   | Pcl_apply (e0, e1N1) ->
       Params.parens_if parens c.conf
@@ -2991,7 +2991,7 @@ and fmt_class_expr c ({ast= exp; ctx= ctx0} as xexp) =
       hvbox 2
         (wrap_fits_breaks ~space:false c.conf "(" ")"
            ( fmt_class_expr c (sub_cl ~ctx e)
-           $ fmt " :@ "
+           $ str " :" $ space_break
            $ fmt_class_type c (sub_cty ~ctx t) ) )
       $ fmt_atrs
   | Pcl_extension ext -> fmt_extension c ctx ext $ fmt_atrs
@@ -2999,12 +2999,12 @@ and fmt_class_expr c ({ast= exp; ctx= ctx0} as xexp) =
       hvbox 0
         ( fmt_open_description c ~keyword:"let open"
             ~kw_attributes:pcl_attributes popen
-        $ fmt " in" $ force_break
+        $ str " in" $ force_break
         $ fmt_class_expr c (sub_cl ~ctx cl) )
 
 and fmt_class_field_kind c ctx = function
   | Cfk_virtual typ ->
-      (fmt "@ : " $ fmt_core_type c (sub_typ ~ctx typ), noop, noop, noop)
+      (space_break $ str ": " $ fmt_core_type c (sub_typ ~ctx typ), noop, noop, noop)
   | Cfk_concrete
       ( _
       , { pexp_desc=
@@ -3028,17 +3028,17 @@ and fmt_class_field_kind c ctx = function
             match args with x :: _ -> x.loc | [] -> e.pexp_loc
           in
           Cmts.relocate c.cmts ~src:pexp_loc ~before ~after:e.pexp_loc ;
-          ( fmt "@ : type "
-            $ list args "@ " (fmt_str_loc c)
+          ( space_break $ str ": type "
+            $ list_k args space_break (fmt_str_loc c)
             $ fmt_core_type ~pro:"." ~pro_space:false c (sub_typ ~ctx t)
           , noop
-          , fmt "@;<1 2>="
-          , fmt "@ " $ fmt_expression c (sub_exp ~ctx e) )
+          , break 1 2 $ str "="
+          , space_break $ fmt_expression c (sub_exp ~ctx e) )
       | None ->
-          ( fmt "@ : " $ fmt_core_type c (sub_typ ~ctx poly)
+          ( space_break $ str  ": " $ fmt_core_type c (sub_typ ~ctx poly)
           , noop
-          , fmt "@;<1 2>="
-          , fmt "@ " $ fmt_expression c (sub_exp ~ctx e) ) )
+          , break 1 2 $ str "="
+          , space_break $ fmt_expression c (sub_exp ~ctx e) ) )
   | Cfk_concrete (_, {pexp_desc= Pexp_poly (e, poly); pexp_loc; _}) ->
       let xargs, xbody =
         match poly with
@@ -3059,21 +3059,21 @@ and fmt_class_field_kind c ctx = function
       Cmts.relocate c.cmts ~src:pexp_loc ~before:e.ast.pexp_loc
         ~after:e.ast.pexp_loc ;
       ( noop
-      , fmt_if (not (List.is_empty xargs)) "@ "
+      , fmt_if_k (not (List.is_empty xargs)) space_break
         $ wrap_fun_decl_args c (fmt_expr_fun_args c xargs)
-        $ opt ty (fun t -> fmt "@ : " $ fmt_core_type c (sub_typ ~ctx t))
-      , fmt "@;<1 2>="
-      , fmt "@ " $ fmt_expression c e )
+        $ opt ty (fun t -> space_break $  str ": " $ fmt_core_type c (sub_typ ~ctx t))
+      , break 1 2 $ str "="
+      , space_break $ fmt_expression c e )
   | Cfk_concrete (_, e) ->
       let ty, e =
         match e with
         | {pexp_desc= Pexp_constraint (e, t); _} -> (Some t, e)
         | _ -> (None, e)
       in
-      ( opt ty (fun t -> fmt "@ : " $ fmt_core_type c (sub_typ ~ctx t))
+      ( opt ty (fun t -> space_break $ str ": " $ fmt_core_type c (sub_typ ~ctx t))
       , noop
-      , fmt "@;<1 2>="
-      , fmt "@ " $ fmt_expression c (sub_exp ~ctx e) )
+      , break 1 2 $ str "="
+      , space_break $ fmt_expression c (sub_exp ~ctx e) )
 
 and fmt_class_field c {ast= cf; _} =
   protect c (Clf cf)
@@ -3094,8 +3094,8 @@ and fmt_class_field c {ast= cf; _} =
   | Pcf_inherit (override, cl, parent) ->
       hovbox 2
         ( str "inherit"
-        $ fmt_if (is_override override) "!"
-        $ fmt "@ "
+        $ fmt_if_k (is_override override) (str "!")
+        $ space_break
         $ ( fmt_class_expr c (sub_cl ~ctx cl)
           $ opt parent (fun p -> str " as " $ fmt_str_loc c p) ) )
   | Pcf_method (name, pv, kind) ->
@@ -3127,7 +3127,7 @@ and fmt_class_field c {ast= cf; _} =
             $ eq )
         $ expr )
   | Pcf_constraint (t1, t2) ->
-      fmt "constraint@ "
+      str "constraint" $ space_break
       $ fmt_core_type c (sub_typ ~ctx t1)
       $ str " = "
       $ fmt_core_type c (sub_typ ~ctx t2)
@@ -3154,25 +3154,25 @@ and fmt_class_type_field c {ast= cf; _} =
   @@
   match cf.pctf_desc with
   | Pctf_inherit ct ->
-      hovbox 2 (fmt "inherit@ " $ fmt_class_type c (sub_cty ~ctx ct))
+      hovbox 2 (str "inherit" $ space_break $ fmt_class_type c (sub_cty ~ctx ct))
   | Pctf_method (name, pv, ty) ->
       box_fun_sig_args c 2
         ( hovbox 4
             ( str "method"
             $ fmt_private_virtual_flag c pv
-            $ fmt "@ " $ fmt_str_loc c name )
-        $ fmt " :@ "
+            $ space_break $ fmt_str_loc c name )
+        $ str " :" $ space_break
         $ fmt_core_type c (sub_typ ~ctx ty) )
   | Pctf_val (name, mv, ty) ->
       box_fun_sig_args c 2
         ( hovbox 4
             ( str "val"
             $ fmt_mutable_virtual_flag c mv
-            $ fmt "@ " $ fmt_str_loc c name )
-        $ fmt " :@ "
+            $ space_break $ fmt_str_loc c name )
+        $ str " :" $ space_break
         $ fmt_core_type c (sub_typ ~ctx ty) )
   | Pctf_constraint (t1, t2) ->
-      fmt "constraint@ "
+      str "constraint" $ space_break
       $ fmt_core_type c (sub_typ ~ctx t1)
       $ str " = "
       $ fmt_core_type c (sub_typ ~ctx t2)
@@ -3202,7 +3202,7 @@ and fmt_case c ctx ~first ~last case =
           ( hvbox 0
               ( fmt_pattern c ~pro:p.bar ~parens:paren_lhs xlhs
               $ opt pc_guard (fun g ->
-                    fmt "@;<1 2>when " $ fmt_expression c (sub_exp ~ctx g) )
+                    break 1 2 $ str "when " $ fmt_expression c (sub_exp ~ctx g) )
               )
           $ p.break_before_arrow $ str "->" $ p.break_after_arrow
           $ p.open_paren_branch )
@@ -3226,8 +3226,8 @@ and fmt_value_description ?ext c ctx vd =
     hvbox 0 @@ Cmts.fmt c loc
     @@
     if String.exists s ~f:(function ' ' | '\n' -> true | _ -> false) then
-      wrap "{|" "|}" (str s)
-    else wrap "\"" "\"" (str (String.escaped s))
+      wrap_k (str "{|") (str "|}") (str s)
+    else wrap_k  (str "\"") (str "\"") (str (String.escaped s))
   in
   hvbox 0
     ( doc_before
@@ -3236,18 +3236,18 @@ and fmt_value_description ?ext c ctx vd =
         $ fmt_extension_suffix c ext
         $ str " "
         $ Cmts.fmt c loc
-            (wrap_if
+            (wrap_if_k
                (Std_longident.String_id.is_symbol txt)
-               "( " " )" (str txt) )
+               (str "( ") (str " )") (str txt) )
         $ fmt_core_type c ~pro:":"
             ~box:
               (not
                  ( c.conf.fmt_opts.ocp_indent_compat.v
                  && is_arrow_or_poly pval_type ) )
             ~pro_space:true (sub_typ ~ctx pval_type)
-        $ fmt_if (not (List.is_empty pval_prim)) "@ = "
+        $ fmt_if_k (not (List.is_empty pval_prim)) (space_break $ str "= ")
         $ hvbox_if (List.length pval_prim > 1) 0
-          @@ list pval_prim "@;" fmt_val_prim )
+          @@ list_k pval_prim space_break fmt_val_prim )
     $ fmt_item_attributes c ~pre:(Break (1, 0)) atrs
     $ doc_after )
 
@@ -3257,23 +3257,23 @@ and fmt_tydcl_params c ctx params =
     ( wrap_fits_breaks_if ~space:false c.conf
         (List.length params > 1)
         "(" ")"
-        (list params (Params.comma_sep c.conf) (fun (ty, vc) ->
+        (list_k params (Params.comma_sep c.conf) (fun (ty, vc) ->
              fmt_variance_injectivity c vc
              $ fmt_core_type c (sub_typ ~ctx ty) ) )
-    $ fmt "@ " )
+    $ space_break )
 
 and fmt_class_params c ctx params =
   let fmt_param ~first ~last (ty, vc) =
-    fmt_if (first && Exposed.Left.core_type ty) " "
-    $ fmt_if_k (not first) (fmt (Params.comma_sep c.conf))
+    fmt_if_k (first && Exposed.Left.core_type ty) (str " ")
+    $ fmt_if_k (not first) ((Params.comma_sep c.conf))
     $ fmt_variance_injectivity c vc
     $ fmt_core_type c (sub_typ ~ctx ty)
-    $ fmt_if (last && Exposed.Right.core_type ty) " "
+    $ fmt_if_k (last && Exposed.Right.core_type ty) (str " ")
   in
   fmt_if_k
     (not (List.is_empty params))
     (hvbox 0
-       (wrap_fits_breaks c.conf "[" "]" (list_fl params fmt_param) $ fmt "@ ") )
+       (wrap_fits_breaks c.conf "[" "]" (list_fl params fmt_param) $ space_break) )
 
 and fmt_type_declaration c ?ext ?(pre = "") ?name ?(eq = "=") {ast= decl; _}
     =
@@ -3294,7 +3294,7 @@ and fmt_type_declaration c ?ext ?(pre = "") ?name ?(eq = "=") {ast= decl; _}
   let ctx = Td decl in
   let fmt_abstract_manifest = function
     | Some m ->
-        str " " $ str eq $ fmt_private_flag c priv $ fmt "@ "
+        str " " $ str eq $ fmt_private_flag c priv $ space_break
         $ fmt_core_type c (sub_typ ~ctx m)
     | None -> noop
   in
@@ -3321,20 +3321,20 @@ and fmt_type_declaration c ?ext ?(pre = "") ?name ?(eq = "=") {ast= decl; _}
   let fmt_manifest_kind =
     match ptype_kind with
     | Ptype_abstract -> box_manifest (fmt_abstract_manifest m)
-    | Ptype_variant [] -> box_manifest (fmt_manifest m) $ fmt "@ |"
+    | Ptype_variant [] -> box_manifest (fmt_manifest m) $ space_break $ str "|"
     | Ptype_variant ctor_decls ->
         box_manifest (fmt_manifest m)
-        $ fmt "@ "
+        $ space_break
         $ list_fl ctor_decls (fmt_constructor_declaration c ctx)
     | Ptype_record lbl_decls ->
         let p = Params.get_record_type c.conf in
         let fmt_decl ~first ~last x =
           fmt_if_k (not first) p.sep_before
           $ fmt_label_declaration c ctx x ~last
-          $ fmt_if
+          $ fmt_if_k
               ( last && (not p.box_spaced)
               && Exposed.Right.label_declaration x )
-              " "
+              (str " ")
           $ fmt_if_k (not last) p.sep_after
         in
         box_manifest (fmt_manifest m $ p.docked_before)
@@ -3346,15 +3346,15 @@ and fmt_type_declaration c ?ext ?(pre = "") ?name ?(eq = "=") {ast= decl; _}
   let fmt_cstr (t1, t2, loc) =
     Cmts.fmt c loc
       (hvbox 2
-         ( fmt "constraint@ "
+         ( str "constraint" $ space_break
          $ fmt_core_type c (sub_typ ~ctx t1)
-         $ fmt " =@ "
+         $ str " =" $ space_break
          $ fmt_core_type c (sub_typ ~ctx t2) ) )
   in
   let fmt_cstrs cstrs =
     fmt_if_k
       (not (List.is_empty cstrs))
-      (fmt "@ " $ hvbox 0 (list cstrs "@ " fmt_cstr))
+      (space_break $ hvbox 0 (list_k cstrs space_break fmt_cstr))
   in
   (* Docstring cannot be placed after variant declarations *)
   let force_before =
@@ -3401,11 +3401,11 @@ and fmt_label_declaration c ctx ?(last = false) decl =
             ( hvbox 4
                 ( hvbox 2
                     ( hovbox 2
-                        ( fmt_mutable_flag ~pro:noop ~epi:(fmt "@ ") c
+                        ( fmt_mutable_flag ~pro:noop ~epi:(space_break) c
                             pld_mutable
-                        $ fmt_str_loc c pld_name $ fmt_if field_loose " "
-                        $ fmt ":" )
-                    $ fmt "@ "
+                        $ fmt_str_loc c pld_name $ fmt_if_k field_loose (str " ")
+                        $ str ":" )
+                    $ space_break
                     $ fmt_core_type c (sub_typ ~ctx pld_type)
                     $ fmt_semicolon )
                 $ cmt_after_type )
@@ -3429,7 +3429,7 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
   (* Force break if comment before pcd_loc, it would interfere with an
      eventual comment placed after the previous constructor *)
   fmt_if_k (not first)
-    (fmt_or_k (sparse || has_cmt_before) force_break (fmt "@ "))
+    (fmt_or_k (sparse || has_cmt_before) force_break (space_break))
   $ Cmts.fmt_before ~epi:force_break c pcd_loc
   $ hvbox ~name:"constructor_decl" 2
       ( hovbox
@@ -3439,9 +3439,9 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
               $ Cmts.fmt_before c loc
               $ hvbox 2
                   ( hovbox ~name:"constructor_decl_name" 2
-                      ( wrap_if
+                      ( wrap_if_k
                           (Std_longident.String_id.is_symbol txt)
-                          "( " " )" (str txt)
+                          (str "( ") (str " )") (str txt)
                       $ Cmts.fmt_after c loc )
                   $ fmt_constructor_arguments_result c ctx pcd_vars pcd_args
                       pcd_res ) )
@@ -3451,13 +3451,13 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
 and fmt_constructor_arguments ?vars c ctx ~pre = function
   | Pcstr_tuple typs ->
       let vars =
-        match vars with Some vars -> fmt "@ " $ vars | None -> noop
+        match vars with Some vars -> space_break $ vars | None -> noop
       and typs =
         match typs with
         | [] -> noop
         | _ :: _ ->
-            fmt "@ "
-            $ hvbox 0 (list typs "@ * " (sub_typ ~ctx >> fmt_core_type c))
+            space_break
+            $ hvbox 0 (list_k typs (space_break $ str "* ") (sub_typ ~ctx >> fmt_core_type c))
       in
       pre $ vars $ typs
   | Pcstr_record (loc, lds) ->
@@ -3465,9 +3465,9 @@ and fmt_constructor_arguments ?vars c ctx ~pre = function
       let fmt_ld ~first ~last x =
         fmt_if_k (not first) p.sep_before
         $ fmt_label_declaration c ctx x ~last
-        $ fmt_if
+        $ fmt_if_k
             (last && (not p.box_spaced) && Exposed.Right.label_declaration x)
-            " "
+            (str " ")
         $ fmt_if_k (not last) p.sep_after
       in
       pre
@@ -3481,17 +3481,17 @@ and fmt_constructor_arguments_result c ctx vars args res =
     match (args, res) with
     | Pcstr_tuple [], Some _ -> (noop, str " :")
     | Pcstr_tuple [], None -> (noop, noop)
-    | _ -> (str "-> ", fmt_or (Option.is_none res) " of" " :")
+    | _ -> (str "-> ", fmt_or_k (Option.is_none res) (str " of") (str " :"))
   in
   let fmt_type typ =
-    fmt "@ " $ before_type $ fmt_core_type c (sub_typ ~ctx typ)
+    space_break $ before_type $ fmt_core_type c (sub_typ ~ctx typ)
   in
   let fmt_vars =
     match vars with
     | [] -> None
     | _ ->
         Some
-          ( hvbox 0 (list vars "@ " (fun {txt; _} -> fmt_type_var txt))
+          ( hvbox 0 (list_k vars space_break (fun {txt; _} -> fmt_type_var txt))
           $ str "." )
   in
   fmt_constructor_arguments c ctx ~pre ?vars:fmt_vars args $ opt res fmt_type
@@ -3508,7 +3508,7 @@ and fmt_type_extension ?ext c ctx
   let fmt_ctor ctor = hvbox 0 (fmt_extension_constructor c ctx ctor) in
   Cmts.fmt c ptyext_loc
   @@ hvbox 2
-       ( fmt_docstring c ~epi:(fmt "@,") doc
+       ( fmt_docstring c ~epi:(cut_break) doc
        $ hvbox c.conf.fmt_opts.type_decl_indent.v
            ( str "type"
            $ fmt_extension_suffix c ext
@@ -3549,8 +3549,8 @@ and fmt_extension_constructor c ctx ec =
   @@ fun c ->
   let sep =
     match pext_kind with
-    | Pext_decl (_, _, Some _) -> fmt " :@ "
-    | Pext_decl (_, _, None) | Pext_rebind _ -> fmt " of@ "
+    | Pext_decl (_, _, Some _) -> str " :" $ space_break
+    | Pext_decl (_, _, None) | Pext_rebind _ -> str " of" $ space_break
   in
   Cmts.fmt c pext_loc
   @@ hvbox 4
@@ -3570,14 +3570,14 @@ and fmt_extension_constructor c ctx ec =
 
 and fmt_functor_param c ctx {loc; txt= arg} =
   match arg with
-  | Unit -> Cmts.fmt c loc (wrap "(" ")" (Cmts.fmt_within c loc))
+  | Unit -> Cmts.fmt c loc (wrap_k (str "(") (str ")") (Cmts.fmt_within c loc))
   | Named (name, mt) ->
       let xmt = sub_mty ~ctx mt in
       hvbox 0
         (Cmts.fmt c loc
-           (wrap "(" ")"
+           (wrap_k  (str "(") (str ")")
               (hovbox 0
-                 ( hovbox 0 (fmt_str_loc_opt c name $ fmt "@ : ")
+                 ( hovbox 0 (fmt_str_loc_opt c name $ space_break $ str ": ")
                  $ compose_module (fmt_module_type c xmt) ~f:Fn.id ) ) ) )
 
 and fmt_module_type c ?(rec_ = false) ({ast= mty; _} as xmty) =
@@ -3600,8 +3600,8 @@ and fmt_module_type c ?(rec_ = false) ({ast= mty; _} as xmty) =
       let within = Cmts.fmt_within c ~pro:noop pmty_loc in
       let after = Cmts.fmt_after c pmty_loc in
       { opn= None
-      ; pro= Some (before $ str "sig" $ fmt_if empty " ")
-      ; psp= fmt_if (not empty) "@;<1000 2>"
+      ; pro= Some (before $ str "sig" $ fmt_if_k empty (str " "))
+      ; psp= fmt_if_k (not empty) (break 1000 2)
       ; bdy= (within $ if empty then noop else fmt_signature c ctx s)
       ; cls= noop
       ; esp= fmt_if_k (not empty) force_break
@@ -3617,9 +3617,9 @@ and fmt_module_type c ?(rec_ = false) ({ast= mty; _} as xmty) =
             ( Cmts.fmt_before c pmty_loc
             $ str "functor"
             $ fmt_attributes c ~pre:Blank pmty_attributes
-            $ fmt "@;<1 2>"
-            $ list args "@;<1 2>" (fmt_functor_param c ctx)
-            $ fmt "@;<1 2>->"
+            $ break 1 2
+            $ list_k args (break 1 2) (fmt_functor_param c ctx)
+            $ break 1 2 $ str "->"
             $ opt blk.pro (fun pro -> str " " $ pro) )
       ; epi= Some (fmt_opt blk.epi $ Cmts.fmt_after c pmty_loc)
       ; psp=
@@ -3632,8 +3632,8 @@ and fmt_module_type c ?(rec_ = false) ({ast= mty; _} as xmty) =
         pro=
           Some
             ( Cmts.fmt_before c pmty_loc
-            $ Cmts.fmt c gen_loc (wrap "(" ")" (Cmts.fmt_within c gen_loc))
-            $ fmt "@;<1 2>->"
+            $ Cmts.fmt c gen_loc (wrap_k (str "(") (str ")") (Cmts.fmt_within c gen_loc))
+            $ break 1 2 $ str "->"
             $ opt blk.pro (fun pro -> str " " $ pro) )
       ; epi= Some (fmt_opt blk.epi $ Cmts.fmt_after c pmty_loc)
       ; psp=
@@ -3644,7 +3644,7 @@ and fmt_module_type c ?(rec_ = false) ({ast= mty; _} as xmty) =
       let wcs, mt = Sugar.mod_with (sub_mty ~ctx mty) in
       let fmt_cstr ~first ~last:_ wc =
         let pre = if first then "with" else " and" in
-        fmt_or first "@ " "@," $ fmt_with_constraint c ctx ~pre wc
+        fmt_or_k first space_break cut_break $ fmt_with_constraint c ctx ~pre wc
       in
       let fmt_cstrs ~first:_ ~last:_ (wcs_and, loc, attr) =
         Cmts.fmt c loc
@@ -3655,21 +3655,21 @@ and fmt_module_type c ?(rec_ = false) ({ast= mty; _} as xmty) =
       { empty with
         pro=
           Option.map pro ~f:(fun pro ->
-              open_hvbox 0 $ fmt_if parens "(" $ pro )
+              open_hvbox 0 $ fmt_if_k parens (str"(") $ pro )
       ; psp
       ; bdy=
           fmt_if_k (Option.is_none pro)
-            (open_hvbox (Params.Indent.mty_with c.conf) $ fmt_if parens "(")
+            (open_hvbox (Params.Indent.mty_with c.conf) $ fmt_if_k parens (str "("))
           $ hvbox 0 bdy
           $ fmt_if_k (Option.is_some epi) esp
-          $ fmt_opt epi $ list_fl wcs fmt_cstrs $ fmt_if parens ")"
+          $ fmt_opt epi $ list_fl wcs fmt_cstrs $ fmt_if_k parens (str ")")
           $ close_box
       ; esp= fmt_if_k (Option.is_none epi) esp
       ; epi= Some (Cmts.fmt_after c pmty_loc) }
   | Pmty_typeof me -> (
       let blk = fmt_module_expr c (sub_mod ~ctx me) in
       let epi =
-        fmt_opt blk.epi $ Cmts.fmt_after c pmty_loc $ fmt_if parens ")"
+        fmt_opt blk.epi $ Cmts.fmt_after c pmty_loc $ fmt_if_k parens (str ")")
         $ fmt_attributes c pmty_attributes ~pre:(Break (1, 0))
       in
       match blk.pro with
@@ -3678,14 +3678,14 @@ and fmt_module_type c ?(rec_ = false) ({ast= mty; _} as xmty) =
             pro=
               Some
                 ( Cmts.fmt_before c pmty_loc
-                $ fmt_if parens "(" $ str "module type of " $ pro )
+                $ fmt_if_k parens (str "(") $ str "module type of " $ pro )
           ; epi= Some epi }
       | _ ->
           { blk with
             bdy=
               Cmts.fmt c pmty_loc
               @@ hvbox 2
-                   (fmt_if parens "(" $ fmt "module type of@ " $ blk.bdy)
+                   (fmt_if_k parens (str "(") $ str "module type of" $ space_break $ blk.bdy)
           ; epi= Some epi } )
   | Pmty_extension ext ->
       { empty with
@@ -3719,7 +3719,7 @@ and fmt_signature_item c ?ext {ast= si; _} =
   match si.psig_desc with
   | Psig_attribute attr -> fmt_floating_attributes_and_docstrings c [attr]
   | Psig_exception exc ->
-      let pre = str "exception" $ fmt_extension_suffix c ext $ fmt "@ " in
+      let pre = str "exception" $ fmt_extension_suffix c ext $ space_break in
       hvbox 2 (fmt_type_exception ~pre c ctx exc)
   | Psig_extension (ext, atrs) ->
       let doc_before, doc_after, atrs = fmt_docstring_around_item c atrs in
@@ -3746,7 +3746,7 @@ and fmt_signature_item c ?ext {ast= si; _} =
         | {pmty_desc= Pmty_typeof me; pmty_loc; pmty_attributes= _} ->
             ( kwd
               $ Cmts.fmt c ~pro:(str " ") ~epi:noop pmty_loc
-                  (fmt "@ module type of")
+                  (space_break $ str "module type of")
             , fmt_module_expr c (sub_mod ~ctx me) )
         | _ -> (kwd, fmt_module_type c (sub_mty ~ctx pincl_mod))
       in
@@ -3756,7 +3756,7 @@ and fmt_signature_item c ?ext {ast= si; _} =
         $ hvbox 0
             ( box
                 ( hvbox 2 (keyword $ opt pro (fun pro -> str " " $ pro))
-                $ fmt_or_k (Option.is_some pro) psp (fmt "@;<1 2>")
+                $ fmt_or_k (Option.is_some pro) psp (break 1 2)
                 $ bdy )
             $ esp $ fmt_opt epi
             $ fmt_item_attributes c ~pre:(Break (1, 0)) atrs )
@@ -3795,10 +3795,10 @@ and fmt_class_types ?ext c ~pre ~sep cls =
             ( str (if first then pre else "and")
             $ fmt_if_k first (fmt_extension_suffix c ext)
             $ fmt_virtual_flag c cl.pci_virt
-            $ fmt "@ "
+            $ space_break
             $ fmt_class_params c ctx cl.pci_params
-            $ fmt_str_loc c cl.pci_name $ fmt " " $ str sep )
-          $ fmt "@ "
+            $ fmt_str_loc c cl.pci_name $ str " " $ str sep )
+          $ space_break
         in
         hovbox 2
           ( fmt_class_type c ~pro (sub_cty ~ctx cl.pci_expr)
@@ -3826,21 +3826,21 @@ and fmt_class_exprs ?ext c cls =
                    ( str (if first then "class" else "and")
                    $ fmt_if_k first (fmt_extension_suffix c ext)
                    $ fmt_virtual_flag c cl.pci_virt
-                   $ fmt "@ "
+                   $ space_break
                    $ fmt_class_params c ctx cl.pci_params
                    $ fmt_str_loc c cl.pci_name )
-               $ fmt_if (not (List.is_empty xargs)) "@ "
+               $ fmt_if_k (not (List.is_empty xargs)) space_break
                $ wrap_fun_decl_args c (fmt_class_fun_args c xargs) )
            in
            let intro =
              match cl.pci_constraint with
              | Some ty ->
-                 fmt_class_type c ~pro:(pro $ fmt " :@ ") (sub_cty ~ctx ty)
+                 fmt_class_type c ~pro:(pro $ str " :" $ space_break) (sub_cty ~ctx ty)
              | None -> pro
            in
            hovbox 2
-             ( hovbox 2 (intro $ fmt "@ =")
-             $ fmt "@;"
+             ( hovbox 2 (intro $ space_break $ str "=")
+             $ space_break
              $ fmt_class_expr c (sub_cl ~ctx cl.pci_expr) )
            $ fmt_item_attributes c ~pre:(Break (1, 0)) atrs
          in
@@ -3857,7 +3857,7 @@ and fmt_module c ctx ?rec_ ?epi ?(can_sparse = false) keyword ?(eqty = "=")
         { blk with
           pro=
             Some (str " " $ str eqty $ opt blk.pro (fun pro -> str " " $ pro))
-        ; psp= fmt_if (Option.is_none blk.pro) "@;<1 2>" $ blk.psp } )
+        ; psp= fmt_if_k (Option.is_none blk.pro) (break 1 2) $ blk.psp } )
   in
   let blk_b = Option.value_map xbody ~default:empty ~f:(fmt_module_expr c) in
   let args_p = Params.Mod.get_args c.conf xargs in
@@ -3870,7 +3870,7 @@ and fmt_module c ctx ?rec_ ?epi ?(can_sparse = false) keyword ?(eqty = "=")
     let pro =
       hovbox 1
         ( pro
-        $ Cmts.fmt_before c ~epi:(fmt "@ ") loc
+        $ Cmts.fmt_before c ~epi:(space_break) loc
         $ str "(" $ align_opn $ fmt_str_loc_opt c name $ str " :" )
       $ fmt_or_k (Option.is_some blk.pro) (str " ") (break 1 2)
     and epi = str ")" $ Cmts.fmt_after c loc $ align_cls in
@@ -3881,7 +3881,7 @@ and fmt_module c ctx ?rec_ ?epi ?(can_sparse = false) keyword ?(eqty = "=")
     let pro = pro $ args_p.arg_psp in
     match txt with
     | Unit ->
-        (pro $ Cmts.fmt c loc (wrap "(" ")" (Cmts.fmt_within c loc)), noop)
+        (pro $ Cmts.fmt c loc (wrap_k (str "(") (str ")") (Cmts.fmt_within c loc)), noop)
     | Named (name, mt) ->
         if args_p.dock then
           (* All signatures, put the [epi] into the box of the next arg and
@@ -3912,12 +3912,12 @@ and fmt_module c ctx ?rec_ ?epi ?(can_sparse = false) keyword ?(eqty = "=")
       ( str keyword
       $ fmt_extension_suffix c ext
       $ fmt_attributes c ~pre:(Break (1, 0)) attrs_before
-      $ fmt_if rec_flag " rec" $ fmt "@ " $ fmt_str_loc_opt c name )
+      $ fmt_if_k rec_flag (str " rec") $ space_break $ fmt_str_loc_opt c name )
   in
   let compact =
     Poly.(c.conf.fmt_opts.let_module.v = `Compact) || not can_sparse
   in
-  let fmt_pro = opt blk_b.pro (fun pro -> fmt "@ " $ pro) in
+  let fmt_pro = opt blk_b.pro (fun pro -> space_break $ pro) in
   hvbox
     (if compact then 0 else 2)
     ( doc_before
@@ -3929,22 +3929,22 @@ and fmt_module c ctx ?rec_ ?epi ?(can_sparse = false) keyword ?(eqty = "=")
                     (fmt_args ~pro:intro xargs $ fmt_opt blk_t.pro)
                 $ blk_t.psp $ blk_t.bdy )
             $ blk_t.esp $ fmt_opt blk_t.epi
-            $ fmt_if (Option.is_some xbody) " ="
+            $ fmt_if_k (Option.is_some xbody) (str " =")
             $ fmt_if_k compact fmt_pro )
         $ fmt_if_k (not compact) fmt_pro
         $ blk_b.psp
-        $ fmt_if (Option.is_none blk_b.pro && Option.is_some xbody) "@ "
+        $ fmt_if_k (Option.is_none blk_b.pro && Option.is_some xbody) space_break
         $ blk_b.bdy )
     $ blk_b.esp $ fmt_opt blk_b.epi
     $ fmt_item_attributes c ~pre:(Break (1, 0)) attrs_after
     $ doc_after
     $ opt epi (fun epi ->
           fmt_or_k compact
-            (fmt_or
+            (fmt_or_k
                ( Option.is_some blk_b.epi
                && not c.conf.fmt_opts.ocp_indent_compat.v )
-               " " "@ " )
-            (fmt "@;<1 -2>")
+               (str " ") space_break )
+            ((break 1 (-2)))
           $ epi ) )
 
 and fmt_module_declaration c ~rec_flag ~first {ast= pmd; _} =
@@ -4075,7 +4075,7 @@ and fmt_mod_apply c ctx loc attrs ~parens ~dock_struct me_f arg =
             (* Indent body of docked struct. *)
             { blk with
               opn= Some (open_hvbox 2)
-            ; psp= fmt "@;<1000 2>"
+            ; psp= break 1000 2
             ; cls= close_box
             ; bdy= blk.bdy $ blk.esp $ fmt_opt blk.epi
             ; esp= noop
@@ -4118,13 +4118,13 @@ and fmt_mod_apply c ctx loc attrs ~parens ~dock_struct me_f arg =
       ; bdy=
           hvbox 2
             ( Cmts.fmt_before c loc
-            $ wrap_if parens "(" ")"
+            $ wrap_if_k parens (str "(") (str ")")
                 (fmt_opt blk_f.pro $ blk_f.psp $ blk_f.bdy $ blk_f.esp)
             $ fmt_opt blk_f.epi $ break 1 0
             $
             match arg with
             | `Unit x -> x
-            | `Block (x, _) -> wrap "(" ")" (compose_module x ~f:Fn.id) )
+            | `Block (x, _) -> wrap_k (str "(") (str ")") (compose_module x ~f:Fn.id) )
       ; cls= close_box $ blk_f.cls
       ; epi=
           Option.some_if has_epi
@@ -4139,7 +4139,7 @@ and fmt_module_expr ?(dock_struct = true) c ({ast= m; _} as xmod) =
   match pmod_desc with
   | Pmod_apply_unit (me, loc) ->
       let arg =
-        Cmts.fmt c loc @@ hvbox 0 @@ wrap "(" ")" @@ Cmts.fmt_within c loc
+        Cmts.fmt c loc @@ hvbox 0 @@ wrap_k (str "(") (str ")") @@ Cmts.fmt_within c loc
       in
       fmt_mod_apply c ctx ~parens ~dock_struct pmod_loc pmod_attributes me
         (`Unit arg)
@@ -4164,11 +4164,11 @@ and fmt_module_expr ?(dock_struct = true) c ({ast= m; _} as xmod) =
             ( fmt_opt blk_t.opn $ fmt_opt blk_e.opn
             $ open_hovbox (Params.Indent.mod_constraint c.conf ~lhs:me) )
       ; pro= Some (Cmts.fmt_before c pmod_loc $ str "(")
-      ; psp= fmt "@,"
+      ; psp= cut_break
       ; bdy=
           hvbox 0
             ( fmt_opt blk_e.pro $ blk_e.psp $ blk_e.bdy $ blk_e.esp
-            $ fmt_opt blk_e.epi $ fmt " :"
+            $ fmt_opt blk_e.epi $ str " :"
             $ Params.Mod.break_constraint c.conf ~rhs:mt
             $ hvbox 0
                 ( fmt_opt blk_t.pro $ blk_t.psp $ blk_t.bdy $ blk_t.esp
@@ -4185,14 +4185,14 @@ and fmt_module_expr ?(dock_struct = true) c ({ast= m; _} as xmod) =
       { empty with
         bdy=
           Cmts.fmt c pmod_loc
-            ( fmt_docstring c ~epi:(fmt "@,") doc
+            ( fmt_docstring c ~epi:(cut_break) doc
             $ hvbox 0
-                (wrap_if parens "(" ")"
+                (wrap_if_k parens (str "(") (str ")")
                    ( str "functor"
                    $ fmt_attributes c ~pre:Blank atrs
-                   $ fmt "@;<1 2>"
-                   $ list args "@;<1 2>" (fmt_functor_param c ctx)
-                   $ fmt "@;<1 2>->@;<1 2>"
+                   $ break 1 2
+                   $ list_k args (break 1 2) (fmt_functor_param c ctx)
+                   $ break 1 2 $ str "->" $ break 1 2
                    $ compose_module
                        (fmt_module_expr c (sub_mod ~ctx me))
                        ~f:(hvbox 0) ) ) ) }
@@ -4212,10 +4212,10 @@ and fmt_module_expr ?(dock_struct = true) c ({ast= m; _} as xmod) =
       let within = Cmts.fmt_within c ~pro:noop pmod_loc in
       let after = Cmts.fmt_after c pmod_loc in
       { opn= None
-      ; pro= Some (before $ str "struct" $ fmt_if empty " ")
+      ; pro= Some (before $ str "struct" $ fmt_if_k empty (str " "))
       ; psp=
           fmt_if_k (not empty)
-            (fmt_or c.conf.fmt_opts.break_struct.v "@;<1000 2>" "@;<1 2>")
+            (fmt_or_k c.conf.fmt_opts.break_struct.v (break 1000 2) (break 1 2))
       ; bdy= within $ fmt_structure c ctx sis
       ; cls= noop
       ; esp=
@@ -4314,12 +4314,12 @@ and fmt_structure_item c ~last:last_item ?ext ~semisemi
       $ cbox 0 ~name:"eval" (fmt_expression c (sub_exp ~ctx exp))
       $ fmt_item_attributes c ~pre:Space atrs
   | Pstr_exception extn_constr ->
-      let pre = str "exception" $ fmt_extension_suffix c ext $ fmt "@ " in
+      let pre = str "exception" $ fmt_extension_suffix c ext $ space_break in
       hvbox 2 ~name:"exn" (fmt_type_exception ~pre c ctx extn_constr)
   | Pstr_include {pincl_mod; pincl_attributes= attributes; pincl_loc} ->
       update_config_maybe_disabled c pincl_loc attributes
       @@ fun c ->
-      let keyword = str "include" $ fmt_extension_suffix c ext $ fmt "@ " in
+      let keyword = str "include" $ fmt_extension_suffix c ext $ space_break in
       fmt_module_statement c ~attributes ~keyword (sub_mod ~ctx pincl_mod)
   | Pstr_module mb ->
       fmt_module_binding c ~rec_flag:false ~first:true (sub_mb ~ctx mb)
@@ -4334,7 +4334,7 @@ and fmt_structure_item c ~last:last_item ?ext ~semisemi
           ( str "open!"
           $ opt ext (fun _ -> str " " $ fmt_extension_suffix c ext) )
           (str "open" $ fmt_extension_suffix c ext)
-        $ fmt "@ "
+        $ space_break
       in
       fmt_module_statement c ~attributes ~keyword (sub_mod ~ctx popen_expr)
   | Pstr_primitive vd -> fmt_value_description ?ext c ctx vd
@@ -4400,13 +4400,13 @@ and fmt_let c ~ext ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr ~loc_in
     $ fmt_if_k (not last)
         ( match c.conf.fmt_opts.let_and.v with
         | `Sparse -> force_break
-        | `Compact -> fmt "@ " )
+        | `Compact -> space_break )
   in
   let blank_line_after_in = sequence_blank_line c loc_in body_loc in
   Params.Exp.wrap c.conf ~parens:(parens || has_attr) ~fits_breaks:false
     (vbox 0
        ( hvbox 0 (list_fl bindings fmt_binding)
-       $ ( if blank_line_after_in then fmt "\n@,"
+       $ ( if blank_line_after_in then str "\n" $ cut_break
            else break 1000 indent_after_in )
        $ hvbox 0 fmt_expr ) )
   $ fmt_atrs
@@ -4414,8 +4414,8 @@ and fmt_let c ~ext ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr ~loc_in
 and fmt_value_constraint c vc_opt =
   let fmt_sep x =
     match c.conf.fmt_opts.break_colon.v with
-    | `Before -> fmt "@ " $ str x $ char ' '
-    | `After -> char ' ' $ str x $ fmt "@ "
+    | `Before -> space_break $ str x $ char ' '
+    | `After -> char ' ' $ str x $ space_break
   in
   match vc_opt with
   | Some vc -> (
@@ -4430,14 +4430,14 @@ and fmt_value_constraint c vc_opt =
             , fmt_sep ":"
               $ hvbox 0
                   ( str "type "
-                  $ list pvars " " (fmt_str_loc c)
-                  $ fmt ".@ "
+                  $ list_k pvars (str " ") (fmt_str_loc c)
+                  $ str "." $ space_break
                   $ fmt_core_type c (sub_typ ~ctx typ) ) )
         | `After ->
             ( fmt_sep ":"
               $ hvbox 0
-                  (str "type " $ list pvars " " (fmt_str_loc c) $ str ".")
-            , fmt "@ " $ fmt_core_type c (sub_typ ~ctx typ) ) )
+                  (str "type " $ list_k pvars (str " ") (fmt_str_loc c) $ str ".")
+            , space_break $ fmt_core_type c (sub_typ ~ctx typ) ) )
       | Pvc_coercion {ground; coercion} ->
           ( noop
           , opt ground (fun ty ->
@@ -4507,18 +4507,18 @@ and fmt_value_binding c ~rec_flag ?ext ?in_ ?epi
     let decl =
       fmt_str_loc c lb_op
       $ fmt_extension_suffix c ext
-      $ fmt_attributes c at_attrs $ fmt_if rec_flag " rec"
-      $ fmt_or pat_has_cmt "@ " " "
+      $ fmt_attributes c at_attrs $ fmt_if_k rec_flag (str " rec")
+      $ fmt_or_k pat_has_cmt space_break (str " ")
     and pattern = fmt_pattern c lb_pat
     and args =
       fmt_if_k
         (not (List.is_empty lb_args))
-        (fmt "@ " $ wrap_fun_decl_args c (fmt_expr_fun_args c lb_args))
+        (space_break $ wrap_fun_decl_args c (fmt_expr_fun_args c lb_args))
       $ fmt_newtypes
     in
     box_fun_decl_args c 4 (Params.Align.fun_decl c.conf ~decl ~pattern ~args)
   in
-  fmt_docstring c ~epi:(fmt "@\n") doc1
+  fmt_docstring c ~epi:(force_newline) doc1
   $ cmts_before
   $ hvbox 0
       ( hvbox indent
@@ -4531,9 +4531,9 @@ and fmt_value_binding c ~rec_flag ?ext ?in_ ?epi
                       $ fmt_if_k (not lb_pun)
                           (fmt_or_k c.conf.fmt_opts.ocp_indent_compat.v
                              (fits_breaks " =" ~hint:(1000, 0) "=")
-                             (fmt "@;<1 2>=") )
+                             (break 1 2 $ str  "=") )
                       $ fmt_if_k (not lb_pun) pre_body )
-                  $ fmt_if (not lb_pun) "@ "
+                  $ fmt_if_k (not lb_pun) space_break
                   $ fmt_if_k (not lb_pun) body )
               $ cmts_after
               $ opt loc_in
@@ -4541,7 +4541,7 @@ and fmt_value_binding c ~rec_flag ?ext ?in_ ?epi
           $ in_ )
       $ opt loc_in (Cmts.fmt_after ~pro:force_break c)
       $ epi )
-  $ fmt_docstring c ~pro:(fmt "@\n") doc2
+  $ fmt_docstring c ~pro:(force_newline) doc2
 
 and fmt_module_binding c ~rec_flag ~first {ast= pmb; _} =
   let {pmb_name; pmb_ext_attrs= attrs; _} = pmb in

--- a/lib/Non_overlapping_interval_tree.ml
+++ b/lib/Non_overlapping_interval_tree.ml
@@ -99,11 +99,11 @@ module Make (Itv : IN) = struct
     let open Fmt in
     let rec dump_ tree roots =
       vbox 0
-        (list_k roots cut_break (fun root ->
+        (list roots cut_break (fun root ->
              let children = children tree root in
              vbox 1
                ( str (Sexp.to_string_hum (Itv.comparator.sexp_of_t root))
-               $ wrap_if_k
+               $ wrap_if
                    (not (List.is_empty children))
                    (cut_break $ str "{")
                    (str " }") (dump_ tree children) ) ) )

--- a/lib/Non_overlapping_interval_tree.ml
+++ b/lib/Non_overlapping_interval_tree.ml
@@ -99,13 +99,13 @@ module Make (Itv : IN) = struct
     let open Fmt in
     let rec dump_ tree roots =
       vbox 0
-        (list roots "@," (fun root ->
+        (list_k roots cut_break (fun root ->
              let children = children tree root in
              vbox 1
                ( str (Sexp.to_string_hum (Itv.comparator.sexp_of_t root))
-               $ wrap_if
+               $ wrap_if_k
                    (not (List.is_empty children))
-                   "@,{" " }" (dump_ tree children) ) ) )
+                   (cut_break $ str "{") (str " }") (dump_ tree children) ) ) )
     in
     set_margin 100000000 $ dump_ tree tree.roots
 end

--- a/lib/Non_overlapping_interval_tree.ml
+++ b/lib/Non_overlapping_interval_tree.ml
@@ -105,7 +105,8 @@ module Make (Itv : IN) = struct
                ( str (Sexp.to_string_hum (Itv.comparator.sexp_of_t root))
                $ wrap_if_k
                    (not (List.is_empty children))
-                   (cut_break $ str "{") (str " }") (dump_ tree children) ) ) )
+                   (cut_break $ str "{")
+                   (str " }") (dump_ tree children) ) ) )
     in
     set_margin 100000000 $ dump_ tree tree.roots
 end

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -42,7 +42,7 @@ let parens_if parens (c : Conf.t) ?(disambiguate = false) k =
         Fmt.fits_breaks "(" "(" $ k $ Fmt.fits_breaks ")" ~hint:(1, 0) ")"
     | `Closing_on_separate_line ->
         Fmt.fits_breaks "(" "(" $ k $ Fmt.fits_breaks ")" ~hint:(1000, 0) ")"
-    | `No -> wrap_k (str "(") (str ")") k
+    | `No -> wrap (str "(") (str ")") k
 
 let parens c ?disambiguate k = parens_if true c ?disambiguate k
 
@@ -58,7 +58,7 @@ module Exp = struct
             | `Closing_on_separate_line -> ("(", Some (1000, 0), ")")
           else ("", None, "")
         in
-        wrap_if_k (parens || parens_nested) (Fmt.fits_breaks "(" opn)
+        wrap_if (parens || parens_nested) (Fmt.fits_breaks "(" opn)
           (Fmt.fits_breaks ")" ?hint cls)
           k
       else k
@@ -91,7 +91,7 @@ module Exp = struct
       | `Closing_on_separate_line ->
           Fmt.fits_breaks "(" "(" $ k
           $ Fmt.fits_breaks ")" ~hint:(1000, offset_closing_paren) ")"
-      | `No -> wrap_k (str "(") (str ")") k
+      | `No -> wrap (str "(") (str ")") k
 
   let box_fun_decl_args c ~parens ~kw ~args ~annot =
     let box_decl, should_box_args =
@@ -225,18 +225,18 @@ let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
         , sub_exp ~ctx:(Exp ast) nested_exp )
     | _ ->
         let close_paren =
-          fmt_if_k parens_branch
+          fmt_if parens_branch
             ( match c.fmt_opts.indicate_multiline_delimiters.v with
             | `Space -> space_break $ str ")"
             | `No -> cut_break $ str ")"
             | `Closing_on_separate_line -> break 1000 (-2) $ str ")" )
         in
-        (fmt_if_k parens_branch (str " ("), close_paren, xast)
+        (fmt_if parens_branch (str " ("), close_paren, xast)
   in
   match c.fmt_opts.break_cases.v with
   | `Fit ->
-      { leading_space= fmt_if_k (not first) space_break
-      ; bar= fmt_or_k first (if_newline "| ") (str "| ")
+      { leading_space= fmt_if (not first) space_break
+      ; bar= fmt_or first (if_newline "| ") (str "| ")
       ; box_all= hvbox indent
       ; box_pattern_arrow= hovbox 2
       ; break_before_arrow= break 1 0
@@ -247,15 +247,15 @@ let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
       ; branch_expr
       ; close_paren_branch }
   | `Nested ->
-      { leading_space= fmt_if_k (not first) space_break
-      ; bar= fmt_or_k first (if_newline "| ") (str "| ")
+      { leading_space= fmt_if (not first) space_break
+      ; bar= fmt_or first (if_newline "| ") (str "| ")
       ; box_all= Fn.id
       ; box_pattern_arrow= hovbox 0
       ; break_before_arrow= break 1 2
-      ; break_after_arrow= fmt_if_k (not parens_branch) (break 0 3)
+      ; break_after_arrow= fmt_if (not parens_branch) (break 0 3)
       ; open_paren_branch
       ; break_after_opening_paren=
-          fmt_or_k (indent > 2) (break 1 4) (break 1 2)
+          fmt_or (indent > 2) (break 1 4) (break 1 2)
       ; expr_parens
       ; branch_expr
       ; close_paren_branch }
@@ -265,7 +265,7 @@ let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
       ; box_all= hovbox indent
       ; box_pattern_arrow= hovbox 0
       ; break_before_arrow= break 1 2
-      ; break_after_arrow= fmt_if_k (not parens_branch) (break 0 3)
+      ; break_after_arrow= fmt_if (not parens_branch) (break 0 3)
       ; open_paren_branch
       ; break_after_opening_paren= space_break
       ; expr_parens
@@ -277,7 +277,7 @@ let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
       ; box_all= hvbox indent
       ; box_pattern_arrow= hovbox 0
       ; break_before_arrow= break 1 2
-      ; break_after_arrow= fmt_if_k (not parens_branch) (break 0 3)
+      ; break_after_arrow= fmt_if (not parens_branch) (break 0 3)
       ; open_paren_branch
       ; break_after_opening_paren= space_break
       ; expr_parens
@@ -289,7 +289,7 @@ let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
       ; box_all= hvbox indent
       ; box_pattern_arrow= hovbox 0
       ; break_before_arrow= break 1 2
-      ; break_after_arrow= fmt_if_k (not parens_branch) (break 0 3)
+      ; break_after_arrow= fmt_if (not parens_branch) (break 0 3)
       ; open_paren_branch
       ; break_after_opening_paren= break 1000 0
       ; expr_parens
@@ -297,7 +297,7 @@ let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
       ; close_paren_branch }
 
 let wrap_collec c ~space_around opn cls =
-  if space_around then wrap_k (str opn $ char ' ') (break 1 0 $ str cls)
+  if space_around then wrap (str opn $ char ' ') (break 1 0 $ str cls)
   else wrap_fits_breaks c opn cls
 
 let wrap_record (c : Conf.t) =
@@ -309,7 +309,7 @@ let wrap_tuple (c : Conf.t) ~parens ~no_parens_if_break items =
     | `Before -> fits_breaks ", " ~hint:(1000, -2) ", "
     | `After -> str "," $ space_break
   in
-  let k = list_k items tuple_sep Fn.id in
+  let k = list items tuple_sep Fn.id in
   if parens then wrap_fits_breaks c "(" ")" (hvbox 0 k)
   else if no_parens_if_break then k
   else fits_breaks "" "( " $ hvbox 0 k $ fits_breaks "" ~hint:(1, 0) ")"
@@ -331,26 +331,26 @@ let get_record_type (c : Conf.t) =
   let break_before, sep_before, sep_after =
     match c.fmt_opts.break_separators.v with
     | `Before ->
-        ( fmt_or_k dock (break space 2) space_break
-        , fmt_or_k sparse_type_decl
+        ( fmt_or dock (break space 2) space_break
+        , fmt_or sparse_type_decl
             (force_break $ str "; ")
             (cut_break $ str "; ")
         , noop )
     | `After ->
-        ( fmt_or_k dock (break space 0) space_break
+        ( fmt_or dock (break space 0) space_break
         , noop
-        , fmt_or_k dock
-            (fmt_or_k sparse_type_decl force_break space_break)
-            (fmt_or_k sparse_type_decl (break 1000 2) (break 1 2)) )
+        , fmt_or dock
+            (fmt_or sparse_type_decl force_break space_break)
+            (fmt_or sparse_type_decl (break 1000 2) (break 1 2)) )
   in
-  { docked_before= fmt_if_k dock (str " {")
+  { docked_before= fmt_if dock (str " {")
   ; break_before
   ; box_record= (fun k -> if dock then k else hvbox 0 (wrap_record c k))
   ; box_spaced= c.fmt_opts.space_around_records.v
   ; sep_before
   ; sep_after
-  ; break_after= fmt_if_k dock (break space (-2))
-  ; docked_after= fmt_if_k dock (str "}") }
+  ; break_after= fmt_if dock (break space (-2))
+  ; docked_after= fmt_if dock (str "}") }
 
 type elements_collection =
   { box: Fmt.t -> Fmt.t
@@ -367,8 +367,7 @@ let get_record_expr (c : Conf.t) =
   let dock = c.fmt_opts.dock_collection_brackets.v in
   let box k =
     if dock then
-      hvbox 0
-        (wrap_k (str "{") (str "}") (break space 2 $ k $ break space 0))
+      hvbox 0 (wrap (str "{") (str "}") (break space 2 $ k $ break space 0))
     else hvbox 0 (wrap_record c k)
   in
   ( ( match c.fmt_opts.break_separators.v with
@@ -381,7 +380,7 @@ let get_record_expr (c : Conf.t) =
         { box
         ; sep_before= noop
         ; sep_after_non_final= str ";" $ break 1 2
-        ; sep_after_final= fmt_if_k dock (fits_breaks ~level:0 "" ";") } )
+        ; sep_after_final= fmt_if dock (fits_breaks ~level:0 "" ";") } )
   , {break_after_with= break 1 2} )
 
 let box_collec (c : Conf.t) =
@@ -399,7 +398,7 @@ let collection_expr (c : Conf.t) ~space_around opn cls =
           (fun k ->
             if dock then
               hvbox 0
-                (wrap_k (str opn) (str cls)
+                (wrap (str opn) (str cls)
                    ( break space (String.length opn + 1)
                    $ box_collec c 0 k $ break space 0 ) )
             else box_collec c 0 (wrap_collec c ~space_around opn cls k) )
@@ -411,15 +410,15 @@ let collection_expr (c : Conf.t) ~space_around opn cls =
           (fun k ->
             if dock then
               hvbox 0
-                (wrap_k (str opn) (str cls)
+                (wrap (str opn) (str cls)
                    (break space 2 $ box_collec c 0 k $ break space 0) )
             else box_collec c 0 (wrap_collec c ~space_around opn cls k) )
       ; sep_before= noop
       ; sep_after_non_final=
-          fmt_or_k dock
+          fmt_or dock
             (str ";" $ break 1 0)
             (char ';' $ break 1 (String.length opn + 1))
-      ; sep_after_final= fmt_if_k dock (fits_breaks ~level:1 "" ";") }
+      ; sep_after_final= fmt_if dock (fits_breaks ~level:1 "" ";") }
 
 let get_list_expr (c : Conf.t) =
   collection_expr c ~space_around:c.fmt_opts.space_around_lists.v "[" "]"
@@ -438,7 +437,7 @@ let box_pattern_docked (c : Conf.t) ~ctx ~space_around opn cls k =
     | _ -> (0, 0)
   in
   hvbox indent_opn
-    (wrap_k (str opn) (str cls) (break space 2 $ k $ break space indent_cls))
+    (wrap (str opn) (str cls) (break space 2 $ k $ break space indent_cls))
 
 let get_record_pat (c : Conf.t) ~ctx =
   let params, _ = get_record_expr c in
@@ -491,8 +490,8 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
     | _ -> (false, xbch)
   in
   let wrap_parens ~wrap_breaks k =
-    if beginend then wrap_k (str "begin") (str "end") (wrap_breaks k)
-    else if parens_bch then wrap_k (str "(") (str ")") (wrap_breaks k)
+    if beginend then wrap (str "begin") (str "end") (wrap_breaks k)
+    else if parens_bch then wrap (str "(") (str ")") (wrap_breaks k)
     else k
   in
   let get_parens_breaks ~opn_hint_indent ~cls_hint:(ch_sp, ch_sl) =
@@ -500,32 +499,32 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
     let oh_other = ((if beginend then 1 else 0), opn_hint_indent) in
     if beginend then
       let _, offset = ch_sl in
-      wrap_k (brk oh_other) (break 1000 offset)
+      wrap (brk oh_other) (break 1000 offset)
     else
       match imd with
-      | `Space -> wrap_k (brk (1, opn_hint_indent)) (brk ch_sp)
-      | `No -> wrap_k (brk oh_other) noop
-      | `Closing_on_separate_line -> wrap_k (brk oh_other) (brk ch_sl)
+      | `Space -> wrap (brk (1, opn_hint_indent)) (brk ch_sp)
+      | `No -> wrap (brk oh_other) noop
+      | `Closing_on_separate_line -> wrap (brk oh_other) (brk ch_sl)
   in
   let cond () =
     match xcond with
     | Some xcnd ->
         hvbox 0
           ( hvbox 2
-              ( fmt_if_k (not first) (str "else ")
+              ( fmt_if (not first) (str "else ")
               $ str "if"
-              $ fmt_if_k first (fmt_opt fmt_extension_suffix)
+              $ fmt_if first (fmt_opt fmt_extension_suffix)
               $ fmt_attributes $ space_break $ fmt_cond xcnd )
           $ space_break $ str "then" )
     | None -> str "else"
   in
-  let branch_pro = fmt_or_k (beginend || parens_bch) (str " ") (break 1 2) in
+  let branch_pro = fmt_or (beginend || parens_bch) (str " ") (break 1 2) in
   match c.fmt_opts.if_then_else.v with
   | `Compact ->
       { box_branch= hovbox 2
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
-      ; branch_pro= fmt_or_k (beginend || parens_bch) (str " ") space_break
+      ; branch_pro= fmt_or (beginend || parens_bch) (str " ") space_break
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:
@@ -542,15 +541,14 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
       ; branch_pro
-      ; wrap_parens= wrap_parens ~wrap_breaks:(wrap_k (break 1000 2) noop)
+      ; wrap_parens= wrap_parens ~wrap_breaks:(wrap (break 1000 2) noop)
       ; box_expr= Some false
       ; expr_pro= None
       ; expr_eol= Some (break 1 2)
       ; branch_expr
       ; break_end_branch=
-          fmt_if_k (parens_bch || beginend || not last) (break 1000 0)
-      ; space_between_branches= fmt_if_k (beginend || parens_bch) (str " ")
-      }
+          fmt_if (parens_bch || beginend || not last) (break 1000 0)
+      ; space_between_branches= fmt_if (beginend || parens_bch) (str " ") }
   | `Fit_or_vertical ->
       { box_branch=
           hovbox
@@ -568,7 +566,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
       ; box_expr= Some false
       ; expr_pro=
           Some
-            (fmt_if_k
+            (fmt_if
                (not (Location.is_single_line expr_loc c.fmt_opts.margin.v))
                (break_unless_newline 1000 2) )
       ; expr_eol= Some (break 1 2)
@@ -602,7 +600,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
       ; cond=
           opt xcond (fun xcnd ->
               hvbox 2
-                ( fmt_or_k first
+                ( fmt_or first
                     (str "if" $ fmt_opt fmt_extension_suffix)
                     (str "else if")
                 $ fmt_attributes $ space_break $ fmt_cond xcnd )
@@ -610,9 +608,9 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
       ; box_keyword_and_expr=
           (fun k ->
             hvbox 2
-              (fmt_or_k (Option.is_some xcond) (str "then") (str "else") $ k)
+              (fmt_or (Option.is_some xcond) (str "then") (str "else") $ k)
             )
-      ; branch_pro= fmt_or_k (beginend || parens_bch) (str " ") space_break
+      ; branch_pro= fmt_or (beginend || parens_bch) (str " ") space_break
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -164,7 +164,7 @@ val match_indent : ?default:int -> Conf.t -> parens:bool -> ctx:Ast.t -> int
     option, or using the [default] indentation (0 if not provided) if the
     option does not apply. *)
 
-val comma_sep : Conf.t -> Fmt.s
+val comma_sep : Conf.t -> Fmt.t
 (** [comma_sep c] returns the format string used to separate two elements
     with a comma, depending on the `break-separators` option. *)
 

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -261,7 +261,7 @@ let format (type ext std) (ext_fg : ext Extended_ast.t)
           $ set_max_indent conf.fmt_opts.max_indent.v
           $ fmt_if
               (not (String.is_empty ext_t.prefix))
-              (str ext_t.prefix $ flush_newline)
+              (str ext_t.prefix $ force_newline)
           $ with_optional_box_debug ~box_debug
               (Fmt_ast.fmt_ast ext_fg ~debug:conf.opr_opts.debug.v
                  ext_t.source cmts_t conf ext_t.ast ) )

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -259,7 +259,7 @@ let format (type ext std) (ext_fg : ext Extended_ast.t)
           ~buffer_size:(String.length prev_source)
           ( set_margin conf.fmt_opts.margin.v
           $ set_max_indent conf.fmt_opts.max_indent.v
-          $ fmt_if_k
+          $ fmt_if
               (not (String.is_empty ext_t.prefix))
               (str ext_t.prefix $ flush_newline)
           $ with_optional_box_debug ~box_debug

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -261,7 +261,7 @@ let format (type ext std) (ext_fg : ext Extended_ast.t)
           $ set_max_indent conf.fmt_opts.max_indent.v
           $ fmt_if_k
               (not (String.is_empty ext_t.prefix))
-              (str ext_t.prefix $ fmt "@.")
+              (str ext_t.prefix $ flush_newline)
           $ with_optional_box_debug ~box_debug
               (Fmt_ast.fmt_ast ext_fg ~debug:conf.opr_opts.debug.v
                  ext_t.source cmts_t conf ext_t.ast ) )

--- a/test/unit/test_fmt.ml
+++ b/test/unit/test_fmt.ml
@@ -17,7 +17,7 @@ let tests_lazy =
           r := Some s ;
           Fmt.str s
         in
-        let term = Fmt.fmt_if_k false (pp "hello") in
+        let term = Fmt.fmt_if false (pp "hello") in
         let expected = "" in
         let expected_r = Some "hello" in
         let got = eval_fmt term in
@@ -35,7 +35,7 @@ let tests_lazy =
               r := Some s ;
               Fmt.str s )
         in
-        let term = Fmt.fmt_if_k false (pp "hello") in
+        let term = Fmt.fmt_if false (pp "hello") in
         let expected = "" in
         let expected_r = None in
         let got = eval_fmt term in
@@ -75,7 +75,7 @@ let tests_list_pn =
   ; test "does not call pp if not formatting" ~expected:"" ~expected_calls:[]
       (fun pp_spy ->
         let l = ["a"; "b"; "c"; "d"; "e"] in
-        Fmt.fmt_if_k false (Fmt.list_pn l pp_spy) ) ]
+        Fmt.fmt_if false (Fmt.list_pn l pp_spy) ) ]
 
 let tests_list_k =
   let test name ~expected ~expected_calls f =
@@ -96,11 +96,11 @@ let tests_list_k =
   [ test "evaluation order" ~expected:"a b c d e"
       ~expected_calls:["a"; "b"; "c"; "d"; "e"] (fun pp_spy ->
         let l = ["a"; "b"; "c"; "d"; "e"] in
-        Fmt.list_k l (Fmt.str " ") pp_spy )
+        Fmt.list l (Fmt.str " ") pp_spy )
   ; test "does not call pp if not formatting" ~expected:"" ~expected_calls:[]
       (fun pp_spy ->
         let l = ["a"; "b"; "c"; "d"; "e"] in
-        Fmt.fmt_if_k false (Fmt.list_k l (Fmt.str " ") pp_spy) ) ]
+        Fmt.fmt_if false (Fmt.list l (Fmt.str " ") pp_spy) ) ]
 
 let tests_sequence =
   let test name term ~expected =


### PR DESCRIPTION
This PR is a big refactoring that completely removes format syntax such as `"@;<1000 -2>" from ocamlformat.

Instead, documented combinators are used.

The first commit should be more readable, because `dune fmt` was not called on it, and as such the diff is smaller than the total.