### PR TITLE
Fix unecessary break due to comment in polymorphic variants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@ profile. This started with version 0.26.0.
 - Fix missing parentheses around a let in class expressions (#2599, @Julow)
 - Fix dropped attribute in `(module M : S [@attr])` (#2602, @Julow)
 - Build on OCaml 5.3 (#2603, @adamchol, @Julow)
+- Fix unecessary break due to comment in polymorphic variants (#2606, @Julow)
 
 ### Changes
 - The location of attributes for structure items is now tracked and preserved. (#2247, @EmileTrotignon)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1064,7 +1064,7 @@ and fmt_row_field c ctx {prf_desc; prf_attributes; prf_loc} =
     | Rinherit typ -> fmt_core_type c (sub_typ ~ctx typ)
   in
   hvbox 0
-    ( hvbox (Params.Indent.variant_type_arg c.conf) (Cmts.fmt c prf_loc row)
+    ( Cmts.fmt c prf_loc (hvbox (Params.Indent.variant_type_arg c.conf) row)
     $ fmt_attributes_and_docstrings c prf_attributes )
 
 and fmt_pattern_attributes c xpat k =

--- a/test/passing/tests/variants.ml
+++ b/test/passing/tests/variants.ml
@@ -14,3 +14,9 @@ let _ = (* xx *) `(* yy *) A (* zz *)
 let _ = (* xx *) `B (* zz *)
 
 let _ = `(* yy *) C (* zz *)
+
+type t =
+  [ `Fooooo
+  | (* Other inline element markup. *)
+    `Simple_reference of string
+  | `Fooooo ]


### PR DESCRIPTION
The previous formatting was:

    | (* Other inline element markup. *)
      `Simple_reference of
      string