### PR TITLE
Fix error when asterisk prefixed comment looses its asterisks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,8 @@ profile. This started with version 0.26.0.
 - ocamlformat is now more robust when used as a library to print modified ASTs
   (#2659, @v-gb)
 
+- Fix crash due to edge case with asterisk-prefixed comments (#2674, @Julow)
+
 ### Changed
 
 - `begin if`, `lazy begin`, `begin match` and `begin fun` can now be printed on

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -166,7 +166,10 @@ let normalize_cmt (conf : Conf.t) =
           else Docstring.normalize_text txt
       | Code txt -> self#code txt
       | Asterisk_prefixed lines ->
-          String.concat ~sep:" " (List.map ~f:Docstring.normalize_text lines)
+          (* Note: An asterisk prefixed comment can turn into a normal
+             comment if it's two lines long and its second line is
+             whitespaces. They must normalize to the same thing. *)
+          String.concat ~sep:"" (List.map ~f:Docstring.normalize_text lines)
 
     method doc d = docstring conf ~normalize_code:self#code d
 

--- a/test/passing/refs.default/wrap_comments.ml.ref
+++ b/test/passing/refs.default/wrap_comments.ml.ref
@@ -230,3 +230,6 @@ let _ = f (* foo
  * ---
  *   3
  *)
+
+(* Multiline comment with the comment close on its own line
+ *)

--- a/test/passing/refs.janestreet/wrap_comments.ml.ref
+++ b/test/passing/refs.janestreet/wrap_comments.ml.ref
@@ -258,3 +258,6 @@ let _ =
  * ---
  *   3
  *)
+
+(* Multiline comment with the comment close on its own line
+ *)

--- a/test/passing/refs.ocamlformat/wrap_comments.ml.ref
+++ b/test/passing/refs.ocamlformat/wrap_comments.ml.ref
@@ -225,3 +225,6 @@ let _ = f (* foo
  * ---
  *   3
  *)
+
+(* Multiline comment with the comment close on its own line
+ *)

--- a/test/passing/tests/wrap_comments.ml
+++ b/test/passing/tests/wrap_comments.ml
@@ -257,3 +257,6 @@ let _ =
  * ---
  *   3
  *)
+
+(* Multiline comment with the comment close on its own line
+ * *)


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/2668

An asterisk prefixed comment can turn into a normal comment if it's two lines long and its second line is whitespaces. They must normalize to the same thing. For example:

    (* Multiline comment with the comment close on its own line
     * *)

formats to:

    (* Multiline comment with the comment close on its own line
     *)