### PR TITLE
Add missing parens in pattern in 'let+ (Cstr _) : t = ...'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,9 @@ profile. This started with version 0.26.0.
 - `Ast_mapper.default_mapper` now iterates on the location of `in` in `let+ .. in ..`
   (#2658, @v-gb)
 
+- Fix missing parentheses in `let+ (Cstr _) : _ = _` (#2661, @Julow)
+  This caused a crash as the generated code wasn't valid syntax.
+
 ## 0.27.0
 
 ### Highlight

--- a/test/passing/refs.default/let_binding-deindent-fun.ml.ref
+++ b/test/passing/refs.default/let_binding-deindent-fun.ml.ref
@@ -262,3 +262,11 @@ let _ =
   | Strict | Alias -> Immutable
   | StrictOpt -> Mutable
 ;;
+
+let rewrite_export =
+  let (Raw id) : binary indice = () in
+  let (a, b) : a * b = () in
+  let+ (Raw id) : binary indice = () in
+  let+ (a, b) : a * b = () in
+  ()
+;;

--- a/test/passing/refs.default/let_binding-in_indent.ml.ref
+++ b/test/passing/refs.default/let_binding-in_indent.ml.ref
@@ -262,3 +262,11 @@ let _ =
   | Strict | Alias -> Immutable
   | StrictOpt -> Mutable
 ;;
+
+let rewrite_export =
+  let (Raw id) : binary indice = () in
+  let (a, b) : a * b = () in
+      let+ (Raw id) : binary indice = () in
+          let+ (a, b) : a * b = () in
+              ()
+;;

--- a/test/passing/refs.default/let_binding-indent.ml.ref
+++ b/test/passing/refs.default/let_binding-indent.ml.ref
@@ -263,3 +263,11 @@ let _ =
   | Strict | Alias -> Immutable
   | StrictOpt -> Mutable
 ;;
+
+let rewrite_export =
+      let (Raw id) : binary indice = () in
+      let (a, b) : a * b = () in
+      let+ (Raw id) : binary indice = () in
+      let+ (a, b) : a * b = () in
+      ()
+;;

--- a/test/passing/refs.default/let_binding.ml.ref
+++ b/test/passing/refs.default/let_binding.ml.ref
@@ -262,3 +262,11 @@ let _ =
   | Strict | Alias -> Immutable
   | StrictOpt -> Mutable
 ;;
+
+let rewrite_export =
+  let (Raw id) : binary indice = () in
+  let (a, b) : a * b = () in
+  let+ (Raw id) : binary indice = () in
+  let+ (a, b) : a * b = () in
+  ()
+;;

--- a/test/passing/refs.janestreet/let_binding-deindent-fun.ml.ref
+++ b/test/passing/refs.janestreet/let_binding-deindent-fun.ml.ref
@@ -315,3 +315,11 @@ let _ =
   | Strict | Alias -> Immutable
   | StrictOpt -> Mutable
 ;;
+
+let rewrite_export =
+  let (Raw id) : binary indice = () in
+  let (a, b) : a * b = () in
+  let+ (Raw id) : binary indice = () in
+  let+ (a, b) : a * b = () in
+  ()
+;;

--- a/test/passing/refs.janestreet/let_binding-in_indent.ml.ref
+++ b/test/passing/refs.janestreet/let_binding-in_indent.ml.ref
@@ -315,3 +315,11 @@ let _ =
   | Strict | Alias -> Immutable
   | StrictOpt -> Mutable
 ;;
+
+let rewrite_export =
+  let (Raw id) : binary indice = () in
+  let (a, b) : a * b = () in
+      let+ (Raw id) : binary indice = () in
+          let+ (a, b) : a * b = () in
+              ()
+;;

--- a/test/passing/refs.janestreet/let_binding-indent.ml.ref
+++ b/test/passing/refs.janestreet/let_binding-indent.ml.ref
@@ -315,3 +315,11 @@ let _ =
   | Strict | Alias -> Immutable
   | StrictOpt -> Mutable
 ;;
+
+let rewrite_export =
+      let (Raw id) : binary indice = () in
+      let (a, b) : a * b = () in
+      let+ (Raw id) : binary indice = () in
+      let+ (a, b) : a * b = () in
+      ()
+;;

--- a/test/passing/refs.janestreet/let_binding.ml.ref
+++ b/test/passing/refs.janestreet/let_binding.ml.ref
@@ -315,3 +315,11 @@ let _ =
   | Strict | Alias -> Immutable
   | StrictOpt -> Mutable
 ;;
+
+let rewrite_export =
+  let (Raw id) : binary indice = () in
+  let (a, b) : a * b = () in
+  let+ (Raw id) : binary indice = () in
+  let+ (a, b) : a * b = () in
+  ()
+;;

--- a/test/passing/refs.ocamlformat/let_binding-deindent-fun.ml.ref
+++ b/test/passing/refs.ocamlformat/let_binding-deindent-fun.ml.ref
@@ -289,3 +289,11 @@ let _ =
   | StrictOpt ->
       Mutable
 ;;
+
+let rewrite_export =
+  let (Raw id) : binary indice = () in
+  let (a, b) : a * b = () in
+  let+ (Raw id) : binary indice = () in
+  let+ (a, b) : a * b = () in
+  ()
+;;

--- a/test/passing/refs.ocamlformat/let_binding-in_indent.ml.ref
+++ b/test/passing/refs.ocamlformat/let_binding-in_indent.ml.ref
@@ -289,3 +289,11 @@ let _ =
   | StrictOpt ->
       Mutable
 ;;
+
+let rewrite_export =
+  let (Raw id) : binary indice = () in
+  let (a, b) : a * b = () in
+      let+ (Raw id) : binary indice = () in
+          let+ (a, b) : a * b = () in
+              ()
+;;

--- a/test/passing/refs.ocamlformat/let_binding-indent.ml.ref
+++ b/test/passing/refs.ocamlformat/let_binding-indent.ml.ref
@@ -290,3 +290,11 @@ let _ =
   | StrictOpt ->
       Mutable
 ;;
+
+let rewrite_export =
+      let (Raw id) : binary indice = () in
+      let (a, b) : a * b = () in
+      let+ (Raw id) : binary indice = () in
+      let+ (a, b) : a * b = () in
+      ()
+;;

--- a/test/passing/refs.ocamlformat/let_binding.ml.ref
+++ b/test/passing/refs.ocamlformat/let_binding.ml.ref
@@ -289,3 +289,11 @@ let _ =
   | StrictOpt ->
       Mutable
 ;;
+
+let rewrite_export =
+  let (Raw id) : binary indice = () in
+  let (a, b) : a * b = () in
+  let+ (Raw id) : binary indice = () in
+  let+ (a, b) : a * b = () in
+  ()
+;;

--- a/test/passing/tests/let_binding.ml
+++ b/test/passing/tests/let_binding.ml
@@ -269,3 +269,10 @@ let _ =
   function
   | Strict | Alias -> Immutable
   | StrictOpt -> Mutable
+
+let rewrite_export =
+  let (Raw id) : binary indice = () in
+  let (a, b) : a * b = () in
+  let+ (Raw id) : binary indice = () in
+  let+ (a, b) : a * b = () in
+  ()


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/2657

The parentheses check is unified between value_binding and binding_op to prevent similar bugs in the future.