### PR TITLE
Fix dropped comments before begin-end case

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@ profile. This started with version 0.26.0.
 - Fix formatting of type vars in GADT constructors (#2518, @Julow)
 - Fix `[@ocamlformat "disable"]` inside `class type` constructs. (#2525, @EmileTrotignon)
 - Fix the formatting of the `in` keyword when `[@ocamlformat disable]` is attached to a let-binding (#2242, @EmileTrotignon)
+- Fix dropped comments before `begin .. end` in a match case (#2541, @Julow)
 
 ### Changes
 - The location of attributes for structure items is now tracked and preserved. (#2247, @EmileTrotignon)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3213,10 +3213,10 @@ and fmt_case c ctx ~first ~last case =
     | Ppat_or _ when Option.is_some pc_guard -> true
     | _ -> parenze_pat xlhs
   in
-  let eol =
-    Option.some_if (Cmts.has_before c.cmts pc_rhs.pexp_loc) force_break
+  let cmts_before = Cmts.has_before c.cmts pc_rhs.pexp_loc in
+  let p =
+    Params.get_cases c.conf ~ctx ~first ~last ~cmts_before ~xbch:xrhs
   in
-  let p = Params.get_cases c.conf ~ctx ~first ~last ~xbch:xrhs in
   p.leading_space $ leading_cmt
   $ p.box_all
       ( p.box_pattern_arrow
@@ -3229,7 +3229,8 @@ and fmt_case c ctx ~first ~last case =
           $ p.open_paren_branch )
       $ p.break_after_opening_paren
       $ hovbox 0
-          ( fmt_expression ?eol c ?parens:p.expr_parens p.branch_expr
+          ( fmt_expression ?eol:p.expr_eol c ?parens:p.expr_parens
+              p.branch_expr
           $ p.close_paren_branch ) )
 
 and fmt_value_description c ctx vd =

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -178,10 +178,12 @@ type cases =
   ; open_paren_branch: Fmt.t
   ; break_after_opening_paren: Fmt.t
   ; expr_parens: bool option
+  ; expr_eol: Fmt.t option
   ; branch_expr: expression Ast.xt
   ; close_paren_branch: Fmt.t }
 
-let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
+let get_cases (c : Conf.t) ~ctx ~first ~last ~cmts_before
+    ~xbch:({ast; _} as xast) =
   let indent =
     match (c.fmt_opts.cases_matching_exp_indent.v, (ctx, ast.pexp_desc)) with
     | ( `Compact
@@ -211,7 +213,8 @@ let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
   let indent = if align_nested_match then 0 else indent in
   let open_paren_branch, close_paren_branch, branch_expr =
     match ast with
-    | {pexp_desc= Pexp_beginend nested_exp; pexp_attributes= []; _} ->
+    | {pexp_desc= Pexp_beginend nested_exp; pexp_attributes= []; _}
+      when not cmts_before ->
         let close_paren =
           let offset =
             match c.fmt_opts.break_cases.v with `Nested -> 0 | _ -> -2
@@ -231,6 +234,7 @@ let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
         in
         (fmt_if parens_branch (str " ("), close_paren, xast)
   in
+  let expr_eol = Option.some_if cmts_before force_break in
   match c.fmt_opts.break_cases.v with
   | `Fit ->
       { leading_space= fmt_if (not first) space_break
@@ -242,6 +246,7 @@ let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
       ; open_paren_branch
       ; break_after_opening_paren= space_break
       ; expr_parens
+      ; expr_eol
       ; branch_expr
       ; close_paren_branch }
   | `Nested ->
@@ -255,6 +260,7 @@ let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
       ; break_after_opening_paren=
           fmt_or (indent > 2) (break 1 4) (break 1 2)
       ; expr_parens
+      ; expr_eol
       ; branch_expr
       ; close_paren_branch }
   | `Fit_or_vertical ->
@@ -267,6 +273,7 @@ let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
       ; open_paren_branch
       ; break_after_opening_paren= space_break
       ; expr_parens
+      ; expr_eol
       ; branch_expr
       ; close_paren_branch }
   | `Toplevel | `All ->
@@ -279,6 +286,7 @@ let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
       ; open_paren_branch
       ; break_after_opening_paren= space_break
       ; expr_parens
+      ; expr_eol
       ; branch_expr
       ; close_paren_branch }
   | `Vertical ->
@@ -291,6 +299,7 @@ let get_cases (c : Conf.t) ~ctx ~first ~last ~xbch:({ast; _} as xast) =
       ; open_paren_branch
       ; break_after_opening_paren= break 1000 0
       ; expr_parens
+      ; expr_eol
       ; branch_expr
       ; close_paren_branch }
 

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -80,6 +80,7 @@ type cases =
   ; open_paren_branch: Fmt.t
   ; break_after_opening_paren: Fmt.t
   ; expr_parens: bool option
+  ; expr_eol: Fmt.t option
   ; branch_expr: expression Ast.xt  (** Expression on the RHS of the [->]. *)
   ; close_paren_branch: Fmt.t }
 
@@ -88,6 +89,7 @@ val get_cases :
   -> ctx:Ast.t
   -> first:bool
   -> last:bool
+  -> cmts_before:bool
   -> xbch:expression Ast.xt
   -> cases
 

--- a/test/passing/tests/exp_grouping-parens.ml.ref
+++ b/test/passing/tests/exp_grouping-parens.ml.ref
@@ -335,3 +335,17 @@ let _ =
       loop
     end
     [@attr]
+
+let _ =
+  match x with
+  | _ ->
+      (* xxx *)
+      y
+
+let _ =
+  match x with
+  | _ ->
+    begin
+      y
+    end
+    [@foo]

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -272,3 +272,14 @@ let _ =
   if something_changed then begin[@attr]
     loop
   end
+
+let _ =
+  match x with
+  | _ ->
+      (* xxx *)
+      begin y end
+
+let _ =
+  match x with
+  | _ ->
+      begin[@foo] y end

--- a/test/passing/tests/exp_grouping.ml.ref
+++ b/test/passing/tests/exp_grouping.ml.ref
@@ -389,3 +389,19 @@ let _ =
       loop
     end
     [@attr]
+
+let _ =
+  match x with
+  | _ ->
+    (* xxx *)
+    begin
+      y
+    end
+
+let _ =
+  match x with
+  | _ ->
+    begin
+      y
+    end
+    [@foo]


### PR DESCRIPTION
Fix: https://github.com/ocaml-ppx/ocamlformat/issues/2539