### PR TITLE
add box_debug to new fmt combinators for breaks

### DIFF
--- a/lib/Fmt.ml
+++ b/lib/Fmt.ml
@@ -94,11 +94,20 @@ let break n o =
 
 let force_break = break 1000 0
 
-let space_break = with_pp (fun fs -> Format_.pp_print_space fs ())
+let space_break =
+  with_pp (fun fs ->
+      Box_debug.space_break fs ;
+      Format_.pp_print_space fs () )
 
-let cut_break = with_pp (fun fs -> Format_.pp_print_cut fs ())
+let cut_break =
+  with_pp (fun fs ->
+      Box_debug.cut_break fs ;
+      Format_.pp_print_cut fs () )
 
-let force_newline = with_pp (fun fs -> Format_.pp_force_newline fs ())
+let force_newline =
+  with_pp (fun fs ->
+      Box_debug.force_newline fs ;
+      Format_.pp_force_newline fs () )
 
 let cbreak ~fits ~breaks =
   with_pp (fun fs ->

--- a/lib/box_debug.ml
+++ b/lib/box_debug.ml
@@ -105,6 +105,14 @@ let break fs n o =
      %i</span></div>"
     n o n o
 
+let space_break fs =
+  debugf fs "<div class=\"break space_break\">space_break</div>"
+
+let cut_break fs = debugf fs "<div class=\"break cut_break\">cut_break</div>"
+
+let force_newline fs =
+  debugf fs "<div class=\"break force_newline\">force_newline</div>"
+
 let pp_keyword fs s = fprintf_as_0 fs "<span class=\"keyword\">%s</span>" s
 
 let _pp_format_lit fs =


### PR DESCRIPTION
This adds output to box_debug for the following combinators :
- space_break
- cut_break
- force_newline