### PR TITLE
janestreet: Fix indent of comments in records

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,7 +65,7 @@ profile. This started with version 0.26.0.
 - \* Improve formatting of functor arguments (#2505, @Julow)
   This also reduce the indentation of functor arguments with long signatures.
 
-- Improvements to the Janestreet profile (#2445, #2314, #2460, #2593, @Julow, @tdelvecchio-jsc)
+- Improvements to the Janestreet profile (#2445, #2314, #2460, #2593, #2612, @Julow, @tdelvecchio-jsc)
 
 - \* Undo let-bindings and methods normalizations (#2523, #2529, @gpetiot)
   This remove the rewriting of some forms of let-bindings and methods:

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3446,12 +3446,12 @@ and fmt_label_declaration c ctx ?(last = false) decl =
              (fits_breaks ~level:5 "" ";") )
           (str ";")
   in
+  let indent_cmts = Params.Indent.record_docstring c.conf in
   hovbox 0
     ( Cmts.fmt_before c pld_loc
-    $ hvbox
-        (Params.Indent.record_docstring c.conf)
+    $ hvbox indent_cmts
         ( hvbox 3
-            ( hvbox 4
+            ( hvbox indent_cmts
                 ( hvbox 2
                     ( hovbox 2
                         ( fmt_mutable_flag ~pro:noop ~epi:space_break c

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -3275,7 +3275,7 @@
  (action
   (with-stdout-to js_record.ml.stdout
    (with-stderr-to js_record.ml.stderr
-     (run %{bin:ocamlformat} --margin-check %{dep:tests/js_record.ml})))))
+     (run %{bin:ocamlformat} --margin-check --profile=janestreet --max-iter=3 %{dep:tests/js_record.ml})))))
 
 (rule
  (alias runtest)

--- a/test/passing/tests/js_record.ml
+++ b/test/passing/tests/js_record.ml
@@ -101,3 +101,17 @@ type t =
     : Something_lengthy.t
         list
   }
+
+type t =
+  { for_intf : Dune_rules.Module_name.t list
+    (* direct module dependencies for the interface *)
+  ; for_impl : Dune_rules.Module_name.t list
+    (* direct module dependencies for the implementation *)
+}
+
+type t =
+  { for_intf : Dune_rules.Module_name.t list
+        (* direct module dependencies for the interface *)
+    (* direct module dependencies for the interface *)
+  ; for_impl : Dune_rules.Module_name.t list
+}

--- a/test/passing/tests/js_record.ml.opts
+++ b/test/passing/tests/js_record.ml.opts
@@ -1,0 +1,2 @@
+--profile=janestreet
+--max-iter=3

--- a/test/passing/tests/js_record.ml.ref
+++ b/test/passing/tests/js_record.ml.ref
@@ -1,38 +1,52 @@
-type x = {foo: int; bar: int}
+type x =
+  { foo : int
+  ; bar : int
+  }
 
-let x = {x with foo= 3; bar= 5}
+let x = { x with foo = 3; bar = 5 }
 
 let x =
   { (* blah blah blah *)
-    foo= 3
-  ; bar= 5 }
+    foo = 3
+  ; bar = 5
+  }
+;;
 
-let x = [{x with foo= 3; bar= 5}]
+let x = [ { x with foo = 3; bar = 5 } ]
 
 let x =
   [ { (* blah blah blah *)
-      foo= 3
-    ; bar= 5 } ]
+      foo = 3
+    ; bar = 5
+    }
+  ]
+;;
 
-let x = {M.x with M.foo= 3}
-
-let x = {x with M.foo= 3}
-
-let x = {M.foo= 3}
-
-let _ = {foo with Bar.field1= value1; field2= value2}
-
-let _ = {foo with Bar.field1= value1; field2= value2}
+let x = { M.x with M.foo = 3 }
+let x = { x with M.foo = 3 }
+let x = { M.foo = 3 }
+let _ = { foo with Bar.field1 = value1; field2 = value2 }
+let _ = { foo with Bar.field1 = value1; field2 = value2 }
 
 (* multicomponent record module pathname *)
-let _ = {A.B.a= b; c= d}
+let _ = { A.B.a = b; c = d }
 
-type t = {a: something_lengthy list list [@default String.Map.empty]}
+type t = { a : something_lengthy list list [@default String.Map.empty] }
+type t = { a : Something_lengthy.t list list [@default String.Map.empty] }
+type t = { a : something_lengthy list list }
+type t = { a : Something_lengthy.t list list }
+type t = { a : Something_lengthy.t list }
 
-type t = {a: Something_lengthy.t list list [@default String.Map.empty]}
+type t =
+  { for_intf : Dune_rules.Module_name.t list
+    (* direct module dependencies for the interface *)
+  ; for_impl : Dune_rules.Module_name.t list
+    (* direct module dependencies for the implementation *)
+  }
 
-type t = {a: something_lengthy list list}
-
-type t = {a: Something_lengthy.t list list}
-
-type t = {a: Something_lengthy.t list}
+type t =
+  { for_intf : Dune_rules.Module_name.t list
+    (* direct module dependencies for the interface *)
+    (* direct module dependencies for the interface *)
+  ; for_impl : Dune_rules.Module_name.t list
+  }


### PR DESCRIPTION
Distinction between comments attached to the type or to the field is not needed.