### PR TITLE
fix Ast_mapper not mapping over `in` location in `let+ .. in ..`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@ profile. This started with version 0.26.0.
 
 - Print valid syntax for the corner case (1).a (#2653, @v-gb)
 
+- `Ast_mapper.default_mapper` now iterates on the location of `in` in `let+ .. in ..`
+  (#2658, @v-gb)
+
 ## 0.27.0
 
 ### Highlight

--- a/test/passing/refs.default/sequence-preserve.ml.ref
+++ b/test/passing/refs.default/sequence-preserve.ml.ref
@@ -112,8 +112,8 @@ let _ =
 let foo x y =
   do_some_setup x;
   let* () = do_some_setup y in
-
   (* Empty line after letop *)
+
   important_function x;
   another_important_function x y;
   cleanup x y

--- a/test/passing/refs.janestreet/sequence-preserve.ml.ref
+++ b/test/passing/refs.janestreet/sequence-preserve.ml.ref
@@ -126,8 +126,8 @@ let _ =
 let foo x y =
   do_some_setup x;
   let* () = do_some_setup y in
-
   (* Empty line after letop *)
+
   important_function x;
   another_important_function x y;
   cleanup x y

--- a/test/passing/refs.ocamlformat/sequence-preserve.ml.ref
+++ b/test/passing/refs.ocamlformat/sequence-preserve.ml.ref
@@ -110,8 +110,8 @@ let _ =
 let foo x y =
   do_some_setup x ;
   let* () = do_some_setup y in
-
   (* Empty line after letop *)
+
   important_function x ;
   another_important_function x y ;
   cleanup x y

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -545,8 +545,7 @@ module E = struct
     | Pexp_ident x -> ident ~loc ~attrs (map_loc sub x)
     | Pexp_constant x -> constant ~loc ~attrs (sub.constant sub x)
     | Pexp_let (lbs, e, loc_in) ->
-      let loc_in = sub.location sub loc_in in
-        let_ ~loc ~loc_in ~attrs (sub.value_bindings sub lbs)
+        let_ ~loc ~loc_in:(sub.location sub loc_in) ~attrs (sub.value_bindings sub lbs)
           (sub.expr sub e)
     | Pexp_function (ps, c, b) ->
       function_ ~loc ~attrs
@@ -637,7 +636,7 @@ module E = struct
     | Pexp_letopen (o, e) ->
         letopen ~loc ~attrs (sub.open_declaration sub o) (sub.expr sub e)
     | Pexp_letop {let_; ands; body; loc_in} ->
-        letop ~loc ~attrs ~loc_in (sub.binding_op sub let_)
+        letop ~loc ~attrs ~loc_in:(sub.location sub loc_in) (sub.binding_op sub let_)
           (List.map (sub.binding_op sub) ands) (sub.expr sub body)
     | Pexp_extension x -> extension ~loc ~attrs (sub.extension sub x)
     | Pexp_unreachable -> unreachable ~loc ~attrs ()


### PR DESCRIPTION
No idea why a test is impacted, but it seems to be an improvement.