### PR TITLE
`begin fun x ->` now can be printed on a single line

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2893,6 +2893,21 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
   | Pexp_indexop_access x ->
       pro $ fmt_indexop_access c ctx ~fmt_atrs ~has_attr ~parens x
   | Pexp_hole -> pro $ hvbox 0 (fmt_hole () $ fmt_atrs)
+  | Pexp_beginend
+      ( { pexp_desc= Pexp_function (args, typ, body)
+        ; pexp_attributes= function_attrs
+        ; _ } as f ) ->
+      let wrap_intro x =
+        hvbox 0
+          ( hvbox 0 (str "begin" $ fmt_extension_suffix c ext $ fmt_atrs)
+          $ break 1 2 $ x )
+        $ break 1000 0
+      in
+      hvbox 2
+        (fmt_function ~wrap_intro ~box ~ctx:(Exp f) ~ctx0 ~label:Nolabel
+           ~parens:false ~attrs:function_attrs ~loc:pexp_loc c
+           (args, typ, body) )
+      $ force_break $ str "end"
   | Pexp_beginend e ->
       let wrap_beginend k =
         let opn =

--- a/test/passing/refs.default/attributes.ml.ref
+++ b/test/passing/refs.default/attributes.ml.ref
@@ -394,9 +394,8 @@ let () =
   let () =
     S.ntyp Cbor_type.Reserved
     @@ S.tok
-         begin [@warning "-4"]
-           fun ev ->
-             match ev with Cbor_event.Reserved int -> Some int | _ -> None
+         begin [@warning "-4"] fun ev ->
+           match ev with Cbor_event.Reserved int -> Some int | _ -> None
          end
   in
   ()

--- a/test/passing/refs.default/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.default/exp_grouping-parens.ml.ref
@@ -349,3 +349,47 @@ let _ =
       begin [@foo]
         y
       end
+
+let v = map x (fun x y z -> y)
+
+let v =
+  map x (fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y)
+
+let v =
+  map x
+    (fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y)
+
+let v =
+  map x
+    (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+      print y;
+      z)
+
+let v =
+  map x
+    (fun
+      x
+      argggggggggggggggggggggggggggggggggg
+      gggggggggggggggggggg
+      ggggggggggggggg
+    -> y)
+
+let v =
+  map x
+    (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+      print y;
+      z)
+
+let v =
+  map x (fun x y z ->
+      ya f;
+      a f b)
+
+let v =
+  map x
+    [%ext1
+      fun%ext2 x y z ->
+        ya f;
+        a f b]

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -16,13 +16,12 @@ let () =
 
 let () =
   List.iter
-    begin
-      fun v ->
-        (* do a lot of things *)
-        let a = "a" in
-        let b = "b" in
-        let c = "c" in
-        ()
+    begin fun v ->
+      (* do a lot of things *)
+      let a = "a" in
+      let b = "b" in
+      let c = "c" in
+      ()
     end
     values
 
@@ -407,3 +406,60 @@ let _ =
       begin [@foo]
         y
       end
+
+let v =
+  map x
+    begin fun x y z ->
+      y
+    end
+
+let v =
+  map x
+    begin fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y
+    end
+
+let v =
+  map x
+    begin
+      fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y
+    end
+
+let v =
+  map x
+    (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+      print y;
+      z)
+
+let v =
+  map x
+    begin
+      fun x
+        argggggggggggggggggggggggggggggggggg
+        gggggggggggggggggggg
+        ggggggggggggggg
+      ->
+      y
+    end
+
+let v =
+  map x
+    (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+      print y;
+      z)
+
+let v =
+  map x
+    begin fun x y z ->
+      ya f;
+      a f b
+    end
+
+let v =
+  map x
+    begin%ext1
+      fun%ext2 x y z ->
+        ya f;
+        a f b
+    end

--- a/test/passing/refs.janestreet/attributes.ml.ref
+++ b/test/passing/refs.janestreet/attributes.ml.ref
@@ -444,11 +444,10 @@ let () =
   let () =
     S.ntyp Cbor_type.Reserved
     @@ S.tok
-         begin [@warning "-4"]
-           fun ev ->
-             match ev with
-             | Cbor_event.Reserved int -> Some int
-             | _ -> None
+         begin [@warning "-4"] fun ev ->
+           match ev with
+           | Cbor_event.Reserved int -> Some int
+           | _ -> None
          end
   in
   ()

--- a/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
@@ -409,3 +409,43 @@ let _ =
       y
     end
 ;;
+
+let v = map x (fun x y z -> y)
+let v = map x (fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg -> y)
+
+let v =
+  map x (fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg -> y)
+;;
+
+let v =
+  map x (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+    print y;
+    z)
+;;
+
+let v =
+  map
+    x
+    (fun x argggggggggggggggggggggggggggggggggg gggggggggggggggggggg ggggggggggggggg -> y)
+;;
+
+let v =
+  map x (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+    print y;
+    z)
+;;
+
+let v =
+  map x (fun x y z ->
+    ya f;
+    a f b)
+;;
+
+let v =
+  map
+    x
+    [%ext1
+      fun%ext2 x y z ->
+        ya f;
+        a f b]
+;;

--- a/test/passing/refs.janestreet/exp_grouping.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping.ml.ref
@@ -18,13 +18,12 @@ let () =
 
 let () =
   List.iter
-    begin
-      fun v ->
-        (* do a lot of things *)
-        let a = "a" in
-        let b = "b" in
-        let c = "c" in
-        ()
+    begin fun v ->
+      (* do a lot of things *)
+      let a = "a" in
+      let b = "b" in
+      let c = "c" in
+      ()
     end
     values
 ;;
@@ -476,5 +475,69 @@ let _ =
   | _ ->
     begin [@foo]
       y
+    end
+;;
+
+let v =
+  map
+    x
+    begin fun x y z ->
+      y
+    end
+;;
+
+let v =
+  map
+    x
+    begin fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y
+    end
+;;
+
+let v =
+  map
+    x
+    begin fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y
+    end
+;;
+
+let v =
+  map x (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+    print y;
+    z)
+;;
+
+let v =
+  map
+    x
+    begin
+      fun x argggggggggggggggggggggggggggggggggg gggggggggggggggggggg ggggggggggggggg ->
+      y
+    end
+;;
+
+let v =
+  map x (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+    print y;
+    z)
+;;
+
+let v =
+  map
+    x
+    begin fun x y z ->
+      ya f;
+      a f b
+    end
+;;
+
+let v =
+  map
+    x
+    begin%ext1
+      fun%ext2 x y z ->
+        ya f;
+        a f b
     end
 ;;

--- a/test/passing/refs.ocamlformat/attributes.ml.ref
+++ b/test/passing/refs.ocamlformat/attributes.ml.ref
@@ -440,9 +440,8 @@ let () =
   let () =
     S.ntyp Cbor_type.Reserved
     @@ S.tok
-         begin [@warning "-4"]
-           fun ev ->
-             match ev with Cbor_event.Reserved int -> Some int | _ -> None
+         begin [@warning "-4"] fun ev ->
+           match ev with Cbor_event.Reserved int -> Some int | _ -> None
          end
   in
   ()

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
@@ -350,3 +350,37 @@ let _ =
     begin [@foo]
       y
     end
+
+let v = map x (fun x y z -> y)
+
+let v =
+  map x (fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y )
+
+let v =
+  map x
+    (fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y )
+
+let v =
+  map x
+    (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+      print y ; z )
+
+let v =
+  map x
+    (fun
+      x
+      argggggggggggggggggggggggggggggggggg
+      gggggggggggggggggggg
+      ggggggggggggggg
+    -> y )
+
+let v =
+  map x
+    (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+      print y ; z )
+
+let v = map x (fun x y z -> ya f ; a f b)
+
+let v = map x [%ext1 fun%ext2 x y z -> ya f ; a f b]

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -16,13 +16,12 @@ let () =
 
 let () =
   List.iter
-    begin
-      fun v ->
-        (* do a lot of things *)
-        let a = "a" in
-        let b = "b" in
-        let c = "c" in
-        ()
+    begin fun v ->
+      (* do a lot of things *)
+      let a = "a" in
+      let b = "b" in
+      let c = "c" in
+      ()
     end
     values
 
@@ -407,4 +406,56 @@ let _ =
   | _ ->
     begin [@foo]
       y
+    end
+
+let v =
+  map x
+    begin fun x y z ->
+      y
+    end
+
+let v =
+  map x
+    begin fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y
+    end
+
+let v =
+  map x
+    begin
+      fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y
+    end
+
+let v =
+  map x
+    (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+      print y ; z )
+
+let v =
+  map x
+    begin
+      fun x
+        argggggggggggggggggggggggggggggggggg
+        gggggggggggggggggggg
+        ggggggggggggggg
+      ->
+      y
+    end
+
+let v =
+  map x
+    (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+      print y ; z )
+
+let v =
+  map x
+    begin fun x y z ->
+      ya f ; a f b
+    end
+
+let v =
+  map x
+    begin%ext1
+      fun%ext2 x y z -> ya f ; a f b
     end

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -283,3 +283,60 @@ let _ =
   match x with
   | _ ->
       begin[@foo] y end
+
+let v =
+  map x
+    begin fun x y z ->
+      y
+    end
+
+let v =
+  map x
+    begin fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y
+    end
+
+let v =
+  map x
+    begin
+      fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y
+    end
+
+let v =
+  map x
+    (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+    print y;
+    z)
+
+let v =
+  map x
+    begin
+      fun x
+        argggggggggggggggggggggggggggggggggg
+        gggggggggggggggggggg
+        ggggggggggggggg
+      ->
+      y
+    end
+
+let v =
+  map x
+    (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+    print y;
+    z)
+
+let v =
+  map x
+    begin fun x y z ->
+      ya f;
+      a f b
+    end
+
+let v =
+  map x
+    begin%ext1
+      fun%ext2 x y z ->
+        ya f;
+        a f b
+    end


### PR DESCRIPTION
```ocaml
map x 
  begin 
    fun y ->
      print x;
      y
  end
```
is now 
```ocaml
map x 
  begin fun y ->
    print x;
    y
  end
```

This is a nice improvement that partially solves one of the biggest issue we have with ocamlformat at ahrefs.

A further improvement could be 

```ocaml
map x begin fun y ->
  print x;
  y
end
```
but thats more debatable and should probably be in another PR.
 