### PR TITLE
Correct --wrap-comments doc on docstrings

### DIFF
--- a/doc/manpage_ocamlformat.mld
+++ b/doc/manpage_ocamlformat.mld
@@ -456,12 +456,12 @@ OPTIONS (CODE FORMATTING STYLE)
            attributes.
 
        --wrap-comments
-           Wrap comments and docstrings. Comments and docstrings are divided
-           into paragraphs by open lines (two or more consecutive newlines),
-           and each paragraph is wrapped at the margin. Multi-line comments
-           with vertically-aligned asterisks on the left margin are not
-           wrapped. Consecutive comments with both left and right margin
-           aligned are not wrapped either. The flag is unset by default.
+           Comments are divided into paragraphs by open lines (two or more
+           consecutive newlines), and each paragraph is wrapped at the
+           margin. Multi-line comments with vertically-aligned asterisks on
+           the left margin are not wrapped. Consecutive comments with both
+           left and right margin aligned are not wrapped either. The flag is
+           unset by default.
 
        --wrap-fun-args
            Style for function call. The flag is set by default.

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -1289,12 +1289,11 @@ module Formatting = struct
 
   let wrap_comments =
     let doc =
-      "Wrap comments and docstrings. Comments and docstrings are divided \
-       into paragraphs by open lines (two or more consecutive newlines), \
-       and each paragraph is wrapped at the margin. Multi-line comments \
-       with vertically-aligned asterisks on the left margin are not \
-       wrapped. Consecutive comments with both left and right margin \
-       aligned are not wrapped either."
+      "Comments are divided into paragraphs by open lines (two or more \
+       consecutive newlines), and each paragraph is wrapped at the margin. \
+       Multi-line comments with vertically-aligned asterisks on the left \
+       margin are not wrapped. Consecutive comments with both left and \
+       right margin aligned are not wrapped either."
     in
     Decl.flag ~default ~names:["wrap-comments"] ~doc ~kind
       (fun conf elt -> update conf ~f:(fun f -> {f with wrap_comments= elt}))


### PR DESCRIPTION
--wrap-comments do not apply to docstrings.