### PR TITLE
`begin if` bugfix

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2426,7 +2426,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                         else None
                       in
                       let p =
-                        Params.get_if_then_else c.conf ~pro:(fmt_if first pro_inner) ~first ~last
+                        Params.get_if_then_else c.conf
+                          ~pro:(fmt_if first pro_inner) ~first ~last
                           ~parens_bch ~parens_prev_bch:!parens_prev_bch
                           ~xcond ~xbch ~expr_loc:pexp_loc
                           ~fmt_extension_suffix:

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2426,7 +2426,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                         else None
                       in
                       let p =
-                        Params.get_if_then_else c.conf ~first ~last
+                        Params.get_if_then_else c.conf ~pro:(fmt_if first pro_inner) ~first ~last
                           ~parens_bch ~parens_prev_bch:!parens_prev_bch
                           ~xcond ~xbch ~expr_loc:pexp_loc
                           ~fmt_extension_suffix:
@@ -2439,7 +2439,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                       in
                       parens_prev_bch := parens_bch ;
                       p.box_branch
-                        ( fmt_if first pro_inner $ p.cond
+                        ( p.cond
                         $ p.box_keyword_and_expr
                             ( p.branch_pro
                             $ p.wrap_parens

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -769,7 +769,7 @@ type if_then_else =
   ; break_end_branch: Fmt.t
   ; space_between_branches: Fmt.t }
 
-let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
+let get_if_then_else (c : Conf.t) ~pro ~first ~last ~parens_bch ~parens_prev_bch
     ~xcond ~xbch ~expr_loc ~fmt_extension_suffix ~fmt_attributes ~fmt_cond
     ~cmts_before_kw ~cmts_after_kw =
   let imd = c.fmt_opts.indicate_multiline_delimiters.v in
@@ -803,13 +803,13 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
         hvbox 2
           ( hvbox 0
               ( hvbox 2
-                  ( fmt_if (not first) (str "else ")
+                  ( pro $ fmt_if (not first) (str "else ")
                   $ str "if"
                   $ fmt_if first (fmt_opt fmt_extension_suffix)
                   $ fmt_attributes $ space_break $ fmt_cond xcnd )
               $ space_break $ cmts_before_kw $ str "then" )
           $ opt cmts_after_kw Fn.id )
-    | None -> cmts_before_kw $ hvbox 2 (str "else" $ opt cmts_after_kw Fn.id)
+    | None -> cmts_before_kw $ hvbox 2 (pro $ str "else" $ opt cmts_after_kw Fn.id)
   in
   let branch_pro ?(indent = 2) () =
     if Option.is_some cmts_after_kw then break 1000 indent
@@ -901,7 +901,7 @@ let get_if_then_else (c : Conf.t) ~first ~last ~parens_bch ~parens_prev_bch
         match xcond with
         | Some xcond ->
             hvbox 2
-              ( fmt_or first
+              (pro $ fmt_or first
                   (str "if" $ fmt_opt fmt_extension_suffix)
                   (str "else if")
               $ fmt_attributes $ space_break $ fmt_cond xcond

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -769,9 +769,9 @@ type if_then_else =
   ; break_end_branch: Fmt.t
   ; space_between_branches: Fmt.t }
 
-let get_if_then_else (c : Conf.t) ~pro ~first ~last ~parens_bch ~parens_prev_bch
-    ~xcond ~xbch ~expr_loc ~fmt_extension_suffix ~fmt_attributes ~fmt_cond
-    ~cmts_before_kw ~cmts_after_kw =
+let get_if_then_else (c : Conf.t) ~pro ~first ~last ~parens_bch
+    ~parens_prev_bch ~xcond ~xbch ~expr_loc ~fmt_extension_suffix
+    ~fmt_attributes ~fmt_cond ~cmts_before_kw ~cmts_after_kw =
   let imd = c.fmt_opts.indicate_multiline_delimiters.v in
   let beginend, branch_expr =
     let ast = xbch.Ast.ast in
@@ -803,13 +803,15 @@ let get_if_then_else (c : Conf.t) ~pro ~first ~last ~parens_bch ~parens_prev_bch
         hvbox 2
           ( hvbox 0
               ( hvbox 2
-                  ( pro $ fmt_if (not first) (str "else ")
+                  ( pro
+                  $ fmt_if (not first) (str "else ")
                   $ str "if"
                   $ fmt_if first (fmt_opt fmt_extension_suffix)
                   $ fmt_attributes $ space_break $ fmt_cond xcnd )
               $ space_break $ cmts_before_kw $ str "then" )
           $ opt cmts_after_kw Fn.id )
-    | None -> cmts_before_kw $ hvbox 2 (pro $ str "else" $ opt cmts_after_kw Fn.id)
+    | None ->
+        cmts_before_kw $ hvbox 2 (pro $ str "else" $ opt cmts_after_kw Fn.id)
   in
   let branch_pro ?(indent = 2) () =
     if Option.is_some cmts_after_kw then break 1000 indent
@@ -901,7 +903,8 @@ let get_if_then_else (c : Conf.t) ~pro ~first ~last ~parens_bch ~parens_prev_bch
         match xcond with
         | Some xcond ->
             hvbox 2
-              (pro $ fmt_or first
+              ( pro
+              $ fmt_or first
                   (str "if" $ fmt_opt fmt_extension_suffix)
                   (str "else if")
               $ fmt_attributes $ space_break $ fmt_cond xcond

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -195,6 +195,7 @@ type if_then_else =
 
 val get_if_then_else :
      Conf.t
+  -> pro:Fmt.t
   -> first:bool
   -> last:bool
   -> parens_bch:bool

--- a/test/passing/refs.default/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.default/exp_grouping-parens.ml.ref
@@ -417,3 +417,60 @@ let _ =
     (fun xxxxxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzzzzz ->
       print_endline xxxxxxxxx;
       f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz)
+
+[@@@ocamlformat "if-then-else=fit-or-vertical"]
+
+let _ =
+  if b then (
+    e1;
+    e2)
+  else (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more)
+
+let _ =
+  if b then (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more)
+  else if b1 then (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more)
+  else
+    e
+;;
+
+f
+  (if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooong then
+     ()
+   else
+     ())
+;;
+
+f
+  (if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then
+     ()
+   else
+     ())
+;;
+
+f
+  (if even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then
+     ()
+   else
+     ())
+;;
+
+f
+  (if and_ even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+   then
+     ()
+   else
+     ())
+
+let () =
+  f
+    (if a___________________________________________________________________
+     then
+       b_________________________________________________________________
+     else
+       c_________________________________________________________________)

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -527,7 +527,7 @@ f
 
 f
   begin if even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
-        then
+  then
     ()
   else
     ()
@@ -536,9 +536,8 @@ f
 
 f
   begin if
-          and_ even
-            loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
-        then
+    and_ even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  then
     ()
   else
     ()
@@ -547,8 +546,8 @@ f
 let () =
   f
     begin if
-            a___________________________________________________________________
-          then
+      a___________________________________________________________________
+    then
       b_________________________________________________________________
     else
       c_________________________________________________________________

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -483,3 +483,73 @@ let _ =
     print_endline xxxxxxxxx;
     f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
   end
+
+[@@@ocamlformat "if-then-else=fit-or-vertical"]
+
+let _ =
+  if b then begin
+    e1;
+    e2
+  end
+  else begin
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more
+  end
+
+let _ =
+  if b then begin
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more
+  end
+  else if b1 then begin
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more
+  end
+  else
+    e
+;;
+
+f
+  begin if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooong then
+    ()
+  else
+    ()
+  end
+;;
+
+f
+  begin if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then
+    ()
+  else
+    ()
+  end
+;;
+
+f
+  begin if even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+        then
+    ()
+  else
+    ()
+  end
+;;
+
+f
+  begin if
+          and_ even
+            loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+        then
+    ()
+  else
+    ()
+  end
+
+let () =
+  f
+    begin if
+            a___________________________________________________________________
+          then
+      b_________________________________________________________________
+    else
+      c_________________________________________________________________
+    end

--- a/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
@@ -477,3 +477,60 @@ let _ =
       print_endline xxxxxxxxx;
       f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz)
 ;;
+
+[@@@ocamlformat "if-then-else=fit-or-vertical"]
+
+let _ =
+  if b then (
+    e1;
+    e2)
+  else (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more)
+;;
+
+let _ =
+  if b then (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more)
+  else if b1 then (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more)
+  else
+    e
+;;
+
+f
+  (if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooong then
+     ()
+   else
+     ())
+;;
+
+f
+  (if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then
+     ()
+   else
+     ())
+;;
+
+f
+  (if even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then
+     ()
+   else
+     ())
+;;
+
+f
+  (if and_ even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then
+     ()
+   else
+     ())
+
+let () =
+  f
+    (if a___________________________________________________________________ then
+       b_________________________________________________________________
+     else
+       c_________________________________________________________________)
+;;

--- a/test/passing/refs.janestreet/exp_grouping.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping.ml.ref
@@ -557,3 +557,69 @@ let _ =
     f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
   end
 ;;
+
+[@@@ocamlformat "if-then-else=fit-or-vertical"]
+
+let _ =
+  if b then begin
+    e1;
+    e2
+  end
+  else begin
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more
+  end
+;;
+
+let _ =
+  if b then begin
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more
+  end
+  else if b1 then begin
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more
+  end
+  else
+    e
+;;
+
+f
+  begin if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooong then
+    ()
+  else
+    ()
+  end
+;;
+
+f
+  begin if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then
+    ()
+  else
+    ()
+  end
+;;
+
+f
+  begin if even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then
+    ()
+  else
+    ()
+  end
+;;
+
+f
+  begin if and_ even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then
+    ()
+  else
+    ()
+  end
+
+let () =
+  f
+    begin if a___________________________________________________________________ then
+      b_________________________________________________________________
+    else
+      c_________________________________________________________________
+    end
+;;

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
@@ -409,3 +409,59 @@ let _ =
     (fun xxxxxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzzzzz ->
       print_endline xxxxxxxxx ;
       f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz )
+
+[@@@ocamlformat "if-then-else=fit-or-vertical"]
+
+let _ =
+  if b then (
+    e1 ; e2 )
+  else (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more )
+
+let _ =
+  if b then (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more )
+  else if b1 then (
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more )
+  else
+    e
+;;
+
+f
+  ( if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooong then
+      ()
+    else
+      () )
+;;
+
+f
+  ( if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then
+      ()
+    else
+      () )
+;;
+
+f
+  ( if even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then
+      ()
+    else
+      () )
+;;
+
+f
+  ( if and_ even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+    then
+      ()
+    else
+      () )
+
+let () =
+  f
+    ( if a___________________________________________________________________
+      then
+        b_________________________________________________________________
+      else
+        c_________________________________________________________________ )

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -519,7 +519,7 @@ f
 
 f
   begin if even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
-        then
+  then
     ()
   else
     ()
@@ -528,9 +528,8 @@ f
 
 f
   begin if
-          and_ even
-            loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
-        then
+    and_ even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  then
     ()
   else
     ()
@@ -539,8 +538,8 @@ f
 let () =
   f
     begin if
-            a___________________________________________________________________
-          then
+      a___________________________________________________________________
+    then
       b_________________________________________________________________
     else
       c_________________________________________________________________

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -476,3 +476,72 @@ let _ =
     print_endline xxxxxxxxx ;
     f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
   end
+
+[@@@ocamlformat "if-then-else=fit-or-vertical"]
+
+let _ =
+  if b then begin
+    e1 ; e2
+  end
+  else begin
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more
+  end
+
+let _ =
+  if b then begin
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more
+  end
+  else if b1 then begin
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break ;
+    this is more
+  end
+  else
+    e
+;;
+
+f
+  begin if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooong then
+    ()
+  else
+    ()
+  end
+;;
+
+f
+  begin if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger then
+    ()
+  else
+    ()
+  end
+;;
+
+f
+  begin if even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+        then
+    ()
+  else
+    ()
+  end
+;;
+
+f
+  begin if
+          and_ even
+            loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+        then
+    ()
+  else
+    ()
+  end
+
+let () =
+  f
+    begin if
+            a___________________________________________________________________
+          then
+      b_________________________________________________________________
+    else
+      c_________________________________________________________________
+    end

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -366,3 +366,67 @@ let _ =
     print_endline xxxxxxxxx;
     f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
   end
+
+[@@@ocamlformat "if-then-else=fit-or-vertical"]
+
+let _ =
+  if b
+  then begin
+    e1;
+    e2
+  end
+  else begin
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more
+  end
+
+let _ =
+  if b
+  then begin
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more
+  end
+  else if b1
+  then begin
+    something loooooooooooooooooooooooooooooooong enough to_trigger a break;
+    this is more
+  end
+  else e
+;;
+
+f
+  begin if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+  then ()
+  else ()
+  end
+;;
+
+f
+  begin if loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  then ()
+  else ()
+  end
+;;
+
+f
+  begin if even loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  then ()
+  else ()
+  end
+;;
+
+f
+  begin if
+          and_ even
+            loooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
+  then ()
+  else ()
+  end
+
+let () =
+  f
+    begin if
+            a___________________________________________________________________
+    then b_________________________________________________________________
+    else c_________________________________________________________________
+    end


### PR DESCRIPTION
There was a bug in the formatting of `begin if` that I just introduced : 

```ocaml

let () =
  f
    begin if
            a___________________________________________________________________
          then
      b_________________________________________________________________
    else
      c_________________________________________________________________
    end
```

This PR fixes that bug.