### PR TITLE
Simplify fmt_function

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1494,9 +1494,13 @@ and fmt_indexop_access c ctx ~fmt_atrs ~has_attr ~parens x =
 
 (** Format a [Pexp_function]. [wrap_intro] wraps up to after the [->] and is
     responsible for breaking. *)
-and fmt_function ?(last_arg = false) ?force_closing_paren ~ctx ~ctx0 ?pro
-    ~wrap_intro ?box:(should_box = true) ~label ?(parens = false) ?ext ~attrs
-    ~loc c (args, typ, body) =
+and fmt_function ?force_closing_paren ~ctx ~ctx0 ?pro ~wrap_intro
+    ?box:(should_box = true) ?(parens = false) ?ext ~attrs ~loc c
+    (args, typ, body) =
+  let last_arg =
+    Params.Exp.ctx_is_apply_and_exp_is_last_arg_and_other_args_are_simple
+      c.conf ~ctx ~ctx0
+  in
   let should_box =
     should_box
     ||
@@ -1504,7 +1508,7 @@ and fmt_function ?(last_arg = false) ?force_closing_paren ~ctx ~ctx0 ?pro
     | _ :: _, _, Pfunction_cases _ -> true
     | _ -> false
   in
-  let has_label = match label with Nolabel -> false | _ -> true in
+  let has_label = Params.Exp.ctx_is_apply_and_exp_is_arg_with_label ~ctx ~ctx0 in
   (* Make sure the comment is placed after the eventual label but not into
      the inner box if no label is present. Side effects of Cmts.fmt c.cmts
      before Sugar.fun_ is important. *)
@@ -1515,13 +1519,6 @@ and fmt_function ?(last_arg = false) ?force_closing_paren ~ctx ~ctx0 ?pro
     if has_label then (false, noop, cmts) else (has_cmts, cmts, noop)
   in
   let break_fun = Params.Exp.break_fun_kw c.conf ~ctx ~ctx0 ~last_arg in
-  let (label_sep : t) =
-    (* Break between the label and the fun to avoid ocp-indent's alignment.
-       If a label is present, arguments should be indented more than the
-       arrow and the eventually breaking [fun] keyword. *)
-    if c.conf.fmt_opts.ocp_indent_compat.v then str ":" $ cut_break
-    else str ":"
-  in
   let fmt_typ typ = fmt_type_pcstr c ~ctx ~constraint_ctx:`Fun typ in
   let fmt_fun_args_typ args typ =
     let kw =
@@ -1649,7 +1646,7 @@ and fmt_function ?(last_arg = false) ?force_closing_paren ~ctx ~ctx0 ?pro
         $ hvbox_if has_cmts_outer 0
             ( cmts_outer
             $ Params.Exp.box_fun_decl ~ctx0 c.conf
-                ( pro_inner $ fmt_label label label_sep $ cmts_inner
+                ( pro_inner $ cmts_inner
                 $ opn_paren $ head ) ) )
     in
     body ~pro $ cls_paren
@@ -1690,7 +1687,9 @@ and fmt_label_arg ?(box = true) ?eol c (lbl, ({ast= arg; _} as xarg)) =
       fmt_expression c ~box ~pro xarg
   | (Labelled _ | Optional _), Pexp_function (args, typ, body) ->
       let wrap_intro x = hovbox 2 x $ space_break in
-      fmt_function ~box ~ctx:(Exp arg) ~wrap_intro ~ctx0:xarg.ctx ~label:lbl
+      let label_sep = Params.Exp.fun_label_sep c.conf in
+      let pro = fmt_label lbl label_sep in
+      fmt_function ~pro ~box ~ctx:(Exp arg) ~wrap_intro ~ctx0:xarg.ctx
         ~parens:true ~attrs:arg.pexp_attributes ~loc:arg.pexp_loc c
         (args, typ, body)
   | _ ->
@@ -2007,7 +2006,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                          str "%"
                          $ hovbox 2 (fmt_str_loc c name $ space_break $ x)
                          $ space_break )
-                       ~label:Nolabel ~parens:false
+                        ~parens:false
                        ~attrs:call.pexp_attributes ~loc:call.pexp_loc c
                        (args, typ, body) ) )
              $ space_break $ str ";" $ space_break
@@ -2041,7 +2040,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                          str "%"
                          $ hovbox 2 (fmt_str_loc c name $ space_break $ x)
                          $ space_break )
-                       ~label:Nolabel ~parens:false
+                       ~parens:false
                        ~attrs:retn.pexp_attributes ~loc:retn.pexp_loc c
                        (args, typ, body) ) ) ) )
   | Pexp_infix ({txt= ":="; loc}, r, v)
@@ -2120,7 +2119,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                   $ space_break
                   $ hovbox 0 (fmt_str_loc c op $ space_break $ intro) )
                 $ fmt_or followed_by_infix_op force_break space_break )
-              ~label:Nolabel ~attrs:r.pexp_attributes ~loc:r.pexp_loc c
+              ~attrs:r.pexp_attributes ~loc:r.pexp_loc c
               (args, typ, body)
           $ fmt_if has_attr (str ")")
           $ fmt_atrs )
@@ -2238,8 +2237,10 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
               then Fit
               else Break
             in
-            fmt_function ~last_arg:true ~force_closing_paren ~ctx:inner_ctx
-              ~ctx0:ctx ~wrap_intro ~label:lbl ~parens:true
+            let label_sep = Params.Exp.fun_label_sep c.conf in
+            let pro = fmt_label lbl label_sep in
+            fmt_function ~pro ~force_closing_paren ~ctx:inner_ctx ~ctx0:ctx
+              ~wrap_intro ~parens:true
               ~attrs:last_arg.pexp_attributes ~loc:last_arg.pexp_loc c
               (largs, ltyp, lbody)
           in
@@ -2373,7 +2374,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       let wrap_intro intro =
         hovbox ~name:"fmt_expression | Pexp_function" 2 intro $ space_break
       in
-      fmt_function ~pro ~wrap_intro ~box ~ctx ~ctx0 ~label:Nolabel ~parens
+      fmt_function ~pro ~wrap_intro ~box ~ctx ~ctx0 ~parens
         ?ext ~attrs:pexp_attributes ~loc:pexp_loc c (args, typ, body)
   | Pexp_ident {txt; loc} ->
       let outer_parens = has_attr && parens in
@@ -4754,7 +4755,7 @@ and fmt_value_binding c ~ctx0 ~rec_flag ?in_ ?epi
             let wrap_intro intro =
               hovbox 2 (fmt_opt pro $ intro) $ space_break
             in
-            fmt_function ~ctx ~ctx0 ~wrap_intro ?box ~label:Nolabel ~attrs:[]
+            fmt_function ~ctx ~ctx0 ~wrap_intro ?box ~attrs:[]
               ~loc:lb_loc c ([], None, body)
         | Pfunction_body body ->
             fmt_expression c ?pro ?box (sub_exp ~ctx body)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1508,7 +1508,9 @@ and fmt_function ?force_closing_paren ~ctx ~ctx0 ?pro ~wrap_intro
     | _ :: _, _, Pfunction_cases _ -> true
     | _ -> false
   in
-  let has_label = Params.Exp.ctx_is_apply_and_exp_is_arg_with_label ~ctx ~ctx0 in
+  let has_label =
+    Params.Exp.ctx_is_apply_and_exp_is_arg_with_label ~ctx ~ctx0
+  in
   (* Make sure the comment is placed after the eventual label but not into
      the inner box if no label is present. Side effects of Cmts.fmt c.cmts
      before Sugar.fun_ is important. *)
@@ -1646,8 +1648,7 @@ and fmt_function ?force_closing_paren ~ctx ~ctx0 ?pro ~wrap_intro
         $ hvbox_if has_cmts_outer 0
             ( cmts_outer
             $ Params.Exp.box_fun_decl ~ctx0 c.conf
-                ( pro_inner $ cmts_inner
-                $ opn_paren $ head ) ) )
+                (pro_inner $ cmts_inner $ opn_paren $ head) ) )
     in
     body ~pro $ cls_paren
   in
@@ -2006,9 +2007,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                          str "%"
                          $ hovbox 2 (fmt_str_loc c name $ space_break $ x)
                          $ space_break )
-                        ~parens:false
-                       ~attrs:call.pexp_attributes ~loc:call.pexp_loc c
-                       (args, typ, body) ) )
+                       ~parens:false ~attrs:call.pexp_attributes
+                       ~loc:call.pexp_loc c (args, typ, body) ) )
              $ space_break $ str ";" $ space_break
              $ list grps (str " ;" $ force_break) fmt_grp ) )
   | Pexp_infix
@@ -2040,9 +2040,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                          str "%"
                          $ hovbox 2 (fmt_str_loc c name $ space_break $ x)
                          $ space_break )
-                       ~parens:false
-                       ~attrs:retn.pexp_attributes ~loc:retn.pexp_loc c
-                       (args, typ, body) ) ) ) )
+                       ~parens:false ~attrs:retn.pexp_attributes
+                       ~loc:retn.pexp_loc c (args, typ, body) ) ) ) )
   | Pexp_infix ({txt= ":="; loc}, r, v)
     when is_simple c.conf (expression_width c) (sub_exp ~ctx r) ->
       let bol_indent = Params.Indent.assignment_operator_bol c.conf in
@@ -2119,8 +2118,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                   $ space_break
                   $ hovbox 0 (fmt_str_loc c op $ space_break $ intro) )
                 $ fmt_or followed_by_infix_op force_break space_break )
-              ~attrs:r.pexp_attributes ~loc:r.pexp_loc c
-              (args, typ, body)
+              ~attrs:r.pexp_attributes ~loc:r.pexp_loc c (args, typ, body)
           $ fmt_if has_attr (str ")")
           $ fmt_atrs )
   | Pexp_infix _ ->
@@ -2240,9 +2238,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
             let label_sep = Params.Exp.fun_label_sep c.conf in
             let pro = fmt_label lbl label_sep in
             fmt_function ~pro ~force_closing_paren ~ctx:inner_ctx ~ctx0:ctx
-              ~wrap_intro ~parens:true
-              ~attrs:last_arg.pexp_attributes ~loc:last_arg.pexp_loc c
-              (largs, ltyp, lbody)
+              ~wrap_intro ~parens:true ~attrs:last_arg.pexp_attributes
+              ~loc:last_arg.pexp_loc c (largs, ltyp, lbody)
           in
           hvbox_if has_attr 0
             ( expr_epi
@@ -2374,8 +2371,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       let wrap_intro intro =
         hovbox ~name:"fmt_expression | Pexp_function" 2 intro $ space_break
       in
-      fmt_function ~pro ~wrap_intro ~box ~ctx ~ctx0 ~parens
-        ?ext ~attrs:pexp_attributes ~loc:pexp_loc c (args, typ, body)
+      fmt_function ~pro ~wrap_intro ~box ~ctx ~ctx0 ~parens ?ext
+        ~attrs:pexp_attributes ~loc:pexp_loc c (args, typ, body)
   | Pexp_ident {txt; loc} ->
       let outer_parens = has_attr && parens in
       pro
@@ -4755,8 +4752,8 @@ and fmt_value_binding c ~ctx0 ~rec_flag ?in_ ?epi
             let wrap_intro intro =
               hovbox 2 (fmt_opt pro $ intro) $ space_break
             in
-            fmt_function ~ctx ~ctx0 ~wrap_intro ?box ~attrs:[]
-              ~loc:lb_loc c ([], None, body)
+            fmt_function ~ctx ~ctx0 ~wrap_intro ?box ~attrs:[] ~loc:lb_loc c
+              ([], None, body)
         | Pfunction_body body ->
             fmt_expression c ?pro ?box (sub_exp ~ctx body)
       in

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -39,38 +39,9 @@ let ctx_is_rhs_of_infix ~ctx0 ~ctx =
       true
   | _ -> false
 
-(** Return [None] if [ctx0] is not an application or [ctx] is not one of its
-    argument. *)
-let ctx_is_apply_and_exp_is_arg ~ctx ctx0 =
-  match (ctx, ctx0) with
-  | Exp exp, Exp {pexp_desc= Pexp_apply (_, args); _} ->
-      let last_lbl, last_arg = List.last_exn args in
-      if phys_equal last_arg exp then Some (last_lbl, exp, true)
-      else
-        List.find_map
-          ~f:(fun (lbl, x) ->
-            if phys_equal x exp then Some (lbl, exp, false) else None )
-          args
-  | _ -> None
-
 let ctx_is_apply_and_exp_is_func ~ctx ctx0 =
   match (ctx, ctx0) with
   | Exp exp, Exp {pexp_desc= Pexp_apply (func, _); _} -> phys_equal func exp
-  | _ -> false
-
-let ctx_is_apply_and_exp_is_last_arg_and_other_args_are_simple c ~ctx ctx0 =
-  match (ctx, ctx0) with
-  | Exp exp, Exp {pexp_desc= Pexp_apply (_, args); _} ->
-      let (_lbl, last_arg), args_before =
-        match List.rev args with
-        | [] -> assert false
-        | hd :: tl -> (hd, List.rev tl)
-      in
-      let args_are_simple =
-        List.for_all args_before ~f:(fun (_, eI) ->
-            is_simple c (fun _ -> 0) (sub_exp ~ctx:ctx0 eI) )
-      in
-      Poly.equal last_arg exp && args_are_simple
   | _ -> false
 
 (** [ctx_is_let_or_fun ~ctx ctx0] checks whether [ctx0] is a let binding containing
@@ -112,6 +83,45 @@ let parens_if parens (c : Conf.t) ?(disambiguate = false) k =
 let parens c ?disambiguate k = parens_if true c ?disambiguate k
 
 module Exp = struct
+
+  (** Return [None] if [ctx0] is not an application or [ctx] is not one of its
+    argument.
+    Else, returns [lbl, exp, is_last] where [lbl] is the label of the argument,
+    [exp] is the epxression in [ctx], and [is_last] is true if [exp] is the last
+    argument.*)
+let ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 =
+  match (ctx, ctx0) with
+  | Exp exp, Exp {pexp_desc= Pexp_apply (_, args); _} ->
+      let last_lbl, last_arg = List.last_exn args in
+      if phys_equal last_arg exp then Some (last_lbl, exp, true)
+      else
+        List.find_map
+          ~f:(fun (lbl, x) ->
+            if phys_equal x exp then Some (lbl, exp, false) else None )
+          args
+  | _ -> None
+
+  let ctx_is_apply_and_exp_is_arg_with_label ~ctx ~ctx0 =
+    match ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 with
+    | Some ((Labelled _  | Optional _), _ , _) -> true
+    | _ -> false
+
+  let ctx_is_apply_and_exp_is_last_arg_and_other_args_are_simple c ~ctx ~ctx0
+      =
+    match (ctx, ctx0) with
+    | Exp exp, Exp {pexp_desc= Pexp_apply (_, args); _} ->
+        let (_lbl, last_arg), args_before =
+          match List.rev args with
+          | [] -> assert false
+          | hd :: tl -> (hd, List.rev tl)
+        in
+        let args_are_simple =
+          List.for_all args_before ~f:(fun (_, eI) ->
+              is_simple c (fun _ -> 0) (sub_exp ~ctx:ctx0 eI) )
+        in
+        Poly.equal last_arg exp && args_are_simple
+    | _ -> false
+
   module Infix_op_arg = struct
     let wrap (c : Conf.t) ?(parens_nested = false) ~parens k =
       if parens || parens_nested then
@@ -158,7 +168,7 @@ module Exp = struct
 
   let break_fun_kw c ~ctx ~ctx0 ~last_arg =
     let is_labelled_arg =
-      match ctx_is_apply_and_exp_is_arg ~ctx ctx0 with
+      match ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 with
       | Some ((Labelled _ | Optional _), _, _) -> true
       | _ -> false
     in
@@ -182,7 +192,7 @@ module Exp = struct
     let box_decl, should_box_args =
       if ocp c then
         let is_labelled_arg =
-          match ctx_is_apply_and_exp_is_arg ~ctx ctx0 with
+          match ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 with
           | Some ((Labelled _ | Optional _), _, _) -> true
           | _ -> false
         in
@@ -194,7 +204,7 @@ module Exp = struct
         let box =
           if is_let_func then if kw_in_box then hovbox ~name 4 else Fn.id
           else
-            match ctx_is_apply_and_exp_is_arg ~ctx ctx0 with
+            match ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 with
             | Some (_, _, true) ->
                 (* Is last arg. *) hvbox ~name (if parens then 0 else 2)
             | Some (Nolabel, _, false) ->
@@ -224,7 +234,7 @@ module Exp = struct
         let begins_line loc =
           Source.begins_line ~ignore_spaces:true source loc
         in
-        match ctx_is_apply_and_exp_is_arg ~ctx ctx0 with
+        match ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 with
         | Some (Nolabel, fun_exp, is_last_arg) ->
             if begins_line fun_exp.pexp_loc then if is_last_arg then 5 else 3
             else 2
@@ -239,7 +249,7 @@ module Exp = struct
         | None -> if ctx_is_apply_and_exp_is_func ~ctx ctx0 then 3 else 2
       else if
         ctx_is_apply_and_exp_is_last_arg_and_other_args_are_simple c ~ctx
-          ctx0
+          ~ctx0
       then 4
       else 2
     in
@@ -274,7 +284,7 @@ module Exp = struct
     | _ -> break 1 ~-2
 
   let single_line_function ~ctx ~ctx0 ~args =
-    match ctx_is_apply_and_exp_is_arg ~ctx ctx0 with
+    match ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 with
     | Some (_, _, true) -> List.is_empty args
     | _ -> false
 
@@ -283,7 +293,7 @@ module Exp = struct
     else if Poly.equal c.fmt_opts.function_indent_nested.v `Always then
       c.fmt_opts.function_indent.v
     else
-      match ctx_is_apply_and_exp_is_arg ~ctx ctx0 with
+      match ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 with
       | Some _ -> 2
       | None -> if ocp c && parens then 2 else 0
 
@@ -300,7 +310,7 @@ module Exp = struct
     | _ ->
         if
           ctx_is_apply_and_exp_is_last_arg_and_other_args_are_simple c ~ctx
-            ctx0
+            ~ctx0
           || ctx_is_let_or_fun ~ctx ctx0
         then Fn.id
         else hvbox indent
@@ -335,6 +345,13 @@ module Exp = struct
       match ctx0 with
       | Exp {pexp_desc= Pexp_ifthenelse _; _} -> false
       | _ -> true
+
+  let fun_label_sep (c: Conf.t) =
+    (* Break between the label and the fun to avoid ocp-indent's alignment.
+        If a label is present, arguments should be indented more than the
+        arrow and the eventually breaking [fun] keyword. *)
+    if c.fmt_opts.ocp_indent_compat.v then str ":" $ cut_break
+    else str ":"
 end
 
 module Mod = struct
@@ -1000,7 +1017,7 @@ module Indent = struct
         if c.fmt_opts.let_binding_deindent_fun.v then 1 else 0
     | _ when ctx_is_infix ctx0 -> 0
     | _ when ocp c -> (
-      match ctx_is_apply_and_exp_is_arg ~ctx ctx0 with
+      match Exp.ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 with
       | Some (_, _, true) -> (* Last argument *) 2
       | _ -> if parens then 3 else 2 )
     | _ -> 2

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -83,27 +83,26 @@ let parens_if parens (c : Conf.t) ?(disambiguate = false) k =
 let parens c ?disambiguate k = parens_if true c ?disambiguate k
 
 module Exp = struct
-
   (** Return [None] if [ctx0] is not an application or [ctx] is not one of its
     argument.
     Else, returns [lbl, exp, is_last] where [lbl] is the label of the argument,
     [exp] is the epxression in [ctx], and [is_last] is true if [exp] is the last
     argument.*)
-let ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 =
-  match (ctx, ctx0) with
-  | Exp exp, Exp {pexp_desc= Pexp_apply (_, args); _} ->
-      let last_lbl, last_arg = List.last_exn args in
-      if phys_equal last_arg exp then Some (last_lbl, exp, true)
-      else
-        List.find_map
-          ~f:(fun (lbl, x) ->
-            if phys_equal x exp then Some (lbl, exp, false) else None )
-          args
-  | _ -> None
+  let ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 =
+    match (ctx, ctx0) with
+    | Exp exp, Exp {pexp_desc= Pexp_apply (_, args); _} ->
+        let last_lbl, last_arg = List.last_exn args in
+        if phys_equal last_arg exp then Some (last_lbl, exp, true)
+        else
+          List.find_map
+            ~f:(fun (lbl, x) ->
+              if phys_equal x exp then Some (lbl, exp, false) else None )
+            args
+    | _ -> None
 
   let ctx_is_apply_and_exp_is_arg_with_label ~ctx ~ctx0 =
     match ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 with
-    | Some ((Labelled _  | Optional _), _ , _) -> true
+    | Some ((Labelled _ | Optional _), _, _) -> true
     | _ -> false
 
   let ctx_is_apply_and_exp_is_last_arg_and_other_args_are_simple c ~ctx ~ctx0
@@ -346,12 +345,11 @@ let ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 =
       | Exp {pexp_desc= Pexp_ifthenelse _; _} -> false
       | _ -> true
 
-  let fun_label_sep (c: Conf.t) =
+  let fun_label_sep (c : Conf.t) =
     (* Break between the label and the fun to avoid ocp-indent's alignment.
-        If a label is present, arguments should be indented more than the
-        arrow and the eventually breaking [fun] keyword. *)
-    if c.fmt_opts.ocp_indent_compat.v then str ":" $ cut_break
-    else str ":"
+       If a label is present, arguments should be indented more than the
+       arrow and the eventually breaking [fun] keyword. *)
+    if c.fmt_opts.ocp_indent_compat.v then str ":" $ cut_break else str ":"
 end
 
 module Mod = struct

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -93,14 +93,13 @@ module Exp : sig
   (** whether the [pro] argument should be displayed as an inner or outer
         prologue when printing [Pexp_ifthenelse]. *)
 
-  val ctx_is_apply_and_exp_is_arg_with_label:
-     ctx:Ast.t -> ctx0:Ast.t -> bool
-
+  val ctx_is_apply_and_exp_is_arg_with_label :
+    ctx:Ast.t -> ctx0:Ast.t -> bool
 
   val ctx_is_apply_and_exp_is_last_arg_and_other_args_are_simple :
     Conf_t.t -> ctx:Ast.t -> ctx0:Ast.t -> bool
 
-  val fun_label_sep: Conf.t -> Fmt.t
+  val fun_label_sep : Conf.t -> Fmt.t
 end
 
 module Mod : sig

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -92,6 +92,15 @@ module Exp : sig
   val ifthenelse_inner_pro : parens:bool -> ctx0:Ast.t -> bool
   (** whether the [pro] argument should be displayed as an inner or outer
         prologue when printing [Pexp_ifthenelse]. *)
+
+  val ctx_is_apply_and_exp_is_arg_with_label:
+     ctx:Ast.t -> ctx0:Ast.t -> bool
+
+
+  val ctx_is_apply_and_exp_is_last_arg_and_other_args_are_simple :
+    Conf_t.t -> ctx:Ast.t -> ctx0:Ast.t -> bool
+
+  val fun_label_sep: Conf.t -> Fmt.t
 end
 
 module Mod : sig


### PR DESCRIPTION
last_arg and has_label is computed from context, label is given in `pro`.

This has no diff, and just make `fmt_function` a little more generic.

I want to confirm that there are no diffs on test-branch, and then merge.