### PR TITLE
`|> map (fun` is indented correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,17 @@ profile. This started with version 0.26.0.
   (* after *)
   print_endline "foo" ;;
   let a = 3
+
+- \* `|> map (fun` is now indented from `|>` and not from `map` (#2686, @EmileTrotignon):
+  ```ocaml
+  (* before *)
+  v
+  |>>>>>> map (fun x ->
+              x )
+  (* after *)
+  v
+  |>>>>>> map (fun x ->
+      x )
   ```
 
 ## 0.27.0

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -97,14 +97,14 @@ let json_of_ols_results ?name (results : Bechamel.Analyze.OLS.t results) :
   let results =
     metrics_by_test |> Hashtbl.to_seq
     |> Seq.map (fun (test_name, metrics) ->
-           let metrics =
-             metrics |> Hashtbl.to_seq
-             |> Seq.map (fun (metric_name, ols) ->
-                    (metric_name, json_of_ols ols) )
-             |> List.of_seq
-             |> fun bindings -> `Assoc bindings
-           in
-           `Assoc [("name", `String test_name); ("metrics", metrics)] )
+        let metrics =
+          metrics |> Hashtbl.to_seq
+          |> Seq.map (fun (metric_name, ols) ->
+              (metric_name, json_of_ols ols) )
+          |> List.of_seq
+          |> fun bindings -> `Assoc bindings
+        in
+        `Assoc [("name", `String test_name); ("metrics", metrics)] )
     |> List.of_seq
     |> fun items -> `List items
   in

--- a/bin/ocamlformat/dune
+++ b/bin/ocamlformat/dune
@@ -18,8 +18,7 @@
   (:standard -open Ocamlformat_stdlib))
  (instrumentation
   (backend bisect_ppx))
- (libraries ocamlformat-lib bin_conf)
- (modes byte native))
+ (libraries ocamlformat-lib bin_conf))
 
 (rule
  (with-stdout-to

--- a/bin/ocamlformat/dune
+++ b/bin/ocamlformat/dune
@@ -18,7 +18,8 @@
   (:standard -open Ocamlformat_stdlib))
  (instrumentation
   (backend bisect_ppx))
- (libraries ocamlformat-lib bin_conf))
+ (libraries ocamlformat-lib bin_conf)
+ (modes byte native))
 
 (rule
  (with-stdout-to

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -979,7 +979,7 @@ end = struct
         assert (
           List.exists ptype_params ~f:fst_f
           || List.exists ptype_cstrs ~f:(fun (t1, t2, _) ->
-                 typ == t1 || typ == t2 )
+              typ == t1 || typ == t2 )
           || ( match ptype_kind with
              | Ptype_variant cd1N ->
                  List.exists cd1N ~f:(fun {pcd_args; pcd_res; _} ->
@@ -1517,7 +1517,7 @@ end = struct
     | Pexp_record (e1N, e0) ->
         Option.for_all e0 ~f:Exp.is_trivial
         && List.for_all e1N ~f:(fun (_, c, eo) ->
-               Option.is_none c && Option.for_all eo ~f:Exp.is_trivial )
+            Option.is_none c && Option.for_all eo ~f:Exp.is_trivial )
         && fit_margin c (width xexp)
     | Pexp_indexop_access {pia_lhs; pia_kind; pia_rhs= None; _} ->
         Exp.is_trivial pia_lhs
@@ -2202,7 +2202,7 @@ end = struct
         | Pexp_infix (_, _, e2)
           when e2 == exp
                && Option.value_map ~default:false (prec_ast ctx) ~f:(fun p ->
-                      Prec.compare p Apply < 0 ) ->
+                   Prec.compare p Apply < 0 ) ->
             true
         | Pexp_tuple e1N -> List.last_exn e1N == xexp.ast
         | _ -> false

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1858,6 +1858,7 @@ and fmt_infix_op_args c ~parens xexp op_args =
       match xarg.ast.pexp_desc with
       | Pexp_function _ | Pexp_beginend _ ->
           hvbox 0 (fmt_expression c ~pro ~parens xarg)
+      | _ when Params.Exp.is_apply_and_last_arg_is_function_and_other_args_are_simple c.conf xarg.ast ->  hvbox 0 (fmt_expression c ~pro ~parens xarg)
       | _ ->
           hvbox 0
             ( pro

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -494,8 +494,8 @@ let fmt_tag_args ?arg ?txt c tag =
   at $ str tag
   $ opt arg (fun x -> char ' ' $ x)
   $ opt txt (function
-      | [] -> noop
-      | x -> space_break $ hovbox 0 (fmt_nestable_block_elements c x) )
+    | [] -> noop
+    | x -> space_break $ hovbox 0 (fmt_nestable_block_elements c x) )
 
 let wrap_see = function
   | `Url -> wrap (str "<") (str ">")

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -43,7 +43,7 @@ let dedup_cmts fragment ast comments =
 let normalize_comments ~normalize_cmt dedup fmt comments =
   dedup comments
   |> List.sort ~compare:(fun a b ->
-         Migrate_ast.Location.compare (Cmt.loc a) (Cmt.loc b) )
+      Migrate_ast.Location.compare (Cmt.loc a) (Cmt.loc b) )
   |> List.iter ~f:(fun cmt -> Format.fprintf fmt "%s," (normalize_cmt cmt))
 
 let normalize_parse_result ~normalize_cmt ast_kind ast comments =

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -350,9 +350,10 @@ module Exp = struct
        If a label is present, arguments should be indented more than the
        arrow and the eventually breaking [fun] keyword. *)
     if c.fmt_opts.ocp_indent_compat.v then str ":" $ cut_break else str ":"
+
   let is_apply_and_last_arg_is_function_and_other_args_are_simple c exp =
     match exp.pexp_desc with
-    |  Pexp_apply (_, args) ->
+    | Pexp_apply (_, args) ->
         let (_lbl, last_arg), args_before =
           match List.rev args with
           | [] -> assert false
@@ -362,7 +363,11 @@ module Exp = struct
           List.for_all args_before ~f:(fun (_, eI) ->
               is_simple c (fun _ -> 0) (sub_exp ~ctx:(Exp exp) eI) )
         in
-        let is_function = match last_arg.pexp_desc with Pexp_function _ -> true | _ -> false in
+        let is_function =
+          match last_arg.pexp_desc with
+          | Pexp_function _ -> true
+          | _ -> false
+        in
         is_function && args_are_simple
     | _ -> false
 end

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -350,6 +350,21 @@ module Exp = struct
        If a label is present, arguments should be indented more than the
        arrow and the eventually breaking [fun] keyword. *)
     if c.fmt_opts.ocp_indent_compat.v then str ":" $ cut_break else str ":"
+  let is_apply_and_last_arg_is_function_and_other_args_are_simple c exp =
+    match exp.pexp_desc with
+    |  Pexp_apply (_, args) ->
+        let (_lbl, last_arg), args_before =
+          match List.rev args with
+          | [] -> assert false
+          | hd :: tl -> (hd, List.rev tl)
+        in
+        let args_are_simple =
+          List.for_all args_before ~f:(fun (_, eI) ->
+              is_simple c (fun _ -> 0) (sub_exp ~ctx:(Exp exp) eI) )
+        in
+        let is_function = match last_arg.pexp_desc with Pexp_function _ -> true | _ -> false in
+        is_function && args_are_simple
+    | _ -> false
 end
 
 module Mod = struct

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -252,7 +252,7 @@ module Exp = struct
       then 4
       else 2
     in
-    let name = "Params.box_fun_expr" in
+    let name = Printf.sprintf "Params.box_fun_expr %i" indent in
     let mkbox = if ctx_is_let_or_fun ~ctx ctx0 then hvbox else hovbox in
     (mkbox ~name indent, ~-indent)
 

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -100,6 +100,7 @@ module Exp : sig
     Conf_t.t -> ctx:Ast.t -> ctx0:Ast.t -> bool
 
   val fun_label_sep : Conf.t -> Fmt.t
+  val is_apply_and_last_arg_is_function_and_other_args_are_simple: Conf.t -> expression -> bool
 end
 
 module Mod : sig

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -100,7 +100,9 @@ module Exp : sig
     Conf_t.t -> ctx:Ast.t -> ctx0:Ast.t -> bool
 
   val fun_label_sep : Conf.t -> Fmt.t
-  val is_apply_and_last_arg_is_function_and_other_args_are_simple: Conf.t -> expression -> bool
+
+  val is_apply_and_last_arg_is_function_and_other_args_are_simple :
+    Conf.t -> expression -> bool
 end
 
 module Mod : sig

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -297,7 +297,7 @@ let format (type ext std) (ext_fg : ext Extended_ast.t)
       let exn_args () =
         [("output file", dump_formatted ~suffix:".invalid-ast" fmted)]
         |> List.filter_map ~f:(fun (s, f_opt) ->
-               Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)) )
+            Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)) )
       in
       let* ext_t_new =
         match
@@ -339,7 +339,7 @@ let format (type ext std) (ext_fg : ext Extended_ast.t)
             ; ("old ast", old_ast)
             ; ("new ast", new_ast) ]
             |> List.filter_map ~f:(fun (s, f_opt) ->
-                   Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)) )
+                Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)) )
           in
           if
             Normalize_std_ast.equal std_fg ~ignore_doc_comments:true conf

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -467,7 +467,7 @@ let is_in_listing_file ~listings ~filename =
               In_channel.input_lines ch
               |> Migrate_ast.Location.of_lines ~filename:listing_filename
               |> List.filter ~f:(fun Location.{txt= l; _} ->
-                     not (drop_line l) )
+                  not (drop_line l) )
             in
             List.find_map lines ~f:(fun {txt= line; loc} ->
                 match Fpath.of_string line with

--- a/test/passing/refs.default/attributes.ml.ref
+++ b/test/passing/refs.default/attributes.ml.ref
@@ -407,7 +407,7 @@ let () =
     S.ntyp Cbor_type.Reserved
     @@ (S.tok (fun ev ->
             match ev with Cbor_event.Reserved int -> Some int | _ -> None)
-       [@warning "-4"])
+    [@warning "-4"])
   in
   ()
 ;;

--- a/test/passing/refs.default/infix_arg_grouping.ml.err
+++ b/test/passing/refs.default/infix_arg_grouping.ml.err
@@ -1,1 +1,2 @@
-Warning: infix_arg_grouping.ml:74 exceeds the margin
+Warning: infix_arg_grouping.ml:26 exceeds the margin
+Warning: infix_arg_grouping.ml:72 exceeds the margin

--- a/test/passing/refs.default/infix_arg_grouping.ml.ref
+++ b/test/passing/refs.default/infix_arg_grouping.ml.ref
@@ -11,22 +11,20 @@ user_error
 hvbox 1
   (str "\""
   $ list_pn lines (fun ?prev curr ?next ->
-        let drop = function ' ' -> true | _ -> false in
-        let line =
-          if Option.is_none prev then curr else String.lstrip ~drop curr
-        in
-        fmt_line line
-        $ opt next (fun next ->
-              let spc =
-                match String.lfindi next ~f:(fun _ c -> not (drop c)) with
-                | Some 0 -> ""
-                | Some i -> escape_string (String.sub next 0 i)
-                | None -> escape_string next
-              in
-              fmt "\\n"
-              $ fmt_if_k
-                  (not (String.is_empty next))
-                  (str spc $ pre_break 0 "\\" 0)))
+      let drop = function ' ' -> true | _ -> false in
+      let line =
+        if Option.is_none prev then curr else String.lstrip ~drop curr
+      in
+      fmt_line line
+      $ opt next (fun next ->
+          let spc =
+            match String.lfindi next ~f:(fun _ c -> not (drop c)) with
+            | Some 0 -> ""
+            | Some i -> escape_string (String.sub next 0 i)
+            | None -> escape_string next
+          in
+          fmt "\\n"
+          $ fmt_if_k (not (String.is_empty next)) (str spc $ pre_break 0 "\\" 0)))
   $ str "\"" $ Option.call ~f:epi)
 ;;
 
@@ -56,8 +54,8 @@ hvbox 0
   $ wrap "(" ")"
       (str txt
       $ opt mt (fun _ ->
-            fmt "@ : " $ Option.call ~f:pro_t $ psp_t $ fmt "@;<1 2>" $ bdy_t
-            $ esp_t $ Option.call ~f:epi_t))
+          fmt "@ : " $ Option.call ~f:pro_t $ psp_t $ fmt "@;<1 2>" $ bdy_t
+          $ esp_t $ Option.call ~f:epi_t))
   $ fmt " ->@ " $ Option.call ~f:pro_e $ psp_e $ bdy_e $ esp_e
   $ Option.call ~f:epi_e)
 ;;

--- a/test/passing/refs.default/js_source.ml.ref
+++ b/test/passing/refs.default/js_source.ml.ref
@@ -700,7 +700,7 @@ let _ =
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
-       ~fooooooooooooooooooooooooooooooo:(fun foo -> bar)
+    ~fooooooooooooooooooooooooooooooo:(fun foo -> bar)
 
 let _ =
   fooooooooooooooooooooooooooooooo
@@ -711,29 +711,29 @@ let _ =
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
-       ~fooooooooooooooooooooooooooooooo:(fun foo ->
+    ~fooooooooooooooooooooooooooooooo:(fun foo ->
       match bar with Some _ -> foo | None -> baz)
 
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
-       (fun foo -> bar)
+    (fun foo -> bar)
 
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
-       (fun foo -> match bar with Some _ -> foo | None -> baz)
+    (fun foo -> match bar with Some _ -> foo | None -> baz)
 
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
-       ~fooooooooooooooooooooooooooooooo (fun foo ->
+    ~fooooooooooooooooooooooooooooooo (fun foo ->
       match bar with Some _ -> foo | None -> baz)
 
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooofooooooooooooooooooooooooooooooofoooooooooo
-       (fun foo -> match bar with Some _ -> foo | None -> baz)
+    (fun foo -> match bar with Some _ -> foo | None -> baz)
 
 let _ =
   fooooooooooooooooooooooooooooooo
@@ -743,7 +743,7 @@ let _ =
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
-       (function
+    (function
     | Some _ -> foo
     | None -> baz)
 

--- a/test/passing/refs.default/js_source.ml.ref
+++ b/test/passing/refs.default/js_source.ml.ref
@@ -298,16 +298,16 @@ let x =
 let x =
   some_value
   |> some_fun (fun x ->
-         do_something ();
-         do_something_else ();
-         return_this_value)
+      do_something ();
+      do_something_else ();
+      return_this_value)
 
 let x =
   some_value
   ^ some_fun (fun x ->
-        do_something ();
-        do_something_else ();
-        return_this_value)
+      do_something ();
+      do_something_else ();
+      return_this_value)
 
 let bind t ~f =
   unfold_step
@@ -398,20 +398,20 @@ let _ =
 let _ =
   foo
   |> List.map ~f:(fun x ->
-         do_something ();
-         do_something ();
-         do_something ();
-         do_something ();
-         do_something_else ())
+      do_something ();
+      do_something ();
+      do_something ();
+      do_something ();
+      do_something_else ())
 
 let _ =
   foo
   |> List.map ~f:(fun x ->
-         do_something ();
-         do_something ();
-         do_something ();
-         do_something ();
-         do_something_else ())
+      do_something ();
+      do_something ();
+      do_something ();
+      do_something ();
+      do_something_else ())
   |> bar
 
 let _ =
@@ -424,11 +424,11 @@ let _ = foo |> List.map (function A -> do_something ())
 let _ =
   foo
   |> List.map (function
-       | A -> do_something ()
-       | A -> do_something ()
-       | A -> do_something ()
-       | A -> do_something ()
-       | A -> do_something_else ())
+    | A -> do_something ()
+    | A -> do_something ()
+    | A -> do_something ()
+    | A -> do_something ()
+    | A -> do_something_else ())
   |> bar
 
 let _ =
@@ -712,7 +712,7 @@ let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
        ~fooooooooooooooooooooooooooooooo:(fun foo ->
-         match bar with Some _ -> foo | None -> baz)
+      match bar with Some _ -> foo | None -> baz)
 
 let _ =
   fooooooooooooooooooooooooooooooo
@@ -728,7 +728,7 @@ let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
        ~fooooooooooooooooooooooooooooooo (fun foo ->
-         match bar with Some _ -> foo | None -> baz)
+      match bar with Some _ -> foo | None -> baz)
 
 let _ =
   fooooooooooooooooooooooooooooooo
@@ -738,14 +738,14 @@ let _ =
 let _ =
   fooooooooooooooooooooooooooooooo
   |> foooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (function
-         | foo -> bar)
+      | foo -> bar)
 
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
        (function
-       | Some _ -> foo
-       | None -> baz)
+    | Some _ -> foo
+    | None -> baz)
 
 (* *)
 

--- a/test/passing/refs.default/list-space_around.ml.ref
+++ b/test/passing/refs.default/list-space_around.ml.ref
@@ -72,7 +72,7 @@ let _ =
   make_single_trace create_loc message
   :: make_single_trace create_loc create_message
   :: List.map call_chain ~f:(fun foooooooooooooooooooooooooooo ->
-         fooooooooooooooooooooooooooooooo foooooooooooo [])
+      fooooooooooooooooooooooooooooooo foooooooooooo [])
   :: foooooooo :: fooooooooooooooooo
 
 let _ =

--- a/test/passing/refs.default/list.ml.ref
+++ b/test/passing/refs.default/list.ml.ref
@@ -72,7 +72,7 @@ let _ =
   make_single_trace create_loc message
   :: make_single_trace create_loc create_message
   :: List.map call_chain ~f:(fun foooooooooooooooooooooooooooo ->
-         fooooooooooooooooooooooooooooooo foooooooooooo [])
+      fooooooooooooooooooooooooooooooo foooooooooooo [])
   :: foooooooo :: fooooooooooooooooo
 
 let _ =

--- a/test/passing/refs.default/max_indent.ml.ref
+++ b/test/passing/refs.default/max_indent.ml.ref
@@ -13,6 +13,14 @@ let () =
     in
     fooooooooooo x)
 
+let () =
+  List.iter
+    (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
+    let x =
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+    in
+    fooooooooooo x)
+
 let foooooooooo =
   foooooooooooooooooooooo
   |> Option.bind ~f:(function

--- a/test/passing/refs.default/max_indent.ml.ref
+++ b/test/passing/refs.default/max_indent.ml.ref
@@ -1,25 +1,25 @@
 let () =
   fooooo
   |> List.iter (fun x ->
-       let x = x $ y in
-       fooooooooooo x)
+    let x = x $ y in
+    fooooooooooo x)
 
 let () =
   fooooo
   |> List.iter
        (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
-       let x =
-         some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
-       in
-       fooooooooooo x)
+    let x =
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+    in
+    fooooooooooo x)
 
 let foooooooooo =
   foooooooooooooooooooooo
   |> Option.bind ~f:(function
-       | Pform.Expansion.Var (Values l) -> Some (static l)
-       | Macro (Ocaml_config, s) ->
-         Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
-       | Macro (Env, s) -> Option.map ~f:static (expand_env t var s))
+    | Pform.Expansion.Var (Values l) -> Some (static l)
+    | Macro (Ocaml_config, s) ->
+      Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
+    | Macro (Env, s) -> Option.map ~f:static (expand_env t var s))
 
 let fooooooooooooo =
   match lbls with
@@ -88,13 +88,13 @@ let x =
 let x =
   some_value
   |> some_fun (fun x ->
-       do_something ();
-       do_something_else ();
-       return_this_value)
+    do_something ();
+    do_something_else ();
+    return_this_value)
 
 let x =
   some_value
   ^ some_fun (fun x ->
-      do_something ();
-      do_something_else ();
-      return_this_value)
+    do_something ();
+    do_something_else ();
+    return_this_value)

--- a/test/passing/refs.default/max_indent.ml.ref
+++ b/test/passing/refs.default/max_indent.ml.ref
@@ -7,7 +7,7 @@ let () =
 let () =
   fooooo
   |> List.iter
-       (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
+    (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
     let x =
       some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
     in

--- a/test/passing/refs.janestreet/max_indent.ml.err
+++ b/test/passing/refs.janestreet/max_indent.ml.err
@@ -1,1 +1,1 @@
-Warning: max_indent.ml:34 exceeds the margin
+Warning: max_indent.ml:40 exceeds the margin

--- a/test/passing/refs.janestreet/max_indent.ml.ref
+++ b/test/passing/refs.janestreet/max_indent.ml.ref
@@ -12,6 +12,12 @@ let () =
     fooooooooooo x)
 ;;
 
+let () =
+  List.iter (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
+    let x = some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y in
+    fooooooooooo x)
+;;
+
 let foooooooooo =
   foooooooooooooooooooooo
   |> Option.bind ~f:(function

--- a/test/passing/refs.ocamlformat/attributes.ml.ref
+++ b/test/passing/refs.ocamlformat/attributes.ml.ref
@@ -453,7 +453,7 @@ let () =
     S.ntyp Cbor_type.Reserved
     @@ (S.tok (fun ev ->
             match ev with Cbor_event.Reserved int -> Some int | _ -> None )
-       [@warning "-4"] )
+    [@warning "-4"] )
   in
   ()
 ;;

--- a/test/passing/refs.ocamlformat/infix_arg_grouping.ml.err
+++ b/test/passing/refs.ocamlformat/infix_arg_grouping.ml.err
@@ -1,0 +1,1 @@
+Warning: infix_arg_grouping.ml:29 exceeds the margin

--- a/test/passing/refs.ocamlformat/infix_arg_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/infix_arg_grouping.ml.ref
@@ -11,25 +11,23 @@ user_error
 hvbox 1
   ( str "\""
   $ list_pn lines (fun ?prev curr ?next ->
-        let drop = function ' ' -> true | _ -> false in
-        let line =
-          if Option.is_none prev then curr else String.lstrip ~drop curr
-        in
-        fmt_line line
-        $ opt next (fun next ->
-              let spc =
-                match String.lfindi next ~f:(fun _ c -> not (drop c)) with
-                | Some 0 ->
-                    ""
-                | Some i ->
-                    escape_string (String.sub next 0 i)
-                | None ->
-                    escape_string next
-              in
-              fmt "\\n"
-              $ fmt_if_k
-                  (not (String.is_empty next))
-                  (str spc $ pre_break 0 "\\" 0) ) )
+      let drop = function ' ' -> true | _ -> false in
+      let line =
+        if Option.is_none prev then curr else String.lstrip ~drop curr
+      in
+      fmt_line line
+      $ opt next (fun next ->
+          let spc =
+            match String.lfindi next ~f:(fun _ c -> not (drop c)) with
+            | Some 0 ->
+                ""
+            | Some i ->
+                escape_string (String.sub next 0 i)
+            | None ->
+                escape_string next
+          in
+          fmt "\\n"
+          $ fmt_if_k (not (String.is_empty next)) (str spc $ pre_break 0 "\\" 0) ) )
   $ str "\"" $ Option.call ~f:epi )
 ;;
 
@@ -60,8 +58,8 @@ hvbox 0
   $ wrap "(" ")"
       ( str txt
       $ opt mt (fun _ ->
-            fmt "@ : " $ Option.call ~f:pro_t $ psp_t $ fmt "@;<1 2>" $ bdy_t
-            $ esp_t $ Option.call ~f:epi_t ) )
+          fmt "@ : " $ Option.call ~f:pro_t $ psp_t $ fmt "@;<1 2>" $ bdy_t
+          $ esp_t $ Option.call ~f:epi_t ) )
   $ fmt " ->@ " $ Option.call ~f:pro_e $ psp_e $ bdy_e $ esp_e
   $ Option.call ~f:epi_e )
 ;;

--- a/test/passing/refs.ocamlformat/js_source.ml.ref
+++ b/test/passing/refs.ocamlformat/js_source.ml.ref
@@ -289,12 +289,12 @@ let x =
 let x =
   some_value
   |> some_fun (fun x ->
-         do_something () ; do_something_else () ; return_this_value )
+      do_something () ; do_something_else () ; return_this_value )
 
 let x =
   some_value
   ^ some_fun (fun x ->
-        do_something () ; do_something_else () ; return_this_value )
+      do_something () ; do_something_else () ; return_this_value )
 
 let bind t ~f =
   unfold_step
@@ -391,20 +391,20 @@ let _ =
 let _ =
   foo
   |> List.map ~f:(fun x ->
-         do_something () ;
-         do_something () ;
-         do_something () ;
-         do_something () ;
-         do_something_else () )
+      do_something () ;
+      do_something () ;
+      do_something () ;
+      do_something () ;
+      do_something_else () )
 
 let _ =
   foo
   |> List.map ~f:(fun x ->
-         do_something () ;
-         do_something () ;
-         do_something () ;
-         do_something () ;
-         do_something_else () )
+      do_something () ;
+      do_something () ;
+      do_something () ;
+      do_something () ;
+      do_something_else () )
   |> bar
 
 let _ =
@@ -417,16 +417,16 @@ let _ = foo |> List.map (function A -> do_something ())
 let _ =
   foo
   |> List.map (function
-       | A ->
-           do_something ()
-       | A ->
-           do_something ()
-       | A ->
-           do_something ()
-       | A ->
-           do_something ()
-       | A ->
-           do_something_else () )
+    | A ->
+        do_something ()
+    | A ->
+        do_something ()
+    | A ->
+        do_something ()
+    | A ->
+        do_something ()
+    | A ->
+        do_something_else () )
   |> bar
 
 let _ =
@@ -720,7 +720,7 @@ let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
        ~fooooooooooooooooooooooooooooooo:(fun foo ->
-         match bar with Some _ -> foo | None -> baz )
+      match bar with Some _ -> foo | None -> baz )
 
 let _ =
   fooooooooooooooooooooooooooooooo
@@ -736,7 +736,7 @@ let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
        ~fooooooooooooooooooooooooooooooo (fun foo ->
-         match bar with Some _ -> foo | None -> baz )
+      match bar with Some _ -> foo | None -> baz )
 
 let _ =
   fooooooooooooooooooooooooooooooo
@@ -746,16 +746,16 @@ let _ =
 let _ =
   fooooooooooooooooooooooooooooooo
   |> foooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (function
-         | foo -> bar )
+      | foo -> bar )
 
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
        (function
-       | Some _ ->
-           foo
-       | None ->
-           baz )
+    | Some _ ->
+        foo
+    | None ->
+        baz )
 
 (* *)
 

--- a/test/passing/refs.ocamlformat/js_source.ml.ref
+++ b/test/passing/refs.ocamlformat/js_source.ml.ref
@@ -708,7 +708,7 @@ let _ =
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
-       ~fooooooooooooooooooooooooooooooo:(fun foo -> bar )
+    ~fooooooooooooooooooooooooooooooo:(fun foo -> bar )
 
 let _ =
   fooooooooooooooooooooooooooooooo
@@ -719,29 +719,29 @@ let _ =
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
-       ~fooooooooooooooooooooooooooooooo:(fun foo ->
+    ~fooooooooooooooooooooooooooooooo:(fun foo ->
       match bar with Some _ -> foo | None -> baz )
 
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
-       (fun foo -> bar )
+    (fun foo -> bar )
 
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
-       (fun foo -> match bar with Some _ -> foo | None -> baz )
+    (fun foo -> match bar with Some _ -> foo | None -> baz )
 
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
-       ~fooooooooooooooooooooooooooooooo (fun foo ->
+    ~fooooooooooooooooooooooooooooooo (fun foo ->
       match bar with Some _ -> foo | None -> baz )
 
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooofooooooooooooooooooooooooooooooofoooooooooo
-       (fun foo -> match bar with Some _ -> foo | None -> baz )
+    (fun foo -> match bar with Some _ -> foo | None -> baz )
 
 let _ =
   fooooooooooooooooooooooooooooooo
@@ -751,7 +751,7 @@ let _ =
 let _ =
   fooooooooooooooooooooooooooooooo
   |> fooooooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo
-       (function
+    (function
     | Some _ ->
         foo
     | None ->

--- a/test/passing/refs.ocamlformat/list-space_around.ml.ref
+++ b/test/passing/refs.ocamlformat/list-space_around.ml.ref
@@ -79,7 +79,7 @@ let _ =
   make_single_trace create_loc message
   :: make_single_trace create_loc create_message
   :: List.map call_chain ~f:(fun foooooooooooooooooooooooooooo ->
-         fooooooooooooooooooooooooooooooo foooooooooooo [] )
+      fooooooooooooooooooooooooooooooo foooooooooooo [] )
   :: foooooooo :: fooooooooooooooooo
 
 let _ =

--- a/test/passing/refs.ocamlformat/list.ml.ref
+++ b/test/passing/refs.ocamlformat/list.ml.ref
@@ -77,7 +77,7 @@ let _ =
   make_single_trace create_loc message
   :: make_single_trace create_loc create_message
   :: List.map call_chain ~f:(fun foooooooooooooooooooooooooooo ->
-         fooooooooooooooooooooooooooooooo foooooooooooo [] )
+      fooooooooooooooooooooooooooooooo foooooooooooo [] )
   :: foooooooo :: fooooooooooooooooo
 
 let _ =

--- a/test/passing/refs.ocamlformat/max_indent.ml.ref
+++ b/test/passing/refs.ocamlformat/max_indent.ml.ref
@@ -7,7 +7,7 @@ let () =
 let () =
   fooooo
   |> List.iter
-       (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
+    (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
     let x =
       some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
     in

--- a/test/passing/refs.ocamlformat/max_indent.ml.ref
+++ b/test/passing/refs.ocamlformat/max_indent.ml.ref
@@ -13,6 +13,14 @@ let () =
     in
     fooooooooooo x )
 
+let () =
+  List.iter
+    (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
+    let x =
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+    in
+    fooooooooooo x )
+
 let foooooooooo =
   foooooooooooooooooooooo
   |> Option.bind ~f:(function

--- a/test/passing/refs.ocamlformat/max_indent.ml.ref
+++ b/test/passing/refs.ocamlformat/max_indent.ml.ref
@@ -1,27 +1,27 @@
 let () =
   fooooo
   |> List.iter (fun x ->
-       let x = x $ y in
-       fooooooooooo x )
+    let x = x $ y in
+    fooooooooooo x )
 
 let () =
   fooooo
   |> List.iter
        (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
-       let x =
-         some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
-       in
-       fooooooooooo x )
+    let x =
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+    in
+    fooooooooooo x )
 
 let foooooooooo =
   foooooooooooooooooooooo
   |> Option.bind ~f:(function
-       | Pform.Expansion.Var (Values l) ->
-           Some (static l)
-       | Macro (Ocaml_config, s) ->
-           Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
-       | Macro (Env, s) ->
-           Option.map ~f:static (expand_env t var s) )
+    | Pform.Expansion.Var (Values l) ->
+        Some (static l)
+    | Macro (Ocaml_config, s) ->
+        Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
+    | Macro (Env, s) ->
+        Option.map ~f:static (expand_env t var s) )
 
 let fooooooooooooo =
   match lbls with
@@ -84,9 +84,9 @@ let x =
 let x =
   some_value
   |> some_fun (fun x ->
-       do_something () ; do_something_else () ; return_this_value )
+    do_something () ; do_something_else () ; return_this_value )
 
 let x =
   some_value
   ^ some_fun (fun x ->
-      do_something () ; do_something_else () ; return_this_value )
+    do_something () ; do_something_else () ; return_this_value )

--- a/test/passing/tests/max_indent.ml
+++ b/test/passing/tests/max_indent.ml
@@ -14,6 +14,15 @@ let () =
        in
        fooooooooooo x )
 
+let () =
+ List.iter
+    (fun
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
+    let x =
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+    in
+    fooooooooooo x )
+
 let foooooooooo =
   foooooooooooooooooooooo
   |> Option.bind ~f:(function

--- a/test/rpc/rpc_test.ml
+++ b/test/rpc/rpc_test.ml
@@ -75,13 +75,13 @@ let start ?versions () =
             0.18.0) is installed." )
   | x -> x )
   |> Result.map_error ~f:(fun (`Msg msg) ->
-         state := Errored ;
-         log
-           "An error occured while initializing and configuring ocamlformat:\n\
-            %s\n\
-            %!"
-           msg ;
-         `No_process )
+      state := Errored ;
+      log
+        "An error occured while initializing and configuring ocamlformat:\n\
+         %s\n\
+         %!"
+        msg ;
+      `No_process )
 
 let get_client ?versions () =
   match !state with

--- a/test/rpc/rpc_test_fail.ml
+++ b/test/rpc/rpc_test_fail.ml
@@ -73,13 +73,13 @@ let start () =
             0.18.0) is installed." )
   | x -> x )
   |> Result.map_error ~f:(fun (`Msg msg) ->
-         state := Errored ;
-         log
-           "An error occured while initializing and configuring ocamlformat:\n\
-            %s\n\
-            %!"
-           msg ;
-         `No_process )
+      state := Errored ;
+      log
+        "An error occured while initializing and configuring ocamlformat:\n\
+         %s\n\
+         %!"
+        msg ;
+      `No_process )
 
 let get_client () =
   match !state with

--- a/test/unit/test_translation_unit.ml
+++ b/test/unit/test_translation_unit.ml
@@ -14,8 +14,8 @@ let test_parse_and_format kind_name ~fg test_name ~input ~expected =
         Translation_unit.parse_and_format fg ~input_name:"<test>"
           ~source:input Conf.default
         |> Result.map_error ~f:(fun e ->
-               Translation_unit.Error.print Stdlib.Format.str_formatter e ;
-               Stdlib.Format.flush_str_formatter () )
+            Translation_unit.Error.print Stdlib.Format.str_formatter e ;
+            Stdlib.Format.flush_str_formatter () )
       in
       let expected = Result.map_error expected ~f:normalize_eol in
       Alcotest.(check (result string string)) test_name expected actual )


### PR DESCRIPTION
from

```ocaml
let _ =
  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
  |>>>>>> map (fun xxxxxxx ->
              xxxxxxxxxxxxxxxxxxxxxxx ;
              aaaaaaaaaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaaaaaa )

```

to

```ocaml
let _ =
  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
  |>>>>>> map (fun xxxxxxx ->
      xxxxxxxxxxxxxxxxxxxxxxx ;
      aaaaaaaaaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaaaaaa )
```

In my opinion this is quite a big fix. Implementation is relatively simple.

Fixes issue #2650 