### PR TITLE
Label arg begin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,9 +35,9 @@ profile. This started with version 0.26.0.
 
 ### Changed
 
-- `begin if`, `lazy begin`, `begin match` and `begin fun` can now be printed on
+- \* `~arg:begin`, `begin if`, `lazy begin`, `begin match` and `begin fun` can now be printed on
   the same line, with one less indentation level for the body of the inner
-  expression. (#2664, #2666, #2671, #2672, @EmileTrotignon) For example :
+  expression. (#2664, #2666, #2671, #2672, #2681, @EmileTrotignon) For example :
   ```ocaml
   (* before *)
   begin
@@ -49,27 +49,6 @@ profile. This started with version 0.26.0.
     some code
   end
   ```
-
-- `~args:begin` is now printed on the same line:
-  ```ocaml
-  map
-    ~arg1
-    ~arg2:begin
-      ...
-    end
-    ~arg3
-  ```
-  instead of
-  ```ocaml
-  map
-    ~arg1
-    ~arg2:
-      begin
-        ...
-      end
-    ~arg3
-  ```
-  (#2681, @EmileTrotignon)
 
 ## 0.27.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,27 @@ profile. This started with version 0.26.0.
   end
   ```
 
+- `~args:begin` is now printed on the same line:
+  ```ocaml
+  map
+    ~arg1
+    ~arg2:begin
+      ...
+    end
+    ~arg3
+  ```
+  instead of
+  ```ocaml
+  map
+    ~arg1
+    ~arg2:
+      begin
+        ...
+      end
+    ~arg3
+  ```
+  (#2681, @EmileTrotignon)
+
 ## 0.27.0
 
 ### Highlight

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1685,6 +1685,9 @@ and fmt_label_arg ?(box = true) ?eol c (lbl, ({ast= arg; _} as xarg)) =
                ~pro:(fmt_label lbl (str ":" $ break 0 2))
                ~box xarg )
         $ cmts_after )
+  | (Labelled _ | Optional _), Pexp_beginend _ ->
+      let pro = fmt_label lbl (str ":") in
+      fmt_expression c ~box ~pro xarg
   | (Labelled _ | Optional _), Pexp_function (args, typ, body) ->
       let wrap_intro x = hovbox 2 x $ space_break in
       fmt_function ~box ~ctx:(Exp arg) ~wrap_intro ~ctx0:xarg.ctx ~label:lbl

--- a/test/passing/refs.default/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.default/exp_grouping-parens.ml.ref
@@ -482,3 +482,27 @@ let _ =
       force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
       return value)
     ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:(fun
+        x
+        aaaaaaaaaaaaaaaaaaaaaaaaa
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      ->
+      function_ body;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+      return value)
+    ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:
+      (match
+         x aaaaaaaaaaaaaaaaaaaaaaaaa
+           aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+       with
+      | A -> aaaaaaaaaaaa
+      | B -> bbbbbbbbbbbbbbbbb b bbbbbbbbbbbbbbbbb
+      | C -> c cccccccccccccccccc cccccccccccccccccccccccccccccc)
+    ~last ~args

--- a/test/passing/refs.default/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.default/exp_grouping-parens.ml.ref
@@ -474,3 +474,11 @@ let () =
        b_________________________________________________________________
      else
        c_________________________________________________________________)
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:(fun x ->
+      function_ body;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+      return value)
+    ~last ~args

--- a/test/passing/refs.default/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.default/exp_grouping-parens.ml.ref
@@ -506,3 +506,11 @@ let _ =
       | B -> bbbbbbbbbbbbbbbbb b bbbbbbbbbbbbbbbbb
       | C -> c cccccccccccccccccc cccccccccccccccccccccccccccccc)
     ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:
+      (function_ body;
+       force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+       return value)
+    ~last ~args

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -584,3 +584,12 @@ let _ =
     | C -> c cccccccccccccccccc cccccccccccccccccccccccccccccc
     end
     ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:begin
+      function_ body;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+      return value
+    end
+    ~last ~args

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -552,3 +552,13 @@ let () =
     else
       c_________________________________________________________________
     end
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:
+      begin fun x ->
+        function_ body;
+        force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+        return value
+      end
+    ~last ~args

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -555,10 +555,32 @@ let () =
 
 let _ =
   f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
-    ~label:
-      begin fun x ->
-        function_ body;
-        force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
-        return value
-      end
+    ~label:begin fun x ->
+      function_ body;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+      return value
+    end
+    ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:begin fun x
+      aaaaaaaaaaaaaaaaaaaaaaaaa
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ->
+      function_ body;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+      return value
+    end
+    ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:begin match
+      x aaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    with
+    | A -> aaaaaaaaaaaa
+    | B -> bbbbbbbbbbbbbbbbb b bbbbbbbbbbbbbbbbb
+    | C -> c cccccccccccccccccc cccccccccccccccccccccccccccccc
+    end
     ~last ~args

--- a/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
@@ -578,3 +578,16 @@ let _ =
     ~last
     ~args
 ;;
+
+let _ =
+  f
+    ~aaaaaaaaaaaaaaaaaaaaaaaaaa
+    ~bbbbbbbbbbbbbbbbbbbbbbb
+    ~ccccccccccccccccccccc
+    ~label:
+      (function_ body;
+       force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+       return value)
+    ~last
+    ~args
+;;

--- a/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
@@ -547,3 +547,34 @@ let _ =
     ~last
     ~args
 ;;
+
+let _ =
+  f
+    ~aaaaaaaaaaaaaaaaaaaaaaaaaa
+    ~bbbbbbbbbbbbbbbbbbbbbbb
+    ~ccccccccccccccccccccc
+    ~label:
+      (fun
+        x aaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+      function_ body;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+      return value)
+    ~last
+    ~args
+;;
+
+let _ =
+  f
+    ~aaaaaaaaaaaaaaaaaaaaaaaaaa
+    ~bbbbbbbbbbbbbbbbbbbbbbb
+    ~ccccccccccccccccccccc
+    ~label:
+      (match
+         x aaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+       with
+       | A -> aaaaaaaaaaaa
+       | B -> bbbbbbbbbbbbbbbbb b bbbbbbbbbbbbbbbbb
+       | C -> c cccccccccccccccccc cccccccccccccccccccccccccccccc)
+    ~last
+    ~args
+;;

--- a/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
@@ -534,3 +534,16 @@ let () =
      else
        c_________________________________________________________________)
 ;;
+
+let _ =
+  f
+    ~aaaaaaaaaaaaaaaaaaaaaaaaaa
+    ~bbbbbbbbbbbbbbbbbbbbbbb
+    ~ccccccccccccccccccccc
+    ~label:(fun x ->
+      function_ body;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+      return value)
+    ~last
+    ~args
+;;

--- a/test/passing/refs.janestreet/exp_grouping.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping.ml.ref
@@ -629,12 +629,43 @@ let _ =
     ~aaaaaaaaaaaaaaaaaaaaaaaaaa
     ~bbbbbbbbbbbbbbbbbbbbbbb
     ~ccccccccccccccccccccc
-    ~label:
-      begin fun x ->
-        function_ body;
-        force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
-        return value
-      end
+    ~label:begin fun x ->
+      function_ body;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+      return value
+    end
+    ~last
+    ~args
+;;
+
+let _ =
+  f
+    ~aaaaaaaaaaaaaaaaaaaaaaaaaa
+    ~bbbbbbbbbbbbbbbbbbbbbbb
+    ~ccccccccccccccccccccc
+    ~label:begin fun x
+                   aaaaaaaaaaaaaaaaaaaaaaaaa
+                   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+      function_ body;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+      return value
+    end
+    ~last
+    ~args
+;;
+
+let _ =
+  f
+    ~aaaaaaaaaaaaaaaaaaaaaaaaaa
+    ~bbbbbbbbbbbbbbbbbbbbbbb
+    ~ccccccccccccccccccccc
+    ~label:begin match
+      x aaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    with
+    | A -> aaaaaaaaaaaa
+    | B -> bbbbbbbbbbbbbbbbb b bbbbbbbbbbbbbbbbb
+    | C -> c cccccccccccccccccc cccccccccccccccccccccccccccccc
+    end
     ~last
     ~args
 ;;

--- a/test/passing/refs.janestreet/exp_grouping.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping.ml.ref
@@ -623,3 +623,18 @@ let () =
       c_________________________________________________________________
     end
 ;;
+
+let _ =
+  f
+    ~aaaaaaaaaaaaaaaaaaaaaaaaaa
+    ~bbbbbbbbbbbbbbbbbbbbbbb
+    ~ccccccccccccccccccccc
+    ~label:
+      begin fun x ->
+        function_ body;
+        force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+        return value
+      end
+    ~last
+    ~args
+;;

--- a/test/passing/refs.janestreet/exp_grouping.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping.ml.ref
@@ -669,3 +669,17 @@ let _ =
     ~last
     ~args
 ;;
+
+let _ =
+  f
+    ~aaaaaaaaaaaaaaaaaaaaaaaaaa
+    ~bbbbbbbbbbbbbbbbbbbbbbb
+    ~ccccccccccccccccccccc
+    ~label:begin
+      function_ body;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+      return value
+    end
+    ~last
+    ~args
+;;

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
@@ -473,3 +473,30 @@ let _ =
       force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk ;
       return value )
     ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:(fun
+        x
+        aaaaaaaaaaaaaaaaaaaaaaaaa
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      ->
+      function_ body ;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk ;
+      return value )
+    ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:
+      ( match
+          x aaaaaaaaaaaaaaaaaaaaaaaaa
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        with
+      | A ->
+          aaaaaaaaaaaa
+      | B ->
+          bbbbbbbbbbbbbbbbb b bbbbbbbbbbbbbbbbb
+      | C ->
+          c cccccccccccccccccc cccccccccccccccccccccccccccccc )
+    ~last ~args

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
@@ -465,3 +465,11 @@ let () =
         b_________________________________________________________________
       else
         c_________________________________________________________________ )
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:(fun x ->
+      function_ body ;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk ;
+      return value )
+    ~last ~args

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
@@ -500,3 +500,11 @@ let _ =
       | C ->
           c cccccccccccccccccc cccccccccccccccccccccccccccccc )
     ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:
+      ( function_ body ;
+        force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk ;
+        return value )
+    ~last ~args

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -544,3 +544,13 @@ let () =
     else
       c_________________________________________________________________
     end
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:
+      begin fun x ->
+        function_ body ;
+        force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk ;
+        return value
+      end
+    ~last ~args

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -547,10 +547,35 @@ let () =
 
 let _ =
   f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
-    ~label:
-      begin fun x ->
-        function_ body ;
-        force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk ;
-        return value
-      end
+    ~label:begin fun x ->
+      function_ body ;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk ;
+      return value
+    end
+    ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:begin fun x
+      aaaaaaaaaaaaaaaaaaaaaaaaa
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ->
+      function_ body ;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk ;
+      return value
+    end
+    ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:begin match
+      x aaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    with
+    | A ->
+        aaaaaaaaaaaa
+    | B ->
+        bbbbbbbbbbbbbbbbb b bbbbbbbbbbbbbbbbb
+    | C ->
+        c cccccccccccccccccc cccccccccccccccccccccccccccccc
+    end
     ~last ~args

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -579,3 +579,12 @@ let _ =
         c cccccccccccccccccc cccccccccccccccccccccccccccccc
     end
     ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:begin
+      function_ body ;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk ;
+      return value
+    end
+    ~last ~args

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -439,3 +439,22 @@ let _ =
       return value
     end
     ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:begin fun x aaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+      function_ body;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+      return value
+    end
+    ~last ~args
+
+
+    let _ =
+      f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+        ~label:begin match x aaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa with
+          | A -> aaaaaaaaaaaa
+          | B -> bbbbbbbbbbbbbbbbb b bbbbbbbbbbbbbbbbb
+          | C -> c cccccccccccccccccc cccccccccccccccccccccccccccccc
+        end
+        ~last ~args

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -450,11 +450,11 @@ let _ =
     ~last ~args
 
 
-    let _ =
-      f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
-        ~label:begin match x aaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa with
-          | A -> aaaaaaaaaaaa
-          | B -> bbbbbbbbbbbbbbbbb b bbbbbbbbbbbbbbbbb
-          | C -> c cccccccccccccccccc cccccccccccccccccccccccccccccc
-        end
-        ~last ~args
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:begin match x aaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa with
+      | A -> aaaaaaaaaaaa
+      | B -> bbbbbbbbbbbbbbbbb b bbbbbbbbbbbbbbbbb
+      | C -> c cccccccccccccccccc cccccccccccccccccccccccccccccc
+    end
+    ~last ~args

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -449,12 +449,20 @@ let _ =
     end
     ~last ~args
 
-
 let _ =
   f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
     ~label:begin match x aaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa with
       | A -> aaaaaaaaaaaa
       | B -> bbbbbbbbbbbbbbbbb b bbbbbbbbbbbbbbbbb
       | C -> c cccccccccccccccccc cccccccccccccccccccccccccccccc
+    end
+    ~last ~args
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:begin
+      function_ body;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+      return value
     end
     ~last ~args

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -430,3 +430,12 @@ let () =
     then b_________________________________________________________________
     else c_________________________________________________________________
     end
+
+let _ =
+  f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
+    ~label:begin fun x ->
+      function_ body;
+      force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
+      return value
+    end
+    ~last ~args


### PR DESCRIPTION
fix formatting of `f ~arg:begin ... end ~arg2`:

instead of

```ocaml
f ~arg
  ~arg2:
    begin
      ...
    end
  ~arg3
```
you get: 
```ocaml
f ~arg
  ~arg2:begin
    ...
  end
  ~arg3
```
