### PR TITLE
no new line in `@@ match`

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -423,8 +423,7 @@ module Structure_item = struct
   let break_between s cc (i1, c1) (i2, c2) =
     cmts_between s cc i1.pstr_loc i2.pstr_loc
     || has_doc i1 || has_doc i2
-    ||
-    match
+    || match
       Conf.
         (c1.fmt_opts.module_item_spacing.v, c2.fmt_opts.module_item_spacing.v)
     with
@@ -509,8 +508,7 @@ module Signature_item = struct
   let break_between s cc (i1, c1) (i2, c2) =
     cmts_between s cc i1.psig_loc i2.psig_loc
     || has_doc i1 || has_doc i2
-    ||
-    match
+    || match
       Conf.
         (c1.fmt_opts.module_item_spacing.v, c2.fmt_opts.module_item_spacing.v)
     with
@@ -576,8 +574,7 @@ module Td = struct
   let break_between s cc (i1, c1) (i2, c2) =
     cmts_between s cc i1.ptype_loc i2.ptype_loc
     || has_doc i1 || has_doc i2
-    ||
-    match
+    || match
       Conf.
         (c1.fmt_opts.module_item_spacing.v, c2.fmt_opts.module_item_spacing.v)
     with
@@ -590,8 +587,7 @@ end
 module Class_field = struct
   let has_doc itm =
     List.exists ~f:Attr.is_doc itm.pcf_attributes
-    ||
-    match itm.pcf_desc with
+    || match itm.pcf_desc with
     | Pcf_attribute atr -> Attr.is_doc atr
     | _ -> false
 
@@ -604,8 +600,7 @@ module Class_field = struct
   let break_between s cc (i1, c1) (i2, c2) =
     cmts_between s cc i1.pcf_loc i2.pcf_loc
     || has_doc i1 || has_doc i2
-    ||
-    match
+    || match
       Conf.
         (c1.fmt_opts.module_item_spacing.v, c2.fmt_opts.module_item_spacing.v)
     with
@@ -617,8 +612,7 @@ end
 module Class_type_field = struct
   let has_doc itm =
     List.exists ~f:Attr.is_doc itm.pctf_attributes
-    ||
-    match itm.pctf_desc with
+    || match itm.pctf_desc with
     | Pctf_attribute atr -> Attr.is_doc atr
     | _ -> false
 
@@ -631,8 +625,7 @@ module Class_type_field = struct
   let break_between s cc (i1, c1) (i2, c2) =
     cmts_between s cc i1.pctf_loc i2.pctf_loc
     || has_doc i1 || has_doc i2
-    ||
-    match
+    || match
       Conf.
         (c1.fmt_opts.module_item_spacing.v, c2.fmt_opts.module_item_spacing.v)
     with
@@ -939,16 +932,14 @@ end = struct
     in
     let check_class_type {pci_expr= {pcty_desc; _}; pci_params; _} =
       List.exists pci_params ~f:(fun (t, _) -> t == typ)
-      ||
-      match pcty_desc with
+      || match pcty_desc with
       | Pcty_constr (_, l) -> List.exists l ~f:(fun x -> x == typ)
       | Pcty_arrow (t, _) -> List.exists t ~f:(fun x -> x.pap_type == typ)
       | _ -> false
     in
     let check_class_expr {pci_expr= {pcl_desc; _}; pci_params; _} =
       List.exists pci_params ~f:(fun (t, _) -> t == typ)
-      ||
-      match pcl_desc with
+      || match pcl_desc with
       | Pcl_constr (_, l) -> List.exists l ~f:(fun x -> x == typ)
       | _ -> false
     in
@@ -997,12 +988,12 @@ end = struct
           || List.exists ptype_cstrs ~f:(fun (t1, t2, _) ->
                  typ == t1 || typ == t2 )
           || ( match ptype_kind with
-             | Ptype_variant cd1N ->
-                 List.exists cd1N ~f:(fun {pcd_args; pcd_res; _} ->
-                     check_cstr pcd_args || Option.exists pcd_res ~f )
-             | Ptype_record ld1N ->
-                 List.exists ld1N ~f:(fun {pld_type; _} -> typ == pld_type)
-             | _ -> false )
+          | Ptype_variant cd1N ->
+              List.exists cd1N ~f:(fun {pcd_args; pcd_res; _} ->
+                  check_cstr pcd_args || Option.exists pcd_res ~f )
+          | Ptype_record ld1N ->
+              List.exists ld1N ~f:(fun {pld_type; _} -> typ == pld_type)
+          | _ -> false )
           || Option.exists ptype_manifest ~f )
     | Cty {pcty_desc; _} ->
         assert (
@@ -1218,16 +1209,14 @@ end = struct
     let check_extensions = function PPat (p, _) -> p == pat | _ -> false in
     let check_subpat ppat =
       ppat == pat
-      ||
-      match ppat.ppat_desc with
+      || match ppat.ppat_desc with
       | Ppat_constraint (p, _) -> p == pat
       | _ -> false
     in
     let check_cases = List.exists ~f:(fun c -> c.pc_lhs == pat) in
     let check_binding {pvb_pat; pvb_body; _} =
       check_subpat pvb_pat
-      ||
-      match pvb_body with
+      || match pvb_body with
       | Pfunction_body _ -> false
       | Pfunction_cases (cases, _, _) -> check_cases cases
     in
@@ -1539,8 +1528,8 @@ end = struct
     | Pexp_indexop_access {pia_lhs; pia_kind; pia_rhs= None; _} ->
         Exp.is_trivial pia_lhs
         && ( match pia_kind with
-           | Builtin idx -> Exp.is_trivial idx
-           | Dotop (_, _, idx) -> List.for_all idx ~f:Exp.is_trivial )
+        | Builtin idx -> Exp.is_trivial idx
+        | Dotop (_, _, idx) -> List.for_all idx ~f:Exp.is_trivial )
         && fit_margin c (width xexp)
     | Pexp_prefix (_, e) -> Exp.is_trivial e && fit_margin c (width xexp)
     | Pexp_infix ({txt= ":="; _}, _, _) -> false
@@ -1865,8 +1854,7 @@ end = struct
       parenthesized in context [ctx]. *)
   let parenze_mty {ctx; ast= mty} =
     Mty.has_trailing_attributes mty
-    ||
-    match (ctx, mty.pmty_desc) with
+    || match (ctx, mty.pmty_desc) with
     | Mty {pmty_desc= Pmty_with _; _}, Pmty_with _ -> true
     | _ -> false
 
@@ -1874,8 +1862,7 @@ end = struct
       parenthesized in context [ctx]. *)
   let parenze_mod {ctx; ast= m} =
     Mod.has_trailing_attributes m
-    ||
-    match (ctx, m.pmod_desc) with
+    || match (ctx, m.pmod_desc) with
     (* The RHS of an application is always parenthesized already. *)
     | Mod {pmod_desc= Pmod_apply (_, x); _}, Pmod_functor _ when m == x ->
         false
@@ -1895,8 +1882,7 @@ end = struct
     let parenze_pat_in_binding ~constraint_ =
       (* Some patterns must be parenthesed when followed by a colon. *)
       (exposed_right_colon pat && Option.is_some constraint_)
-      ||
-      match pat.ppat_desc with
+      || match pat.ppat_desc with
       | Ppat_construct (_, Some _)
        |Ppat_variant (_, Some _)
        |Ppat_cons _ | Ppat_alias _ | Ppat_or _ ->
@@ -1923,8 +1909,7 @@ end = struct
   let parenze_pat ({ctx; ast= pat} as xpat) =
     assert_check_pat xpat ;
     Pat.has_trailing_attributes pat
-    ||
-    match (ctx, pat.ppat_desc) with
+    || match (ctx, pat.ppat_desc) with
     | Pat {ppat_desc= Ppat_cons pl; _}, Ppat_cons _
       when List.last_exn pl == pat ->
         false
@@ -2260,8 +2245,7 @@ end = struct
     assert_check_exp xexp ;
     Hashtbl.find marked_parenzed_inner_nested_match exp
     |> Option.value ~default:false
-    ||
-    match (ctx, exp) with
+    || match (ctx, exp) with
     | Str {pstr_desc= Pstr_eval _; _}, _ -> false
     | Lb pvb, _ when dont_parenze_exp_in_bindings [pvb] exp -> false
     | Exp {pexp_desc= Pexp_let ({pvbs_bindings; _}, _, _); _}, _

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -608,8 +608,7 @@ let fmt_cmts_aux t (conf : Conf.t) cmts ~fmt_code pos =
          | group ->
              list group force_break (fun cmt ->
                  wrap (str "(*") (str "*)") (str (Cmt.txt cmt)) ) )
-         $
-         match next with
+         $ match next with
          | Some (next :: _) ->
              let last = List.last_exn group in
              fmt_if

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1877,7 +1877,7 @@ and fmt_infix_op_args c ~parens xexp op_args =
       hovbox 2 (fmt_expression c ~parens ~box:false ~pro xarg)
     else
       match xarg.ast.pexp_desc with
-      | Pexp_function _ | Pexp_beginend _ ->
+      | Pexp_function _ | Pexp_beginend _ | Pexp_match _ ->
           hvbox 0 (fmt_expression c ~pro ~parens xarg)
       | _ ->
           hvbox 0
@@ -1950,7 +1950,7 @@ and fmt_match c ?pro ?eol ~loc ~parens ~infix_ext_attrs ctx xexp cs e0
   let indent = Params.match_indent c.conf ~parens ~ctx:ctx0 in
   let pro_outer, pro_inner =
     let pro = fmt_opt pro in
-    if Params.Exp.match_inner_pro ~ctx0 ~parens then (noop, pro)
+    if Params.Exp.match_inner_pro ~parens then (noop, pro)
     else (pro, noop)
   in
   hvbox indent
@@ -2643,7 +2643,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       let parens = parens || has_attr in
       let cmts_before = Cmts.fmt_before c ?eol pexp_loc in
       let pro_outer, pro_inner =
-        if Params.Exp.match_inner_pro ~ctx0 ~parens then (noop, pro)
+        if Params.Exp.match_inner_pro ~parens then (noop, pro)
         else (pro, noop)
       in
       (* side effects of Cmts.fmt_before before [fmt_pattern] is important *)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1866,7 +1866,7 @@ and fmt_infix_op_args c ~parens xexp op_args =
       hovbox 2 (fmt_expression c ~parens ~box:false ~pro xarg)
     else
       match xarg.ast.pexp_desc with
-      | Pexp_function _ | Pexp_beginend _ | Pexp_match _ ->
+      | Pexp_function _ | Pexp_beginend _ | Pexp_match _ | Pexp_try _ ->
           hvbox 0 (fmt_expression c ~pro ~parens xarg)
       | _ ->
           hvbox 0

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -326,9 +326,7 @@ module Exp = struct
     | Str _ | Lb _ | Clf _ | Exp {pexp_desc= Pexp_let _; _} -> hovbox 4 k
     | _ -> hvbox 2 k
 
-  let match_inner_pro ~parens =
-     not parens
-
+  let match_inner_pro ~parens = not parens
 
   let function_inner_pro ~has_cmts_outer ~ctx0 =
     if has_cmts_outer then false

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -326,10 +326,9 @@ module Exp = struct
     | Str _ | Lb _ | Clf _ | Exp {pexp_desc= Pexp_let _; _} -> hovbox 4 k
     | _ -> hvbox 2 k
 
-  let match_inner_pro ~ctx0 ~parens =
-    if parens then false
-    else
-      match ctx0 with Exp {pexp_desc= Pexp_infix _; _} -> false | _ -> true
+  let match_inner_pro ~parens =
+     not parens
+
 
   let function_inner_pro ~has_cmts_outer ~ctx0 =
     if has_cmts_outer then false

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -940,7 +940,7 @@ let match_indent ?(default = 0) (c : Conf.t) ~parens ~(ctx : Ast.t) =
   match (c.fmt_opts.match_indent_nested.v, ctx) with
   | `Always, _ | _, (Top | Sig _ | Str _) -> c.fmt_opts.match_indent.v
   | _, Exp {pexp_desc= Pexp_infix _; _}
-    when c.fmt_opts.ocp_indent_compat.v && parens ->
+    when parens ->
       2 (* Match is docked *)
   | _ -> default
 

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -81,7 +81,7 @@ module Exp : sig
   val box_fun_decl : ctx0:Ast.t -> Conf.t -> Fmt.t -> Fmt.t
   (** Box a function decl from the label to the arrow. *)
 
-  val match_inner_pro : ctx0:Ast.t -> parens:bool -> bool
+  val match_inner_pro : parens:bool -> bool
   (**  whether the [pro] argument of [fmt_match] should be displayed as an inner
      or outer prologue.*)
 

--- a/test/passing/refs.default/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.default/exp_grouping-parens.ml.ref
@@ -524,8 +524,7 @@ let _ =
 
 let _ =
   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  |>>>>>
-  match xxxxxxx with
+  |>>>>> match xxxxxxx with
   | A -> xxxxxxxxxxxxxxxxxxxxxxx
   | B -> aaaaaaaaaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaaaaaa
 
@@ -537,15 +536,13 @@ let _ =
 
 let main =
   Lwt.run
-  @@
-  match a with
+  @@ match a with
   | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B -> bbbbbbbbbbbbbbbbbbbbbb
 
 let main =
   Lwt.run
-  @@
-  match%lwt a with
+  @@ match%lwt a with
   | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B -> bbbbbbbbbbbbbbbbbbbbbb
 

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -610,15 +610,13 @@ let _ =
 
 let main =
   Lwt.run
-  @@
-  match a with
+  @@ match a with
   | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B -> bbbbbbbbbbbbbbbbbbbbbb
 
 let main =
   Lwt.run
-  @@
-  match%lwt a with
+  @@ match%lwt a with
   | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B -> bbbbbbbbbbbbbbbbbbbbbb
 

--- a/test/passing/refs.default/js_source.ml.err
+++ b/test/passing/refs.default/js_source.ml.err
@@ -4,4 +4,4 @@ Warning: js_source.ml:224 exceeds the margin
 Warning: js_source.ml:229 exceeds the margin
 Warning: js_source.ml:240 exceeds the margin
 Warning: js_source.ml:328 exceeds the margin
-Warning: js_source.ml:809 exceeds the margin
+Warning: js_source.ml:808 exceeds the margin

--- a/test/passing/refs.default/js_source.ml.ref
+++ b/test/passing/refs.default/js_source.ml.ref
@@ -468,15 +468,15 @@ end
 let _ =
   foo
   $$ (match group with
-  | [] -> impossible "previous match"
-  | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
+    | [] -> impossible "previous match"
+    | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
   $$ bar
 
 let _ =
   foo
   $$ (try group with
-     | [] -> impossible "previous match"
-     | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
+    | [] -> impossible "previous match"
+    | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
   $$ bar
 
 let _ =

--- a/test/passing/refs.default/js_source.ml.ref
+++ b/test/passing/refs.default/js_source.ml.ref
@@ -468,8 +468,8 @@ end
 let _ =
   foo
   $$ (match group with
-     | [] -> impossible "previous match"
-     | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
+  | [] -> impossible "previous match"
+  | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
   $$ bar
 
 let _ =
@@ -481,8 +481,7 @@ let _ =
 
 let _ =
   x == exp
-  ||
-  match x with
+  || match x with
   | { pexp_desc = Pexp_constraint (e, _); _ } -> loop e
   | _ -> false
 

--- a/test/passing/refs.default/match.ml.ref
+++ b/test/passing/refs.default/match.ml.ref
@@ -122,8 +122,7 @@ let () =
 
 let _ =
   f arg arg arg
-  @@
-  match f with
+  @@ match f with
   | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B -> bbbbbbbbbbbbbbbbbbbbbb
 

--- a/test/passing/refs.default/match.ml.ref
+++ b/test/passing/refs.default/match.ml.ref
@@ -119,3 +119,15 @@ let () =
   | _ :: _ :: _ :: _ -> bbb bbbbb bbbbbbb bbbb bbbb
   | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
   | [] -> ff dda asa
+
+let _ =
+  f arg arg arg
+  @@
+  match f with
+  | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | B -> bbbbbbbbbbbbbbbbbbbbbb
+
+let _ =
+  f arg arg arg @@ function
+  | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | B -> bbbbbbbbbbbbbbbbbbbbbb

--- a/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
@@ -608,8 +608,7 @@ let _ =
 
 let _ =
   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  |>>>>>
-  match xxxxxxx with
+  |>>>>> match xxxxxxx with
   | A -> xxxxxxxxxxxxxxxxxxxxxxx
   | B -> aaaaaaaaaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaaaaaa
 ;;
@@ -623,16 +622,14 @@ let _ =
 
 let main =
   Lwt.run
-  @@
-  match a with
+  @@ match a with
   | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B -> bbbbbbbbbbbbbbbbbbbbbb
 ;;
 
 let main =
   Lwt.run
-  @@
-  match%lwt a with
+  @@ match%lwt a with
   | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B -> bbbbbbbbbbbbbbbbbbbbbb
 ;;

--- a/test/passing/refs.janestreet/exp_grouping.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping.ml.ref
@@ -706,16 +706,14 @@ let _ =
 
 let main =
   Lwt.run
-  @@
-  match a with
+  @@ match a with
   | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B -> bbbbbbbbbbbbbbbbbbbbbb
 ;;
 
 let main =
   Lwt.run
-  @@
-  match%lwt a with
+  @@ match%lwt a with
   | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B -> bbbbbbbbbbbbbbbbbbbbbb
 ;;

--- a/test/passing/refs.janestreet/js_pattern.ml.ref
+++ b/test/passing/refs.janestreet/js_pattern.ml.ref
@@ -44,8 +44,7 @@ let 0 =
 
 let _ =
   a
-  ||
-  match a with
+  || match a with
   | a -> true
   | b -> false
 ;;

--- a/test/passing/refs.janestreet/js_source.ml.err
+++ b/test/passing/refs.janestreet/js_source.ml.err
@@ -2,4 +2,4 @@ Warning: js_source.ml:10 exceeds the margin
 Warning: js_source.ml:115 exceeds the margin
 Warning: js_source.ml:174 exceeds the margin
 Warning: js_source.ml:249 exceeds the margin
-Warning: js_source.ml:747 exceeds the margin
+Warning: js_source.ml:746 exceeds the margin

--- a/test/passing/refs.janestreet/js_source.ml.ref
+++ b/test/passing/refs.janestreet/js_source.ml.ref
@@ -567,8 +567,7 @@ let _ =
 
 let _ =
   x == exp
-  ||
-  match x with
+  || match x with
   | { pexp_desc = Pexp_constraint (e, _); _ } -> loop e
   | _ -> false
 ;;

--- a/test/passing/refs.janestreet/match.ml.ref
+++ b/test/passing/refs.janestreet/match.ml.ref
@@ -168,3 +168,18 @@ let () =
   | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
   | [] -> ff dda asa
 ;;
+
+let _ =
+  f arg arg arg
+  @@
+  match f with
+  | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | B -> bbbbbbbbbbbbbbbbbbbbbb
+;;
+
+let _ =
+  f arg arg arg
+  @@ function
+  | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | B -> bbbbbbbbbbbbbbbbbbbbbb
+;;

--- a/test/passing/refs.janestreet/match.ml.ref
+++ b/test/passing/refs.janestreet/match.ml.ref
@@ -171,8 +171,7 @@ let () =
 
 let _ =
   f arg arg arg
-  @@
-  match f with
+  @@ match f with
   | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B -> bbbbbbbbbbbbbbbbbbbbbb
 ;;

--- a/test/passing/refs.janestreet/ocp_indent_compat-break_colon_after.ml.ref
+++ b/test/passing/refs.janestreet/ocp_indent_compat-break_colon_after.ml.ref
@@ -94,8 +94,7 @@ let add_edge target dep =
       edge_count
       target
       (1
-       +
-       try Hashtbl.find edge_count target with
+       + try Hashtbl.find edge_count target with
        | Not_found -> 0);
     if not (Hashtbl.mem edge_count dep) then Hashtbl.add edge_count dep 0)
 ;;

--- a/test/passing/refs.janestreet/ocp_indent_compat.ml.ref
+++ b/test/passing/refs.janestreet/ocp_indent_compat.ml.ref
@@ -94,8 +94,7 @@ let add_edge target dep =
       edge_count
       target
       (1
-       +
-       try Hashtbl.find edge_count target with
+       + try Hashtbl.find edge_count target with
        | Not_found -> 0);
     if not (Hashtbl.mem edge_count dep) then Hashtbl.add edge_count dep 0)
 ;;

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
@@ -518,8 +518,7 @@ let _ =
 
 let _ =
   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  |>>>>>
-  match xxxxxxx with
+  |>>>>> match xxxxxxx with
   | A ->
       xxxxxxxxxxxxxxxxxxxxxxx
   | B ->
@@ -533,8 +532,7 @@ let _ =
 
 let main =
   Lwt.run
-  @@
-  match a with
+  @@ match a with
   | A ->
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B ->
@@ -542,8 +540,7 @@ let main =
 
 let main =
   Lwt.run
-  @@
-  match%lwt a with
+  @@ match%lwt a with
   | A ->
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B ->

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -605,8 +605,7 @@ let _ =
 
 let main =
   Lwt.run
-  @@
-  match a with
+  @@ match a with
   | A ->
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B ->
@@ -614,8 +613,7 @@ let main =
 
 let main =
   Lwt.run
-  @@
-  match%lwt a with
+  @@ match%lwt a with
   | A ->
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B ->

--- a/test/passing/refs.ocamlformat/js_source.ml.err
+++ b/test/passing/refs.ocamlformat/js_source.ml.err
@@ -5,5 +5,5 @@ Warning: js_source.ml:154 exceeds the margin
 Warning: js_source.ml:219 exceeds the margin
 Warning: js_source.ml:224 exceeds the margin
 Warning: js_source.ml:235 exceeds the margin
-Warning: js_source.ml:628 exceeds the margin
-Warning: js_source.ml:828 exceeds the margin
+Warning: js_source.ml:631 exceeds the margin
+Warning: js_source.ml:831 exceeds the margin

--- a/test/passing/refs.ocamlformat/js_source.ml.ref
+++ b/test/passing/refs.ocamlformat/js_source.ml.ref
@@ -466,10 +466,10 @@ end
 let _ =
   foo
   $$ ( match group with
-     | [] ->
-         impossible "previous match"
-     | [cmt] ->
-         fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt )
+  | [] ->
+      impossible "previous match"
+  | [cmt] ->
+      fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt )
   $$ bar
 
 let _ =
@@ -483,8 +483,11 @@ let _ =
 
 let _ =
   x == exp
-  ||
-  match x with {pexp_desc= Pexp_constraint (e, _); _} -> loop e | _ -> false
+  || match x with
+  | {pexp_desc= Pexp_constraint (e, _); _} ->
+      loop e
+  | _ ->
+      false
 
 let _ =
   let module M = struct

--- a/test/passing/refs.ocamlformat/js_source.ml.ref
+++ b/test/passing/refs.ocamlformat/js_source.ml.ref
@@ -466,19 +466,19 @@ end
 let _ =
   foo
   $$ ( match group with
-  | [] ->
-      impossible "previous match"
-  | [cmt] ->
-      fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt )
+    | [] ->
+        impossible "previous match"
+    | [cmt] ->
+        fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt )
   $$ bar
 
 let _ =
   foo
   $$ ( try group with
-     | [] ->
-         impossible "previous match"
-     | [cmt] ->
-         fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt )
+    | [] ->
+        impossible "previous match"
+    | [cmt] ->
+        fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt )
   $$ bar
 
 let _ =

--- a/test/passing/refs.ocamlformat/match.ml.ref
+++ b/test/passing/refs.ocamlformat/match.ml.ref
@@ -148,8 +148,7 @@ let () =
 
 let _ =
   f arg arg arg
-  @@
-  match f with
+  @@ match f with
   | A ->
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   | B ->

--- a/test/passing/refs.ocamlformat/match.ml.ref
+++ b/test/passing/refs.ocamlformat/match.ml.ref
@@ -145,3 +145,20 @@ let () =
         cc cccc cccc cccc cccc ccc cccccc cccc
     | [] ->
         ff dda asa
+
+let _ =
+  f arg arg arg
+  @@
+  match f with
+  | A ->
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | B ->
+      bbbbbbbbbbbbbbbbbbbbbb
+
+let _ =
+  f arg arg arg
+  @@ function
+  | A ->
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | B ->
+      bbbbbbbbbbbbbbbbbbbbbb

--- a/test/passing/tests/match.ml
+++ b/test/passing/tests/match.ml
@@ -118,3 +118,16 @@ let () =
   | _ :: _ :: _ -> cc cccc cccc cccc cccc ccc cccccc cccc
   | [] -> ff dda asa
 
+
+let _ =
+  f arg arg arg
+  @@ match f with
+  | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | B -> bbbbbbbbbbbbbbbbbbbbbb
+
+
+let _ =
+  f arg arg arg
+  @@ function
+  | A -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | B -> bbbbbbbbbbbbbbbbbbbbbb


### PR DESCRIPTION
```ocaml
Lwt.run
@@ match x with
| A -> a
| B -> b
```
instead of 
```ocaml
Lwt.run
@@
match x with
| A -> a
| B -> b
```

This is good because there is one less newline, and because it is more consistent with the `@@ function` formatting:

```ocaml
Lwt.run
@@ function
| A -> a
| B -> b
```

There are two issues that need to be addressed before merging:

- with operator `||`, it looks weird:
```ocaml
my_bool
|| match x with
| A -> true
| B -> false
```

Maybe this is okay. The same weirdness could also happen with `function`, even if its less likely.
 
- when the `match` is in parens, the code says it shouldnt format like it does, but it still does, with a weird indentation: 
```ocaml
let _ =
  foo
  $$ (match group with
    | [] -> impossible "previous match"
    | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
  $$ bar
;;
```
This is not necessarily bad, but the indentation should be fixed, and why this is happening should be understood before merging.