### PR TITLE
Don't normalize newlines in parser-standard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ profile. This started with version 0.26.0.
 
 ### Highlight
 
-- \* Support OCaml 5.2 syntax (#2519, #2544, #2590, #2596, #2621, @Julow, @EmileTrotignon)
+- \* Support OCaml 5.2 syntax (#2519, #2544, #2590, #2596, #2621, #2626, @Julow, @EmileTrotignon)
   This includes local open in types, raw identifiers, and the new
   representation for functions.
   This might change the formatting of some functions due to the formatting code

--- a/test/passing/gen/dune.inc
+++ b/test/passing/gen/dune.inc
@@ -3490,6 +3490,21 @@
 (rule
  (deps .ocamlformat dune-project)
  (action
+  (with-stdout-to newlines.ml.stdout
+   (with-stderr-to newlines.ml.stderr
+     (run %{bin:ocamlformat} --name newlines.ml --margin-check %{dep:../tests/newlines.ml})))))
+
+(rule
+ (alias runtest)
+ (action (diff newlines.ml.ref newlines.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (action (diff newlines.ml.err newlines.ml.stderr)))
+
+(rule
+ (deps .ocamlformat dune-project)
+ (action
   (with-stdout-to object.ml.stdout
    (with-stderr-to object.ml.stderr
      (run %{bin:ocamlformat} --name object.ml --margin-check %{dep:../tests/object.ml})))))

--- a/test/passing/refs.default/newlines.ml.ref
+++ b/test/passing/refs.default/newlines.ml.ref
@@ -1,0 +1,18 @@
+(* TEST *)
+
+let check ~kind ~input ~result =
+  if input <> result then
+    Printf.printf "FAIL: %s %S should normalize to %S\n" kind input result
+;;
+
+check ~kind:"string literal" ~input:"\n" ~result:"\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n";
+
+check ~kind:"string literal" ~input:"\n" ~result:"\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n";
+
+check ~kind:"string literal" ~input:"\n" ~result:"\r\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\r\n"

--- a/test/passing/refs.janestreet/newlines.ml.ref
+++ b/test/passing/refs.janestreet/newlines.ml.ref
@@ -1,0 +1,28 @@
+(* TEST *)
+
+let check ~kind ~input ~result =
+  if input <> result
+  then Printf.printf "FAIL: %s %S should normalize to %S\n" kind input result
+;;
+
+check ~kind:"string literal" ~input:"\n" ~result:"\n";
+check
+  ~kind:"quoted string literal"
+  ~input:
+    {|
+|}
+  ~result:"\n";
+check ~kind:"string literal" ~input:"\n" ~result:"\n";
+check
+  ~kind:"quoted string literal"
+  ~input:
+    {|
+|}
+  ~result:"\n";
+check ~kind:"string literal" ~input:"\n" ~result:"\r\n";
+check
+  ~kind:"quoted string literal"
+  ~input:
+    {|
+|}
+  ~result:"\r\n"

--- a/test/passing/refs.ocamlformat/newlines.ml.ref
+++ b/test/passing/refs.ocamlformat/newlines.ml.ref
@@ -1,0 +1,16 @@
+(* TEST *)
+
+let check ~kind ~input ~result =
+  if input <> result then
+    Printf.printf "FAIL: %s %S should normalize to %S\n" kind input result
+;;
+
+check ~kind:"string literal" ~input:"\n" ~result:"\n" ;
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n" ;
+check ~kind:"string literal" ~input:"\n" ~result:"\n" ;
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n" ;
+check ~kind:"string literal" ~input:"\n" ~result:"\r\n" ;
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\r\n"

--- a/test/passing/tests/newlines.ml
+++ b/test/passing/tests/newlines.ml
@@ -1,0 +1,23 @@
+(* TEST *)
+
+let check ~kind ~input ~result =
+  if input <> result then
+    Printf.printf "FAIL: %s %S should normalize to %S
+"
+      kind input result
+;;
+
+check ~kind:"string literal" ~input:"
+" ~result:"\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n";
+
+check ~kind:"string literal" ~input:"
+" ~result:"\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n";
+
+check ~kind:"string literal" ~input:"
+" ~result:"\r\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\r\n";

--- a/vendor/parser-standard/lexer.mll
+++ b/vendor/parser-standard/lexer.mll
@@ -144,6 +144,7 @@ let store_string s = Buffer.add_string string_buffer s
 let store_substring s ~pos ~len = Buffer.add_substring string_buffer s pos len
 
 let store_lexeme lexbuf = store_string (Lexing.lexeme lexbuf)
+(*
 let store_normalized_newline newline =
   (* #12502: we normalize "\r\n" to "\n" at lexing time,
      to avoid behavior difference due to OS-specific
@@ -169,6 +170,10 @@ let store_normalized_newline newline =
   if len = 1
   then store_string_char '\n'
   else store_substring newline ~pos:1 ~len:(len - 1)
+*)
+let store_normalized_newline newline =
+  (* OCamlformat: We preserve the line endings in string literals. *)
+  store_string newline
 
 (* To store the position of the beginning of a string and comment *)
 let string_start_loc = ref Location.none


### PR DESCRIPTION
This was causing a changed AST error, perhaps due to an interaction with Format's handling of '\r\n'.

'newlines.ml' is from the compiler's testsuite.