### PR TITLE
Allow custom commands for running ocamlformat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ profile. This started with version 0.26.0.
 - Support OCaml 5.2 syntax (#2519, @Julow)
   This includes:
   + Local open in types.
+- Allow a custom command to be used to run ocamlformat in the emacs plugin (#2577, @gridbugs)
 
 ### Changed
 

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -48,7 +48,9 @@
 
 (defcustom ocamlformat-command "ocamlformat"
   "The `ocamlformat' command."
-  :type 'string
+  :type '(choice
+	  (string :tag "The name of the ocamlformat executable")
+	  (repeat :tag "The prefix of the command to run to run ocamlformat" string))
   :group 'ocamlformat)
 
 (defcustom ocamlformat-enable 'enable
@@ -266,15 +268,23 @@ is nil."
            ((eq ocamlformat-file-kind 'implementation)
             (list "--impl"))
            ((eq ocamlformat-file-kind 'interface)
-            (list "--intf")))))
+            (list "--intf"))))
+	 (ocamlformat-exe
+	  (if (listp ocamlformat-command)
+	      (car ocamlformat-command)
+	    ocamlformat-command))
+	 (ocamlformat-prefix-args
+	  (if (listp ocamlformat-command)
+	      (cdr ocamlformat-command)
+	    '())))
     (unwind-protect
         (save-restriction
           (widen)
           (write-region nil nil bufferfile)
           (if (zerop
                (apply #'call-process
-                      ocamlformat-command nil (list :file errorfile) nil
-                      (append margin-args enable-args extension-args
+                      ocamlformat-exe nil (list :file errorfile) nil
+                      (append ocamlformat-prefix-args margin-args enable-args extension-args
                               (list
                                "--name" buffer-file-name
                                "--output" outputfile bufferfile))))


### PR DESCRIPTION
Currently it's possible to customize the path or name of the ocamlformat executable that gets run by the emacs ocamlformat package. However sometimes it's desirable to run ocamlformat by running a multi-word command, such as `opam exec ocamlformat --`. This change adds support running coamlformat with custom multi-word commands by allowing the `ocamlformat-command` variable to be set to a list of strings.