### PR TITLE
odoc: Fix formatting of paragraphs in lists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,6 +105,7 @@ profile. This started with version 0.26.0.
 - Display `a##b` instead of `a ## b` and similarly for operators that start with # (#2580, @v-gb)
 - \* Fix arrow type indentation with `break-separators=before` (#2598, @Julow)
 - Fix missing parentheses around a let in class expressions (#2599, @Julow)
+- Fix formatting of paragraphs in lists in documentation (#2607, @Julow)
 
 ## 0.26.2 (2024-04-18)
 

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -268,7 +268,7 @@ let rec fmt_inline_elements c elements =
 
 and fmt_nestable_block_element c elm =
   match elm.Loc.value with
-  | `Paragraph elems -> fmt_inline_elements c elems
+  | `Paragraph elems -> hovbox 0 (fmt_inline_elements c elems)
   | `Code_block (s1, s2) -> fmt_code_block c s1 s2
   | `Math_block s -> fmt_math_block s
   | `Verbatim s -> fmt_verbatim_block ~loc:elm.location s

--- a/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
+++ b/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
@@ -641,3 +641,12 @@ type x =
 (** at@ *)
 
 (** \@at *)
+
+(** Lists can't be nested
+    - foo
+    - module system documentation including
+    {ol
+    {- bar}
+    {- baz}
+    }
+*)

--- a/test/passing/tests/doc_comments-no-wrap.mli.ref
+++ b/test/passing/tests/doc_comments-no-wrap.mli.ref
@@ -683,3 +683,12 @@ type x =
 (** at@ *)
 
 (** \@at *)
+
+(** Lists can't be nested
+    {ul
+     {- foo }
+     {- module system documentation including
+        + bar
+        + baz
+     }
+    } *)

--- a/test/passing/tests/doc_comments.mli
+++ b/test/passing/tests/doc_comments.mli
@@ -648,3 +648,12 @@ type x =
 
 (** at@ *)
 (** \@at *)
+
+(** Lists can't be nested
+    - foo
+    - module system documentation including
+    {ol
+    {- bar}
+    {- baz}
+    }
+*)

--- a/test/passing/tests/doc_comments.mli.ref
+++ b/test/passing/tests/doc_comments.mli.ref
@@ -677,3 +677,12 @@ type x =
 (** at@ *)
 
 (** \@at *)
+
+(** Lists can't be nested
+    {ul
+     {- foo }
+     {- module system documentation including
+        + bar
+        + baz
+     }
+    } *)


### PR DESCRIPTION
The boxing of paragraphs was wrong in heavy-syntax lists:

    (** Lists can't be nested
        {ul
         {- foo }
         {- module
            system
            documentation
            including
            + bar
            + baz
         }
        } *)