### PR TITLE
Cmdliner 2.0.0 compat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,16 @@ profile. This started with version 0.26.0.
 
 ## unreleased
 
+### Deprecated
+
+- Starting in this release, ocamlformat can use cmdliner >= 2.0.0. When that is
+  the case, the tool no longer accept unambiguous option names prefixes. For
+  example, `--max-iter` is not accepted anymore, you have to pass the full
+  option `--max-iters`. This does not apply to the keys in the `.ocamlformat`
+  configuration files, which have always required the full name.
+  See dbuenzli/cmdliner#200.
+  (#2680, @emillon)
+
 ### Fixed
 
 - Fixed `wrap-comments=true` not working with the janestreet profile (#2645, @Julow)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ profile. This started with version 0.26.0.
 ### Deprecated
 
 - Starting in this release, ocamlformat can use cmdliner >= 2.0.0. When that is
-  the case, the tool no longer accept unambiguous option names prefixes. For
+  the case, the tool no longer accepts unambiguous option names prefixes. For
   example, `--max-iter` is not accepted anymore, you have to pass the full
   option `--max-iters`. This does not apply to the keys in the `.ocamlformat`
   configuration files, which have always required the full name.

--- a/lib/Conf_decl.ml
+++ b/lib/Conf_decl.ml
@@ -11,14 +11,6 @@
 
 module Error = Conf_t.Error
 
-let ocaml_version_conv =
-  let parse x =
-    match Ocaml_version.of_string x with
-    | Ok x -> `Ok x
-    | Error (`Msg x) -> `Error x
-  in
-  (parse, Ocaml_version.pp)
-
 type typ = Int | Bool | Ocaml_version | Choice of string list
 
 module UI = struct
@@ -30,6 +22,8 @@ module UI = struct
 end
 
 open Cmdliner
+
+let ocaml_version_conv = Arg.conv (Ocaml_version.of_string, Ocaml_version.pp)
 
 type kind = Formatting | Operational
 (* type from = [ `Default | `Profile of string * updated_from | `Updated of

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -166,17 +166,17 @@ let check =
 let inputs =
   let docv = "SRC" in
   let file_or_dash =
-    let parse, print = Arg.non_dir_file in
+    let parse = Arg.conv_parser Arg.non_dir_file in
+    let print = Arg.conv_printer Arg.non_dir_file in
     let print fmt = function
       | Stdin -> print fmt "<standard input>"
       | File x -> print fmt x
     in
     let parse = function
-      | "-" -> `Ok Stdin
-      | s -> (
-        match parse s with `Ok x -> `Ok (File x) | `Error x -> `Error x )
+      | "-" -> Ok Stdin
+      | s -> parse s |> Result.map ~f:(fun x -> File x)
     in
-    (parse, print)
+    Arg.conv (parse, print)
   in
   let doc =
     "Input files. At least one is required, and exactly one without \

--- a/test/passing/gen/dune.inc
+++ b/test/passing/gen/dune.inc
@@ -1244,7 +1244,7 @@
  (action
   (with-stdout-to comments_in_record-break_separator-after.ml.stdout
    (with-stderr-to comments_in_record-break_separator-after.ml.stderr
-     (run %{bin:ocamlformat} --name comments_in_record-break_separator-after.ml --margin-check --break-separator=after %{dep:../tests/comments_in_record.ml})))))
+     (run %{bin:ocamlformat} --name comments_in_record-break_separator-after.ml --margin-check --break-separators=after %{dep:../tests/comments_in_record.ml})))))
 
 (rule
  (alias runtest)
@@ -1262,7 +1262,7 @@
  (action
   (with-stdout-to comments_in_record-break_separator-before.ml.stdout
    (with-stderr-to comments_in_record-break_separator-before.ml.stderr
-     (run %{bin:ocamlformat} --name comments_in_record-break_separator-before.ml --margin-check --break-separator=before %{dep:../tests/comments_in_record.ml})))))
+     (run %{bin:ocamlformat} --name comments_in_record-break_separator-before.ml --margin-check --break-separators=before %{dep:../tests/comments_in_record.ml})))))
 
 (rule
  (alias runtest)

--- a/test/passing/gen/dune.inc
+++ b/test/passing/gen/dune.inc
@@ -443,7 +443,7 @@
  (action
   (with-stdout-to break_cases-toplevel.ml.stdout
    (with-stderr-to break_cases-toplevel.ml.stderr
-     (run %{bin:ocamlformat} --name break_cases-toplevel.ml --margin-check --break-cases=toplevel --max-iter=4 %{dep:../tests/break_cases.ml})))))
+     (run %{bin:ocamlformat} --name break_cases-toplevel.ml --margin-check --break-cases=toplevel --max-iters=4 %{dep:../tests/break_cases.ml})))))
 
 (rule
  (alias runtest)
@@ -482,7 +482,7 @@
  (action
   (with-stdout-to break_cases.ml.stdout
    (with-stderr-to break_cases.ml.stderr
-     (run %{bin:ocamlformat} --name break_cases.ml --margin-check --break-cases=fit --max-iter=4 %{dep:../tests/break_cases.ml})))))
+     (run %{bin:ocamlformat} --name break_cases.ml --margin-check --break-cases=fit --max-iters=4 %{dep:../tests/break_cases.ml})))))
 
 (rule
  (alias runtest)
@@ -716,7 +716,7 @@
  (action
   (with-stdout-to break_separators-after.ml.stdout
    (with-stderr-to break_separators-after.ml.stderr
-     (run %{bin:ocamlformat} --name break_separators-after.ml --margin-check --break-separators=after --max-iter=3 %{dep:../tests/break_separators.ml})))))
+     (run %{bin:ocamlformat} --name break_separators-after.ml --margin-check --break-separators=after --max-iters=3 %{dep:../tests/break_separators.ml})))))
 
 (rule
  (alias runtest)
@@ -734,7 +734,7 @@
  (action
   (with-stdout-to break_separators-after_docked.ml.stdout
    (with-stderr-to break_separators-after_docked.ml.stderr
-     (run %{bin:ocamlformat} --name break_separators-after_docked.ml --margin-check --break-separators=after --dock-collection-brackets --max-iter=3 %{dep:../tests/break_separators.ml})))))
+     (run %{bin:ocamlformat} --name break_separators-after_docked.ml --margin-check --break-separators=after --dock-collection-brackets --max-iters=3 %{dep:../tests/break_separators.ml})))))
 
 (rule
  (alias runtest)
@@ -752,7 +752,7 @@
  (action
   (with-stdout-to break_separators-before_docked.ml.stdout
    (with-stderr-to break_separators-before_docked.ml.stderr
-     (run %{bin:ocamlformat} --name break_separators-before_docked.ml --margin-check --break-separators=before --dock-collection-brackets --max-iter=3 %{dep:../tests/break_separators.ml})))))
+     (run %{bin:ocamlformat} --name break_separators-before_docked.ml --margin-check --break-separators=before --dock-collection-brackets --max-iters=3 %{dep:../tests/break_separators.ml})))))
 
 (rule
  (alias runtest)
@@ -770,7 +770,7 @@
  (action
   (with-stdout-to break_separators.ml.stdout
    (with-stderr-to break_separators.ml.stderr
-     (run %{bin:ocamlformat} --name break_separators.ml --margin-check --break-separators=before --max-iter=3 %{dep:../tests/break_separators.ml})))))
+     (run %{bin:ocamlformat} --name break_separators.ml --margin-check --break-separators=before --max-iters=3 %{dep:../tests/break_separators.ml})))))
 
 (rule
  (alias runtest)
@@ -1136,7 +1136,7 @@
  (action
   (with-stdout-to comments-no-wrap.ml.stdout
    (with-stderr-to comments-no-wrap.ml.stderr
-     (run %{bin:ocamlformat} --name comments-no-wrap.ml --margin-check --no-wrap-comments --max-iter=4 %{dep:../tests/comments.ml})))))
+     (run %{bin:ocamlformat} --name comments-no-wrap.ml --margin-check --no-wrap-comments --max-iters=4 %{dep:../tests/comments.ml})))))
 
 (rule
  (alias runtest)
@@ -1154,7 +1154,7 @@
  (action
   (with-stdout-to comments.ml.stdout
    (with-stderr-to comments.ml.stderr
-     (run %{bin:ocamlformat} --name comments.ml --margin-check --max-iter=4 %{dep:../tests/comments.ml})))))
+     (run %{bin:ocamlformat} --name comments.ml --margin-check --max-iters=4 %{dep:../tests/comments.ml})))))
 
 (rule
  (alias runtest)
@@ -1190,7 +1190,7 @@
  (action
   (with-stdout-to comments_args.ml.stdout
    (with-stderr-to comments_args.ml.stderr
-     (run %{bin:ocamlformat} --name comments_args.ml --margin-check --max-iter=4 %{dep:../tests/comments_args.ml})))))
+     (run %{bin:ocamlformat} --name comments_args.ml --margin-check --max-iters=4 %{dep:../tests/comments_args.ml})))))
 
 (rule
  (alias runtest)
@@ -2246,7 +2246,7 @@
  (action
   (with-stdout-to fun_function.ml.stdout
    (with-stderr-to fun_function.ml.stderr
-     (run %{bin:ocamlformat} --name fun_function.ml --margin-check --max-iter=3 %{dep:../tests/fun_function.ml})))))
+     (run %{bin:ocamlformat} --name fun_function.ml --margin-check --max-iters=3 %{dep:../tests/fun_function.ml})))))
 
 (rule
  (alias runtest)
@@ -3167,7 +3167,7 @@
  (action
   (with-stdout-to js_args.ml.stdout
    (with-stderr-to js_args.ml.stderr
-     (run %{bin:ocamlformat} --name js_args.ml --margin-check --max-iter=3 %{dep:../tests/js_args.ml})))))
+     (run %{bin:ocamlformat} --name js_args.ml --margin-check --max-iters=3 %{dep:../tests/js_args.ml})))))
 
 (rule
  (alias runtest)
@@ -3221,7 +3221,7 @@
  (action
   (with-stdout-to js_fun.ml.stdout
    (with-stderr-to js_fun.ml.stderr
-     (run %{bin:ocamlformat} --name js_fun.ml --margin-check --max-iter=3 %{dep:../tests/js_fun.ml})))))
+     (run %{bin:ocamlformat} --name js_fun.ml --margin-check --max-iters=3 %{dep:../tests/js_fun.ml})))))
 
 (rule
  (alias runtest)
@@ -3239,7 +3239,7 @@
  (action
   (with-stdout-to js_map.ml.stdout
    (with-stderr-to js_map.ml.stderr
-     (run %{bin:ocamlformat} --name js_map.ml --margin-check --max-iter=3 %{dep:../tests/js_map.ml})))))
+     (run %{bin:ocamlformat} --name js_map.ml --margin-check --max-iters=3 %{dep:../tests/js_map.ml})))))
 
 (rule
  (alias runtest)
@@ -3275,7 +3275,7 @@
  (action
   (with-stdout-to js_poly.ml.stdout
    (with-stderr-to js_poly.ml.stderr
-     (run %{bin:ocamlformat} --name js_poly.ml --margin-check --max-iter=3 %{dep:../tests/js_poly.ml})))))
+     (run %{bin:ocamlformat} --name js_poly.ml --margin-check --max-iters=3 %{dep:../tests/js_poly.ml})))))
 
 (rule
  (alias runtest)
@@ -3293,7 +3293,7 @@
  (action
   (with-stdout-to js_record.ml.stdout
    (with-stderr-to js_record.ml.stderr
-     (run %{bin:ocamlformat} --name js_record.ml --margin-check --max-iter=3 %{dep:../tests/js_record.ml})))))
+     (run %{bin:ocamlformat} --name js_record.ml --margin-check --max-iters=3 %{dep:../tests/js_record.ml})))))
 
 (rule
  (alias runtest)
@@ -3999,7 +3999,7 @@
  (action
   (with-stdout-to module_item_spacing-preserve.ml.stdout
    (with-stderr-to module_item_spacing-preserve.ml.stderr
-     (run %{bin:ocamlformat} --name module_item_spacing-preserve.ml --margin-check --max-iter=3 --module-item-spacing=preserve %{dep:../tests/module_item_spacing.ml})))))
+     (run %{bin:ocamlformat} --name module_item_spacing-preserve.ml --margin-check --max-iters=3 --module-item-spacing=preserve %{dep:../tests/module_item_spacing.ml})))))
 
 (rule
  (alias runtest)
@@ -4017,7 +4017,7 @@
  (action
   (with-stdout-to module_item_spacing-sparse.ml.stdout
    (with-stderr-to module_item_spacing-sparse.ml.stderr
-     (run %{bin:ocamlformat} --name module_item_spacing-sparse.ml --margin-check --max-iter=3 --module-item-spacing=sparse %{dep:../tests/module_item_spacing.ml})))))
+     (run %{bin:ocamlformat} --name module_item_spacing-sparse.ml --margin-check --max-iters=3 --module-item-spacing=sparse %{dep:../tests/module_item_spacing.ml})))))
 
 (rule
  (alias runtest)
@@ -4035,7 +4035,7 @@
  (action
   (with-stdout-to module_item_spacing.ml.stdout
    (with-stderr-to module_item_spacing.ml.stderr
-     (run %{bin:ocamlformat} --name module_item_spacing.ml --margin-check --max-iter=3 --module-item-spacing=compact %{dep:../tests/module_item_spacing.ml})))))
+     (run %{bin:ocamlformat} --name module_item_spacing.ml --margin-check --max-iters=3 --module-item-spacing=compact %{dep:../tests/module_item_spacing.ml})))))
 
 (rule
  (alias runtest)
@@ -4053,7 +4053,7 @@
  (action
   (with-stdout-to module_item_spacing.mli.stdout
    (with-stderr-to module_item_spacing.mli.stderr
-     (run %{bin:ocamlformat} --name module_item_spacing.mli --margin-check --max-iter=3 %{dep:../tests/module_item_spacing.mli})))))
+     (run %{bin:ocamlformat} --name module_item_spacing.mli --margin-check --max-iters=3 %{dep:../tests/module_item_spacing.mli})))))
 
 (rule
  (alias runtest)
@@ -4829,7 +4829,7 @@
  (action
   (with-stdout-to reformat_string.ml.stdout
    (with-stderr-to reformat_string.ml.stderr
-     (run %{bin:ocamlformat} --name reformat_string.ml --margin-check --max-iter=3 %{dep:../tests/reformat_string.ml})))))
+     (run %{bin:ocamlformat} --name reformat_string.ml --margin-check --max-iters=3 %{dep:../tests/reformat_string.ml})))))
 
 (rule
  (alias runtest)
@@ -4957,7 +4957,7 @@
  (action
   (with-stdout-to sequence-preserve.ml.stdout
    (with-stderr-to sequence-preserve.ml.stderr
-     (run %{bin:ocamlformat} --name sequence-preserve.ml --margin-check --sequence-blank-line=preserve-one --max-iter=3 %{dep:../tests/sequence.ml})))))
+     (run %{bin:ocamlformat} --name sequence-preserve.ml --margin-check --sequence-blank-line=preserve-one --max-iters=3 %{dep:../tests/sequence.ml})))))
 
 (rule
  (alias runtest)

--- a/test/passing/tests/break_cases-toplevel.ml.opts
+++ b/test/passing/tests/break_cases-toplevel.ml.opts
@@ -1,2 +1,2 @@
 --break-cases=toplevel
---max-iter=4
+--max-iters=4

--- a/test/passing/tests/break_cases.ml.opts
+++ b/test/passing/tests/break_cases.ml.opts
@@ -1,2 +1,2 @@
 --break-cases=fit
---max-iter=4
+--max-iters=4

--- a/test/passing/tests/break_separators-after.ml.opts
+++ b/test/passing/tests/break_separators-after.ml.opts
@@ -1,2 +1,2 @@
 --break-separators=after
---max-iter=3
+--max-iters=3

--- a/test/passing/tests/break_separators-after_docked.ml.opts
+++ b/test/passing/tests/break_separators-after_docked.ml.opts
@@ -1,3 +1,3 @@
 --break-separators=after
 --dock-collection-brackets
---max-iter=3
+--max-iters=3

--- a/test/passing/tests/break_separators-before_docked.ml.opts
+++ b/test/passing/tests/break_separators-before_docked.ml.opts
@@ -1,3 +1,3 @@
 --break-separators=before
 --dock-collection-brackets
---max-iter=3
+--max-iters=3

--- a/test/passing/tests/break_separators.ml.opts
+++ b/test/passing/tests/break_separators.ml.opts
@@ -1,2 +1,2 @@
 --break-separators=before
---max-iter=3
+--max-iters=3

--- a/test/passing/tests/comments-no-wrap.ml.opts
+++ b/test/passing/tests/comments-no-wrap.ml.opts
@@ -1,2 +1,2 @@
 --no-wrap-comments
---max-iter=4
+--max-iters=4

--- a/test/passing/tests/comments.ml.opts
+++ b/test/passing/tests/comments.ml.opts
@@ -1,1 +1,1 @@
---max-iter=4
+--max-iters=4

--- a/test/passing/tests/comments_args.ml.opts
+++ b/test/passing/tests/comments_args.ml.opts
@@ -1,1 +1,1 @@
---max-iter=4
+--max-iters=4

--- a/test/passing/tests/comments_in_record-break_separator-after.ml.opts
+++ b/test/passing/tests/comments_in_record-break_separator-after.ml.opts
@@ -1,1 +1,1 @@
---break-separator=after
+--break-separators=after

--- a/test/passing/tests/comments_in_record-break_separator-before.ml.opts
+++ b/test/passing/tests/comments_in_record-break_separator-before.ml.opts
@@ -1,1 +1,1 @@
---break-separator=before
+--break-separators=before

--- a/test/passing/tests/fun_function.ml.opts
+++ b/test/passing/tests/fun_function.ml.opts
@@ -1,1 +1,1 @@
---max-iter=3
+--max-iters=3

--- a/test/passing/tests/js_args.ml.opts
+++ b/test/passing/tests/js_args.ml.opts
@@ -1,1 +1,1 @@
---max-iter=3
+--max-iters=3

--- a/test/passing/tests/js_fun.ml.opts
+++ b/test/passing/tests/js_fun.ml.opts
@@ -1,1 +1,1 @@
---max-iter=3
+--max-iters=3

--- a/test/passing/tests/js_map.ml.opts
+++ b/test/passing/tests/js_map.ml.opts
@@ -1,1 +1,1 @@
---max-iter=3
+--max-iters=3

--- a/test/passing/tests/js_poly.ml.opts
+++ b/test/passing/tests/js_poly.ml.opts
@@ -1,1 +1,1 @@
---max-iter=3
+--max-iters=3

--- a/test/passing/tests/js_record.ml.opts
+++ b/test/passing/tests/js_record.ml.opts
@@ -1,1 +1,1 @@
---max-iter=3
+--max-iters=3

--- a/test/passing/tests/module_item_spacing-preserve.ml.opts
+++ b/test/passing/tests/module_item_spacing-preserve.ml.opts
@@ -1,2 +1,2 @@
---max-iter=3
+--max-iters=3
 --module-item-spacing=preserve

--- a/test/passing/tests/module_item_spacing-sparse.ml.opts
+++ b/test/passing/tests/module_item_spacing-sparse.ml.opts
@@ -1,2 +1,2 @@
---max-iter=3
+--max-iters=3
 --module-item-spacing=sparse

--- a/test/passing/tests/module_item_spacing.ml.opts
+++ b/test/passing/tests/module_item_spacing.ml.opts
@@ -1,2 +1,2 @@
---max-iter=3
+--max-iters=3
 --module-item-spacing=compact

--- a/test/passing/tests/module_item_spacing.mli.opts
+++ b/test/passing/tests/module_item_spacing.mli.opts
@@ -1,1 +1,1 @@
---max-iter=3
+--max-iters=3

--- a/test/passing/tests/reformat_string.ml.opts
+++ b/test/passing/tests/reformat_string.ml.opts
@@ -1,1 +1,1 @@
---max-iter=3
+--max-iters=3

--- a/test/passing/tests/sequence-preserve.ml.opts
+++ b/test/passing/tests/sequence-preserve.ml.opts
@@ -1,1 +1,1 @@
---sequence-blank-line=preserve-one --max-iter=3
+--sequence-blank-line=preserve-one --max-iters=3


### PR DESCRIPTION
Fixes #2667

This adds compatibility with cmdliner 2.0.0 (while keeping the existing code compatible with older versions).

The 2 changes are:
- the `conv` type becomes abstract, so we use `Arg.conv`, `Arg.conv_parser`, and `Arg.conv_printer` where necessary
- unambiguous prefixes are not selected anymore, so we use the full names (`--max-iters` instead of `max-iter`, etc) in tests

This can be tested by pinning cmdliner to its dev branch and ocp-indent to OCamlPro/ocp-indent#328.
