### PR TITLE
5.2 support: Raw identifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,9 @@ profile. This started with version 0.26.0.
 
 ### Highlight
 
-- \* Support OCaml 5.2 syntax (#2519, #2544, #2590, #2596, @Julow, @EmileTrotignon)
-  This includes local open in types and the new representation for functions.
+- \* Support OCaml 5.2 syntax (#2519, #2544, #2590, #2596, #2619, @Julow, @EmileTrotignon, @ccasin)
+  This includes local open in types, raw identifiers, and the new
+  representation for functions.
   This might change the formatting of some functions due to the formatting code
   being completely rewritten.
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -592,7 +592,7 @@ let fmt_type_var s =
   (* [' a'] is a valid type variable, the space is required to not lex as a
      char. https://github.com/ocaml/ocaml/pull/2034 *)
   $ fmt_if (String.length s > 1 && Char.equal s.[1] '\'') (str " ")
-  $ str s
+  $ ident s
 
 let rec fmt_extension_aux c ctx ~key (ext, pld) =
   match (ext.txt, pld, ctx) with
@@ -1451,7 +1451,7 @@ and fmt_param_newtype c = function
   | names ->
       cbox 0
         (Params.parens c.conf
-           (str "type " $ list names space_break (fmt_str_loc c)) )
+           (str "type " $ list names space_break (fmt_ident_loc c)) )
 
 and fmt_expr_fun_arg c fp =
   let ctx = Fpe fp in
@@ -3415,6 +3415,11 @@ and fmt_type_declaration c ?(pre = "") ?name ?(eq = "=") {ast= decl; _} =
     let fit = Tyd.is_simple decl in
     fmt_docstring_around_item_attrs ~force_before ~fit c ptype_attributes
   in
+  let type_name =
+    match name with
+    | Some name -> fmt_longident_loc ~constructor:false c name
+    | None -> ident txt
+  in
   let box_manifest k =
     hvbox c.conf.fmt_opts.type_decl_indent.v
       ( str pre
@@ -3424,9 +3429,7 @@ and fmt_type_declaration c ?(pre = "") ?name ?(eq = "=") {ast= decl; _} =
       $ hvbox_if
           (not (List.is_empty ptype_params))
           0
-          ( fmt_tydcl_params c ctx ptype_params
-          $ Option.value_map name ~default:(str txt)
-              ~f:(fmt_longident_loc ~constructor:false c) )
+          (fmt_tydcl_params c ctx ptype_params $ type_name)
       $ k )
   in
   let fmt_manifest_kind =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -244,11 +244,10 @@ let escape_ident s = if Lexer.is_keyword s then "\\#" ^ s else s
 let ident s = str (escape_ident s)
 
 let rec fmt_longident ~constructor (li : Longident.t) =
-  let str = if constructor then str else ident in
   let fmt_id id =
-    wrap_if
-      (Std_longident.String_id.is_symbol id)
-      (str "( ") (str " )") (str id)
+    let is_symbol = Std_longident.String_id.is_symbol id in
+    let str = if constructor || is_symbol then str else ident in
+    wrap_if is_symbol (str "( ") (str " )") (str id)
   in
   match li with
   | Lident id -> fmt_id id
@@ -277,6 +276,9 @@ let fmt_ident_loc c ?pre {txt; loc} =
 
 let fmt_str_loc_opt c ?pre ?(default = "_") {txt; loc} =
   Cmts.fmt c loc (opt pre str $ str (Option.value ~default txt))
+
+let fmt_ident_loc_opt c ?pre ?default {txt; loc} =
+  fmt_str_loc_opt c ?pre ?default {txt= Option.map txt ~f:escape_ident; loc}
 
 let variant_var c ({txt= x; loc} : variant_var) =
   Cmts.fmt c loc @@ (str "`" $ fmt_ident_loc c x)
@@ -4005,7 +4007,7 @@ and fmt_module c ctx ?rec_ ?epi ?(can_sparse = false) keyword ?(eqty = "=")
       hovbox 1
         ( pro
         $ Cmts.fmt_before c ~epi:space_break loc
-        $ str "(" $ align_opn $ fmt_str_loc_opt c name $ str " :" )
+        $ str "(" $ align_opn $ fmt_ident_loc_opt c name $ str " :" )
       $ fmt_or (Option.is_some blk.pro) (str " ") (break 1 2)
     and epi = str ")" $ Cmts.fmt_after c loc $ align_cls in
     compose_module' ~box:false ~pro ~epi blk
@@ -4049,7 +4051,7 @@ and fmt_module c ctx ?rec_ ?epi ?(can_sparse = false) keyword ?(eqty = "=")
       $ fmt_extension_suffix c ext
       $ fmt_attributes c ~pre:(Break (1, 0)) attrs_before
       $ fmt_if rec_flag (str " rec")
-      $ space_break $ fmt_str_loc_opt c name )
+      $ space_break $ fmt_ident_loc_opt c name )
   in
   let compact =
     Poly.(c.conf.fmt_opts.let_module.v = `Compact) || not can_sparse

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -914,7 +914,7 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
         (Params.Indent.type_constr c.conf)
         ( fmt_core_type c (sub_typ ~ctx t1)
         $ space_break
-        $ fmt_longident_loc c ~constructor:true lid )
+        $ fmt_longident_loc c ~constructor:false lid )
   | Ptyp_constr (lid, t1N) ->
       hvbox
         (Params.Indent.type_constr c.conf)
@@ -1135,10 +1135,9 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
   match ppat_desc with
   | Ppat_any -> str "_"
   | Ppat_var {txt; loc} ->
-      Cmts.fmt c loc
-      @@ wrap_if
-           (Std_longident.String_id.is_symbol txt)
-           (str "( ") (str " )") (ident txt)
+      let is_symbol = Std_longident.String_id.is_symbol txt in
+      let str = if is_symbol then str else ident in
+      Cmts.fmt c loc @@ wrap_if is_symbol (str "( ") (str " )") (str txt)
   | Ppat_alias (pat, {txt; loc}) ->
       let paren_pat =
         match pat.ppat_desc with
@@ -1186,7 +1185,7 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
                     hvbox 0
                       (Params.parens c.conf
                          ( str "type "
-                         $ list names space_break (fmt_str_loc c) ) )
+                         $ list names space_break (fmt_ident_loc c) ) )
                     $ space_break )
               $ fmt_pattern c (sub_pat ~ctx pat) ) ) )
   | Ppat_variant (lbl, None) -> variant_var c lbl

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4586,14 +4586,14 @@ and fmt_value_constraint c vc_opt =
             , fmt_constraint_sep c ":"
               $ hvbox 0
                   ( str "type "
-                  $ list pvars (str " ") (fmt_str_loc c)
+                  $ list pvars (str " ") (fmt_ident_loc c)
                   $ str "." $ space_break
                   $ fmt_core_type c (sub_typ ~ctx typ) ) )
         | `After ->
             ( fmt_constraint_sep c ":"
               $ hvbox 0
                   ( str "type "
-                  $ list pvars (str " ") (fmt_str_loc c)
+                  $ list pvars (str " ") (fmt_ident_loc c)
                   $ str "." )
             , space_break $ fmt_core_type c (sub_typ ~ctx typ) ) )
       | Pvc_coercion {ground; coercion} ->

--- a/test/passing/gen/dune.inc
+++ b/test/passing/gen/dune.inc
@@ -3835,6 +3835,21 @@
 (rule
  (deps .ocamlformat dune-project)
  (action
+  (with-stdout-to raw_identifiers.ml.stdout
+   (with-stderr-to raw_identifiers.ml.stderr
+     (run %{bin:ocamlformat} --name raw_identifiers.ml --margin-check %{dep:../tests/raw_identifiers.ml})))))
+
+(rule
+ (alias runtest)
+ (action (diff raw_identifiers.ml.ref raw_identifiers.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (action (diff raw_identifiers.ml.err raw_identifiers.ml.stderr)))
+
+(rule
+ (deps .ocamlformat dune-project)
+ (action
   (with-stdout-to recmod.mli.stdout
    (with-stderr-to recmod.mli.stderr
      (run %{bin:ocamlformat} --name recmod.mli --margin-check %{dep:../tests/recmod.mli})))))

--- a/test/passing/refs.default/raw_identifiers.ml.ref
+++ b/test/passing/refs.default/raw_identifiers.ml.ref
@@ -1,0 +1,85 @@
+module M : sig
+  class \#and : object
+    val mutable \#and : int
+    method \#and : int
+  end
+end = struct
+  class \#and =
+    let \#and = 1 in
+    object
+      val mutable \#and = \#and
+      method \#and = 2
+    end
+end
+
+let obj = new M.\#and
+
+module M : sig
+  type \#and = int
+end = struct
+  type \#and = string
+end
+
+let x = (`\#let `\#and : [ `\#let of [ `\#and ] ])
+let (`\#let \#rec) = x
+let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+type t = '\#let
+type \#mutable = { mutable \#mutable : \#mutable }
+
+let rec \#rec = { \#mutable = \#rec }
+
+type \#and = ..
+type \#and += Foo
+
+let x = ( ++ )
+let x = \#let
+let f ~\#let ?\#and () = 1
+
+module type A = sig
+  type ('\#let, 'a) \#virtual = '\#let * 'a as '\#mutable
+
+  val foo : '\#let 'a. 'a -> '\#let -> unit
+
+  type foo = { \#let : int }
+end
+
+module M = struct
+  let ((\#let, foo) as \#val) = (\#mutable, baz)
+  let _ = fun (type \#let foo) -> 1
+  let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+  class \#let =
+    object
+      inherit \#val \#let as \#mutable
+    end
+end
+
+type 'a \#for = 'a list
+type 'a \#sig = 'a \#for
+type \#true = bool
+
+let f \#false = \#false
+
+type t = { x : int \#let }
+
+let x \#let = 42
+let x = f ~\#let:42 ~\#and:43
+let f ~\#let ~\#and : \#let * \#and = x kind_abbrev_ \#let = \#and
+
+type t = T : 'a list -> t
+
+let g x =
+  let (T (type \#for) (_ : \#for list)) = x in
+  ()
+
+let ( lsl ) x y = x lsl y
+let ( lsl ) x y = x lsl y
+
+module type \#sig = sig end
+
+module M = struct
+  let ( mod ) = 1
+end
+
+let _ = M.( mod )

--- a/test/passing/refs.default/raw_identifiers.ml.ref
+++ b/test/passing/refs.default/raw_identifiers.ml.ref
@@ -31,6 +31,7 @@ let rec \#rec = { \#mutable = \#rec }
 
 type \#and = ..
 type \#and += Foo
+(* Not allowed in parser: type t += \#and *)
 
 let x = ( ++ )
 let x = \#let
@@ -58,6 +59,10 @@ end
 type 'a \#for = 'a list
 type 'a \#sig = 'a \#for
 type \#true = bool
+type _ t = \#in t
+type '\#in t
+
+class ['\#in] c = c
 
 let f \#false = \#false
 
@@ -106,3 +111,10 @@ let _ =
   (* let module \#sig = \#sig in *)
   (* let open \#sig in *)
   ()
+
+let%let _ = ()
+let _ = [%let ()]
+let _ = () [@let]
+let _ = () [@@let]
+let f : type \#in. t = ()
+let f : '\#in. t = ()

--- a/test/passing/refs.default/raw_identifiers.ml.ref
+++ b/test/passing/refs.default/raw_identifiers.ml.ref
@@ -65,7 +65,9 @@ type t = { x : int \#let }
 
 let x \#let = 42
 let x = f ~\#let:42 ~\#and:43
-let f ~\#let ~\#and : \#let * \#and = x kind_abbrev_ \#let = \#and
+let f ~\#let ~\#and : \#let * \#and = x;;
+
+kind_abbrev_ \#let = \#and
 
 type t = T : 'a list -> t
 
@@ -83,3 +85,24 @@ module M = struct
 end
 
 let _ = M.( mod )
+
+module type \#sig = M
+module type M = \#sig
+module type M = M with module type \#sig = \#sig
+module type M = M with module type \#sig := \#sig
+
+let _ = \#sig.(())
+
+(* Raw idents in module names are not allowed in parser: *)
+(* let (module \#sig : S) = () *)
+(* module \#sig (A : S) = M *)
+(* module \#sig = M *)
+(* module M (\#sig : S) = M *)
+(* module M = M (functor (\#sig : S) -> struct end) *)
+(* module type S = functor (\#sig : S) -> S' *)
+(* module type M = M with module \#sig = \#sig *)
+(* module type M = M with module \#sig := \#sig *)
+let _ =
+  (* let module \#sig = \#sig in *)
+  (* let open \#sig in *)
+  ()

--- a/test/passing/refs.janestreet/raw_identifiers.ml.ref
+++ b/test/passing/refs.janestreet/raw_identifiers.ml.ref
@@ -31,6 +31,7 @@ let rec \#rec = { \#mutable = \#rec }
 
 type \#and = ..
 type \#and += Foo
+(* Not allowed in parser: type t += \#and *)
 
 let x = ( ++ )
 let x = \#let
@@ -58,6 +59,10 @@ end
 type 'a \#for = 'a list
 type 'a \#sig = 'a \#for
 type \#true = bool
+type _ t = \#in t
+type '\#in t
+
+class ['\#in] c = c
 
 let f \#false = \#false
 
@@ -108,3 +113,10 @@ let _ =
   (* let open \#sig in *)
   ()
 ;;
+
+let%let _ = ()
+let _ = [%let ()]
+let _ = () [@let]
+let _ = () [@@let]
+let f : type \#in. t = ()
+let f : '\#in. t = ()

--- a/test/passing/refs.janestreet/raw_identifiers.ml.ref
+++ b/test/passing/refs.janestreet/raw_identifiers.ml.ref
@@ -65,7 +65,9 @@ type t = { x : int \#let }
 
 let x \#let = 42
 let x = f ~\#let:42 ~\#and:43
-let f ~\#let ~\#and : \#let * \#and = x kind_abbrev_ \#let = \#and
+let f ~\#let ~\#and : \#let * \#and = x;;
+
+kind_abbrev_ \#let = \#and
 
 type t = T : 'a list -> t
 
@@ -84,3 +86,25 @@ module M = struct
 end
 
 let _ = M.( mod )
+
+module type \#sig = M
+module type M = \#sig
+module type M = M with module type \#sig = \#sig
+module type M = M with module type \#sig := \#sig
+
+let _ = \#sig.(())
+
+(* Raw idents in module names are not allowed in parser: *)
+(* let (module \#sig : S) = () *)
+(* module \#sig (A : S) = M *)
+(* module \#sig = M *)
+(* module M (\#sig : S) = M *)
+(* module M = M (functor (\#sig : S) -> struct end) *)
+(* module type S = functor (\#sig : S) -> S' *)
+(* module type M = M with module \#sig = \#sig *)
+(* module type M = M with module \#sig := \#sig *)
+let _ =
+  (* let module \#sig = \#sig in *)
+  (* let open \#sig in *)
+  ()
+;;

--- a/test/passing/refs.janestreet/raw_identifiers.ml.ref
+++ b/test/passing/refs.janestreet/raw_identifiers.ml.ref
@@ -1,0 +1,86 @@
+module M : sig
+  class \#and : object
+    val mutable \#and : int
+    method \#and : int
+  end
+end = struct
+  class \#and =
+    let \#and = 1 in
+    object
+      val mutable \#and = \#and
+      method \#and = 2
+    end
+end
+
+let obj = new M.\#and
+
+module M : sig
+  type \#and = int
+end = struct
+  type \#and = string
+end
+
+let x = (`\#let `\#and : [ `\#let of [ `\#and ] ])
+let (`\#let \#rec) = x
+let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+type t = '\#let
+type \#mutable = { mutable \#mutable : \#mutable }
+
+let rec \#rec = { \#mutable = \#rec }
+
+type \#and = ..
+type \#and += Foo
+
+let x = ( ++ )
+let x = \#let
+let f ~\#let ?\#and () = 1
+
+module type A = sig
+  type ('\#let, 'a) \#virtual = '\#let * 'a as '\#mutable
+
+  val foo : '\#let 'a. 'a -> '\#let -> unit
+
+  type foo = { \#let : int }
+end
+
+module M = struct
+  let ((\#let, foo) as \#val) = \#mutable, baz
+  let _ = fun (type \#let foo) -> 1
+  let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+  class \#let =
+    object
+      inherit \#val \#let as \#mutable
+    end
+end
+
+type 'a \#for = 'a list
+type 'a \#sig = 'a \#for
+type \#true = bool
+
+let f \#false = \#false
+
+type t = { x : int \#let }
+
+let x \#let = 42
+let x = f ~\#let:42 ~\#and:43
+let f ~\#let ~\#and : \#let * \#and = x kind_abbrev_ \#let = \#and
+
+type t = T : 'a list -> t
+
+let g x =
+  let (T (type \#for) (_ : \#for list)) = x in
+  ()
+;;
+
+let ( lsl ) x y = x lsl y
+let ( lsl ) x y = x lsl y
+
+module type \#sig = sig end
+
+module M = struct
+  let ( mod ) = 1
+end
+
+let _ = M.( mod )

--- a/test/passing/refs.ocamlformat/raw_identifiers.ml.ref
+++ b/test/passing/refs.ocamlformat/raw_identifiers.ml.ref
@@ -37,6 +37,7 @@ let rec \#rec = {\#mutable= \#rec}
 type \#and = ..
 
 type \#and += Foo
+(* Not allowed in parser: type t += \#and *)
 
 let x = ( ++ )
 
@@ -70,6 +71,12 @@ type 'a \#for = 'a list
 type 'a \#sig = 'a \#for
 
 type \#true = bool
+
+type _ t = \#in t
+
+type '\#in t
+
+class ['\#in] c = c
 
 let f \#false = \#false
 
@@ -124,3 +131,15 @@ let _ =
   (* let module \#sig = \#sig in *)
   (* let open \#sig in *)
   ()
+
+let%let _ = ()
+
+let _ = [%let ()]
+
+let _ = () [@let]
+
+let _ = () [@@let]
+
+let f : type \#in. t = ()
+
+let f : '\#in. t = ()

--- a/test/passing/refs.ocamlformat/raw_identifiers.ml.ref
+++ b/test/passing/refs.ocamlformat/raw_identifiers.ml.ref
@@ -1,0 +1,100 @@
+module M : sig
+  class \#and : object
+    val mutable \#and : int
+
+    method \#and : int
+  end
+end = struct
+  class \#and =
+    let \#and = 1 in
+    object
+      val mutable \#and = \#and
+
+      method \#and = 2
+    end
+end
+
+let obj = new M.\#and
+
+module M : sig
+  type \#and = int
+end = struct
+  type \#and = string
+end
+
+let x = (`\#let `\#and : [`\#let of [`\#and]])
+
+let (`\#let \#rec) = x
+
+let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+type t = '\#let
+
+type \#mutable = {mutable \#mutable: \#mutable}
+
+let rec \#rec = {\#mutable= \#rec}
+
+type \#and = ..
+
+type \#and += Foo
+
+let x = ( ++ )
+
+let x = \#let
+
+let f ~\#let ?\#and () = 1
+
+module type A = sig
+  type ('\#let, 'a) \#virtual = '\#let * 'a as '\#mutable
+
+  val foo : '\#let 'a. 'a -> '\#let -> unit
+
+  type foo = {\#let: int}
+end
+
+module M = struct
+  let ((\#let, foo) as \#val) = (\#mutable, baz)
+
+  let _ = fun (type \#let foo) -> 1
+
+  let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+  class \#let =
+    object
+      inherit \#val \#let as \#mutable
+    end
+end
+
+type 'a \#for = 'a list
+
+type 'a \#sig = 'a \#for
+
+type \#true = bool
+
+let f \#false = \#false
+
+type t = {x: int \#let}
+
+let x \#let = 42
+
+let x = f ~\#let:42 ~\#and:43
+
+let f ~\#let ~\#and : \#let * \#and = x kind_abbrev_ \#let = \#and
+
+type t = T : 'a list -> t
+
+let g x =
+  let (T (type \#for) (_ : \#for list)) = x in
+  ()
+
+let ( lsl ) x y = x lsl y
+
+let ( lsl ) x y = x lsl y
+
+module type \#sig = sig end
+
+module M = struct
+  let ( mod ) = 1
+end
+
+let _ = M.( mod )

--- a/test/passing/refs.ocamlformat/raw_identifiers.ml.ref
+++ b/test/passing/refs.ocamlformat/raw_identifiers.ml.ref
@@ -79,7 +79,9 @@ let x \#let = 42
 
 let x = f ~\#let:42 ~\#and:43
 
-let f ~\#let ~\#and : \#let * \#and = x kind_abbrev_ \#let = \#and
+let f ~\#let ~\#and : \#let * \#and = x ;;
+
+kind_abbrev_ \#let = \#and
 
 type t = T : 'a list -> t
 
@@ -98,3 +100,27 @@ module M = struct
 end
 
 let _ = M.( mod )
+
+module type \#sig = M
+
+module type M = \#sig
+
+module type M = M with module type \#sig = \#sig
+
+module type M = M with module type \#sig := \#sig
+
+let _ = \#sig.(())
+
+(* Raw idents in module names are not allowed in parser: *)
+(* let (module \#sig : S) = () *)
+(* module \#sig (A : S) = M *)
+(* module \#sig = M *)
+(* module M (\#sig : S) = M *)
+(* module M = M (functor (\#sig : S) -> struct end) *)
+(* module type S = functor (\#sig : S) -> S' *)
+(* module type M = M with module \#sig = \#sig *)
+(* module type M = M with module \#sig := \#sig *)
+let _ =
+  (* let module \#sig = \#sig in *)
+  (* let open \#sig in *)
+  ()

--- a/test/passing/tests/raw_identifiers.ml
+++ b/test/passing/tests/raw_identifiers.ml
@@ -65,6 +65,14 @@ module M = struct
     end
 end
 
+type 'a \#for = 'a list
+
+type 'a \#sig = 'a \#for
+
+type \#true = bool
+
+let f \#false = \#false
+
 type t = {x: int @@ \#let}
 
 let x @ \#let = 42
@@ -74,3 +82,13 @@ let x = (~\#let:42, ~\#and:43)
 let ((~\#let, ~\#and) : \#let:int * \#and:int) = x
 
 kind_abbrev_ \#let = \#and
+
+type t = T : 'a list -> t
+
+let g x =
+  let (T (type \#for) (_ : \#for list)) = x in
+  ()
+
+let ( lsl ) x y = x lsl y
+
+let \#lsl x y = x lsl y

--- a/test/passing/tests/raw_identifiers.ml
+++ b/test/passing/tests/raw_identifiers.ml
@@ -81,6 +81,7 @@ let x = f ~\#let:42 ~\#and:43
 
 let f ~\#let ~\#and : \#let * \#and = x
 
+;;
 kind_abbrev_ \#let = \#and
 
 type t = T : 'a list -> t
@@ -98,3 +99,25 @@ module type \#sig = sig end
 module M = struct let \#mod = 1 end
 
 let _ = M.\#mod
+module type \#sig = M
+
+module type M = \#sig
+
+module type M = M with module type \#sig = \#sig
+module type M = M with module type \#sig := \#sig
+
+let _ = \#sig.( () )
+
+(* Raw idents in module names are not allowed in parser: *)
+(* let (module \#sig : S) = () *)
+(* module \#sig (A : S) = M *)
+(* module \#sig = M *)
+(* module M (\#sig : S) = M *)
+(* module M = M (functor (\#sig : S) -> struct end) *)
+(* module type S = functor (\#sig : S) -> S' *)
+(* module type M = M with module \#sig = \#sig *)
+(* module type M = M with module \#sig := \#sig *)
+let _ =
+  (* let module \#sig = \#sig in *)
+  (* let open \#sig in *)
+  ()

--- a/test/passing/tests/raw_identifiers.ml
+++ b/test/passing/tests/raw_identifiers.ml
@@ -1,0 +1,76 @@
+module M : sig
+  class \#and : object
+    val mutable \#and : int
+
+    method \#and : int
+  end
+end = struct
+  class \#and =
+    let \#and = 1 in
+    object
+      val mutable \#and = \#and
+
+      method \#and = 2
+    end
+end
+
+let obj = new M.\#and
+
+module M : sig
+  type \#and = int
+end = struct
+  type \#and = string
+end
+
+let x = (`\#let `\#and : [`\#let of [`\#and]])
+
+let (`\#let \#rec) = x
+
+let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+type t = '\#let
+
+type \#mutable = {mutable \#mutable: \#mutable}
+
+let rec \#rec = {\#mutable= \#rec}
+
+type \#and = ..
+
+type \#and += Foo
+
+let x = ( ++ )
+
+let x = \#let
+
+let f ~\#let ?\#and () = 1
+
+module type A = sig
+  type ('\#let, 'a) \#virtual = '\#let * 'a as '\#mutable
+
+  val foo : '\#let 'a. 'a -> '\#let -> unit
+
+  type foo = {\#let: int}
+end
+
+module M = struct
+  let ((\#let, foo) as \#val) = (\#mutable, baz)
+
+  let _ = fun (type \#let foo) -> 1
+
+  let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+  class \#let =
+    object
+      inherit \#val \#let as \#mutable
+    end
+end
+
+type t = {x: int @@ \#let}
+
+let x @ \#let = 42
+
+let x = (~\#let:42, ~\#and:43)
+
+let ((~\#let, ~\#and) : \#let:int * \#and:int) = x
+
+kind_abbrev_ \#let = \#and

--- a/test/passing/tests/raw_identifiers.ml
+++ b/test/passing/tests/raw_identifiers.ml
@@ -73,13 +73,13 @@ type \#true = bool
 
 let f \#false = \#false
 
-type t = {x: int @@ \#let}
+type t = {x: int \#let}
 
-let x @ \#let = 42
+let x \#let = 42
 
-let x = (~\#let:42, ~\#and:43)
+let x = f ~\#let:42 ~\#and:43
 
-let ((~\#let, ~\#and) : \#let:int * \#and:int) = x
+let f ~\#let ~\#and : \#let * \#and = x
 
 kind_abbrev_ \#let = \#and
 

--- a/test/passing/tests/raw_identifiers.ml
+++ b/test/passing/tests/raw_identifiers.ml
@@ -37,6 +37,7 @@ let rec \#rec = {\#mutable= \#rec}
 type \#and = ..
 
 type \#and += Foo
+(* Not allowed in parser: type t += \#and *)
 
 let x = ( ++ )
 
@@ -70,6 +71,11 @@ type 'a \#for = 'a list
 type 'a \#sig = 'a \#for
 
 type \#true = bool
+
+type _ t = \#in t
+type '\#in t
+
+class ['\#in] c = c
 
 let f \#false = \#false
 
@@ -121,3 +127,11 @@ let _ =
   (* let module \#sig = \#sig in *)
   (* let open \#sig in *)
   ()
+
+let%\#let _ = ()
+let _ = [%\#let ()]
+let _ = () [@\#let]
+let _ = () [@@\#let]
+
+let f : type \#in. t = ()
+let f : '\#in. t = ()

--- a/test/passing/tests/raw_identifiers.ml
+++ b/test/passing/tests/raw_identifiers.ml
@@ -92,3 +92,9 @@ let g x =
 let ( lsl ) x y = x lsl y
 
 let \#lsl x y = x lsl y
+
+module type \#sig = sig end
+
+module M = struct let \#mod = 1 end
+
+let _ = M.\#mod

--- a/vendor/parser-extended/lexer.mll
+++ b/vendor/parser-extended/lexer.mll
@@ -404,6 +404,7 @@ let hex_float_literal =
   ('.' ['0'-'9' 'A'-'F' 'a'-'f' '_']* )?
   (['p' 'P'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']* )?
 let literal_modifier = ['G'-'Z' 'g'-'z']
+let raw_ident_escape = "\\#"
 
 rule token = parse
   | ('\\' as bs) newline {
@@ -422,6 +423,8 @@ rule token = parse
   | ".~"
       { error lexbuf
           (Reserved_sequence (".~", Some "is reserved for use in MetaOCaml")) }
+  | "~" raw_ident_escape (lowercase identchar * as name) ':'
+      { LABEL name }
   | "~" (lowercase identchar * as name) ':'
       { check_label_name lexbuf name;
         LABEL name }
@@ -430,12 +433,16 @@ rule token = parse
         LABEL name }
   | "?"
       { QUESTION }
+  | "?" raw_ident_escape (lowercase identchar * as name) ':'
+      { OPTLABEL name }
   | "?" (lowercase identchar * as name) ':'
       { check_label_name lexbuf name;
         OPTLABEL name }
   | "?" (lowercase_latin1 identchar_latin1 * as name) ':'
       { warn_latin1 lexbuf;
         OPTLABEL name }
+  | raw_ident_escape (lowercase identchar * as name)
+      { LIDENT name }
   | lowercase identchar * as name
       { try Hashtbl.find keyword_table name
         with Not_found -> LIDENT name }
@@ -494,7 +501,7 @@ rule token = parse
       { CHAR (char_for_octal_code lexbuf 3, s) }
   | "\'" ("\\" 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F'] as s) "\'"
       { CHAR (char_for_hexadecimal_code lexbuf 3, s) }
-  | "\'" ("\\" _ as esc)
+  | "\'" ("\\" [^ '#'] as esc)
       { error lexbuf (Illegal_escape (esc, None)) }
   | "\'\'"
       { error lexbuf Empty_character_literal }


### PR DESCRIPTION
This is the last missing piece for 5.2 support.

Thanks to @ccasin who made the work in https://github.com/janestreet/ocamlformat/pull/88
