### PR TITLE
CI: Disable test-branch on main

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -57,6 +57,7 @@ jobs:
           path: _build/install/default/bin/ocamlformat
 
   test-branch:
+    if: ${{ github.ref != 'refs/heads/main' }}
     needs: build-linux
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Might allow to workflow to complete since https://github.com/ocaml-ppx/ocamlformat/pull/2572. This CI job is not useful.