### PR TITLE
Support 5.2 raw identifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,9 @@ profile. This started with version 0.26.0.
 
 ### Highlight
 
-- \* Support OCaml 5.2 syntax (#2519, #2544, #2590, #2596, @Julow, @EmileTrotignon)
-  This includes local open in types and the new representation for functions.
+- \* Support OCaml 5.2 syntax (#2519, #2544, #2590, #2596, #2621, @Julow, @EmileTrotignon)
+  This includes local open in types, raw identifiers, and the new
+  representation for functions.
   This might change the formatting of some functions due to the formatting code
   being completely rewritten.
 

--- a/test/passing/gen/dune.inc
+++ b/test/passing/gen/dune.inc
@@ -3835,6 +3835,21 @@
 (rule
  (deps .ocamlformat dune-project)
  (action
+  (with-stdout-to raw_identifiers.ml.stdout
+   (with-stderr-to raw_identifiers.ml.stderr
+     (run %{bin:ocamlformat} --name raw_identifiers.ml --margin-check %{dep:../tests/raw_identifiers.ml})))))
+
+(rule
+ (alias runtest)
+ (action (diff raw_identifiers.ml.ref raw_identifiers.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (action (diff raw_identifiers.ml.err raw_identifiers.ml.stderr)))
+
+(rule
+ (deps .ocamlformat dune-project)
+ (action
   (with-stdout-to recmod.mli.stdout
    (with-stderr-to recmod.mli.stderr
      (run %{bin:ocamlformat} --name recmod.mli --margin-check %{dep:../tests/recmod.mli})))))

--- a/test/passing/refs.default/raw_identifiers.ml.ref
+++ b/test/passing/refs.default/raw_identifiers.ml.ref
@@ -1,0 +1,152 @@
+module M : sig
+  class \#and : object
+    val mutable \#and : int
+    method \#and : int
+  end
+end = struct
+  class \#and =
+    let \#and = 1 in
+    object
+      val mutable \#and = \#and
+      method \#and = 2
+    end
+end
+
+let obj = new M.\#and
+
+module M : sig
+  type \#and = int
+end = struct
+  type \#and = string
+end
+
+let x = (`\#let `\#and : [ `\#let of [ `\#and ] ])
+let (`\#let \#rec) = x
+let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+type t = '\#let
+type \#mutable = { mutable \#mutable : \#mutable }
+
+let rec \#rec = { \#mutable = \#rec }
+
+type \#and = ..
+type \#and += Foo
+(* Not allowed in parser: type t += \#and *)
+
+let x = ( ++ )
+let x = \#let
+let f ~\#let ?\#and () = 1
+
+module type A = sig
+  type ('\#let, 'a) \#virtual = '\#let * 'a as '\#mutable
+
+  val foo : '\#let 'a. 'a -> '\#let -> unit
+
+  type foo = { \#let : int }
+end
+
+module M = struct
+  let ((\#let, foo) as \#val) = (\#mutable, baz)
+  let _ = fun (type \#let foo) -> 1
+  let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+  class \#let =
+    object
+      inherit \#val \#let as \#mutable
+    end
+end
+
+type 'a \#for = 'a list
+type 'a \#sig = 'a \#for
+type \#true = bool
+type _ t = \#in t
+type '\#in t
+
+class ['\#in] c = c
+
+let f \#false = \#false
+
+type t = { x : int \#let }
+
+let x \#let = 42
+let x = f ~\#let:42 ~\#and:43
+let f ~\#let ~\#and : \#let * \#and = x;;
+
+kind_abbrev_ \#let = \#and
+
+type t = T : 'a list -> t
+
+let g x =
+  let (T (type \#for) (_ : \#for list)) = x in
+  ()
+
+let ( lsl ) x y = x lsl y
+let \#lsl x y = x lsl y
+
+module type \#sig = sig end
+
+module M = struct
+  let \#mod = 1
+end
+
+let _ = M.\#mod
+
+module type \#sig = M
+module type M = \#sig
+module type M = M with module type \#sig = \#sig
+module type M = M with module type \#sig := \#sig
+
+let _ = \#sig.(())
+
+(* Raw idents in module names are not allowed in parser: *)
+(* let (module \#sig : S) = () *)
+(* module \#sig (A : S) = M *)
+(* module \#sig = M *)
+(* module M (\#sig : S) = M *)
+(* module M = M (functor (\#sig : S) -> struct end) *)
+(* module type S = functor (\#sig : S) -> S' *)
+(* module type M = M with module \#sig = \#sig *)
+(* module type M = M with module \#sig := \#sig *)
+let _ =
+  (* let module \#sig = \#sig in *)
+  (* let open \#sig in *)
+  ()
+
+let%\#let _ = ()
+let _ = [%\#let ()]
+let _ = () [@\#let]
+let _ = () [@@\#let]
+let f : type \#in. t = ()
+let f : '\#in. t = ()
+let \#mod : '\#mod. \#mod = \#mod
+let mlet = M.\#let
+let mtrue = M.\#true
+let mmod = M.\#mod
+
+type tmod = M.\#mod
+type tlet = M.\#let
+type ttrue = M.\#true
+
+(* class \#mod = object end *)
+let f : #M.\#mod -> _ = (new \#mod, new M.\#mod)
+
+class type \#mod = object end
+class type \#let = \#mod
+
+module type \#mod = sig
+  type \#mod
+
+  module type \#mod
+end
+
+module type t = \#mod with type \#mod = M.\#mod and module type \#mod = M.\#mod
+
+type \#mod = [ `A | `B ]
+
+let g = function #\#mod | #M.\#mod -> ()
+
+type \#mod = ..
+type M.\#mod += A
+type t = true of int
+
+let x = true 0

--- a/test/passing/refs.janestreet/raw_identifiers.ml.ref
+++ b/test/passing/refs.janestreet/raw_identifiers.ml.ref
@@ -1,0 +1,159 @@
+module M : sig
+  class \#and : object
+    val mutable \#and : int
+    method \#and : int
+  end
+end = struct
+  class \#and =
+    let \#and = 1 in
+    object
+      val mutable \#and = \#and
+      method \#and = 2
+    end
+end
+
+let obj = new M.\#and
+
+module M : sig
+  type \#and = int
+end = struct
+  type \#and = string
+end
+
+let x = (`\#let `\#and : [ `\#let of [ `\#and ] ])
+let (`\#let \#rec) = x
+let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+type t = '\#let
+type \#mutable = { mutable \#mutable : \#mutable }
+
+let rec \#rec = { \#mutable = \#rec }
+
+type \#and = ..
+type \#and += Foo
+(* Not allowed in parser: type t += \#and *)
+
+let x = ( ++ )
+let x = \#let
+let f ~\#let ?\#and () = 1
+
+module type A = sig
+  type ('\#let, 'a) \#virtual = '\#let * 'a as '\#mutable
+
+  val foo : '\#let 'a. 'a -> '\#let -> unit
+
+  type foo = { \#let : int }
+end
+
+module M = struct
+  let ((\#let, foo) as \#val) = \#mutable, baz
+  let _ = fun (type \#let foo) -> 1
+  let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+  class \#let =
+    object
+      inherit \#val \#let as \#mutable
+    end
+end
+
+type 'a \#for = 'a list
+type 'a \#sig = 'a \#for
+type \#true = bool
+type _ t = \#in t
+type '\#in t
+
+class ['\#in] c = c
+
+let f \#false = \#false
+
+type t = { x : int \#let }
+
+let x \#let = 42
+let x = f ~\#let:42 ~\#and:43
+let f ~\#let ~\#and : \#let * \#and = x;;
+
+kind_abbrev_ \#let = \#and
+
+type t = T : 'a list -> t
+
+let g x =
+  let (T (type \#for) (_ : \#for list)) = x in
+  ()
+;;
+
+let ( lsl ) x y = x lsl y
+let \#lsl x y = x lsl y
+
+module type \#sig = sig end
+
+module M = struct
+  let \#mod = 1
+end
+
+let _ = M.\#mod
+
+module type \#sig = M
+module type M = \#sig
+module type M = M with module type \#sig = \#sig
+module type M = M with module type \#sig := \#sig
+
+let _ = \#sig.(())
+
+(* Raw idents in module names are not allowed in parser: *)
+(* let (module \#sig : S) = () *)
+(* module \#sig (A : S) = M *)
+(* module \#sig = M *)
+(* module M (\#sig : S) = M *)
+(* module M = M (functor (\#sig : S) -> struct end) *)
+(* module type S = functor (\#sig : S) -> S' *)
+(* module type M = M with module \#sig = \#sig *)
+(* module type M = M with module \#sig := \#sig *)
+let _ =
+  (* let module \#sig = \#sig in *)
+  (* let open \#sig in *)
+  ()
+;;
+
+let%\#let _ = ()
+let _ = [%\#let ()]
+let _ = () [@\#let]
+let _ = () [@@\#let]
+let f : type \#in. t = ()
+let f : '\#in. t = ()
+let \#mod : '\#mod. \#mod = \#mod
+let mlet = M.\#let
+let mtrue = M.\#true
+let mmod = M.\#mod
+
+type tmod = M.\#mod
+type tlet = M.\#let
+type ttrue = M.\#true
+
+(* class \#mod = object end *)
+let f : #M.\#mod -> _ = new \#mod, new M.\#mod
+
+class type \#mod = object end
+class type \#let = \#mod
+
+module type \#mod = sig
+  type \#mod
+
+  module type \#mod
+end
+
+module type t = \#mod with type \#mod = M.\#mod and module type \#mod = M.\#mod
+
+type \#mod =
+  [ `A
+  | `B
+  ]
+
+let g = function
+  | #\#mod | #M.\#mod -> ()
+;;
+
+type \#mod = ..
+type M.\#mod += A
+type t = true of int
+
+let x = true 0

--- a/test/passing/refs.ocamlformat/raw_identifiers.ml.ref
+++ b/test/passing/refs.ocamlformat/raw_identifiers.ml.ref
@@ -1,0 +1,186 @@
+module M : sig
+  class \#and : object
+    val mutable \#and : int
+
+    method \#and : int
+  end
+end = struct
+  class \#and =
+    let \#and = 1 in
+    object
+      val mutable \#and = \#and
+
+      method \#and = 2
+    end
+end
+
+let obj = new M.\#and
+
+module M : sig
+  type \#and = int
+end = struct
+  type \#and = string
+end
+
+let x = (`\#let `\#and : [`\#let of [`\#and]])
+
+let (`\#let \#rec) = x
+
+let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+type t = '\#let
+
+type \#mutable = {mutable \#mutable: \#mutable}
+
+let rec \#rec = {\#mutable= \#rec}
+
+type \#and = ..
+
+type \#and += Foo
+(* Not allowed in parser: type t += \#and *)
+
+let x = ( ++ )
+
+let x = \#let
+
+let f ~\#let ?\#and () = 1
+
+module type A = sig
+  type ('\#let, 'a) \#virtual = '\#let * 'a as '\#mutable
+
+  val foo : '\#let 'a. 'a -> '\#let -> unit
+
+  type foo = {\#let: int}
+end
+
+module M = struct
+  let ((\#let, foo) as \#val) = (\#mutable, baz)
+
+  let _ = fun (type \#let foo) -> 1
+
+  let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+  class \#let =
+    object
+      inherit \#val \#let as \#mutable
+    end
+end
+
+type 'a \#for = 'a list
+
+type 'a \#sig = 'a \#for
+
+type \#true = bool
+
+type _ t = \#in t
+
+type '\#in t
+
+class ['\#in] c = c
+
+let f \#false = \#false
+
+type t = {x: int \#let}
+
+let x \#let = 42
+
+let x = f ~\#let:42 ~\#and:43
+
+let f ~\#let ~\#and : \#let * \#and = x ;;
+
+kind_abbrev_ \#let = \#and
+
+type t = T : 'a list -> t
+
+let g x =
+  let (T (type \#for) (_ : \#for list)) = x in
+  ()
+
+let ( lsl ) x y = x lsl y
+
+let \#lsl x y = x lsl y
+
+module type \#sig = sig end
+
+module M = struct
+  let \#mod = 1
+end
+
+let _ = M.\#mod
+
+module type \#sig = M
+
+module type M = \#sig
+
+module type M = M with module type \#sig = \#sig
+
+module type M = M with module type \#sig := \#sig
+
+let _ = \#sig.(())
+
+(* Raw idents in module names are not allowed in parser: *)
+(* let (module \#sig : S) = () *)
+(* module \#sig (A : S) = M *)
+(* module \#sig = M *)
+(* module M (\#sig : S) = M *)
+(* module M = M (functor (\#sig : S) -> struct end) *)
+(* module type S = functor (\#sig : S) -> S' *)
+(* module type M = M with module \#sig = \#sig *)
+(* module type M = M with module \#sig := \#sig *)
+let _ =
+  (* let module \#sig = \#sig in *)
+  (* let open \#sig in *)
+  ()
+
+let%\#let _ = ()
+
+let _ = [%\#let ()]
+
+let _ = () [@\#let]
+
+let _ = () [@@\#let]
+
+let f : type \#in. t = ()
+
+let f : '\#in. t = ()
+
+let \#mod : '\#mod. \#mod = \#mod
+
+let mlet = M.\#let
+
+let mtrue = M.\#true
+
+let mmod = M.\#mod
+
+type tmod = M.\#mod
+
+type tlet = M.\#let
+
+type ttrue = M.\#true
+
+(* class \#mod = object end *)
+let f : #M.\#mod -> _ = (new \#mod, new M.\#mod)
+
+class type \#mod = object end
+
+class type \#let = \#mod
+
+module type \#mod = sig
+  type \#mod
+
+  module type \#mod
+end
+
+module type t = \#mod with type \#mod = M.\#mod and module type \#mod = M.\#mod
+
+type \#mod = [`A | `B]
+
+let g = function #\#mod | #M.\#mod -> ()
+
+type \#mod = ..
+
+type M.\#mod += A
+
+type t = true of int
+
+let x = true 0

--- a/test/passing/tests/raw_identifiers.ml
+++ b/test/passing/tests/raw_identifiers.ml
@@ -1,0 +1,167 @@
+module M : sig
+  class \#and : object
+    val mutable \#and : int
+
+    method \#and : int
+  end
+end = struct
+  class \#and =
+    let \#and = 1 in
+    object
+      val mutable \#and = \#and
+
+      method \#and = 2
+    end
+end
+
+let obj = new M.\#and
+
+module M : sig
+  type \#and = int
+end = struct
+  type \#and = string
+end
+
+let x = (`\#let `\#and : [`\#let of [`\#and]])
+
+let (`\#let \#rec) = x
+
+let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+type t = '\#let
+
+type \#mutable = {mutable \#mutable: \#mutable}
+
+let rec \#rec = {\#mutable= \#rec}
+
+type \#and = ..
+
+type \#and += Foo
+(* Not allowed in parser: type t += \#and *)
+
+let x = ( ++ )
+
+let x = \#let
+
+let f ~\#let ?\#and () = 1
+
+module type A = sig
+  type ('\#let, 'a) \#virtual = '\#let * 'a as '\#mutable
+
+  val foo : '\#let 'a. 'a -> '\#let -> unit
+
+  type foo = {\#let: int}
+end
+
+module M = struct
+  let ((\#let, foo) as \#val) = (\#mutable, baz)
+
+  let _ = fun (type \#let foo) -> 1
+
+  let f g ~\#let ?\#and ?(\#for = \#and) () = g ~\#let ?\#and ()
+
+  class \#let =
+    object
+      inherit \#val \#let as \#mutable
+    end
+end
+
+type 'a \#for = 'a list
+
+type 'a \#sig = 'a \#for
+
+type \#true = bool
+
+type _ t = \#in t
+type '\#in t
+
+class ['\#in] c = c
+
+let f \#false = \#false
+
+type t = {x: int \#let}
+
+let x \#let = 42
+
+let x = f ~\#let:42 ~\#and:43
+
+let f ~\#let ~\#and : \#let * \#and = x
+
+;;
+kind_abbrev_ \#let = \#and
+
+type t = T : 'a list -> t
+
+let g x =
+  let (T (type \#for) (_ : \#for list)) = x in
+  ()
+
+let ( lsl ) x y = x lsl y
+
+let \#lsl x y = x lsl y
+
+module type \#sig = sig end
+
+module M = struct let \#mod = 1 end
+
+let _ = M.\#mod
+module type \#sig = M
+
+module type M = \#sig
+
+module type M = M with module type \#sig = \#sig
+module type M = M with module type \#sig := \#sig
+
+let _ = \#sig.( () )
+
+(* Raw idents in module names are not allowed in parser: *)
+(* let (module \#sig : S) = () *)
+(* module \#sig (A : S) = M *)
+(* module \#sig = M *)
+(* module M (\#sig : S) = M *)
+(* module M = M (functor (\#sig : S) -> struct end) *)
+(* module type S = functor (\#sig : S) -> S' *)
+(* module type M = M with module \#sig = \#sig *)
+(* module type M = M with module \#sig := \#sig *)
+let _ =
+  (* let module \#sig = \#sig in *)
+  (* let open \#sig in *)
+  ()
+
+let%\#let _ = ()
+let _ = [%\#let ()]
+let _ = () [@\#let]
+let _ = () [@@\#let]
+
+let f : type \#in. t = ()
+let f : '\#in. t = ()
+
+let \#mod : '\#mod. \#mod = \#mod
+
+let mlet = M.\#let
+let mtrue = M.\#true
+let mmod = M.\#mod
+type tmod = M.\#mod
+type tlet = M.\#let
+type ttrue = M.\#true
+
+(* class \#mod = object end *)
+let f: #M.\#mod -> _ =  new \#mod, new M.\#mod
+
+class type \#mod = object end
+class type \#let = \#mod
+
+module type \#mod = sig type \#mod module type \#mod  end
+
+module type t =
+  \#mod with type \#mod = M.\#mod
+         and module type \#mod = M.\#mod
+
+type \#mod = [`A | `B ]
+let g = function #\#mod | #M.\#mod -> ()
+
+type \#mod = ..
+type M.\#mod += A
+
+type t = true of int
+let x = true 0

--- a/vendor/parser-extended/lexer.mll
+++ b/vendor/parser-extended/lexer.mll
@@ -404,6 +404,7 @@ let hex_float_literal =
   ('.' ['0'-'9' 'A'-'F' 'a'-'f' '_']* )?
   (['p' 'P'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']* )?
 let literal_modifier = ['G'-'Z' 'g'-'z']
+let raw_ident_escape = "\\#"
 
 rule token = parse
   | ('\\' as bs) newline {
@@ -422,6 +423,8 @@ rule token = parse
   | ".~"
       { error lexbuf
           (Reserved_sequence (".~", Some "is reserved for use in MetaOCaml")) }
+  | "~" (raw_ident_escape lowercase identchar * as name) ':'
+      { LABEL name }
   | "~" (lowercase identchar * as name) ':'
       { check_label_name lexbuf name;
         LABEL name }
@@ -430,12 +433,17 @@ rule token = parse
         LABEL name }
   | "?"
       { QUESTION }
+  | "?" (raw_ident_escape lowercase identchar * as name) ':'
+      { OPTLABEL name }
   | "?" (lowercase identchar * as name) ':'
       { check_label_name lexbuf name;
         OPTLABEL name }
   | "?" (lowercase_latin1 identchar_latin1 * as name) ':'
       { warn_latin1 lexbuf;
         OPTLABEL name }
+  | (raw_ident_escape lowercase identchar * as name)
+      (* Compared to upstream, the raw_ident_escape is part of the lident. *)
+      { LIDENT name }
   | lowercase identchar * as name
       { try Hashtbl.find keyword_table name
         with Not_found -> LIDENT name }
@@ -494,7 +502,7 @@ rule token = parse
       { CHAR (char_for_octal_code lexbuf 3, s) }
   | "\'" ("\\" 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F'] as s) "\'"
       { CHAR (char_for_hexadecimal_code lexbuf 3, s) }
-  | "\'" ("\\" _ as esc)
+  | "\'" ("\\" [^ '#'] as esc)
       { error lexbuf (Illegal_escape (esc, None)) }
   | "\'\'"
       { error lexbuf Empty_character_literal }


### PR DESCRIPTION
3d try after https://github.com/ocaml-ppx/ocamlformat/pull/2619 and https://github.com/ocaml-ppx/ocamlformat/pull/2620 using @hhugo's idea.

Raw identifier syntax is added to the vendored lexer.
Contrary to upstream, the escape sequence (`\#`) is part of the ident. This avoids the need to classify identifiers later in Fmt_ast.