### PR TITLE
Improve comment placement after a `then` or `else`

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2354,6 +2354,13 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                         parenze_exp xbch && not symbol_parens
                       in
                       let parens_exp = false in
+                      let keyword_comments, has_keyword_comments =
+                        let exp_loc = xbch.ast.pexp_loc in
+                        let has = Cmts.has_before c.cmts exp_loc in
+                        let pro = break 1 0 in
+                        ( Cmts.fmt_before ~pro ~epi:noop ~eol:noop c exp_loc
+                        , has )
+                      in
                       let p =
                         Params.get_if_then_else c.conf ~first ~last
                           ~parens_bch ~parens_prev_bch:!parens_prev_bch
@@ -2364,6 +2371,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                           ~fmt_attributes:
                             (fmt_attributes c ~pre:Blank pexp_attributes)
                           ~fmt_cond:(fmt_expression ~box:false c)
+                          ~keyword_comments ~has_keyword_comments
                       in
                       parens_prev_bch := parens_bch ;
                       p.box_branch
@@ -2924,8 +2932,7 @@ and fmt_class_signature c ~ctx ~pro ~epi ?ext self_ fields =
   in
   let ast x = Ctf x in
   let cmts_within =
-    if List.is_empty fields then
-      (* Side effect order is important. *)
+    if List.is_empty fields then (* Side effect order is important. *)
       Cmts.fmt_within ~pro:noop c (Ast.location ctx)
     else noop
   in

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -191,6 +191,8 @@ val get_if_then_else :
   -> fmt_extension_suffix:Fmt.t option
   -> fmt_attributes:Fmt.t
   -> fmt_cond:(expression Ast.xt -> Fmt.t)
+  -> keyword_comments:Fmt.t
+  -> has_keyword_comments:bool
   -> if_then_else
 
 val match_indent : ?default:int -> Conf.t -> parens:bool -> ctx:Ast.t -> int

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -370,8 +370,7 @@ let format (type ext std) (ext_fg : ext Extended_ast.t)
         Error
           (Unstable {iteration= i; prev= prev_source; next= fmted; input_name}
           ) )
-      else
-        (* All good, continue *)
+      else (* All good, continue *)
         print_check ~i:(i + 1) ~conf ~prev_source:fmted ext_t_new std_t_new
   in
   try print_check ~i:1 ~conf ~prev_source ext_parsed std_parsed with

--- a/test/passing/tests/break_string_literals-never.ml.err
+++ b/test/passing/tests/break_string_literals-never.ml.err
@@ -1,7 +1,7 @@
-Warning: tests/break_string_literals.ml:4 exceeds the margin
-Warning: tests/break_string_literals.ml:7 exceeds the margin
-Warning: tests/break_string_literals.ml:11 exceeds the margin
-Warning: tests/break_string_literals.ml:48 exceeds the margin
-Warning: tests/break_string_literals.ml:51 exceeds the margin
-Warning: tests/break_string_literals.ml:63 exceeds the margin
-Warning: tests/break_string_literals.ml:68 exceeds the margin
+Warning: tests/break_string_literals.ml:3 exceeds the margin
+Warning: tests/break_string_literals.ml:6 exceeds the margin
+Warning: tests/break_string_literals.ml:10 exceeds the margin
+Warning: tests/break_string_literals.ml:47 exceeds the margin
+Warning: tests/break_string_literals.ml:50 exceeds the margin
+Warning: tests/break_string_literals.ml:62 exceeds the margin
+Warning: tests/break_string_literals.ml:67 exceeds the margin

--- a/test/passing/tests/break_string_literals-never.ml.ref
+++ b/test/passing/tests/break_string_literals-never.ml.ref
@@ -1,6 +1,5 @@
 let () =
-  if true then
-    (* Shrinking the margin a bit *)
+  if true then (* Shrinking the margin a bit *)
     Format.printf
       "@[<v 2>@{<warning>@{<title>Warning@}@}@,@,\        These are @{<warning>NOT@} the Droids you are looking for!@,@,\        Some more text. Just more letters and words.@,\        All this text is left-aligned because it's part of the UI.@,\        It'll be easier for the user to read this message.@]@\n@."
 

--- a/test/passing/tests/break_string_literals.ml.ref
+++ b/test/passing/tests/break_string_literals.ml.ref
@@ -1,6 +1,5 @@
 let () =
-  if true then
-    (* Shrinking the margin a bit *)
+  if true then (* Shrinking the margin a bit *)
     Format.printf
       "@[<v 2>@{<warning>@{<title>Warning@}@}@,\
        @,\

--- a/test/passing/tests/comments-no-wrap.ml.err
+++ b/test/passing/tests/comments-no-wrap.ml.err
@@ -1,5 +1,5 @@
-Warning: tests/comments.ml:186 exceeds the margin
-Warning: tests/comments.ml:190 exceeds the margin
-Warning: tests/comments.ml:250 exceeds the margin
-Warning: tests/comments.ml:401 exceeds the margin
-Warning: tests/comments.ml:433 exceeds the margin
+Warning: tests/comments.ml:198 exceeds the margin
+Warning: tests/comments.ml:202 exceeds the margin
+Warning: tests/comments.ml:262 exceeds the margin
+Warning: tests/comments.ml:413 exceeds the margin
+Warning: tests/comments.ml:445 exceeds the margin

--- a/test/passing/tests/comments-no-wrap.ml.ref
+++ b/test/passing/tests/comments-no-wrap.ml.ref
@@ -37,16 +37,28 @@ let foo = function Blah, (x, (* old *) y) -> ()
 let foo = function (x, y) (* old *), z -> ()
 
 let _ =
-  if (* a0 *) b (* c0 *) then (* d0 *) e (* f0 *) else (* g0 *) h (* i0 *)
+  if (* a0 *) b (* c0 *) then (* d0 *)
+    e (* f0 *)
+  else (* g0 *)
+    h (* i0 *)
 
 let _ =
-  if (* a1 *) b (* c1 *) then (* d1 *) e (* f1 *) else (* g1 *) h (* i1 *)
+  if (* a1 *) b (* c1 *) then (* d1 *)
+    e (* f1 *)
+  else (* g1 *)
+    h (* i1 *)
 
 let _ =
-  if (* a2 *) B (* c2 *) then (* d2 *) E (* f2 *) else (* g2 *) H (* i2 *)
+  if (* a2 *) B (* c2 *) then (* d2 *)
+    E (* f2 *)
+  else (* g2 *)
+    H (* i2 *)
 
 let _ =
-  if (* a3 *) B (* c3 *) then (* d3 *) E (* f3 *) else (* g3 *) H (* i3 *)
+  if (* a3 *) B (* c3 *) then (* d3 *)
+    E (* f3 *)
+  else (* g3 *)
+    H (* i3 *)
 ;;
 
 match x with

--- a/test/passing/tests/comments.ml.err
+++ b/test/passing/tests/comments.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/comments.ml:252 exceeds the margin
+Warning: tests/comments.ml:264 exceeds the margin

--- a/test/passing/tests/comments.ml.ref
+++ b/test/passing/tests/comments.ml.ref
@@ -37,16 +37,28 @@ let foo = function Blah, (x, (* old *) y) -> ()
 let foo = function (x, y) (* old *), z -> ()
 
 let _ =
-  if (* a0 *) b (* c0 *) then (* d0 *) e (* f0 *) else (* g0 *) h (* i0 *)
+  if (* a0 *) b (* c0 *) then (* d0 *)
+    e (* f0 *)
+  else (* g0 *)
+    h (* i0 *)
 
 let _ =
-  if (* a1 *) b (* c1 *) then (* d1 *) e (* f1 *) else (* g1 *) h (* i1 *)
+  if (* a1 *) b (* c1 *) then (* d1 *)
+    e (* f1 *)
+  else (* g1 *)
+    h (* i1 *)
 
 let _ =
-  if (* a2 *) B (* c2 *) then (* d2 *) E (* f2 *) else (* g2 *) H (* i2 *)
+  if (* a2 *) B (* c2 *) then (* d2 *)
+    E (* f2 *)
+  else (* g2 *)
+    H (* i2 *)
 
 let _ =
-  if (* a3 *) B (* c3 *) then (* d3 *) E (* f3 *) else (* g3 *) H (* i3 *)
+  if (* a3 *) B (* c3 *) then (* d3 *)
+    E (* f3 *)
+  else (* g3 *)
+    H (* i3 *)
 ;;
 
 match x with

--- a/test/passing/tests/ite-compact.ml.ref
+++ b/test/passing/tests/ite-compact.ml.ref
@@ -116,14 +116,16 @@ let foo =
     else some other action
   else some default action
 
-let foo = if cmp < 0 then (* foo *) a + b else (* foo *) a - b
+let foo =
+  if cmp < 0 then (* foo *)
+    a + b
+  else (* foo *)
+    a - b
 
 let foo =
-  if cmp < 0 then
-    (* ast higher precedence than context: no parens *)
+  if cmp < 0 then (* ast higher precedence than context: no parens *)
     false
-  else if cmp > 0 then
-    (* context higher prec than ast: add parens *)
+  else if cmp > 0 then (* context higher prec than ast: add parens *)
     true
   else if Poly.(assoc_of_prec prec_ast = which_child && which_child <> Non)
   then foo
@@ -157,3 +159,14 @@ let _ =
     bar
   then 1
   else 2
+
+let compare s1 s2 =
+  if String.equal s1 s2 then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options then
+    (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1

--- a/test/passing/tests/ite-compact_closing.ml.ref
+++ b/test/passing/tests/ite-compact_closing.ml.ref
@@ -131,14 +131,16 @@ let foo =
     else some other action
   else some default action
 
-let foo = if cmp < 0 then (* foo *) a + b else (* foo *) a - b
+let foo =
+  if cmp < 0 then (* foo *)
+    a + b
+  else (* foo *)
+    a - b
 
 let foo =
-  if cmp < 0 then
-    (* ast higher precedence than context: no parens *)
+  if cmp < 0 then (* ast higher precedence than context: no parens *)
     false
-  else if cmp > 0 then
-    (* context higher prec than ast: add parens *)
+  else if cmp > 0 then (* context higher prec than ast: add parens *)
     true
   else if Poly.(assoc_of_prec prec_ast = which_child && which_child <> Non)
   then foo
@@ -172,3 +174,14 @@ let _ =
     bar
   then 1
   else 2
+
+let compare s1 s2 =
+  if String.equal s1 s2 then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options then
+    (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1

--- a/test/passing/tests/ite-fit_or_vertical.ml.ref
+++ b/test/passing/tests/ite-fit_or_vertical.ml.ref
@@ -140,7 +140,11 @@ let foo =
   else
     some default action
 
-let foo = if cmp < 0 then (* foo *) a + b else (* foo *) a - b
+let foo =
+  if cmp < 0 then (* foo *)
+    a + b
+  else (* foo *)
+    a - b
 
 let foo =
   if cmp < 0 then (* ast higher precedence than context: no parens *)
@@ -191,3 +195,14 @@ let _ =
     1
   else
     2
+
+let compare s1 s2 =
+  if String.equal s1 s2 then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options then
+    (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1

--- a/test/passing/tests/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/tests/ite-fit_or_vertical_closing.ml.ref
@@ -152,7 +152,11 @@ let foo =
   else
     some default action
 
-let foo = if cmp < 0 then (* foo *) a + b else (* foo *) a - b
+let foo =
+  if cmp < 0 then (* foo *)
+    a + b
+  else (* foo *)
+    a - b
 
 let foo =
   if cmp < 0 then (* ast higher precedence than context: no parens *)
@@ -203,3 +207,14 @@ let _ =
     1
   else
     2
+
+let compare s1 s2 =
+  if String.equal s1 s2 then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options then
+    (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1

--- a/test/passing/tests/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/tests/ite-fit_or_vertical_no_indicate.ml.ref
@@ -140,7 +140,11 @@ let foo =
   else
     some default action
 
-let foo = if cmp < 0 then (* foo *) a + b else (* foo *) a - b
+let foo =
+  if cmp < 0 then (* foo *)
+    a + b
+  else (* foo *)
+    a - b
 
 let foo =
   if cmp < 0 then (* ast higher precedence than context: no parens *)
@@ -191,3 +195,14 @@ let _ =
     1
   else
     2
+
+let compare s1 s2 =
+  if String.equal s1 s2 then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options then
+    (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1

--- a/test/passing/tests/ite-kr.ml.ref
+++ b/test/passing/tests/ite-kr.ml.ref
@@ -167,19 +167,15 @@ let foo =
     some default action
 
 let foo =
-  if cmp < 0 then
-    (* foo *)
+  if cmp < 0 then (* foo *)
     a + b
-  else
-    (* foo *)
+  else (* foo *)
     a - b
 
 let foo =
-  if cmp < 0 then
-    (* ast higher precedence than context: no parens *)
+  if cmp < 0 then (* ast higher precedence than context: no parens *)
     false
-  else if cmp > 0 then
-    (* context higher prec than ast: add parens *)
+  else if cmp > 0 then (* context higher prec than ast: add parens *)
     true
   else if Poly.(assoc_of_prec prec_ast = which_child && which_child <> Non)
   then
@@ -226,3 +222,14 @@ let _ =
     1
   else
     2
+
+let compare s1 s2 =
+  if String.equal s1 s2 then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options then
+    (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1

--- a/test/passing/tests/ite-kr_closing.ml.ref
+++ b/test/passing/tests/ite-kr_closing.ml.ref
@@ -177,19 +177,15 @@ let foo =
     some default action
 
 let foo =
-  if cmp < 0 then
-    (* foo *)
+  if cmp < 0 then (* foo *)
     a + b
-  else
-    (* foo *)
+  else (* foo *)
     a - b
 
 let foo =
-  if cmp < 0 then
-    (* ast higher precedence than context: no parens *)
+  if cmp < 0 then (* ast higher precedence than context: no parens *)
     false
-  else if cmp > 0 then
-    (* context higher prec than ast: add parens *)
+  else if cmp > 0 then (* context higher prec than ast: add parens *)
     true
   else if Poly.(assoc_of_prec prec_ast = which_child && which_child <> Non)
   then
@@ -236,3 +232,14 @@ let _ =
     1
   else
     2
+
+let compare s1 s2 =
+  if String.equal s1 s2 then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options then
+    (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1

--- a/test/passing/tests/ite-kw_first.ml.ref
+++ b/test/passing/tests/ite-kw_first.ml.ref
@@ -132,16 +132,19 @@ let foo =
     else some other action
   else some default action
 
-let foo = if cmp < 0 then (* foo *) a + b else (* foo *) a - b
+let foo =
+  if cmp < 0
+  then (* foo *)
+    a + b
+  else (* foo *)
+    a - b
 
 let foo =
   if cmp < 0
-  then
-    (* ast higher precedence than context: no parens *)
+  then (* ast higher precedence than context: no parens *)
     false
   else if cmp > 0
-  then
-    (* context higher prec than ast: add parens *)
+  then (* context higher prec than ast: add parens *)
     true
   else if Poly.(assoc_of_prec prec_ast = which_child && which_child <> Non)
   then foo
@@ -181,3 +184,16 @@ let _ =
     bar
   then 1
   else 2
+
+let compare s1 s2 =
+  if String.equal s1 s2
+  then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options
+  then (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options
+  then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1

--- a/test/passing/tests/ite-kw_first_closing.ml.ref
+++ b/test/passing/tests/ite-kw_first_closing.ml.ref
@@ -147,16 +147,19 @@ let foo =
     else some other action
   else some default action
 
-let foo = if cmp < 0 then (* foo *) a + b else (* foo *) a - b
+let foo =
+  if cmp < 0
+  then (* foo *)
+    a + b
+  else (* foo *)
+    a - b
 
 let foo =
   if cmp < 0
-  then
-    (* ast higher precedence than context: no parens *)
+  then (* ast higher precedence than context: no parens *)
     false
   else if cmp > 0
-  then
-    (* context higher prec than ast: add parens *)
+  then (* context higher prec than ast: add parens *)
     true
   else if Poly.(assoc_of_prec prec_ast = which_child && which_child <> Non)
   then foo
@@ -196,3 +199,16 @@ let _ =
     bar
   then 1
   else 2
+
+let compare s1 s2 =
+  if String.equal s1 s2
+  then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options
+  then (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options
+  then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1

--- a/test/passing/tests/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/tests/ite-kw_first_no_indicate.ml.ref
@@ -131,16 +131,19 @@ let foo =
     else some other action
   else some default action
 
-let foo = if cmp < 0 then (* foo *) a + b else (* foo *) a - b
+let foo =
+  if cmp < 0
+  then (* foo *)
+    a + b
+  else (* foo *)
+    a - b
 
 let foo =
   if cmp < 0
-  then
-    (* ast higher precedence than context: no parens *)
+  then (* ast higher precedence than context: no parens *)
     false
   else if cmp > 0
-  then
-    (* context higher prec than ast: add parens *)
+  then (* context higher prec than ast: add parens *)
     true
   else if Poly.(assoc_of_prec prec_ast = which_child && which_child <> Non)
   then foo
@@ -180,3 +183,16 @@ let _ =
     bar
   then 1
   else 2
+
+let compare s1 s2 =
+  if String.equal s1 s2
+  then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options
+  then (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options
+  then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1

--- a/test/passing/tests/ite-no_indicate.ml.ref
+++ b/test/passing/tests/ite-no_indicate.ml.ref
@@ -115,14 +115,16 @@ let foo =
     else some other action
   else some default action
 
-let foo = if cmp < 0 then (* foo *) a + b else (* foo *) a - b
+let foo =
+  if cmp < 0 then (* foo *)
+    a + b
+  else (* foo *)
+    a - b
 
 let foo =
-  if cmp < 0 then
-    (* ast higher precedence than context: no parens *)
+  if cmp < 0 then (* ast higher precedence than context: no parens *)
     false
-  else if cmp > 0 then
-    (* context higher prec than ast: add parens *)
+  else if cmp > 0 then (* context higher prec than ast: add parens *)
     true
   else if Poly.(assoc_of_prec prec_ast = which_child && which_child <> Non)
   then foo
@@ -156,3 +158,14 @@ let _ =
     bar
   then 1
   else 2
+
+let compare s1 s2 =
+  if String.equal s1 s2 then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options then
+    (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1

--- a/test/passing/tests/ite-vertical.ml.ref
+++ b/test/passing/tests/ite-vertical.ml.ref
@@ -163,19 +163,15 @@ let foo =
     some default action
 
 let foo =
-  if cmp < 0 then
-    (* foo *)
+  if cmp < 0 then (* foo *)
     a + b
-  else
-    (* foo *)
+  else (* foo *)
     a - b
 
 let foo =
-  if cmp < 0 then
-    (* ast higher precedence than context: no parens *)
+  if cmp < 0 then (* ast higher precedence than context: no parens *)
     false
-  else if cmp > 0 then
-    (* context higher prec than ast: add parens *)
+  else if cmp > 0 then (* context higher prec than ast: add parens *)
     true
   else if Poly.(assoc_of_prec prec_ast = which_child && which_child <> Non)
   then
@@ -222,3 +218,14 @@ let _ =
     1
   else
     2
+
+let compare s1 s2 =
+  if String.equal s1 s2 then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options then
+    (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1

--- a/test/passing/tests/ite.ml
+++ b/test/passing/tests/ite.ml
@@ -153,3 +153,14 @@ let _ =
   else if (* bar *)
     bar then 1
   else 2
+
+let compare s1 s2 =
+  if String.equal s1 s2 then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options then
+    (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1

--- a/test/passing/tests/ite.ml.ref
+++ b/test/passing/tests/ite.ml.ref
@@ -116,14 +116,16 @@ let foo =
     else some other action
   else some default action
 
-let foo = if cmp < 0 then (* foo *) a + b else (* foo *) a - b
+let foo =
+  if cmp < 0 then (* foo *)
+    a + b
+  else (* foo *)
+    a - b
 
 let foo =
-  if cmp < 0 then
-    (* ast higher precedence than context: no parens *)
+  if cmp < 0 then (* ast higher precedence than context: no parens *)
     false
-  else if cmp > 0 then
-    (* context higher prec than ast: add parens *)
+  else if cmp > 0 then (* context higher prec than ast: add parens *)
     true
   else if Poly.(assoc_of_prec prec_ast = which_child && which_child <> Non)
   then foo
@@ -157,3 +159,14 @@ let _ =
     bar
   then 1
   else 2
+
+let compare s1 s2 =
+  if String.equal s1 s2 then (* this simplifies the next two cases *)
+    0
+  else if String.equal s1 Cmdliner.Manpage.s_options then
+    (* ensure OPTIONS section is last (hence first in the manual) *)
+    1
+  else if String.equal s2 Cmdliner.Manpage.s_options then (* same as above *)
+    -1
+  else (* reverse order *)
+    String.compare s2 s1


### PR DESCRIPTION
Allow comments on the same line as `then` and `else`, as it was the case in 0.26.2. Also, make sure to avoid formatting any code after a comment in that position.

This was broken since #2507.