### PR TITLE
print valid syntax for the corner case (1).a

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ profile. This started with version 0.26.0.
 
 - Fixed `nested-match=align` not working with `match%ext` (#2648, @EmileTrotignon)
 
+- Print valid syntax for the corner case (1).a (#2653, @v-gb)
+
 ## 0.27.0
 
 ### Highlight

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2338,7 +2338,10 @@ end = struct
       when exp == lhs ->
         true
     | ( Exp {pexp_desc= Pexp_field (e, _); _}
-      , {pexp_desc= Pexp_construct _ | Pexp_cons _; _} )
+      , { pexp_desc=
+            ( Pexp_construct _ | Pexp_cons _
+            | Pexp_constant {pconst_desc= Pconst_integer (_, None); _} )
+        ; _ } )
       when e == exp ->
         true
     | ( Exp {pexp_desc= Pexp_function (_, _, Pfunction_body e); _}

--- a/test/passing/refs.default/record-402.ml.ref
+++ b/test/passing/refs.default/record-402.ml.ref
@@ -78,3 +78,4 @@ let foo
 
 let x = (A B).a
 let x = A (B).a
+let x = (1).a

--- a/test/passing/refs.default/record-loose.ml.ref
+++ b/test/passing/refs.default/record-loose.ml.ref
@@ -78,3 +78,4 @@ let foo
 
 let x = (A B).a
 let x = A (B).a
+let x = (1).a

--- a/test/passing/refs.default/record-tight_decl.ml.ref
+++ b/test/passing/refs.default/record-tight_decl.ml.ref
@@ -78,3 +78,4 @@ let foo
 
 let x = (A B).a
 let x = A (B).a
+let x = (1).a

--- a/test/passing/refs.default/record.ml.ref
+++ b/test/passing/refs.default/record.ml.ref
@@ -78,3 +78,4 @@ let foo
 
 let x = (A B).a
 let x = A (B).a
+let x = (1).a

--- a/test/passing/refs.janestreet/record-402.ml.ref
+++ b/test/passing/refs.janestreet/record-402.ml.ref
@@ -102,3 +102,4 @@ let foo
 
 let x = (A B).a
 let x = A (B).a
+let x = (1).a

--- a/test/passing/refs.janestreet/record-loose.ml.ref
+++ b/test/passing/refs.janestreet/record-loose.ml.ref
@@ -102,3 +102,4 @@ let foo
 
 let x = (A B).a
 let x = A (B).a
+let x = (1).a

--- a/test/passing/refs.janestreet/record-tight_decl.ml.ref
+++ b/test/passing/refs.janestreet/record-tight_decl.ml.ref
@@ -102,3 +102,4 @@ let foo
 
 let x = (A B).a
 let x = A (B).a
+let x = (1).a

--- a/test/passing/refs.janestreet/record.ml.ref
+++ b/test/passing/refs.janestreet/record.ml.ref
@@ -102,3 +102,4 @@ let foo
 
 let x = (A B).a
 let x = A (B).a
+let x = (1).a

--- a/test/passing/refs.ocamlformat/record-402.ml.ref
+++ b/test/passing/refs.ocamlformat/record-402.ml.ref
@@ -78,3 +78,5 @@ let foo
 let x = (A B).a
 
 let x = A (B).a
+
+let x = (1).a

--- a/test/passing/refs.ocamlformat/record-loose.ml.ref
+++ b/test/passing/refs.ocamlformat/record-loose.ml.ref
@@ -78,3 +78,5 @@ let foo
 let x = (A B).a
 
 let x = A (B).a
+
+let x = (1).a

--- a/test/passing/refs.ocamlformat/record-tight_decl.ml.ref
+++ b/test/passing/refs.ocamlformat/record-tight_decl.ml.ref
@@ -78,3 +78,5 @@ let foo
 let x = (A B).a
 
 let x = A (B).a
+
+let x = (1).a

--- a/test/passing/refs.ocamlformat/record.ml.ref
+++ b/test/passing/refs.ocamlformat/record.ml.ref
@@ -78,3 +78,5 @@ let foo
 let x = (A B).a
 
 let x = A (B).a
+
+let x = (1).a

--- a/test/passing/tests/record.ml
+++ b/test/passing/tests/record.ml
@@ -86,3 +86,6 @@ let foo
 let x = (A(B)).a
 
 let x = A(B).a
+
+let x = (1).a
+


### PR DESCRIPTION
Not that I need this syntax, but I was wondering if my use of ocamlformat was adding parens properly, tried this as a tricky example, only to realize that ocamlformat doesn't handle it correctly in the first place. Considering this is handled correctly for Pexp_index_op 5 lines above, might as well handle it here as well.