### PR TITLE
Fix 32bit build in CI

### DIFF
--- a/bin/ocamlformat/dune
+++ b/bin/ocamlformat/dune
@@ -18,8 +18,7 @@
   (:standard -open Ocamlformat_stdlib))
  (instrumentation
   (backend bisect_ppx))
- (libraries ocamlformat-lib bin_conf)
- (modes byte native))
+ (libraries ocamlformat-lib bin_conf))
 
 (rule
  (with-stdout-to


### PR DESCRIPTION
Related: https://github.com/ocaml/opam-repository/pull/26998
The `(modes)` field causes the build to fail on some 32bit platforms.