### PR TITLE
break-struct apply on sig

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,8 @@ profile. This started with version 0.26.0.
   end
   ```
 
+- \* `break-struct=natural` now also applies to `sig ... end`. (#2682, @EmileTrotignon)
+
 ## 0.27.0
 
 ### Highlight

--- a/doc/manpage_ocamlformat.mld
+++ b/doc/manpage_ocamlformat.mld
@@ -130,10 +130,9 @@ OPTIONS (CODE FORMATTING STYLE)
            expanded. The default value is auto.
 
        --break-struct={force|natural}
-           Break struct-end module items. force will break struct-end and
-           sig-end phrases unconditionally. natural will break struct-end and
-           sig-end phrases naturally at the margin. The default value is
-           force.
+           Break struct-end and sig-end items. force will break items
+           unconditionally. natural will break items naturally at the margin.
+           The default value is force.
 
        --cases-exp-indent=COLS
            Indentation of cases expressions (COLS columns). See also the

--- a/doc/manpage_ocamlformat.mld
+++ b/doc/manpage_ocamlformat.mld
@@ -130,9 +130,10 @@ OPTIONS (CODE FORMATTING STYLE)
            expanded. The default value is auto.
 
        --break-struct={force|natural}
-           Break struct-end module items. force will break struct-end phrases
-           unconditionally. natural will break struct-end phrases naturally
-           at the margin. The default value is force.
+           Break struct-end module items. force will break struct-end and
+           sig-end phrases unconditionally. natural will break struct-end and
+           sig-end phrases naturally at the margin. The default value is
+           force.
 
        --cases-exp-indent=COLS
            Indentation of cases expressions (COLS columns). See also the

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -588,9 +588,9 @@ module Formatting = struct
     let names = ["break-struct"] in
     let all =
       [ Decl.Value.make ~name:"force" `Force
-          "$(b,force) will break struct-end phrases unconditionally."
+          "$(b,force) will break struct-end and sig-end phrases unconditionally."
       ; Decl.Value.make ~name:"natural" `Natural
-          "$(b,natural) will break struct-end phrases naturally at the \
+          "$(b,natural) will break struct-end and sig-end phrases naturally at the \
            margin." ]
     in
     Decl.choice ~names ~all ~default ~doc ~kind

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -588,10 +588,11 @@ module Formatting = struct
     let names = ["break-struct"] in
     let all =
       [ Decl.Value.make ~name:"force" `Force
-          "$(b,force) will break struct-end and sig-end phrases unconditionally."
+          "$(b,force) will break struct-end and sig-end phrases \
+           unconditionally."
       ; Decl.Value.make ~name:"natural" `Natural
-          "$(b,natural) will break struct-end and sig-end phrases naturally at the \
-           margin." ]
+          "$(b,natural) will break struct-end and sig-end phrases naturally \
+           at the margin." ]
     in
     Decl.choice ~names ~all ~default ~doc ~kind
       (fun conf elt ->

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -584,15 +584,13 @@ module Formatting = struct
       (fun conf -> conf.fmt_opts.break_string_literals)
 
   let break_struct =
-    let doc = "Break struct-end module items." in
+    let doc = "Break struct-end and sig-end items." in
     let names = ["break-struct"] in
     let all =
       [ Decl.Value.make ~name:"force" `Force
-          "$(b,force) will break struct-end and sig-end phrases \
-           unconditionally."
+          "$(b,force) will break items unconditionally."
       ; Decl.Value.make ~name:"natural" `Natural
-          "$(b,natural) will break struct-end and sig-end phrases naturally \
-           at the margin." ]
+          "$(b,natural) will break items naturally at the margin." ]
     in
     Decl.choice ~names ~all ~default ~doc ~kind
       (fun conf elt ->

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3770,11 +3770,16 @@ and fmt_module_type c ?(rec_ = false) ({ast= mty; _} as xmty) =
       let after = Cmts.fmt_after c pmty_loc in
       { opn= None
       ; pro= Some (before $ str "sig" $ fmt_if empty (str " "))
-      ; psp= fmt_if (not empty) (if c.conf.fmt_opts.break_struct.v then (break 1000 2) else (break 1 2))
+      ; psp=
+          fmt_if (not empty)
+            ( if c.conf.fmt_opts.break_struct.v then break 1000 2
+              else break 1 2 )
       ; bdy= (within $ if empty then noop else fmt_signature c ctx s)
       ; cls= noop
-      ; esp= fmt_if (not empty)
-      (if c.conf.fmt_opts.break_struct.v then force_break else (break 1 0))
+      ; esp=
+          fmt_if (not empty)
+            ( if c.conf.fmt_opts.break_struct.v then force_break
+              else break 1 0 )
       ; epi=
           Some
             ( str "end" $ after
@@ -4404,12 +4409,14 @@ and fmt_module_expr ?(dock_struct = true) c ({ast= m; _} as xmod) =
       ; pro= Some (before $ str "struct" $ fmt_if empty (str " "))
       ; psp=
           fmt_if (not empty)
-            (if c.conf.fmt_opts.break_struct.v then (break 1000 2) else (break 1 2))
+            ( if c.conf.fmt_opts.break_struct.v then break 1000 2
+              else break 1 2 )
       ; bdy= within $ fmt_structure c ctx sis
       ; cls= noop
       ; esp=
           fmt_if (not empty)
-            (if c.conf.fmt_opts.break_struct.v then force_break else (break 1 0))
+            ( if c.conf.fmt_opts.break_struct.v then force_break
+              else break 1 0 )
       ; epi=
           Some
             ( hovbox_if (not empty) 0

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3770,10 +3770,11 @@ and fmt_module_type c ?(rec_ = false) ({ast= mty; _} as xmty) =
       let after = Cmts.fmt_after c pmty_loc in
       { opn= None
       ; pro= Some (before $ str "sig" $ fmt_if empty (str " "))
-      ; psp= fmt_if (not empty) (break 1000 2)
+      ; psp= fmt_if (not empty) (if c.conf.fmt_opts.break_struct.v then (break 1000 2) else (break 1 2))
       ; bdy= (within $ if empty then noop else fmt_signature c ctx s)
       ; cls= noop
-      ; esp= fmt_if (not empty) force_break
+      ; esp= fmt_if (not empty)
+      (if c.conf.fmt_opts.break_struct.v then force_break else (break 1 0))
       ; epi=
           Some
             ( str "end" $ after
@@ -4403,12 +4404,12 @@ and fmt_module_expr ?(dock_struct = true) c ({ast= m; _} as xmod) =
       ; pro= Some (before $ str "struct" $ fmt_if empty (str " "))
       ; psp=
           fmt_if (not empty)
-            (fmt_or c.conf.fmt_opts.break_struct.v (break 1000 2) (break 1 2))
+            (if c.conf.fmt_opts.break_struct.v then (break 1000 2) else (break 1 2))
       ; bdy= within $ fmt_structure c ctx sis
       ; cls= noop
       ; esp=
           fmt_if (not empty)
-            (fmt_or c.conf.fmt_opts.break_struct.v force_break (break 1 0))
+            (if c.conf.fmt_opts.break_struct.v then force_break else (break 1 0))
       ; epi=
           Some
             ( hovbox_if (not empty) 0

--- a/test/passing/refs.default/functor.ml.ref
+++ b/test/passing/refs.default/functor.ml.ref
@@ -89,3 +89,10 @@ module M : functor (A : S) (B : S) -> S = N
 module M : functor (A : S) (B : S) -> S = N
 module M : functor (A : S) (B : S) -> S = N
 module M : (A : S) -> functor (B : S) -> S = N
+
+[@@@ocamlformat "break-struct=natural"]
+
+module M = F ((struct type t end : sig type t end))
+module M = struct type t end
+
+module type S = sig type t end

--- a/test/passing/refs.janestreet/functor.ml.ref
+++ b/test/passing/refs.janestreet/functor.ml.ref
@@ -86,3 +86,12 @@ module M : functor (A : S) (B : S) -> S = N
 module M : functor (A : S) (B : S) -> S = N
 module M : functor (A : S) (B : S) -> S = N
 module M : (A : S) -> functor (B : S) -> S = N
+
+[@@@ocamlformat "break-struct=natural"]
+
+module M = F ((
+    struct type t end : sig type t end))
+
+module M = struct type t end
+
+module type S = sig type t end

--- a/test/passing/refs.ocamlformat/functor.ml.ref
+++ b/test/passing/refs.ocamlformat/functor.ml.ref
@@ -114,3 +114,11 @@ module M : functor (A : S) (B : S) -> S = N
 module M : functor (A : S) (B : S) -> S = N
 
 module M : (A : S) -> functor (B : S) -> S = N
+
+[@@@ocamlformat "break-struct=natural"]
+
+module M = F ((struct type t end : sig type t end))
+
+module M = struct type t end
+
+module type S = sig type t end

--- a/test/passing/tests/functor.ml
+++ b/test/passing/tests/functor.ml
@@ -110,3 +110,11 @@ module M : functor (A : S) -> functor (B : S) -> S = N
 module M : functor (A : S) (B : S) -> S = N
 module M : functor (A : S) -> functor (B : S) -> S = N
 module M : (A : S) -> functor (B : S) -> S = N
+
+[@@@ocamlformat "break-struct=natural"]
+
+module M = F ((struct type t end : sig type t end))
+
+module M = struct type t end
+
+module type S = sig type t end


### PR DESCRIPTION
The `break-struct=natural` setting allows `struct ... end` syntax to be printed on one line.

However, it did not apply to `sig ... end`, which is a very similar syntax. I made it more consistent, even if it does not exactly fit the name. 

I also switched the code I touched from `fmt_or` to `if then else`, which does the same thing but without confusing you.