### PR TITLE
bugfix : Double parens functor constraint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,9 @@ profile. This started with version 0.26.0.
 
 - Fix crash due to edge case with asterisk-prefixed comments (#2674, @Julow)
 
+- Fix double parens around module constraint in functor application :
+  `module M = F ((A : T))` becomes `module M = F (A : T)`. (#2678, @EmileTrotignon)
+
 ### Changed
 
 - `begin if`, `lazy begin`, `begin match` and `begin fun` can now be printed on

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4344,10 +4344,10 @@ and fmt_module_expr ?(dock_struct = true) c ({ast= m; ctx= ctx0} as xmod) =
   | Pmod_constraint (me, mt) ->
       let parens =
         match ctx0 with
-        | Mod {pmod_desc= Pmod_apply (f, _args); _}
-          when not (phys_equal f m) ->
-            (* Pmod_apply arguments always have parens around them, no need to
-               add extra. That's not the case for the applied functor. *)
+        | Mod {pmod_desc= Pmod_apply (f, _args); _} when not (phys_equal f m)
+          ->
+            (* Pmod_apply arguments always have parens around them, no need
+               to add extra. That's not the case for the applied functor. *)
             false
         | _ -> true
       in

--- a/test/passing/refs.default/module.ml.ref
+++ b/test/passing/refs.default/module.ml.ref
@@ -112,3 +112,5 @@ module M =
   module Foo = Bar
 
   type t]
+
+module M = F ((A : T))

--- a/test/passing/refs.default/module.ml.ref
+++ b/test/passing/refs.default/module.ml.ref
@@ -113,4 +113,4 @@ module M =
 
   type t]
 
-module M = F ((A : T))
+module M = F (A : T)

--- a/test/passing/refs.janestreet/module.ml.ref
+++ b/test/passing/refs.janestreet/module.ml.ref
@@ -111,3 +111,5 @@ module M =
     module Foo = Bar
 
     type t]
+
+module M = F ((A : T))

--- a/test/passing/refs.janestreet/module.ml.ref
+++ b/test/passing/refs.janestreet/module.ml.ref
@@ -112,4 +112,4 @@ module M =
 
     type t]
 
-module M = F ((A : T))
+module M = F (A : T)

--- a/test/passing/refs.ocamlformat/module.ml.ref
+++ b/test/passing/refs.ocamlformat/module.ml.ref
@@ -121,3 +121,5 @@ module M =
   module Foo = Bar
 
   type t]
+
+module M = F ((A : T))

--- a/test/passing/refs.ocamlformat/module.ml.ref
+++ b/test/passing/refs.ocamlformat/module.ml.ref
@@ -122,4 +122,4 @@ module M =
 
   type t]
 
-module M = F ((A : T))
+module M = F (A : T)

--- a/test/passing/tests/module.ml
+++ b/test/passing/tests/module.ml
@@ -122,3 +122,6 @@ module M =
   module Foo = Bar
 
   type t]
+
+module M = F (A : T)
+


### PR DESCRIPTION
There used to be a bug where functor application with a constraint had double parens :

```ocaml
module M = F ((A : T))
```

This PR fixes it.

```ocaml
module M = F (A : T)
```