### PR TITLE
Break after 'let%ext'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,6 +110,7 @@ profile. This started with version 0.26.0.
 - Fix missing parentheses around a let in class expressions (#2599, @Julow)
 - Fix formatting of paragraphs in lists in documentation (#2607, @Julow)
 - Avoid unwanted space in references and links text in documentation (#2608, @Julow)
+- \* Avoid large indentation in patterns after `let%ext` (#2615, @Julow)
 
 ## 0.26.2 (2024-04-18)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4571,7 +4571,6 @@ and fmt_value_binding c ~ctx0 ~rec_flag ?in_ ?epi
         (max (c.conf.fmt_opts.let_binding_indent.v - 1) 0, false)
     | _ -> (c.conf.fmt_opts.let_binding_indent.v, false)
   in
-  let pat_has_cmt = Cmts.has_before c.cmts lb_pat.ast.ppat_loc in
   let toplevel, in_, epi, cmts_before, cmts_after =
     match in_ with
     | Some in_ ->
@@ -4591,13 +4590,16 @@ and fmt_value_binding c ~ctx0 ~rec_flag ?in_ ?epi
         , Cmts.Toplevel.fmt_after c lb_loc )
   in
   let ext = lb_attrs.attrs_extension in
+  let should_break_after_keyword =
+    Cmts.has_before c.cmts lb_pat.ast.ppat_loc || Option.is_some ext
+  in
   let decl =
     let decl =
       fmt_str_loc c lb_op
       $ fmt_extension_suffix c ext
       $ fmt_attributes c at_attrs
       $ fmt_if rec_flag (str " rec")
-      $ fmt_or pat_has_cmt space_break (str " ")
+      $ fmt_or should_break_after_keyword space_break (str " ")
     and pattern = fmt_pattern c lb_pat
     and args =
       fmt_if

--- a/test/passing/tests/eliom_ext.eliom
+++ b/test/passing/tests/eliom_ext.eliom
@@ -28,8 +28,9 @@ type some_type = int * string list [@@deriving json]
 
 type another_type = A of some_type | B of another_type [@@deriving json]]
 
-let%server ( (s : int Eliom_shared.React.S.t)
-           , (f : (?step:React.step -> int -> unit) Eliom_shared.Value.t) ) =
+let%server
+    ( (s : int Eliom_shared.React.S.t)
+    , (f : (?step:React.step -> int -> unit) Eliom_shared.Value.t) ) =
   Eliom_shared.React.S.create 0
 
 let%client incr_s () =


### PR DESCRIPTION
This avoids patterns being aligned after the end of the extension label:

    -let%server ( (s : int Eliom_shared.React.S.t)
    -           , (f : (?step:React.step -> int -> unit) Eliom_shared.Value.t) ) =
    +let%server
    +    ( (s : int Eliom_shared.React.S.t)
    +    , (f : (?step:React.step -> int -> unit) Eliom_shared.Value.t) ) =