### PR TITLE
parser-extended: Add missing Ast_mapper rule

### DIFF
--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -504,7 +504,7 @@ module E = struct
       match desc with
       | Pparam_val (lab, def, p) ->
           Pparam_val
-            (lab,
+            (sub.arg_label sub lab,
              map_opt (sub.expr sub) def,
              sub.pat sub p)
       | Pparam_newtype ty ->


### PR DESCRIPTION
Found by test-branch on very recent code. This caused a problem during normalization with this code:
```ocaml
(** {[
      f
        (fun ~f -> x)
    ]} *)
```