### PR TITLE
odoc: Don't add unecessary space in references and links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -106,6 +106,7 @@ profile. This started with version 0.26.0.
 - \* Fix arrow type indentation with `break-separators=before` (#2598, @Julow)
 - Fix missing parentheses around a let in class expressions (#2599, @Julow)
 - Fix formatting of paragraphs in lists in documentation (#2607, @Julow)
+- Avoid unwanted space in references and links text in documentation (#2608, @Julow)
 
 ## 0.26.2 (2024-04-18)
 

--- a/test/passing/tests/doc.mld
+++ b/test/passing/tests/doc.mld
@@ -157,3 +157,6 @@ and we shall get
 ]}
 
 For more about [odoc] commands, simply invoke [odoc --help] in your shell.
+
+Preserve the space between a link/reference and its text:
+{{:foo}bar} {{:foo} bar} {{!foo}bar} {{!foo} bar}

--- a/test/passing/tests/doc.mld.ref
+++ b/test/passing/tests/doc.mld.ref
@@ -1,7 +1,7 @@
 {0 Parent/Child Specification}
 This parent/child specification allows more flexible output support, e.g.,
 per library documentation. See
-{{:https://v3.ocaml.org/packages} v3.ocaml.org/packages}.
+{{:https://v3.ocaml.org/packages}v3.ocaml.org/packages}.
 
 The rules are;
 
@@ -160,3 +160,6 @@ and we shall get
 ]}
 
 For more about [odoc] commands, simply invoke [odoc --help] in your shell.
+
+Preserve the space between a link/reference and its text: {{:foo}bar}
+{{:foo} bar} {{!foo}bar} {{!foo} bar}

--- a/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
+++ b/test/passing/tests/doc_comments-no-parse-docstrings.mli.ref
@@ -650,3 +650,7 @@ type x =
     {- baz}
     }
 *)
+
+(** Space before a reference or link text is preserved. A newline is turned
+    into a space. {{!ref}
+    with newline} and {{!ref} with space}. *)

--- a/test/passing/tests/doc_comments-no-wrap.mli.ref
+++ b/test/passing/tests/doc_comments-no-wrap.mli.ref
@@ -692,3 +692,6 @@ type x =
         + baz
      }
     } *)
+
+(** Space before a reference or link text is preserved. A newline is turned
+    into a space. {{!ref} with newline} and {{!ref} with space}. *)

--- a/test/passing/tests/doc_comments-no-wrap.mli.ref
+++ b/test/passing/tests/doc_comments-no-wrap.mli.ref
@@ -477,8 +477,9 @@ end
     {i fooooooooooooo oooooooo oooooooooo}
     {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
 
-(** {e foooooooo oooooooooo ooooooooo ooooooooo} {{!some ref} fooooooooooooo
-    oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
+(** {e foooooooo oooooooooo ooooooooo ooooooooo}
+    {{!some ref} fooooooooooooo oooooooo oooooooooo}
+    {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
 
 (** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooo
     {b eee + eee eee} *)
@@ -498,8 +499,7 @@ val k : int
        {i fooooooooooooo oooooooo oooooooooo
           {b fooooooooooooo oooooooooooo oooooo ooooooo}}} *)
 
-(** {e
-       {i fooooooooooooo oooooooo oooooooooo
+(** {e {i fooooooooooooo oooooooo oooooooooo
           {b fooooooooooooo oooooooooooo oooooo ooooooo}} foooooooo
        oooooooooo ooooooooo ooooooooo} *)
 

--- a/test/passing/tests/doc_comments.mli
+++ b/test/passing/tests/doc_comments.mli
@@ -657,3 +657,7 @@ type x =
     {- baz}
     }
 *)
+
+(** Space before a reference or link text is preserved. A newline is turned
+    into a space. {{!ref}
+    with newline} and {{!ref} with space}. *)

--- a/test/passing/tests/doc_comments.mli.ref
+++ b/test/passing/tests/doc_comments.mli.ref
@@ -686,3 +686,6 @@ type x =
         + baz
      }
     } *)
+
+(** Space before a reference or link text is preserved. A newline is turned
+    into a space. {{!ref} with newline} and {{!ref} with space}. *)

--- a/test/passing/tests/doc_comments.mli.ref
+++ b/test/passing/tests/doc_comments.mli.ref
@@ -477,8 +477,9 @@ end
     {i fooooooooooooo oooooooo oooooooooo}
     {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
 
-(** {e foooooooo oooooooooo ooooooooo ooooooooo} {{!some ref} fooooooooooooo
-    oooooooo oooooooooo} {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
+(** {e foooooooo oooooooooo ooooooooo ooooooooo}
+    {{!some ref} fooooooooooooo oooooooo oooooooooo}
+    {b fooooooooooooo oooooooooooo oooooo ooooooo} *)
 
 (** foooooooooooooooooooooooooooooooooooooooooooooooooo foooooooooooo
     {b eee + eee eee} *)
@@ -498,8 +499,7 @@ val k : int
        {i fooooooooooooo oooooooo oooooooooo
           {b fooooooooooooo oooooooooooo oooooo ooooooo}}} *)
 
-(** {e
-       {i fooooooooooooo oooooooo oooooooooo
+(** {e {i fooooooooooooo oooooooo oooooooooo
           {b fooooooooooooo oooooooooooo oooooo ooooooo}} foooooooo
        oooooooooo ooooooooo ooooooooo} *)
 

--- a/vendor/odoc-parser/syntax.ml
+++ b/vendor/odoc-parser/syntax.ml
@@ -281,7 +281,8 @@ and delimited_inline_element_list :
   let first_token = peek input in
   match first_token.value with
   | `Space _ ->
-      junk input;
+      (* Preserve leading spaces in markups
+         junk input; *)
       consume_elements ~at_start_of_line:false []
       (* [~at_start_of_line] is [false] here because the preceding token was some
          some markup like '{b', and we didn't move to the next line, so the next

--- a/vendor/odoc-parser/syntax.ml
+++ b/vendor/odoc-parser/syntax.ml
@@ -288,7 +288,8 @@ and delimited_inline_element_list :
          some markup like '{b', and we didn't move to the next line, so the next
          token will not be the first non-whitespace token on its line. *)
   | `Single_newline _ ->
-      junk input;
+      (* Preserve leading spaces in markups
+         junk input; *)
       consume_elements ~at_start_of_line:true []
   | `Blank_line _ as blank ->
       (* In case the markup is immediately followed by a blank line, the error


### PR DESCRIPTION
Avoid adding a space before the text of a reference or link:

    {{!ref}text}
    {{:url}text}

As regular comments might be formatted as docstrings, the space must be preserved if it appears in the source to avoid crashing. odoc-parser is changed to preserve this information.