### PR TITLE
Simplify representation of class field values and methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@ profile. This started with version 0.26.0.
 - \* Don't align breaking module arguments (#2505, @Julow)
 - Improvements to ocp-indent-compat and the Janestreet profile (#2314, @Julow)
 - \* Undo let-bindings normalizations (#2523, @gpetiot)
+- \* Undo method parameters normalizations (#2529, @gpetiot)
+- \* The `break-colon` option is now taken into account for method type constraints (#2529, @gpetiot)
 
 ### Fixed
 

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -126,8 +126,6 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
     let exp = {exp with pexp_loc_stack= []} in
     let {pexp_desc; pexp_loc= loc1; pexp_attributes= attrs1; _} = exp in
     match pexp_desc with
-    | Pexp_poly ({pexp_desc= Pexp_constraint (e, t); _}, None) ->
-        m.expr m {exp with pexp_desc= Pexp_poly (e, Some t)}
     | Pexp_constraint (e, {ptyp_desc= Ptyp_poly ([], _t); _}) -> m.expr m e
     | Pexp_sequence
         ( exp1

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -70,9 +70,7 @@ module Exp = struct
         | Pexp_apply (_, args) -> (
           (* Rhs is an apply and it ends with a [fun]. *)
           match List.last_exn args with
-          | _, {pexp_desc= Pexp_fun _ | Pexp_newtype _ | Pexp_function _; _}
-            ->
-              true
+          | _, {pexp_desc= Pexp_fun _ | Pexp_function _; _} -> true
           | _ -> false )
         | Pexp_match _ | Pexp_try _ -> true
         | _ -> false

--- a/test/passing/tests/break_fun_decl-fit_or_vertical.ml.ref
+++ b/test/passing/tests/break_fun_decl-fit_or_vertical.ml.ref
@@ -80,10 +80,11 @@ let fffffffffffffffffffffffffffffffffff
 class ffffffffffffffffffff =
   object
     method ffffffffffffffffffff
-        :    aaaaaaaaaaaaaaaaaaaaaa
-          -> bbbbbbbbbbbbbbbbbbbbbb
-          -> cccccccccccccccccccccc
-          -> dddddddddddddddddddddd =
+        :
+           aaaaaaaaaaaaaaaaaaaaaa
+        -> bbbbbbbbbbbbbbbbbbbbbb
+        -> cccccccccccccccccccccc
+        -> dddddddddddddddddddddd =
       g
 
     val ffffffffffffffffffff

--- a/test/passing/tests/break_fun_decl-smart.ml.ref
+++ b/test/passing/tests/break_fun_decl-smart.ml.ref
@@ -73,11 +73,11 @@ let fffffffffffffffffffffffffffffffffff
 
 class ffffffffffffffffffff =
   object
-    method ffffffffffffffffffff
-        :    aaaaaaaaaaaaaaaaaaaaaa
-          -> bbbbbbbbbbbbbbbbbbbbbb
-          -> cccccccccccccccccccccc
-          -> dddddddddddddddddddddd =
+    method ffffffffffffffffffff :
+           aaaaaaaaaaaaaaaaaaaaaa
+        -> bbbbbbbbbbbbbbbbbbbbbb
+        -> cccccccccccccccccccccc
+        -> dddddddddddddddddddddd =
       g
 
     val ffffffffffffffffffff

--- a/test/passing/tests/break_fun_decl-wrap.ml.ref
+++ b/test/passing/tests/break_fun_decl-wrap.ml.ref
@@ -55,11 +55,11 @@ let fffffffffffffffffffffffffffffffffff x yyyyyyyyyyyyyyyyyyyyyyyyyyy
 
 class ffffffffffffffffffff =
   object
-    method ffffffffffffffffffff
-        :    aaaaaaaaaaaaaaaaaaaaaa
-          -> bbbbbbbbbbbbbbbbbbbbbb
-          -> cccccccccccccccccccccc
-          -> dddddddddddddddddddddd =
+    method ffffffffffffffffffff :
+           aaaaaaaaaaaaaaaaaaaaaa
+        -> bbbbbbbbbbbbbbbbbbbbbb
+        -> cccccccccccccccccccccc
+        -> dddddddddddddddddddddd =
       g
 
     val ffffffffffffffffffff

--- a/test/passing/tests/break_fun_decl.ml
+++ b/test/passing/tests/break_fun_decl.ml
@@ -55,11 +55,11 @@ let fffffffffffffffffffffffffffffffffff x yyyyyyyyyyyyyyyyyyyyyyyyyyy
 
 class ffffffffffffffffffff =
   object
-    method ffffffffffffffffffff
-        :    aaaaaaaaaaaaaaaaaaaaaa
-          -> bbbbbbbbbbbbbbbbbbbbbb
-          -> cccccccccccccccccccccc
-          -> dddddddddddddddddddddd =
+    method ffffffffffffffffffff :
+           aaaaaaaaaaaaaaaaaaaaaa
+        -> bbbbbbbbbbbbbbbbbbbbbb
+        -> cccccccccccccccccccccc
+        -> dddddddddddddddddddddd =
       g
 
     val ffffffffffffffffffff

--- a/test/passing/tests/js_source.ml.err
+++ b/test/passing/tests/js_source.ml.err
@@ -1,6 +1,6 @@
 Warning: tests/js_source.ml:162 exceeds the margin
-Warning: tests/js_source.ml:9559 exceeds the margin
-Warning: tests/js_source.ml:9663 exceeds the margin
-Warning: tests/js_source.ml:9722 exceeds the margin
-Warning: tests/js_source.ml:9804 exceeds the margin
-Warning: tests/js_source.ml:10303 exceeds the margin
+Warning: tests/js_source.ml:9560 exceeds the margin
+Warning: tests/js_source.ml:9664 exceeds the margin
+Warning: tests/js_source.ml:9723 exceeds the margin
+Warning: tests/js_source.ml:9805 exceeds the margin
+Warning: tests/js_source.ml:10304 exceeds the margin

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -1430,7 +1430,8 @@ let ty_abc : (([ `A of int | `B of string | `C ] as 'a), 'e) ty =
         ]
 
       method inj
-        : type c.  (int -> string -> noarg -> unit, c) ty_sel * c
+        : type c.
+          (int -> string -> noarg -> unit, c) ty_sel * c
           -> [ `A of int | `B of string | `C ] =
         function
         | Thd, v -> `A v
@@ -6078,7 +6079,7 @@ class virtual ['subject, 'event] observer =
 
 class ['event] subject =
   object (self : 'subject)
-    val mutable observers : ('subject, 'event) observer list = []
+    val mutable observers = ([] : ('subject, 'event) observer list)
     method add_observer obs = observers <- obs :: observers
     method notify_observers (e : 'event) = List.iter (fun x -> x#notify self e) observers
   end
@@ -9418,7 +9419,7 @@ let _ = fun (x : < x : int >) y z -> (y :> 'a), (x :> 'a), (z :> 'a)
 
 class ['a] c () =
   object
-    method f : int c = new c ()
+    method f = (new c () : int c)
   end
 
 and ['a] d () =
@@ -9447,7 +9448,7 @@ let _ =
 class ['a] c () =
   object
     constraint 'a = < .. > -> unit
-    method m : 'a = fun x -> ()
+    method m = (fun x -> () : 'a)
   end
 
 let f : type a'. a' = assert false

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -1430,8 +1430,9 @@ let ty_abc : (([ `A of int | `B of string | `C ] as 'a), 'e) ty =
          ]
 
        method inj
-         : type c.  (int -> string -> noarg -> unit, c) ty_sel * c
-                   -> [ `A of int | `B of string | `C ] =
+         : type c.
+           (int -> string -> noarg -> unit, c) ty_sel * c
+           -> [ `A of int | `B of string | `C ] =
          function
          | Thd, v -> `A v
          | Ttl Thd, v -> `B v
@@ -6078,7 +6079,7 @@ class virtual ['subject, 'event] observer =
 
 class ['event] subject =
   object (self : 'subject)
-    val mutable observers : ('subject, 'event) observer list = []
+    val mutable observers = ([] : ('subject, 'event) observer list)
     method add_observer obs = observers <- obs :: observers
     method notify_observers (e : 'event) = List.iter (fun x -> x#notify self e) observers
   end
@@ -9418,7 +9419,7 @@ let _ = fun (x : < x : int >) y z -> (y :> 'a), (x :> 'a), (z :> 'a)
 
 class ['a] c () =
   object
-    method f : int c = new c ()
+    method f = (new c () : int c)
   end
 
 and ['a] d () =
@@ -9447,7 +9448,7 @@ let _ =
 class ['a] c () =
   object
     constraint 'a = < .. > -> unit
-    method m : 'a = fun x -> ()
+    method m = (fun x -> () : 'a)
   end
 
 let f : type a'. a' = assert false

--- a/test/passing/tests/object.ml.ref
+++ b/test/passing/tests/object.ml.ref
@@ -209,16 +209,15 @@ let _ = f ##= (fun x -> x)
 
 let o =
   object
-    method int_bin_op
-        : int t * [`Plus | `Minus | `Mult | `Div | `Mod] * int t -> int t =
+    method int_bin_op :
+        int t * [`Plus | `Minus | `Mult | `Div | `Mod] * int t -> int t =
       fun (a, op, b) -> Int_bin_op (self#expression a, op, self#expression b)
 
     method int_bin_comparison aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbb
-        ccccccccccccccccccccc ddddddddddddddddddddddddd
-        :    int t * [`Eq | `Ne | `Gt | `Ge | `Lt | `Le] * int ttttttttt
-          -> bool tttttttttttttttt rrrrrrrrrrrrrrrrrrrrr
-             rrrrrrrrrrrrrrrrrrrrr
-             rrrrrrrrrrrrrrrrrrrrrrr =
+        ccccccccccccccccccccc ddddddddddddddddddddddddd :
+           int t * [`Eq | `Ne | `Gt | `Ge | `Lt | `Le] * int ttttttttt
+        -> bool tttttttttttttttt rrrrrrrrrrrrrrrrrrrrr rrrrrrrrrrrrrrrrrrrrr
+           rrrrrrrrrrrrrrrrrrrrrrr =
       fun (a, op, b) ->
         Int_bin_comparison (self#expression a, op, self#expression b)
   end

--- a/test/passing/tests/object2.ml.ref
+++ b/test/passing/tests/object2.ml.ref
@@ -19,11 +19,11 @@ class foo =
 
 class virtual map =
   object
-    method visit_expr_node
-        : 'env 'info_0 'info_1.
-             ('env -> 'info_0 -> 'info_1)
-          -> 'env
-          -> 'info_0 expr_node
-          -> 'info_1 expr_node =
+    method visit_expr_node :
+        'env 'info_0 'info_1.
+           ('env -> 'info_0 -> 'info_1)
+        -> 'env
+        -> 'info_0 expr_node
+        -> 'info_1 expr_node =
       assert false
   end

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -5816,7 +5816,7 @@ class virtual ['subject, 'event] observer =
 
 class ['event] subject =
   object (self : 'subject)
-    val mutable observers : ('subject, 'event) observer list = []
+    val mutable observers = ([] : ('subject, 'event) observer list)
 
     method add_observer obs = observers <- obs :: observers
 
@@ -9011,7 +9011,7 @@ let _ = fun (x : < x: int >) y z -> ((y :> 'a), (x :> 'a), (z :> 'a))
 
 class ['a] c () =
   object
-    method f : int c = new c ()
+    method f = (new c () : int c)
   end
 
 and ['a] d () =
@@ -9034,7 +9034,7 @@ class ['a] c () =
   object
     constraint 'a = < .. > -> unit
 
-    method m : 'a = fun x -> ()
+    method m = (fun x -> () : 'a)
   end
 
 let f : type a'. a' = assert false

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -155,9 +155,7 @@ module Exp = struct
   let letexception ?loc ?attrs a b = mk ?loc ?attrs (Pexp_letexception (a, b))
   let assert_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_assert a)
   let lazy_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_lazy a)
-  let poly ?loc ?attrs a b = mk ?loc ?attrs (Pexp_poly (a, b))
   let object_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_object a)
-  let newtype ?loc ?attrs a b = mk ?loc ?attrs (Pexp_newtype (a, b))
   let pack ?loc ?attrs a b = mk ?loc ?attrs (Pexp_pack (a, b))
   let open_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_open (a, b))
   let letopen ?loc ?attrs a b = mk ?loc ?attrs (Pexp_letopen (a, b))
@@ -355,9 +353,6 @@ module Cf = struct
     List.map
       (fun ds -> attribute ~loc:(docstring_loc ds) (text_attr ds))
       f_txt
-
-  let virtual_ ct = Cfk_virtual ct
-  let concrete o e = Cfk_concrete (o, e)
 
   let attr d a = {d with pcf_attributes = d.pcf_attributes @ [a]}
 

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -446,16 +446,9 @@ and expression i ppf x =
   | Pexp_lazy (e) ->
       line i ppf "Pexp_lazy\n";
       expression i ppf e;
-  | Pexp_poly (e, cto) ->
-      line i ppf "Pexp_poly\n";
-      expression i ppf e;
-      option i core_type ppf cto;
   | Pexp_object s ->
       line i ppf "Pexp_object\n";
       class_structure i ppf s
-  | Pexp_newtype (s, e) ->
-      line i ppf "Pexp_newtype %a\n" fmt_string_loc s;
-      expression i ppf e
   | Pexp_pack (me, pt) ->
       line i ppf "Pexp_pack\n";
       module_expr i ppf me;
@@ -778,11 +771,11 @@ and class_field i ppf x =
   | Pcf_val (s, mf, k) ->
       line i ppf "Pcf_val %a\n" fmt_mutable_virtual_flag mf;
       line (i+1) ppf "%a\n" fmt_string_loc s;
-      class_field_kind (i+1) ppf k
+      class_field_value_kind (i+1) ppf k
   | Pcf_method (s, pf, k) ->
       line i ppf "Pcf_method %a\n" fmt_private_virtual_flag pf;
       line (i+1) ppf "%a\n" fmt_string_loc s;
-      class_field_kind (i+1) ppf k
+      class_field_method_kind (i+1) ppf k
   | Pcf_constraint (ct1, ct2) ->
       line i ppf "Pcf_constraint\n";
       core_type (i+1) ppf ct1;
@@ -796,9 +789,20 @@ and class_field i ppf x =
       line i ppf "Pcf_extension %a\n" fmt_string_loc s;
       payload i ppf arg
 
-and class_field_kind i ppf = function
-  | Cfk_concrete (o, e) ->
+and class_field_value_kind i ppf = function
+  | Cfk_concrete (o, tc, e) ->
       line i ppf "Concrete %a\n" fmt_override_flag o;
+      option i type_constraint ppf tc;
+      expression i ppf e
+  | Cfk_virtual t ->
+      line i ppf "Virtual\n";
+      core_type i ppf t
+
+and class_field_method_kind i ppf = function
+  | Cfk_concrete (o, (args, t), e) ->
+      line i ppf "Concrete %a\n" fmt_override_flag o;
+      list i expr_function_param ppf args;
+      option i value_constraint ppf t;
       expression i ppf e
   | Cfk_virtual t ->
       line i ppf "Virtual\n";


### PR DESCRIPTION
Makes #2401 easier.

@Julow some normalizations have been undone (see `js_source.ml`), but the result is closer, and some indentation has to be fixed, but this tremendously simplifies the formatting, and removes the calls to `Sugar.fun_` for `Pexp_newtype` and for `fmt_class_field_kind`.

- `object.ml.ref` can be removed once we fixed the regressions
- in the parser, `args_typ_strict_binding` can be renamed `args_typ_strict_binding` (we finally covered every case)

If you have the time to have a look at the indentation that would be very helpful!