### PR TITLE
Check dune fmt in the github actions

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -41,6 +41,9 @@ jobs:
           opam exec -- dune subst
           opam exec -- dune build -p ocamlformat-lib,ocamlformat
 
+      - name: Format
+        run: opam exec -- dune fmt
+
       - name: Runtest
         run: opam exec -- dune runtest
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -36,13 +36,13 @@ jobs:
       - name: Opam dependencies
         run: opam install --deps-only -t .
 
+      - name: Format
+        run: opam exec -- dune fmt
+
       - name: Build
         run: |
           opam exec -- dune subst
           opam exec -- dune build -p ocamlformat-lib,ocamlformat
-
-      - name: Format
-        run: opam exec -- dune fmt
 
       - name: Runtest
         run: opam exec -- dune runtest

--- a/.github/workflows/build-others.yml
+++ b/.github/workflows/build-others.yml
@@ -40,5 +40,8 @@ jobs:
       - name: Opam dependencies
         run: opam install --deps-only -t .
 
+      - name: Format
+        run: opam exec -- dune fmt
+
       - name: Runtest
         run: opam exec -- dune runtest

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -90,15 +90,12 @@ module Right = struct
 
   (* exception C of ... * ... * < ... > *)
   let type_exception = function
-    | {ptyexn_attributes= {attrs_after= _ :: _; _}; _}
-      ->
-        false
+    | {ptyexn_attributes= {attrs_after= _ :: _; _}; _} -> false
     | {ptyexn_constructor; _} -> extension_constructor ptyexn_constructor
 
   (* val x : < ... > *)
   let value_description = function
-    | {pval_attributes= {attrs_after= _ :: _; _}; _} ->
-        false
+    | {pval_attributes= {attrs_after= _ :: _; _}; _} -> false
     | {pval_prim= _ :: _; _} -> false
     | {pval_type= ct; _} -> core_type ct
 


### PR DESCRIPTION
Since we added:
```
version = ignore
version-check = false
```
in `.ocamlformat` to not make the lint-fmt job of the CI fail, this job is not spawned anymore and we don't catch unformatted files.