### PR TITLE
display `lazy begin` on one line.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,37 +38,37 @@ profile. This started with version 0.26.0.
   (#2664, #2666, #2671, @EmileTrotignon)
   For example :
   ```ocaml
-    (* before *)
-    begin
-      match a with
-      | A -> a
-      | B -> b
-    end
-    (* after *)
-    begin match a with
+  (* before *)
+  begin
+    match a with
     | A -> a
     | B -> b
+  end
+  (* after *)
+  begin match a with
+  | A -> a
+  | B -> b
+  end
+
+  (* before *)
+  begin
+    fun x ->
+      some code
+  end
+  (* after *)
+  begin fun x ->
+    some code
+  end
+
+  (* before *)
+  lazy
+    begin
+      some code
     end
-
-    (* before *)
-      begin
-        fun x ->
-          some code
-      end
-    (* after *)
-      begin fun x ->
-        some code
-      end
-
-    (* before *)
-      lazy
-        begin
-          some code
-        end
-    (* after *)
-      lazy begin
-        some code
-      end
+  (* after *)
+  lazy begin
+    some code
+  end
   ```
 
 ## 0.27.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,33 +40,11 @@ profile. This started with version 0.26.0.
   ```ocaml
   (* before *)
   begin
-    match a with
-    | A -> a
-    | B -> b
-  end
-  (* after *)
-  begin match a with
-  | A -> a
-  | B -> b
-  end
-
-  (* before *)
-  begin
     fun x ->
       some code
   end
   (* after *)
   begin fun x ->
-    some code
-  end
-
-  (* before *)
-  lazy
-    begin
-      some code
-    end
-  (* after *)
-  lazy begin
     some code
   end
   ```

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,40 @@ profile. This started with version 0.26.0.
 - `lazy begin`, `begin match` and `begin fun` can now be printed on the same
   line, with one less indentation level for the body of the inner expression.
   (#2664, #2666, #2671, @EmileTrotignon)
+  For example :
+  ```ocaml
+    (* before *)
+    begin
+      match a with
+      | A -> a
+      | B -> b
+    end
+    (* after *)
+    begin match a with
+    | A -> a
+    | B -> b
+    end
+
+    (* before *)
+      begin
+        fun x ->
+          some code
+      end
+    (* after *)
+      begin fun x ->
+        some code
+      end
+
+    (* before *)
+      lazy
+        begin
+          some code
+        end
+    (* after *)
+      lazy begin
+        some code
+      end
+  ```
 
 ## 0.27.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,8 +33,9 @@ profile. This started with version 0.26.0.
 
 ### Changed
 
-- `begin match` and `begin fun` can now be printed on the same line, with one less indentation
-  level for the body of the inner expression. (#2666, @EmileTrotignon)
+- `lazy begin`, `begin match` and `begin fun` can now be printed on the same
+  line, with one less indentation level for the body of the inner expression.
+  (#2664, #2666, #2671, @EmileTrotignon)
 
 ## 0.27.0
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2916,11 +2916,14 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       $ fmt_atrs
 
 and fmt_lazy c ~ctx ?(pro = noop) ~fmt_atrs ~ext ~parens e =
-  let lazy_ = str "lazy" $ fmt_extension_suffix c ext $ space_break in
+  let lazy_ = str "lazy" $ fmt_extension_suffix c ext in
   let kw_outer, kw_inner =
     match e.pexp_desc with
-    | Pexp_beginend _ -> (noop, lazy_)
-    | _ -> (lazy_, noop)
+    | Pexp_beginend _ ->
+        (* having an unbreakable space is useful for [lazy begin fun ...]
+           when the function has a long list of arguments. *)
+        (noop, lazy_ $ str " ")
+    | _ -> (lazy_ $ space_break, noop)
   in
   pro
   $ hvbox 2

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1948,7 +1948,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
     (* Some expressions format the 'pro' and comments differently. *)
     let cmts_in_pro =
       match exp.pexp_desc with
-      | Pexp_function _ | Pexp_match _ | Pexp_try _ -> noop
+      | Pexp_function _ | Pexp_match _ | Pexp_try _ | Pexp_beginend _ -> noop
       | _ -> Cmts.fmt_before c ?eol pexp_loc
     in
     cmts_in_pro $ pro
@@ -2747,15 +2747,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                     c.conf
                     (List.map es ~f:(sub_exp ~ctx >> fmt_expression c)) )
              $ fmt_atrs ) )
-  | Pexp_lazy e ->
-      pro
-      $ hvbox 2
-          (Params.Exp.wrap c.conf ~parens
-             ( str "lazy"
-             $ fmt_extension_suffix c ext
-             $ space_break
-             $ fmt_expression c (sub_exp ~ctx e)
-             $ fmt_atrs ) )
+  | Pexp_lazy e -> fmt_lazy c ~ctx ~pro ~fmt_atrs ~ext ~parens e
   | Pexp_extension
       ( ext
       , PStr
@@ -2914,7 +2906,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       pro $ fmt_indexop_access c ctx ~fmt_atrs ~has_attr ~parens x
   | Pexp_hole -> pro $ hvbox 0 (fmt_hole () $ fmt_atrs)
   | Pexp_beginend e ->
-      fmt_beginend c ~box ~pro ~ctx ~fmt_atrs ~ext ~indent_wrap ?eol e
+      fmt_beginend c ~loc:pexp_loc ~box ~pro ~ctx ~fmt_atrs ~ext ~indent_wrap
+        ?eol e
   | Pexp_parens e ->
       pro
       $ hvbox 0
@@ -2922,18 +2915,37 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
              (sub_exp ~ctx e) )
       $ fmt_atrs
 
-and fmt_beginend c ?(box = true) ?(pro = noop) ~ctx ~fmt_atrs ~ext
+and fmt_lazy c ~ctx ?(pro = noop) ~fmt_atrs ~ext ~parens e =
+  let lazy_ = str "lazy" $ fmt_extension_suffix c ext in
+  match e with
+  | {pexp_desc= Pexp_beginend _; _} as e ->
+      pro
+      $ hvbox 2
+          (Params.Exp.wrap c.conf ~parens
+             ( fmt_expression c ~pro:(lazy_ $ str " ") (sub_exp ~ctx e)
+             $ fmt_atrs ) )
+  | _ ->
+      pro
+      $ hvbox 2
+          (Params.Exp.wrap c.conf ~parens
+             ( lazy_ $ space_break
+             $ fmt_expression c (sub_exp ~ctx e)
+             $ fmt_atrs ) )
+
+and fmt_beginend c ~loc ?(box = true) ?(pro = noop) ~ctx ~fmt_atrs ~ext
     ~indent_wrap ?eol e =
+  let cmts_before = Cmts.fmt_before c ?eol loc in
   let begin_ = str "begin" $ fmt_extension_suffix c ext $ fmt_atrs
   and end_ = str "end" in
+  cmts_before
+  $
   match e.pexp_desc with
   | Pexp_match _ | Pexp_try _ | Pexp_function _ ->
-      pro
-      $ hvbox 0
-          ( fmt_expression c
-              ~pro:(begin_ $ str " ")
-              ~box ?eol ~parens:false ~indent_wrap (sub_exp ~ctx e)
-          $ break 1 0 $ end_ )
+      hvbox 0
+        ( fmt_expression c
+            ~pro:(pro $ begin_ $ str " ")
+            ~box ?eol ~parens:false ~indent_wrap (sub_exp ~ctx e)
+        $ break 1 0 $ end_ )
   | Pexp_extension
       ( ext_inner
       , PStr
@@ -2943,19 +2955,17 @@ and fmt_beginend c ?(box = true) ?(pro = noop) ~ctx ~fmt_atrs ~ext
               ; _ } as stru ) ] )
     when Source.extension_using_sugar ~name:ext_inner ~payload:e1.pexp_loc ->
       let ctx = Str stru in
-      pro
-      $ hvbox 0
-          ( fmt_expression c ~ext:ext_inner
-              ~pro:(begin_ $ str " ")
-              ~box ?eol ~parens:false ~indent_wrap (sub_exp ~ctx e1)
-          $ break 1 0 $ end_ )
+      hvbox 0
+        ( fmt_expression c ~ext:ext_inner
+            ~pro:(pro $ begin_ $ str " ")
+            ~box ?eol ~parens:false ~indent_wrap (sub_exp ~ctx e1)
+        $ break 1 0 $ end_ )
   | _ ->
-      pro
-      $ hvbox 0
-          ( hvbox 0 begin_ $ break 1 2
-          $ fmt_expression c ~box ?eol ~parens:false ~indent_wrap
-              (sub_exp ~ctx e)
-          $ force_break $ end_ )
+      hvbox 0
+        ( pro $ hvbox 0 begin_ $ break 1 2
+        $ fmt_expression c ~box ?eol ~parens:false ~indent_wrap
+            (sub_exp ~ctx e)
+        $ force_break $ end_ )
 
 and fmt_let_bindings c ~ctx0 ~parens ~has_attr ~fmt_atrs ~fmt_expr ~loc_in
     rec_flag bindings body =

--- a/test/passing/refs.default/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.default/exp_grouping-parens.ml.ref
@@ -392,3 +392,22 @@ let v =
       fun%ext2 x y z ->
         ya f;
         a f b]
+
+let _ =
+  lazy
+    (print_endline xxxxxxxxx;
+     f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz)
+
+let _ =
+  lazy
+    (fun y ->
+      print_endline xxxxxxxxx;
+      f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz)
+
+let _ =
+  lazy
+    (match a with
+    | A -> b
+    | A ->
+        print_endline xxxxxxxxx;
+        f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz)

--- a/test/passing/refs.default/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.default/exp_grouping-parens.ml.ref
@@ -411,3 +411,9 @@ let _ =
     | A ->
         print_endline xxxxxxxxx;
         f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz)
+
+let _ =
+  lazy
+    (fun xxxxxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzzzzz ->
+      print_endline xxxxxxxxx;
+      f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz)

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -476,3 +476,12 @@ let _ =
       print_endline xxxxxxxxx;
       f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
   end
+
+let _ =
+  lazy begin fun xxxxxxxxxxxxxxxxxxxxxxx
+    yyyyyyyyyyyyyyyyyyy
+    zzzzzzzzzzzzzzzzzzzzzzzz
+  ->
+    print_endline xxxxxxxxx;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -456,3 +456,23 @@ let v =
         ya f;
         a f b
     end
+
+let _ =
+  lazy begin
+    print_endline xxxxxxxxx;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end
+
+let _ =
+  lazy begin fun y ->
+    print_endline xxxxxxxxx;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end
+
+let _ =
+  lazy begin match a with
+  | A -> b
+  | A ->
+      print_endline xxxxxxxxx;
+      f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end

--- a/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
@@ -470,3 +470,10 @@ let _ =
        print_endline xxxxxxxxx;
        f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz)
 ;;
+
+let _ =
+  lazy
+    (fun xxxxxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzzzzz ->
+      print_endline xxxxxxxxx;
+      f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz)
+;;

--- a/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
@@ -448,3 +448,25 @@ let v =
         ya f;
         a f b]
 ;;
+
+let _ =
+  lazy
+    (print_endline xxxxxxxxx;
+     f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz)
+;;
+
+let _ =
+  lazy
+    (fun y ->
+      print_endline xxxxxxxxx;
+      f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz)
+;;
+
+let _ =
+  lazy
+    (match a with
+     | A -> b
+     | A ->
+       print_endline xxxxxxxxx;
+       f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz)
+;;

--- a/test/passing/refs.janestreet/exp_grouping.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping.ml.ref
@@ -529,3 +529,26 @@ let v =
         a f b
     end
 ;;
+
+let _ =
+  lazy begin
+    print_endline xxxxxxxxx;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end
+;;
+
+let _ =
+  lazy begin fun y ->
+    print_endline xxxxxxxxx;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end
+;;
+
+let _ =
+  lazy begin match a with
+  | A -> b
+  | A ->
+    print_endline xxxxxxxxx;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end
+;;

--- a/test/passing/refs.janestreet/exp_grouping.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping.ml.ref
@@ -552,3 +552,10 @@ let _ =
     f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
   end
 ;;
+
+let _ =
+  lazy begin fun xxxxxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzzzzz ->
+    print_endline xxxxxxxxx;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end
+;;

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
@@ -383,3 +383,23 @@ let v =
 let v = map x (fun x y z -> ya f ; a f b)
 
 let v = map x [%ext1 fun%ext2 x y z -> ya f ; a f b]
+
+let _ =
+  lazy
+    ( print_endline xxxxxxxxx ;
+      f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz )
+
+let _ =
+  lazy
+    (fun y ->
+      print_endline xxxxxxxxx ;
+      f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz )
+
+let _ =
+  lazy
+    ( match a with
+    | A ->
+        b
+    | A ->
+        print_endline xxxxxxxxx ;
+        f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz )

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
@@ -403,3 +403,9 @@ let _ =
     | A ->
         print_endline xxxxxxxxx ;
         f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz )
+
+let _ =
+  lazy
+    (fun xxxxxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzzzzz ->
+      print_endline xxxxxxxxx ;
+      f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz )

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -448,3 +448,24 @@ let v =
     begin%ext1
       fun%ext2 x y z -> ya f ; a f b
     end
+
+let _ =
+  lazy begin
+    print_endline xxxxxxxxx ;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end
+
+let _ =
+  lazy begin fun y ->
+    print_endline xxxxxxxxx ;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end
+
+let _ =
+  lazy begin match a with
+  | A ->
+      b
+  | A ->
+      print_endline xxxxxxxxx ;
+      f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -469,3 +469,12 @@ let _ =
       print_endline xxxxxxxxx ;
       f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
   end
+
+let _ =
+  lazy begin fun xxxxxxxxxxxxxxxxxxxxxxx
+    yyyyyyyyyyyyyyyyyyy
+    zzzzzzzzzzzzzzzzzzzzzzzz
+  ->
+    print_endline xxxxxxxxx ;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -340,3 +340,23 @@ let v =
         ya f;
         a f b
     end
+
+let _ =
+  lazy begin
+    print_endline xxxxxxxxx;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end
+
+let _ =
+  lazy begin fun y ->
+    print_endline xxxxxxxxx;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end
+
+let _ =
+  lazy begin match a with
+  | A -> b
+  | A ->
+    print_endline xxxxxxxxx;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -360,3 +360,9 @@ let _ =
     print_endline xxxxxxxxx;
     f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
   end
+
+let _ =
+  lazy begin fun xxxxxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzzzzz ->
+    print_endline xxxxxxxxx;
+    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
+  end


### PR DESCRIPTION
I had to improve `fmt_beginend`. Sequences like `lazy begin fun` or `lazy begin match` are also printed on one line.