### PR TITLE
Preserve line endings in delimited string literals

### DIFF
--- a/lib/Literal_lexer.mll
+++ b/lib/Literal_lexer.mll
@@ -81,7 +81,10 @@ and string_aux mode = parse
         string_aux mode lexbuf
       }
   | newline
-      { store_string (Lexing.lexeme lexbuf);
+      { (* See store_normalized_newline in vendor/parser-standard/lexer.mll. *)
+        (match Lexing.lexeme lexbuf with
+        | "\n" -> store_string "\n"
+        | s -> store_string (String.sub s 1 (String.length s - 1)));
         string_aux mode lexbuf }
   | eof
       { raise Parse_error }

--- a/test/passing/gen/dune.inc
+++ b/test/passing/gen/dune.inc
@@ -3490,6 +3490,21 @@
 (rule
  (deps .ocamlformat dune-project)
  (action
+  (with-stdout-to newlines.ml.stdout
+   (with-stderr-to newlines.ml.stderr
+     (run %{bin:ocamlformat} --name newlines.ml --margin-check %{dep:../tests/newlines.ml})))))
+
+(rule
+ (alias runtest)
+ (action (diff newlines.ml.ref newlines.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (action (diff newlines.ml.err newlines.ml.stderr)))
+
+(rule
+ (deps .ocamlformat dune-project)
+ (action
   (with-stdout-to object.ml.stdout
    (with-stderr-to object.ml.stderr
      (run %{bin:ocamlformat} --name object.ml --margin-check %{dep:../tests/object.ml})))))

--- a/test/passing/refs.default/newlines.ml.ref
+++ b/test/passing/refs.default/newlines.ml.ref
@@ -1,0 +1,18 @@
+(* TEST *)
+
+let check ~kind ~input ~result =
+  if input <> result then
+    Printf.printf "FAIL: %s %S should normalize to %S\n" kind input result
+;;
+
+check ~kind:"string literal" ~input:"\n" ~result:"\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n";
+
+check ~kind:"string literal" ~input:"\n" ~result:"\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n";
+
+check ~kind:"string literal" ~input:"\n" ~result:"\r\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\r\n"

--- a/test/passing/refs.janestreet/newlines.ml.ref
+++ b/test/passing/refs.janestreet/newlines.ml.ref
@@ -1,0 +1,28 @@
+(* TEST *)
+
+let check ~kind ~input ~result =
+  if input <> result
+  then Printf.printf "FAIL: %s %S should normalize to %S\n" kind input result
+;;
+
+check ~kind:"string literal" ~input:"\n" ~result:"\n";
+check
+  ~kind:"quoted string literal"
+  ~input:
+    {|
+|}
+  ~result:"\n";
+check ~kind:"string literal" ~input:"\n" ~result:"\n";
+check
+  ~kind:"quoted string literal"
+  ~input:
+    {|
+|}
+  ~result:"\n";
+check ~kind:"string literal" ~input:"\n" ~result:"\r\n";
+check
+  ~kind:"quoted string literal"
+  ~input:
+    {|
+|}
+  ~result:"\r\n"

--- a/test/passing/refs.ocamlformat/newlines.ml.ref
+++ b/test/passing/refs.ocamlformat/newlines.ml.ref
@@ -1,0 +1,16 @@
+(* TEST *)
+
+let check ~kind ~input ~result =
+  if input <> result then
+    Printf.printf "FAIL: %s %S should normalize to %S\n" kind input result
+;;
+
+check ~kind:"string literal" ~input:"\n" ~result:"\n" ;
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n" ;
+check ~kind:"string literal" ~input:"\n" ~result:"\n" ;
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n" ;
+check ~kind:"string literal" ~input:"\n" ~result:"\r\n" ;
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\r\n"

--- a/test/passing/tests/newlines.ml
+++ b/test/passing/tests/newlines.ml
@@ -1,0 +1,23 @@
+(* TEST *)
+
+let check ~kind ~input ~result =
+  if input <> result then
+    Printf.printf "FAIL: %s %S should normalize to %S
+"
+      kind input result
+;;
+
+check ~kind:"string literal" ~input:"
+" ~result:"\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n";
+
+check ~kind:"string literal" ~input:"
+" ~result:"\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\n";
+
+check ~kind:"string literal" ~input:"
+" ~result:"\r\n";
+check ~kind:"quoted string literal" ~input:{|
+|} ~result:"\r\n";


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/2601 and replace https://github.com/ocaml-ppx/ocamlformat/pull/2626
This fixes an AST changed error caught by test-branch in the compiler's testsuite.