### PR TITLE
`map begin fun` on one line, second attempt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,10 +69,11 @@ profile. This started with version 0.26.0.
 
 ### Changed
 
-- \* `|> begin`, `~arg:begin`, `begin if`, `lazy begin`, `begin match` and
-  `begin fun` can now be printed on the same line, with one less indentation
-  level for the body of the inner expression. (#2664, #2666, #2671, #2672,
-  #2681, #2685, @EmileTrotignon) For example :
+- `|> begin`, `~arg:begin`, `begin if`, `lazy begin`, `begin match`,
+  `begin fun` and `map li begin fun`  can now be printed on the same line, with
+  one less indentation level for the body of the inner expression.
+  (#2664, #2666, #2671, #2672, #2681, #2685, #2693, @EmileTrotignon)
+  For example :
   ```ocaml
   (* before *)
   begin

--- a/bin/ocamlformat/dune
+++ b/bin/ocamlformat/dune
@@ -18,7 +18,8 @@
   (:standard -open Ocamlformat_stdlib))
  (instrumentation
   (backend bisect_ppx))
- (libraries ocamlformat-lib bin_conf))
+ (libraries ocamlformat-lib bin_conf)
+ (modes byte native))
 
 (rule
  (with-stdout-to

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2946,8 +2946,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       pro $ fmt_indexop_access c ctx ~fmt_atrs ~has_attr ~parens x
   | Pexp_hole -> pro $ hvbox 0 (fmt_hole () $ fmt_atrs)
   | Pexp_beginend (e, infix_ext_attrs) ->
-      fmt_beginend c ~loc:pexp_loc ~box ~pro ~ctx ~ctx0 ~fmt_atrs ~infix_ext_attrs
-        ~indent_wrap ?eol e
+      fmt_beginend c ~loc:pexp_loc ~box ~pro ~ctx ~ctx0 ~fmt_atrs
+        ~infix_ext_attrs ~indent_wrap ?eol e
   | Pexp_parens e ->
       pro
       $ hvbox 0
@@ -2987,23 +2987,27 @@ and fmt_beginend c ~loc ?(box = true) ?(pro = noop) ~ctx ~ctx0 ~fmt_atrs
     $ str "end" $ fmt_atrs
   in
   let box_beginend_sb = Params.Exp.box_beginend_subexpr c.conf ~ctx ~ctx0 in
-  let beginend_box = if Params.Exp.box_beginend c.conf ~ctx ~ctx0 then hvbox ~name:"beginend" 2 else Fn.id in
+  let beginend_box =
+    if Params.Exp.box_beginend c.conf ~ctx ~ctx0 then
+      hvbox ~name:"beginend" 2
+    else Fn.id
+  in
   cmts_before
   $
   match e.pexp_desc with
   | Pexp_match _ | Pexp_try _ | Pexp_function _ | Pexp_ifthenelse _ ->
       beginend_box
-        ( fmt_expression c
-            ~pro:(pro $ begin_ $ str " ")
-            ~box:false ?eol ~parens:false ~indent_wrap (sub_exp ~ctx e))
-        $ end_
+        (fmt_expression c
+           ~pro:(pro $ begin_ $ str " ")
+           ~box:false ?eol ~parens:false ~indent_wrap (sub_exp ~ctx e) )
+      $ end_
   | _ ->
       beginend_box
         ( hvbox 0 (pro $ begin_)
         $ break 1 2
-        $ fmt_expression c ~box:box_beginend_sb ?eol ~parens:false ~indent_wrap
-            (sub_exp ~ctx e))
-        $ end_
+        $ fmt_expression c ~box:box_beginend_sb ?eol ~parens:false
+            ~indent_wrap (sub_exp ~ctx e) )
+      $ end_
 
 and fmt_let_bindings c ~ctx0 ~parens ~has_attr ~fmt_atrs ~fmt_expr ~loc_in
     rec_flag bindings body =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1875,7 +1875,8 @@ and fmt_infix_op_args c ~parens xexp op_args =
     in
     if Params.Exp.Infix_op_arg.dock c.conf xarg then
       (* Indentation of docked fun or function start before the operator. *)
-      hovbox 2 (fmt_expression c ~parens ~box:false ~pro xarg)
+      hovbox ~name:"Infix_op_arg docked" 2
+        (fmt_expression c ~parens ~box:false ~pro xarg)
     else
       match xarg.ast.pexp_desc with
       | Pexp_function _ | Pexp_beginend _ ->
@@ -2300,14 +2301,16 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
             else Break
           in
           let pro =
-            pro
+            intro_epi
             $ fmt_if parens (str "(")
             $ ( fmt_args_grouped ~epi:fmt_atrs e0 args_before
               $ fmt_if parens (closing_paren c ~force ~offset:(-3)) )
           in
           let label_sep = Params.Exp.fun_label_sep c.conf in
           let pro = pro $ break 1 0 $ fmt_label lbl label_sep in
-          hovbox 4 (fmt_expression c ~pro ~box:false (sub_exp ~ctx last_arg))
+          expr_epi
+          $ hovbox 4
+              (fmt_expression c ~pro ~box:false (sub_exp ~ctx last_arg))
       | _ ->
           let fmt_atrs =
             fmt_attributes c ~pre:(Break (1, -2)) pexp_attributes

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -145,7 +145,11 @@ module Exp = struct
         | Pexp_apply (_, args) -> (
           (* Rhs is an apply and it ends with a [fun]. *)
           match List.last_exn args with
-          | _, {pexp_desc= Pexp_function _; _} -> true
+          | _, {pexp_desc= Pexp_function _; _}
+           |( _
+            , { pexp_desc= Pexp_beginend ({pexp_desc= Pexp_function _; _}, _)
+              ; _ } ) ->
+              true
           | _ -> false )
         | Pexp_match _ | Pexp_try _ -> true
         | _ -> false

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -343,13 +343,23 @@ module Exp = struct
         hvbox (2 - String.length "begin ")
     | _ -> Fn.id
 
-
-  let box_beginend c ~ctx0 ~ctx  =
-    let contains_fun = match ctx with Exp {pexp_desc=Pexp_beginend ({pexp_desc=Pexp_function _; _}, _); _} -> true | _ -> false in
-    (contains_fun) && not (ctx_is_apply_and_exp_is_last_arg_and_other_args_are_simple c ~ctx ~ctx0 )
+  let box_beginend c ~ctx0 ~ctx =
+    let contains_fun =
+      match ctx with
+      | Exp {pexp_desc= Pexp_beginend ({pexp_desc= Pexp_function _; _}, _); _}
+        ->
+          true
+      | _ -> false
+    in
+    contains_fun
+    && not
+         (ctx_is_apply_and_exp_is_last_arg_and_other_args_are_simple c ~ctx
+            ~ctx0 )
 
   let box_beginend_subexpr c ~ctx0 ~ctx =
-    not (ctx_is_apply_and_exp_is_last_arg_and_other_args_are_simple c ~ctx ~ctx0 )
+    not
+      (ctx_is_apply_and_exp_is_last_arg_and_other_args_are_simple c ~ctx
+         ~ctx0 )
 
   let match_inner_pro ~ctx0 ~parens =
     if parens then false

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -86,7 +86,7 @@ module Exp : sig
 
   val box_beginend : Conf.t -> ctx0:Ast.t -> ctx:Ast.t -> bool
 
-  val box_beginend_subexpr: Conf.t -> ctx0:Ast.t -> ctx:Ast.t -> bool
+  val box_beginend_subexpr : Conf.t -> ctx0:Ast.t -> ctx:Ast.t -> bool
 
   val match_inner_pro : ctx0:Ast.t -> parens:bool -> bool
   (**  whether the [pro] argument of [fmt_match] should be displayed as an inner

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -81,6 +81,13 @@ module Exp : sig
   val box_fun_decl : ctx0:Ast.t -> Conf.t -> Fmt.t -> Fmt.t
   (** Box a function decl from the label to the arrow. *)
 
+  val box_fun_decl_after_pro : ctx0:Ast.t -> Fmt.t -> Fmt.t
+  (** Box a function decl from after the [pro] to the arrow. *)
+
+  val box_beginend : Conf.t -> ctx0:Ast.t -> ctx:Ast.t -> bool
+
+  val box_beginend_subexpr: Conf.t -> ctx0:Ast.t -> ctx:Ast.t -> bool
+
   val match_inner_pro : ctx0:Ast.t -> parens:bool -> bool
   (**  whether the [pro] argument of [fmt_match] should be displayed as an inner
      or outer prologue.*)

--- a/test/passing/refs.default/attributes.ml.ref
+++ b/test/passing/refs.default/attributes.ml.ref
@@ -395,8 +395,7 @@ include [@foo] M [@boo]
 let () =
   let () =
     S.ntyp Cbor_type.Reserved
-    @@ S.tok
-         begin[@warning "-4"] fun ev ->
+    @@ S.tok begin[@warning "-4"] fun ev ->
            match ev with Cbor_event.Reserved int -> Some int | _ -> None
          end
   in

--- a/test/passing/refs.default/cases_exp_grouping.ml.ref
+++ b/test/passing/refs.default/cases_exp_grouping.ml.ref
@@ -116,7 +116,9 @@ let a =
   | B -> bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
   end
 
-let a = begin match f x i with A -> a | B -> b end
+let a =
+  begin match f x i with A -> a | B -> b
+  end
 
 let a =
   begin[@a] match[@b]
@@ -175,7 +177,9 @@ let a =
   | B -> bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
   end
 
-let a = begin try f x i with A -> a | B -> b end
+let a =
+  begin try f x i with A -> a | B -> b
+  end
 
 let a =
   begin[@a] try[@b]

--- a/test/passing/refs.default/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.default/exp_grouping-parens.ml.ref
@@ -388,8 +388,7 @@ let v =
       a f b)
 
 let v =
-  map x
-    begin%ext1 fun%ext2 x y z ->
+  map x begin%ext1 fun%ext2 x y z ->
       ya f;
       a f b
     end

--- a/test/passing/refs.default/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.default/exp_grouping-parens.ml.ref
@@ -553,3 +553,47 @@ let _ =
     a
   end
   [@a]
+
+let () =
+  fooooo
+  |>>>>> List.iter (fun a ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x)
+
+let () =
+  fooooo
+  |>>>>> List.iter
+           (fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x)
+
+let () =
+  fooooo
+  |>>>>> List.iter (fun a ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x)
+
+let () =
+  fooooo
+  |>>>>> List.iter aaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaa
+           aaaaaaaaaaaaaa
+           (fun
+             aaaaaaaaaaaaaaaaaaaaaaaaaaa
+             aa
+             aaaaaaaaaaa
+             aaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x)

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -634,3 +634,51 @@ let _ =
     a
   end
   [@a]
+
+let () =
+  fooooo
+  |>>>>> List.iter begin fun a ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x
+           end
+
+let () =
+  fooooo
+  |>>>>> List.iter
+           begin fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x
+           end
+
+let () =
+  fooooo
+  |>>>>> List.iter begin fun a ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x
+           end
+
+let () =
+  fooooo
+  |>>>>> List.iter aaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaa
+           aaaaaaaaaaaaaa
+           begin fun
+             aaaaaaaaaaaaaaaaaaaaaaaaaaa
+             aa
+             aaaaaaaaaaa
+             aaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x
+           end

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -360,8 +360,7 @@ let _ =
 
 let () =
   if a then begin
-    b
-  (* asd *)
+    b (* asd *)
   end
 
 let x =
@@ -397,7 +396,11 @@ let _ =
       end
 
 let _ = match x with _ -> begin[@foo] y end
-let v = map x begin fun x y z -> y end
+
+let v =
+  map x begin fun x y z ->
+      y
+    end
 
 let v =
   map x
@@ -407,9 +410,11 @@ let v =
 
 let v =
   map x
-    begin fun x
+    begin fun
+      x
       arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-    -> y
+    ->
+      y
     end
 
 let v =
@@ -420,11 +425,13 @@ let v =
 
 let v =
   map x
-    begin fun x
+    begin fun
+      x
       argggggggggggggggggggggggggggggggggg
       gggggggggggggggggggg
       ggggggggggggggg
-    -> y
+    ->
+      y
     end
 
 let v =
@@ -434,15 +441,13 @@ let v =
       z)
 
 let v =
-  map x
-    begin fun x y z ->
+  map x begin fun x y z ->
       ya f;
       a f b
     end
 
 let v =
-  map x
-    begin%ext1 fun%ext2 x y z ->
+  map x begin%ext1 fun%ext2 x y z ->
       ya f;
       a f b
     end
@@ -468,10 +473,11 @@ let _ =
   end
 
 let _ =
-  lazy begin fun xxxxxxxxxxxxxxxxxxxxxxx
-    yyyyyyyyyyyyyyyyyyy
-    zzzzzzzzzzzzzzzzzzzzzzzz
-  ->
+  lazy begin fun
+         xxxxxxxxxxxxxxxxxxxxxxx
+         yyyyyyyyyyyyyyyyyyy
+         zzzzzzzzzzzzzzzzzzzzzzzz
+       ->
     print_endline xxxxxxxxx;
     f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
   end
@@ -557,10 +563,11 @@ let _ =
 
 let _ =
   f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
-    ~label:begin fun x
-      aaaaaaaaaaaaaaaaaaaaaaaaa
-      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    ->
+    ~label:begin fun
+             x
+             aaaaaaaaaaaaaaaaaaaaaaaaa
+             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           ->
       function_ body;
       force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk;
       return value

--- a/test/passing/refs.janestreet/attributes.ml.ref
+++ b/test/passing/refs.janestreet/attributes.ml.ref
@@ -443,10 +443,10 @@ let () =
   let () =
     S.ntyp Cbor_type.Reserved
     @@ S.tok begin[@warning "-4"] fun ev ->
-           match ev with
-           | Cbor_event.Reserved int -> Some int
-           | _ -> None
-         end
+        match ev with
+        | Cbor_event.Reserved int -> Some int
+        | _ -> None
+      end
   in
   ()
 ;;

--- a/test/passing/refs.janestreet/attributes.ml.ref
+++ b/test/passing/refs.janestreet/attributes.ml.ref
@@ -442,8 +442,7 @@ include [@foo] M [@boo]
 let () =
   let () =
     S.ntyp Cbor_type.Reserved
-    @@ S.tok
-         begin[@warning "-4"] fun ev ->
+    @@ S.tok begin[@warning "-4"] fun ev ->
            match ev with
            | Cbor_event.Reserved int -> Some int
            | _ -> None

--- a/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
@@ -641,3 +641,39 @@ let _ =
   end
   [@a]
 ;;
+
+let () =
+  fooooo
+  |>>>>> List.iter (fun a ->
+    let x = some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y in
+    fooooooooooo x)
+;;
+
+let () =
+  fooooo
+  |>>>>> List.iter (fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+    let x = some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y in
+    fooooooooooo x)
+;;
+
+let () =
+  fooooo
+  |>>>>> List.iter (fun a ->
+    let x = some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y in
+    fooooooooooo x)
+;;
+
+let () =
+  fooooo
+  |>>>>> List.iter
+           aaaaaaaaaaaa
+           aaaaaaaaaaaaaaaaaaaaa
+           aaaaaaaaaaaaaaa
+           aaaaaaaaaaaaaa
+           (fun
+               aaaaaaaaaaaaaaaaaaaaaaaaaaa aa aaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+              let x =
+                some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+              in
+              fooooooooooo x)
+;;

--- a/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping-parens.ml.ref
@@ -447,9 +447,7 @@ let v =
 ;;
 
 let v =
-  map
-    x
-    begin%ext1 fun%ext2 x y z ->
+  map x begin%ext1 fun%ext2 x y z ->
       ya f;
       a f b
     end

--- a/test/passing/refs.janestreet/exp_grouping.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping.ml.ref
@@ -731,31 +731,25 @@ let _ =
 let () =
   fooooo
   |>>>>> List.iter begin fun a ->
-             let x =
-               some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
-             in
-             fooooooooooo x
-           end
+      let x = some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y in
+      fooooooooooo x
+    end
 ;;
 
 let () =
   fooooo
   |>>>>> List.iter begin fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
-             let x =
-               some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
-             in
-             fooooooooooo x
-           end
+      let x = some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y in
+      fooooooooooo x
+    end
 ;;
 
 let () =
   fooooo
   |>>>>> List.iter begin fun a ->
-             let x =
-               some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
-             in
-             fooooooooooo x
-           end
+      let x = some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y in
+      fooooooooooo x
+    end
 ;;
 
 let () =

--- a/test/passing/refs.janestreet/exp_grouping.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping.ml.ref
@@ -424,8 +424,7 @@ let _ =
 
 let () =
   if a then begin
-    b
-  (* asd *)
+    b (* asd *)
   end
 ;;
 
@@ -471,31 +470,21 @@ let _ =
   | _ -> begin[@foo] y end
 ;;
 
-let v = map x begin fun x y z -> y end
-
 let v =
-  map x begin fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg -> y end
+  map x begin fun x y z ->
+      y
+    end
 ;;
 
 let v =
-  map
-    x
-    begin fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg -> y end
+  map x begin fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y
+    end
 ;;
 
 let v =
-  map x (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
-    print y;
-    z)
-;;
-
-let v =
-  map
-    x
-    begin fun x
-            argggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggg
-            ggggggggggggggg -> y
+  map x begin fun x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
+      y
     end
 ;;
 
@@ -506,18 +495,30 @@ let v =
 ;;
 
 let v =
-  map
-    x
-    begin fun x y z ->
+  map x
+    begin fun x
+            argggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggg
+            ggggggggggggggg ->
+      y
+    end
+;;
+
+let v =
+  map x (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
+    print y;
+    z)
+;;
+
+let v =
+  map x begin fun x y z ->
       ya f;
       a f b
     end
 ;;
 
 let v =
-  map
-    x
-    begin%ext1 fun%ext2 x y z ->
+  map x begin%ext1 fun%ext2 x y z ->
       ya f;
       a f b
     end

--- a/test/passing/refs.janestreet/exp_grouping.ml.ref
+++ b/test/passing/refs.janestreet/exp_grouping.ml.ref
@@ -727,3 +727,47 @@ let _ =
   end
   [@a]
 ;;
+
+let () =
+  fooooo
+  |>>>>> List.iter begin fun a ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+             in
+             fooooooooooo x
+           end
+;;
+
+let () =
+  fooooo
+  |>>>>> List.iter begin fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+             in
+             fooooooooooo x
+           end
+;;
+
+let () =
+  fooooo
+  |>>>>> List.iter begin fun a ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+             in
+             fooooooooooo x
+           end
+;;
+
+let () =
+  fooooo
+  |>>>>> List.iter aaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaa aaaaaaaaaaaaaa
+           begin fun aaaaaaaaaaaaaaaaaaaaaaaaaaa
+                   aa
+                   aaaaaaaaaaa
+                   aaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+             in
+             fooooooooooo x
+           end
+;;

--- a/test/passing/refs.ocamlformat/attributes.ml.ref
+++ b/test/passing/refs.ocamlformat/attributes.ml.ref
@@ -441,8 +441,7 @@ include [@foo] M [@boo]
 let () =
   let () =
     S.ntyp Cbor_type.Reserved
-    @@ S.tok
-         begin[@warning "-4"] fun ev ->
+    @@ S.tok begin[@warning "-4"] fun ev ->
            match ev with Cbor_event.Reserved int -> Some int | _ -> None
          end
   in

--- a/test/passing/refs.ocamlformat/cases_exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/cases_exp_grouping.ml.ref
@@ -124,7 +124,9 @@ let a =
       bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
   end
 
-let a = begin match f x i with A -> a | B -> b end
+let a =
+  begin match f x i with A -> a | B -> b
+  end
 
 let a =
   begin[@a] match[@b]
@@ -199,7 +201,9 @@ let a =
       bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
   end
 
-let a = begin try f x i with A -> a | B -> b end
+let a =
+  begin try f x i with A -> a | B -> b
+  end
 
 let a =
   begin[@a] try[@b]

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
@@ -557,3 +557,47 @@ let _ =
     a
   end
   [@a]
+
+let () =
+  fooooo
+  |>>>>> List.iter (fun a ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x )
+
+let () =
+  fooooo
+  |>>>>> List.iter
+           (fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x )
+
+let () =
+  fooooo
+  |>>>>> List.iter (fun a ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x )
+
+let () =
+  fooooo
+  |>>>>> List.iter aaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaa
+           aaaaaaaaaaaaaa
+           (fun
+             aaaaaaaaaaaaaaaaaaaaaaaaaaa
+             aa
+             aaaaaaaaaaa
+             aaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x )

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
@@ -382,7 +382,10 @@ let v =
 
 let v = map x (fun x y z -> ya f ; a f b)
 
-let v = map x begin%ext1 fun%ext2 x y z -> ya f ; a f b end
+let v =
+  map x begin%ext1 fun%ext2 x y z ->
+      ya f ; a f b
+    end
 
 let _ =
   lazy

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -360,8 +360,7 @@ let _ =
 
 let () =
   if a then begin
-    b
-  (* asd *)
+    b (* asd *)
   end
 
 let x =
@@ -399,7 +398,10 @@ let _ =
 
 let _ = match x with _ -> begin[@foo] y end
 
-let v = map x begin fun x y z -> y end
+let v =
+  map x begin fun x y z ->
+      y
+    end
 
 let v =
   map x
@@ -409,9 +411,11 @@ let v =
 
 let v =
   map x
-    begin fun x
+    begin fun
+      x
       arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-    -> y
+    ->
+      y
     end
 
 let v =
@@ -421,11 +425,13 @@ let v =
 
 let v =
   map x
-    begin fun x
+    begin fun
+      x
       argggggggggggggggggggggggggggggggggg
       gggggggggggggggggggg
       ggggggggggggggg
-    -> y
+    ->
+      y
     end
 
 let v =
@@ -433,9 +439,15 @@ let v =
     (fun x yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy z ->
       print y ; z )
 
-let v = map x begin fun x y z -> ya f ; a f b end
+let v =
+  map x begin fun x y z ->
+      ya f ; a f b
+    end
 
-let v = map x begin%ext1 fun%ext2 x y z -> ya f ; a f b end
+let v =
+  map x begin%ext1 fun%ext2 x y z ->
+      ya f ; a f b
+    end
 
 let _ =
   lazy begin
@@ -459,10 +471,11 @@ let _ =
   end
 
 let _ =
-  lazy begin fun xxxxxxxxxxxxxxxxxxxxxxx
-    yyyyyyyyyyyyyyyyyyy
-    zzzzzzzzzzzzzzzzzzzzzzzz
-  ->
+  lazy begin fun
+         xxxxxxxxxxxxxxxxxxxxxxx
+         yyyyyyyyyyyyyyyyyyy
+         zzzzzzzzzzzzzzzzzzzzzzzz
+       ->
     print_endline xxxxxxxxx ;
     f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
   end
@@ -547,10 +560,11 @@ let _ =
 
 let _ =
   f ~aaaaaaaaaaaaaaaaaaaaaaaaaa ~bbbbbbbbbbbbbbbbbbbbbbb ~ccccccccccccccccccccc
-    ~label:begin fun x
-      aaaaaaaaaaaaaaaaaaaaaaaaa
-      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    ->
+    ~label:begin fun
+             x
+             aaaaaaaaaaaaaaaaaaaaaaaaa
+             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           ->
       function_ body ;
       force breakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk ;
       return value

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -640,3 +640,51 @@ let _ =
     a
   end
   [@a]
+
+let () =
+  fooooo
+  |>>>>> List.iter begin fun a ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x
+           end
+
+let () =
+  fooooo
+  |>>>>> List.iter
+           begin fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x
+           end
+
+let () =
+  fooooo
+  |>>>>> List.iter begin fun a ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x
+           end
+
+let () =
+  fooooo
+  |>>>>> List.iter aaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaa
+           aaaaaaaaaaaaaa
+           begin fun
+             aaaaaaaaaaaaaaaaaaaaaaaaaaa
+             aa
+             aaaaaaaaaaa
+             aaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x
+           end

--- a/test/passing/tests/exp_grouping.ml
+++ b/test/passing/tests/exp_grouping.ml
@@ -503,3 +503,47 @@ let main =
   | B -> bbbbbbbbbbbbbbbbbbbbbb
 
 let _ = begin a end [@a]
+
+let () =
+  fooooo
+  |>>>>> List.iter begin fun a ->
+      let x =
+        some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+      in
+      fooooooooooo x
+    end
+
+let () =
+  fooooo
+  |>>>>> List.iter
+           begin fun aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x
+           end
+
+let () =
+  fooooo
+  |>>>>> List.iter begin fun a ->
+      let x =
+        some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+      in
+      fooooooooooo x
+    end
+
+let () =
+  fooooo
+  |>>>>> List.iter aaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaa
+           aaaaaaaaaaaaaa
+           begin fun aaaaaaaaaaaaaaaaaaaaaaaaaaa
+                   aa
+                   aaaaaaaaaaa
+                   aaaaaaaaaaaaaaaaaaaaaaaaaaaaa ->
+             let x =
+               some_really_really_really_long_name_that_doesn't_fit_on_the_line
+               $ y
+             in
+             fooooooooooo x
+           end


### PR DESCRIPTION
Same goal as #2675 , but with a cleaner implementation that uses `pro` instead.

The box structure is not ideal, because `fmt_function` cannot open a box in the middle of `pro`, but the only case where this is an issue is the following :

```ocaml
let _ =
  lazy begin fun
         xxxxxxxxxxxxxxxxxxxxxxx
         yyyyyyyyyyyyyyyyyyy
         zzzzzzzzzzzzzzzzzzzzzzzz
       ->
    print_endline xxxxxxxxx ;
    f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
  end
```