### PR TITLE
vscode debugger config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "OCaml earlybird (experimental)",
+            "type": "ocaml.earlybird",
+            "request": "launch",
+            "program": "${workspaceRoot}/_build/default/bin/ocamlformat/main.bc",
+            "arguments": ["-g", "${workspaceRoot}/test.ml"],
+            "stopOnEntry": true
+        }
+    ]
+}

--- a/bin/ocamlformat/dune
+++ b/bin/ocamlformat/dune
@@ -18,7 +18,8 @@
   (:standard -open Ocamlformat_stdlib))
  (instrumentation
   (backend bisect_ppx))
- (libraries ocamlformat-lib bin_conf))
+ (libraries ocamlformat-lib bin_conf)
+ (modes byte native))
 
 (rule
  (with-stdout-to


### PR DESCRIPTION
This adds config for the debuger provided by the earlybird vscode extension.
There might be some issues with enabling bytecode mode, but I do not know of any.

Its very very useful if you use vscode, I have managed to understand behaviours that were hard to debug-print with this.