### PR TITLE
nest-match=align now works with match%ext.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ profile. This started with version 0.26.0.
   Asterisk-prefixed comments are also now formatted the same way as with the
   default profile.
 
+- Fixed `nested-match=align` not working with `match%ext` (#2648, @EmileTrotignon)
+
 ## 0.27.0
 
 ### Highlight

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -380,7 +380,7 @@ let get_or_pattern_is_nested ~ctx pat =
       not
         (List.exists bindings.pvbs_bindings ~f:(function
           | {pvb_body= Pfunction_cases (cases, _, _); _} -> check_cases cases
-          | _ -> false ) )
+          | _ -> false ))
   | _ -> true
 
 let get_or_pattern_sep ?(cmts_before = false) ?(space = false) (c : Conf.t)

--- a/test/passing/refs.default/match.ml.ref
+++ b/test/passing/refs.default/match.ml.ref
@@ -71,3 +71,51 @@ let x =
 
 let _ = match x with _ -> b >>= fun () -> c
 let () = match () with _ -> ( fun _ : _ -> match () with _ -> ()) | _ -> ()
+
+[@@@ocamlformat "nested-match=align"]
+
+let () =
+  match f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+  match g y with
+  | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+  | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+  | [] -> ff dda asa
+
+let () =
+  match%ext1 f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+  match g y with
+  | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+  | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+  | [] -> ff dda asa
+
+let () =
+  match f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+  match%ext2 g y with
+  | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+  | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+  | [] -> ff dda asa
+
+let () =
+  match f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+      [%ext2
+        match g y with
+        | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+        | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+        | [] -> ff dda asa]
+
+let () =
+  match%ext1 f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+  match%ext2 g y with
+  | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+  | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+  | [] -> ff dda asa

--- a/test/passing/refs.janestreet/match.ml.ref
+++ b/test/passing/refs.janestreet/match.ml.ref
@@ -115,3 +115,56 @@ let () =
        | _ -> ()))
   | _ -> ()
 ;;
+
+[@@@ocamlformat "nested-match=align"]
+
+let () =
+  match f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+  match g y with
+  | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+  | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+  | [] -> ff dda asa
+;;
+
+let () =
+  match%ext1 f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+  match g y with
+  | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+  | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+  | [] -> ff dda asa
+;;
+
+let () =
+  match f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+  match%ext2 g y with
+  | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+  | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+  | [] -> ff dda asa
+;;
+
+let () =
+  match f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+    [%ext2
+      match g y with
+      | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+      | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+      | [] -> ff dda asa]
+;;
+
+let () =
+  match%ext1 f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+  match%ext2 g y with
+  | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+  | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+  | [] -> ff dda asa
+;;

--- a/test/passing/refs.ocamlformat/match.ml.ref
+++ b/test/passing/refs.ocamlformat/match.ml.ref
@@ -77,3 +77,71 @@ let x =
 let _ = match x with _ -> b >>= fun () -> c
 
 let () = match () with _ -> ( fun _ : _ -> match () with _ -> () ) | _ -> ()
+
+[@@@ocamlformat "nested-match=align"]
+
+let () =
+  match f x with
+  | _ :: _ ->
+      aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+    match g y with
+    | _ :: _ :: _ :: _ ->
+        bbb bbbbb bbbbbbb bbbb bbbb
+    | _ :: _ :: _ ->
+        cc cccc cccc cccc cccc ccc cccccc cccc
+    | [] ->
+        ff dda asa
+
+let () =
+  match%ext1 f x with
+  | _ :: _ ->
+      aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+    match g y with
+    | _ :: _ :: _ :: _ ->
+        bbb bbbbb bbbbbbb bbbb bbbb
+    | _ :: _ :: _ ->
+        cc cccc cccc cccc cccc ccc cccccc cccc
+    | [] ->
+        ff dda asa
+
+let () =
+  match f x with
+  | _ :: _ ->
+      aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+    match%ext2 g y with
+    | _ :: _ :: _ :: _ ->
+        bbb bbbbb bbbbbbb bbbb bbbb
+    | _ :: _ :: _ ->
+        cc cccc cccc cccc cccc ccc cccccc cccc
+    | [] ->
+        ff dda asa
+
+let () =
+  match f x with
+  | _ :: _ ->
+      aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+      [%ext2
+        match g y with
+        | _ :: _ :: _ :: _ ->
+            bbb bbbbb bbbbbbb bbbb bbbb
+        | _ :: _ :: _ ->
+            cc cccc cccc cccc cccc ccc cccccc cccc
+        | [] ->
+            ff dda asa]
+
+let () =
+  match%ext1 f x with
+  | _ :: _ ->
+      aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+    match%ext2 g y with
+    | _ :: _ :: _ :: _ ->
+        bbb bbbbb bbbbbbb bbbb bbbb
+    | _ :: _ :: _ ->
+        cc cccc cccc cccc cccc ccc cccccc cccc
+    | [] ->
+        ff dda asa

--- a/test/passing/tests/match.ml
+++ b/test/passing/tests/match.ml
@@ -69,3 +69,52 @@ let () =
      | _ -> ())
   | _ -> ()
 ;;
+
+[@@@ocamlformat "nested-match=align"]
+
+let () =
+  match f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+  match g y with
+  | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+  | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+  | [] -> ff dda asa
+
+let () =
+  match%ext1 f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+  match g y with
+  | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+  | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+  | [] -> ff dda asa
+
+let () =
+  match f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+  match%ext2 g y with
+  | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+  | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+  | [] -> ff dda asa
+
+let () =
+  match f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+      [%ext2
+        match g y with
+        | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+        | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+        | [] -> ff dda asa]
+
+let () =
+  match%ext1 f x with
+  | _ :: _ -> aaaaa aaaa a aa aaaaaa aaaa
+  | _ ->
+  match%ext2 g y with
+  | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
+  | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
+  | [] -> ff dda asa
+


### PR DESCRIPTION
match%ext used to not be treated the same by nest-match-align. This is now fixed.

Requested in Issue #2081 

Seems to be a very lightweight patch, and that the bug was not present at all in the test base.