### PR TITLE
make the formating of `map li begin fun` the same as `map li ( fun`.

### DIFF
--- a/test/passing/refs.default/attributes.ml.ref
+++ b/test/passing/refs.default/attributes.ml.ref
@@ -393,10 +393,8 @@ include [@foo] M [@boo]
 let () =
   let () =
     S.ntyp Cbor_type.Reserved
-    @@ S.tok
-         begin [@warning "-4"] fun ev ->
-           match ev with Cbor_event.Reserved int -> Some int | _ -> None
-         end
+    @@ S.tok (fun [@warning "-4"] ev ->
+           match ev with Cbor_event.Reserved int -> Some int | _ -> None)
   in
   ()
 

--- a/test/passing/refs.default/exp_grouping-parens.ml.err
+++ b/test/passing/refs.default/exp_grouping-parens.ml.err
@@ -1,0 +1,1 @@
+Warning: exp_grouping-parens.ml:577 exceeds the margin

--- a/test/passing/refs.default/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.default/exp_grouping-parens.ml.ref
@@ -576,3 +576,5 @@ let _ =
       | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       | _ ->
           bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+
+let a = fffffff (* a *) (fun () -> a) (* cmt *)

--- a/test/passing/refs.default/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.default/exp_grouping-parens.ml.ref
@@ -377,6 +377,15 @@ let v =
 
 let v =
   map x
+    (fun
+      x
+      argggggggggggggggggggggggggggggggggg
+      gggggggggggggggggggg
+      ggggggggggggggg
+    -> y)
+
+let v =
+  map x
     (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
       print y;
       z)
@@ -514,3 +523,56 @@ let _ =
        force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
        return value)
     ~last ~args
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(function
+    | _ -> a
+    | _ -> b)
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(function
+    | _ -> a
+    | _ -> b)
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function _ -> a | _ -> bbbbbbbbbbbbb)
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function
+    | _ -> a
+    | _ -> bbbbbbbbbbbbbbbbbbbbb)
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb (function
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b)
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(function
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b)
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(fun x ->
+      match x with
+      | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ -> b)
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(fun x ->
+      match x with
+      | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ -> b)
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(fun x ->
+      match x with
+      | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ ->
+          bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)

--- a/test/passing/refs.default/exp_grouping.ml.err
+++ b/test/passing/refs.default/exp_grouping.ml.err
@@ -1,0 +1,1 @@
+Warning: exp_grouping.ml:668 exceeds the margin

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -404,7 +404,10 @@ let _ =
         y
       end
 
-let v = map x begin fun x y z -> y end
+let v =
+  map x begin fun x y z ->
+      y
+    end
 
 let v =
   map x
@@ -414,9 +417,9 @@ let v =
 
 let v =
   map x
-    begin fun x
-      arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-    -> y
+    begin fun
+      x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y
     end
 
 let v =
@@ -427,12 +430,23 @@ let v =
 
 let v =
   map x
-    begin fun x
+    begin fun
+      x
       argggggggggggggggggggggggggggggggggg
       gggggggggggggggggggg
       ggggggggggggggg
-    -> y
+    ->
+      y
     end
+
+let v =
+  map x
+    (fun
+      x
+      argggggggggggggggggggggggggggggggggg
+      gggggggggggggggggggg
+      ggggggggggggggg
+    -> y)
 
 let v =
   map x
@@ -441,8 +455,7 @@ let v =
       z)
 
 let v =
-  map x
-    begin fun x y z ->
+  map x begin fun x y z ->
       ya f;
       a f b
     end
@@ -593,3 +606,64 @@ let _ =
       return value
     end
     ~last ~args
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(function
+    | _ -> a
+    | _ -> b)
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:begin function
+    | _ -> a
+    | _ -> b
+    end
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:begin function
+    | _ -> a
+    | _ -> bbbbbbbbbbbbb
+    end
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function
+    | _ -> a
+    | _ -> bbbbbbbbbbbbbbbbbbbbb)
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    begin function
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b
+    end
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:begin function
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b
+    end
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:begin fun x ->
+      match x with
+      | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ -> b
+    end
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(fun x ->
+      match x with
+      | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ -> b)
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(fun x ->
+      match x with
+      | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ ->
+          bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -667,3 +667,8 @@ let _ =
       | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       | _ ->
           bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+
+let a =
+  fffffff begin (* a *) fun () -> a
+      (* cmt *)
+    end

--- a/test/passing/refs.janestreet/attributes.ml.ref
+++ b/test/passing/refs.janestreet/attributes.ml.ref
@@ -443,12 +443,10 @@ include [@foo] M [@boo]
 let () =
   let () =
     S.ntyp Cbor_type.Reserved
-    @@ S.tok
-         begin [@warning "-4"] fun ev ->
-           match ev with
-           | Cbor_event.Reserved int -> Some int
-           | _ -> None
-         end
+    @@ S.tok (fun [@warning "-4"] ev ->
+      match ev with
+      | Cbor_event.Reserved int -> Some int
+      | _ -> None)
   in
   ()
 ;;

--- a/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
@@ -429,6 +429,12 @@ let v =
 ;;
 
 let v =
+  map
+    x
+    (fun x argggggggggggggggggggggggggggggggggg gggggggggggggggggggg ggggggggggggggg -> y)
+;;
+
+let v =
   map x (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
     print y;
     z)
@@ -590,4 +596,61 @@ let _ =
        return value)
     ~last
     ~args
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function
+    | _ -> a
+    | _ -> b)
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function
+    | _ -> a
+    | _ -> b)
+;;
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function
+    | _ -> a
+    | _ -> bbbbbbbbbbbbb)
+;;
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function
+    | _ -> a
+    | _ -> bbbbbbbbbbbbbbbbbbbbb)
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb (function
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b)
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b)
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(fun x ->
+    match x with
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b)
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(fun x ->
+    match x with
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b)
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(fun x ->
+    match x with
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
 ;;

--- a/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
@@ -654,3 +654,5 @@ let _ =
     | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     | _ -> bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
 ;;
+
+let a = fffffff (* a *) (fun () -> a) (* cmt *)

--- a/test/passing/refs.janestreet/exp_grouping.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping.ml.ref
@@ -475,32 +475,22 @@ let _ =
     end
 ;;
 
-let v = map x begin fun x y z -> y end
-
 let v =
-  map x begin fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg -> y end
+  map x begin fun x y z ->
+    y
+  end
 ;;
 
 let v =
-  map
-    x
-    begin fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg -> y end
+  map x begin fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+    y
+  end
 ;;
 
 let v =
-  map x (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
-    print y;
-    z)
-;;
-
-let v =
-  map
-    x
-    begin fun x
-            argggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggg
-            ggggggggggggggg -> y
-    end
+  map x begin fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+    y
+  end
 ;;
 
 let v =
@@ -512,10 +502,29 @@ let v =
 let v =
   map
     x
-    begin fun x y z ->
-      ya f;
-      a f b
-    end
+    begin fun
+        x argggggggggggggggggggggggggggggggggg gggggggggggggggggggg ggggggggggggggg ->
+    y
+  end
+;;
+
+let v =
+  map
+    x
+    (fun x argggggggggggggggggggggggggggggggggg gggggggggggggggggggg ggggggggggggggg -> y)
+;;
+
+let v =
+  map x (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+    print y;
+    z)
+;;
+
+let v =
+  map x begin fun x y z ->
+    ya f;
+    a f b
+  end
 ;;
 
 let v =
@@ -682,4 +691,66 @@ let _ =
     end
     ~last
     ~args
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function
+    | _ -> a
+    | _ -> b)
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb ~f:begin function
+    | _ -> a
+    | _ -> b
+    end
+;;
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:begin function
+    | _ -> a
+    | _ -> bbbbbbbbbbbbb
+    end
+;;
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function
+    | _ -> a
+    | _ -> bbbbbbbbbbbbbbbbbbbbb)
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb begin function
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b
+    end
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb ~f:begin function
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b
+    end
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb ~f:begin fun x ->
+    match x with
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b
+  end
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(fun x ->
+    match x with
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b)
+;;
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(fun x ->
+    match x with
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
 ;;

--- a/test/passing/refs.janestreet/exp_grouping.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping.ml.ref
@@ -754,3 +754,9 @@ let _ =
     | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     | _ -> bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
 ;;
+
+let a =
+  fffffff begin (* a *) fun () -> a
+    (* cmt *)
+  end
+;;

--- a/test/passing/refs.ocamlformat/attributes.ml.ref
+++ b/test/passing/refs.ocamlformat/attributes.ml.ref
@@ -439,10 +439,8 @@ include [@foo] M [@boo]
 let () =
   let () =
     S.ntyp Cbor_type.Reserved
-    @@ S.tok
-         begin [@warning "-4"] fun ev ->
-           match ev with Cbor_event.Reserved int -> Some int | _ -> None
-         end
+    @@ S.tok (fun [@warning "-4"] ev ->
+           match ev with Cbor_event.Reserved int -> Some int | _ -> None )
   in
   ()
 

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.err
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.err
@@ -1,0 +1,1 @@
+Warning: exp_grouping-parens.ml:586 exceeds the margin

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
@@ -585,3 +585,5 @@ let _ =
           aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       | _ ->
           bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
+
+let a = fffffff (* a *) (fun () -> a) (* cmt *)

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
@@ -377,6 +377,15 @@ let v =
 
 let v =
   map x
+    (fun
+      x
+      argggggggggggggggggggggggggggggggggg
+      gggggggggggggggggggg
+      ggggggggggggggg
+    -> y )
+
+let v =
+  map x
     (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
       print y ; z )
 
@@ -508,3 +517,71 @@ let _ =
         force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk ;
         return value )
     ~last ~args
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(function
+    | _ ->
+        a
+    | _ ->
+        b )
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(function
+    | _ ->
+        a
+    | _ ->
+        b )
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function _ -> a | _ -> bbbbbbbbbbbbb)
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function
+    | _ ->
+        a
+    | _ ->
+        bbbbbbbbbbbbbbbbbbbbb )
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb (function
+    | _ ->
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ ->
+        b )
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(function
+    | _ ->
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ ->
+        b )
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(fun x ->
+      match x with
+      | _ ->
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ ->
+          b )
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(fun x ->
+      match x with
+      | _ ->
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ ->
+          b )
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(fun x ->
+      match x with
+      | _ ->
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ ->
+          bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb )

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.err
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.err
@@ -1,0 +1,1 @@
+Warning: exp_grouping.ml:684 exceeds the margin

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -405,7 +405,10 @@ let _ =
       y
     end
 
-let v = map x begin fun x y z -> y end
+let v =
+  map x begin fun x y z ->
+      y
+    end
 
 let v =
   map x
@@ -415,9 +418,9 @@ let v =
 
 let v =
   map x
-    begin fun x
-      arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-    -> y
+    begin fun
+      x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y
     end
 
 let v =
@@ -427,19 +430,33 @@ let v =
 
 let v =
   map x
-    begin fun x
+    begin fun
+      x
       argggggggggggggggggggggggggggggggggg
       gggggggggggggggggggg
       ggggggggggggggg
-    -> y
+    ->
+      y
     end
+
+let v =
+  map x
+    (fun
+      x
+      argggggggggggggggggggggggggggggggggg
+      gggggggggggggggggggg
+      ggggggggggggggg
+    -> y )
 
 let v =
   map x
     (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
       print y ; z )
 
-let v = map x begin fun x y z -> ya f ; a f b end
+let v =
+  map x begin fun x y z ->
+      ya f ; a f b
+    end
 
 let v =
   map x
@@ -588,3 +605,81 @@ let _ =
       return value
     end
     ~last ~args
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(function
+    | _ ->
+        a
+    | _ ->
+        b )
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:begin function
+    | _ ->
+        a
+    | _ ->
+        b
+    end
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:begin function
+    | _ ->
+        a
+    | _ ->
+        bbbbbbbbbbbbb
+    end
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function
+    | _ ->
+        a
+    | _ ->
+        bbbbbbbbbbbbbbbbbbbbb )
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    begin function
+    | _ ->
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ ->
+        b
+    end
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:begin function
+    | _ ->
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ ->
+        b
+    end
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:begin fun x ->
+      match x with
+      | _ ->
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ ->
+          b
+    end
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(fun x ->
+      match x with
+      | _ ->
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ ->
+          b )
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(fun x ->
+      match x with
+      | _ ->
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ ->
+          bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb )

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -683,3 +683,8 @@ let _ =
           aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       | _ ->
           bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb )
+
+let a =
+  fffffff begin (* a *) fun () -> a
+      (* cmt *)
+    end

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -322,6 +322,17 @@ let v =
 
 let v =
   map x
+    (
+      fun x
+        argggggggggggggggggggggggggggggggggg
+        gggggggggggggggggggg
+        ggggggggggggggg
+      ->
+      y
+    )
+
+let v =
+  map x
     (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
     print y;
     z)
@@ -466,3 +477,60 @@ let _ =
       return value
     end
     ~last ~args
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(function
+    | _ -> a
+    | _ -> b)
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:begin function
+    | _ -> a
+    | _ -> b
+    end
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:begin function _ -> a | _ -> bbbbbbbbbbbbb
+    end
+
+let _ =
+  f aaaabbbbbbbbbbbbbbbbbbbbbbb ~f:(function _ -> a | _ -> bbbbbbbbbbbbbbbbbbbbb
+  )
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    begin function
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b
+    end
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:begin function
+    | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | _ -> b
+    end
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:begin fun x ->
+      match x with
+      | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ -> b
+    end
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(fun x ->
+      match x with
+      | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ -> b)
+
+let _ =
+  f aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb
+    ~f:(fun x ->
+      match x with
+      | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      | _ -> bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -534,3 +534,8 @@ let _ =
       match x with
       | _ -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       | _ -> bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+
+let a =
+  fffffff begin (* a *) fun () -> a
+      (* cmt *)
+    end


### PR DESCRIPTION
As written above.  Implementation was annoying, because I had to touch `fmt_function` a little bit.

This is not as clean as the other `begin` PRs, but I don't think I have a choice, because I am trying to replicate a formatting that is already an exception. I tried to share the maximum amount of code.