### PR TITLE
promote ocp docking for infix apply.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,6 +104,22 @@ profile. This started with version 0.26.0.
   let a = 3
   ```
 
+- \* Infix apply docking behaviour from --ocp-indent-compat is promoted to
+ everyone. The most common effect is that `|> map (fun` is now indented from
+ `|>` and not from `map`:
+  ```ocaml
+  (* before *)
+  v
+  |>>>>>> map (fun x ->
+              x )
+  (* after *)
+  v
+  |>>>>>> map (fun x ->
+      x )
+  ```
+  `@@ match` can now also be on one line.
+  (#2694, @EmileTrotignon)
+
 ## 0.27.0
 
 ### Highlight

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -97,14 +97,14 @@ let json_of_ols_results ?name (results : Bechamel.Analyze.OLS.t results) :
   let results =
     metrics_by_test |> Hashtbl.to_seq
     |> Seq.map (fun (test_name, metrics) ->
-           let metrics =
-             metrics |> Hashtbl.to_seq
-             |> Seq.map (fun (metric_name, ols) ->
-                    (metric_name, json_of_ols ols) )
-             |> List.of_seq
-             |> fun bindings -> `Assoc bindings
-           in
-           `Assoc [("name", `String test_name); ("metrics", metrics)] )
+        let metrics =
+          metrics |> Hashtbl.to_seq
+          |> Seq.map (fun (metric_name, ols) ->
+              (metric_name, json_of_ols ols) )
+          |> List.of_seq
+          |> fun bindings -> `Assoc bindings
+        in
+        `Assoc [("name", `String test_name); ("metrics", metrics)] )
     |> List.of_seq
     |> fun items -> `List items
   in

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -995,14 +995,14 @@ end = struct
         assert (
           List.exists ptype_params ~f:fst_f
           || List.exists ptype_cstrs ~f:(fun (t1, t2, _) ->
-                 typ == t1 || typ == t2 )
+              typ == t1 || typ == t2 )
           || ( match ptype_kind with
-             | Ptype_variant cd1N ->
-                 List.exists cd1N ~f:(fun {pcd_args; pcd_res; _} ->
-                     check_cstr pcd_args || Option.exists pcd_res ~f )
-             | Ptype_record ld1N ->
-                 List.exists ld1N ~f:(fun {pld_type; _} -> typ == pld_type)
-             | _ -> false )
+            | Ptype_variant cd1N ->
+                List.exists cd1N ~f:(fun {pcd_args; pcd_res; _} ->
+                    check_cstr pcd_args || Option.exists pcd_res ~f )
+            | Ptype_record ld1N ->
+                List.exists ld1N ~f:(fun {pld_type; _} -> typ == pld_type)
+            | _ -> false )
           || Option.exists ptype_manifest ~f )
     | Cty {pcty_desc; _} ->
         assert (
@@ -1534,13 +1534,13 @@ end = struct
     | Pexp_record (e1N, e0) ->
         Option.for_all e0 ~f:Exp.is_trivial
         && List.for_all e1N ~f:(fun (_, c, eo) ->
-               Option.is_none c && Option.for_all eo ~f:Exp.is_trivial )
+            Option.is_none c && Option.for_all eo ~f:Exp.is_trivial )
         && fit_margin c (width xexp)
     | Pexp_indexop_access {pia_lhs; pia_kind; pia_rhs= None; _} ->
         Exp.is_trivial pia_lhs
         && ( match pia_kind with
-           | Builtin idx -> Exp.is_trivial idx
-           | Dotop (_, _, idx) -> List.for_all idx ~f:Exp.is_trivial )
+          | Builtin idx -> Exp.is_trivial idx
+          | Dotop (_, _, idx) -> List.for_all idx ~f:Exp.is_trivial )
         && fit_margin c (width xexp)
     | Pexp_prefix (_, e) -> Exp.is_trivial e && fit_margin c (width xexp)
     | Pexp_infix ({txt= ":="; _}, _, _) -> false
@@ -2218,7 +2218,7 @@ end = struct
         | Pexp_infix (_, _, e2)
           when e2 == exp
                && Option.value_map ~default:false (prec_ast ctx) ~f:(fun p ->
-                      Prec.compare p Apply < 0 ) ->
+                   Prec.compare p Apply < 0 ) ->
             true
         | Pexp_tuple e1N -> List.last_exn e1N == xexp.ast
         | _ -> false

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -595,19 +595,19 @@ let fmt_cmts_aux t (conf : Conf.t) cmts ~fmt_code pos =
   vbox 0 ~name:"cmts"
     (list_pn groups (fun ~prev:_ group ~next ->
          ( match group with
-         | [] -> impossible "previous match"
-         | [cmt] ->
-             let break =
-               fmt_if
-                 ( conf.fmt_opts.ocp_indent_compat.v
-                 && Poly.(pos = Cmt.After)
-                 && String.contains (Cmt.txt cmt) '\n' )
-                 (break_unless_newline 1000 0)
-             in
-             break $ fmt_cmt conf cmt ~fmt_code
-         | group ->
-             list group force_break (fun cmt ->
-                 wrap (str "(*") (str "*)") (str (Cmt.txt cmt)) ) )
+           | [] -> impossible "previous match"
+           | [cmt] ->
+               let break =
+                 fmt_if
+                   ( conf.fmt_opts.ocp_indent_compat.v
+                   && Poly.(pos = Cmt.After)
+                   && String.contains (Cmt.txt cmt) '\n' )
+                   (break_unless_newline 1000 0)
+               in
+               break $ fmt_cmt conf cmt ~fmt_code
+           | group ->
+               list group force_break (fun cmt ->
+                   wrap (str "(*") (str "*)") (str (Cmt.txt cmt)) ) )
          $
          match next with
          | Some (next :: _) ->

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1873,7 +1873,7 @@ and fmt_infix_op_args c ~parens xexp op_args =
       ((not very_last) && exposed_right_exp Ast.Non_apply xarg.ast)
       || parenze_exp xarg
     in
-    if Params.Exp.Infix_op_arg.dock c.conf xarg then
+    if Params.Exp.Infix_op_arg.dock xarg then
       (* Indentation of docked fun or function start before the operator. *)
       hovbox ~name:"Infix_op_arg docked" 2
         (fmt_expression c ~parens ~box:false ~pro xarg)
@@ -2247,8 +2247,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
            parenthesis. *)
         let dock_fun_arg =
           (* Do not dock the arguments when there's more than one. *)
-          (not c.conf.fmt_opts.ocp_indent_compat.v)
-          || Location.line_difference e0.pexp_loc last_arg.pexp_loc = 0
+          Location.line_difference e0.pexp_loc last_arg.pexp_loc = 0
         in
         if parens || not dock_fun_arg then (noop, pro) else (pro, noop)
       in

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -222,10 +222,10 @@ let fmt_item_list c ctx0 update_config ast fmt_item items =
   let loc = Ast.location ctx in
   maybe_disabled c loc [] (fun c -> fmt_item c ctx ~prev ~next itm)
   $ opt next (fun (i_n, c_n) ->
-        fmt_or
-          (break_between c (ctx, c.conf) (ast i_n, c_n.conf))
-          (str "\n" $ force_break)
-          (fmt_or break_struct force_break space_break) )
+      fmt_or
+        (break_between c (ctx, c.conf) (ast i_n, c_n.conf))
+        (str "\n" $ force_break)
+        (fmt_or break_struct force_break space_break) )
 
 let fmt_recmodule c ctx items fmt_item ast sub =
   let update_config c i = update_config c (Ast.attributes (ast i)) in
@@ -462,7 +462,7 @@ let fmt_docstring_around_item' ?(is_val = false) ?(force_before = false)
       let floating_doc, doc =
         doc
         |> List.map ~f:(fun (({txt; loc}, _) as doc) ->
-               (Docstring.parse ~loc txt, doc) )
+            (Docstring.parse ~loc txt, doc) )
         |> List.partition_tf ~f:(fun (_, (_, floating)) -> floating)
       in
       let placement =
@@ -849,8 +849,8 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
   update_config_maybe_disabled c ptyp_loc ptyp_attributes
   @@ fun c ->
   ( match pro with
-  | Some pro -> fmt_constraint_sep ~pro_space c pro
-  | None -> noop )
+    | Some pro -> fmt_constraint_sep ~pro_space c pro
+    | None -> noop )
   $
   let doc, atrs = doc_atrs ptyp_attributes in
   Cmts.fmt c ptyp_loc
@@ -1116,8 +1116,8 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
   let parens = match parens with Some b -> b | None -> parenze_pat xpat in
   (match ctx0 with Pat {ppat_desc= Ppat_tuple _; _} -> hvbox 0 | _ -> Fn.id)
   @@ ( match ppat_desc with
-     | Ppat_or _ -> fun k -> Cmts.fmt c ppat_loc @@ k
-     | _ -> fun k -> Cmts.fmt c ppat_loc @@ (fmt_opt pro $ k) )
+    | Ppat_or _ -> fun k -> Cmts.fmt c ppat_loc @@ k
+    | _ -> fun k -> Cmts.fmt c ppat_loc @@ (fmt_opt pro $ k) )
   @@ hovbox_if box 0
   @@ fmt_pattern_attributes c xpat
   @@
@@ -1495,7 +1495,7 @@ and fmt_indexop_access c ctx ~fmt_atrs ~has_attr ~parens x =
                         (str ";" $ space_break)
                         (sub_exp ~ctx >> fmt_expression c) ) )
            $ opt pia_rhs (fun e ->
-                 fmt_assign_arrow c $ fmt_expression c (sub_exp ~ctx e) ) )
+               fmt_assign_arrow c $ fmt_expression c (sub_exp ~ctx e) ) )
        $ fmt_atrs ) )
 
 (** Format a [Pexp_function]. [wrap_intro] wraps up to after the [->] and is
@@ -2692,8 +2692,8 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                              ( fmt_pattern c ~pro:(if_newline "| ")
                                  (sub_pat ~ctx pc_lhs)
                              $ opt pc_guard (fun g ->
-                                   space_break $ str "when "
-                                   $ fmt_expression c (sub_exp ~ctx g) )
+                                 space_break $ str "when "
+                                 $ fmt_expression c (sub_exp ~ctx g) )
                              $ space_break $ str "->"
                              $ fmt_if parens_here (str " (") ) )
                      $ break 1 2
@@ -3380,8 +3380,8 @@ and fmt_case c ctx ~first ~last case =
           ( hvbox 0
               ( fmt_pattern c ~pro:p.bar ~parens:paren_lhs xlhs
               $ opt pc_guard (fun g ->
-                    break 1 2 $ str "when "
-                    $ fmt_expression c (sub_exp ~ctx g) ) )
+                  break 1 2 $ str "when " $ fmt_expression c (sub_exp ~ctx g) )
+              )
           $ p.break_before_arrow $ str "->" $ p.break_after_arrow
           $ p.open_paren_branch )
       $ p.break_after_opening_paren
@@ -3713,9 +3713,9 @@ and fmt_type_extension c ctx
            $ str " +="
            $ fmt_private_flag c ptyext_private
            $ list_fl ptyext_constructors (fun ~first ~last:_ x ->
-                 let bar_fits = if first then "" else "| " in
-                 cbreak ~fits:("", 1, bar_fits) ~breaks:("", 0, "| ")
-                 $ fmt_ctor x ) )
+               let bar_fits = if first then "" else "| " in
+               cbreak ~fits:("", 1, bar_fits) ~breaks:("", 0, "| ")
+               $ fmt_ctor x ) )
        $ fmt_item_attributes c ~pre:(Break (1, 0)) attrs_after )
 
 and fmt_type_exception ~pre c ctx
@@ -4027,46 +4027,46 @@ and fmt_class_types c ~pre ~sep cls =
 and fmt_class_exprs c cls =
   hvbox 0
   @@ list_fl cls (fun ~first ~last:_ cl ->
-         update_config_maybe_disabled_attrs c cl.pci_loc cl.pci_attributes
-         @@ fun c ->
-         let ctx = Cd cl in
-         let xargs = cl.pci_args in
-         let ext = cl.pci_attributes.attrs_extension in
-         let doc_before, doc_after, attrs_before, attrs_after =
-           let force_before = not (Cl.is_simple cl.pci_expr) in
-           fmt_docstring_around_item_attrs ~force_before c cl.pci_attributes
-         in
-         let class_expr =
-           let pro =
-             box_fun_decl_args c 2
-               ( hovbox 2
-                   ( str (if first then "class" else "and")
-                   $ fmt_if first (fmt_extension_suffix c ext)
-                   $ fmt_attributes c ~pre:(Break (1, 0)) attrs_before
-                   $ fmt_virtual_flag c cl.pci_virt
-                   $ space_break
-                   $ fmt_class_params c ctx cl.pci_params
-                   $ fmt_str_loc c cl.pci_name )
-               $ fmt_if (not (List.is_empty xargs)) space_break
-               $ wrap_fun_decl_args c (fmt_class_fun_args c xargs) )
-           in
-           let intro =
-             match cl.pci_constraint with
-             | Some ty ->
-                 fmt_class_type c
-                   ~pro:(pro $ str " :" $ space_break)
-                   (sub_cty ~ctx ty)
-             | None -> pro
-           in
-           hovbox 2
-             ( hovbox 2 (intro $ space_break $ str "=")
-             $ space_break
-             $ fmt_class_expr c (sub_cl ~ctx cl.pci_expr) )
-           $ fmt_item_attributes c ~pre:(Break (1, 0)) attrs_after
-         in
-         fmt_if (not first) (str "\n" $ force_break)
-         $ hovbox 0
-           @@ Cmts.fmt c cl.pci_loc (doc_before $ class_expr $ doc_after) )
+      update_config_maybe_disabled_attrs c cl.pci_loc cl.pci_attributes
+      @@ fun c ->
+      let ctx = Cd cl in
+      let xargs = cl.pci_args in
+      let ext = cl.pci_attributes.attrs_extension in
+      let doc_before, doc_after, attrs_before, attrs_after =
+        let force_before = not (Cl.is_simple cl.pci_expr) in
+        fmt_docstring_around_item_attrs ~force_before c cl.pci_attributes
+      in
+      let class_expr =
+        let pro =
+          box_fun_decl_args c 2
+            ( hovbox 2
+                ( str (if first then "class" else "and")
+                $ fmt_if first (fmt_extension_suffix c ext)
+                $ fmt_attributes c ~pre:(Break (1, 0)) attrs_before
+                $ fmt_virtual_flag c cl.pci_virt
+                $ space_break
+                $ fmt_class_params c ctx cl.pci_params
+                $ fmt_str_loc c cl.pci_name )
+            $ fmt_if (not (List.is_empty xargs)) space_break
+            $ wrap_fun_decl_args c (fmt_class_fun_args c xargs) )
+        in
+        let intro =
+          match cl.pci_constraint with
+          | Some ty ->
+              fmt_class_type c
+                ~pro:(pro $ str " :" $ space_break)
+                (sub_cty ~ctx ty)
+          | None -> pro
+        in
+        hovbox 2
+          ( hovbox 2 (intro $ space_break $ str "=")
+          $ space_break
+          $ fmt_class_expr c (sub_cl ~ctx cl.pci_expr) )
+        $ fmt_item_attributes c ~pre:(Break (1, 0)) attrs_after
+      in
+      fmt_if (not first) (str "\n" $ force_break)
+      $ hovbox 0
+        @@ Cmts.fmt c cl.pci_loc (doc_before $ class_expr $ doc_after) )
 
 and fmt_module c ctx ?rec_ ?epi ?(can_sparse = false) keyword ?(eqty = "=")
     name xargs xbody xmty ~attrs ~rec_flag =
@@ -4164,13 +4164,13 @@ and fmt_module c ctx ?rec_ ?epi ?(can_sparse = false) keyword ?(eqty = "=")
     $ fmt_item_attributes c ~pre:(Break (1, 0)) attrs_after
     $ doc_after
     $ opt epi (fun epi ->
-          fmt_or compact
-            (fmt_or
-               ( Option.is_some blk_b.epi
-               && not c.conf.fmt_opts.ocp_indent_compat.v )
-               (str " ") space_break )
-            (break 1 (-2))
-          $ epi ) )
+        fmt_or compact
+          (fmt_or
+             ( Option.is_some blk_b.epi
+             && not c.conf.fmt_opts.ocp_indent_compat.v )
+             (str " ") space_break )
+          (break 1 (-2))
+        $ epi ) )
 
 and fmt_module_declaration c ~rec_flag ~first {ast= pmd; _} =
   protect c (Md pmd)

--- a/lib/Fmt_odoc.ml
+++ b/lib/Fmt_odoc.ml
@@ -494,8 +494,8 @@ let fmt_tag_args ?arg ?txt c tag =
   at $ str tag
   $ opt arg (fun x -> char ' ' $ x)
   $ opt txt (function
-      | [] -> noop
-      | x -> space_break $ hovbox 0 (fmt_nestable_block_elements c x) )
+    | [] -> noop
+    | x -> space_break $ hovbox 0 (fmt_nestable_block_elements c x) )
 
 let wrap_see = function
   | `Url -> wrap (str "<") (str ">")

--- a/lib/Non_overlapping_interval_tree.ml
+++ b/lib/Non_overlapping_interval_tree.ml
@@ -55,8 +55,8 @@ module Make (Itv : IN) = struct
            if Itv.contains root elt then
              let ancestors = root :: ancestors in
              ( match Map.find map root with
-             | Some children -> parents map children ~ancestors elt
-             | None -> ancestors )
+               | Some children -> parents map children ~ancestors elt
+               | None -> ancestors )
              |> Option.some
            else None ) )
 

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -43,7 +43,7 @@ let dedup_cmts fragment ast comments =
 let normalize_comments ~normalize_cmt dedup fmt comments =
   dedup comments
   |> List.sort ~compare:(fun a b ->
-         Migrate_ast.Location.compare (Cmt.loc a) (Cmt.loc b) )
+      Migrate_ast.Location.compare (Cmt.loc a) (Cmt.loc b) )
   |> List.iter ~f:(fun cmt -> Format.fprintf fmt "%s," (normalize_cmt cmt))
 
 let normalize_parse_result ~normalize_cmt ast_kind ast comments =

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -139,18 +139,18 @@ module Exp = struct
       else k
 
     let dock xarg =
-        match xarg.ast.pexp_desc with
-        | Pexp_apply (_, args) -> (
-          (* Rhs is an apply and it ends with a [fun]. *)
-          match List.last_exn args with
-          | _, {pexp_desc= Pexp_function _; _}
-           |( _
-            , { pexp_desc= Pexp_beginend ({pexp_desc= Pexp_function _; _}, _)
-              ; _ } ) ->
-              true
-          | _ -> false )
-        | Pexp_match _ | Pexp_try _ -> true
-        | _ -> false
+      match xarg.ast.pexp_desc with
+      | Pexp_apply (_, args) -> (
+        (* Rhs is an apply and it ends with a [fun]. *)
+        match List.last_exn args with
+        | _, {pexp_desc= Pexp_function _; _}
+         |( _
+          , {pexp_desc= Pexp_beginend ({pexp_desc= Pexp_function _; _}, _); _}
+          ) ->
+            true
+        | _ -> false )
+      | Pexp_match _ | Pexp_try _ -> true
+      | _ -> false
   end
 
   let wrap (c : Conf.t) ?(disambiguate = false) ?(fits_breaks = true)
@@ -248,9 +248,10 @@ module Exp = struct
             match ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 with
             | Some (Nolabel, fun_exp, is_last_arg) ->
                 if begins_line fun_exp.pexp_loc then
-                  if is_last_arg then 5 else
-                  (* TODO Is this branch dead ? Changing the value doesn't
-                   change anything in the test suite. *)
+                  if is_last_arg then 5
+                  else
+                    (* TODO Is this branch dead ? Changing the value doesn't
+                       change anything in the test suite. *)
                     3
                 else 2
             | Some ((Labelled x | Optional x), fun_exp, is_last_arg) ->

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -138,9 +138,7 @@ module Exp = struct
           k
       else k
 
-    let dock (c : Conf.t) xarg =
-      if not c.fmt_opts.ocp_indent_compat.v then false
-      else
+    let dock xarg =
         match xarg.ast.pexp_desc with
         | Pexp_apply (_, args) -> (
           (* Rhs is an apply and it ends with a [fun]. *)
@@ -250,7 +248,10 @@ module Exp = struct
             match ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 with
             | Some (Nolabel, fun_exp, is_last_arg) ->
                 if begins_line fun_exp.pexp_loc then
-                  if is_last_arg then 5 else 3
+                  if is_last_arg then 5 else
+                  (* TODO Is this branch dead ? Changing the value doesn't
+                   change anything in the test suite. *)
+                    3
                 else 2
             | Some ((Labelled x | Optional x), fun_exp, is_last_arg) ->
                 if begins_line fun_exp.pexp_loc then
@@ -986,8 +987,7 @@ let get_if_then_else (c : Conf.t) ~pro ~first ~last ~parens_bch
 let match_indent ?(default = 0) (c : Conf.t) ~parens ~(ctx : Ast.t) =
   match (c.fmt_opts.match_indent_nested.v, ctx) with
   | `Always, _ | _, (Top | Sig _ | Str _) -> c.fmt_opts.match_indent.v
-  | _, Exp {pexp_desc= Pexp_infix _; _}
-    when c.fmt_opts.ocp_indent_compat.v && parens ->
+  | _, Exp {pexp_desc= Pexp_infix _; _} when parens ->
       2 (* Match is docked *)
   | _ -> default
 

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -20,7 +20,7 @@ module Exp : sig
   module Infix_op_arg : sig
     val wrap : Conf.t -> ?parens_nested:bool -> parens:bool -> Fmt.t -> Fmt.t
 
-    val dock : Conf.t -> expression Ast.xt -> bool
+    val dock : expression Ast.xt -> bool
     (** Whether the RHS of an infix operator should be docked. *)
   end
 

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -297,7 +297,7 @@ let format (type ext std) (ext_fg : ext Extended_ast.t)
       let exn_args () =
         [("output file", dump_formatted ~suffix:".invalid-ast" fmted)]
         |> List.filter_map ~f:(fun (s, f_opt) ->
-               Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)) )
+            Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)) )
       in
       let* ext_t_new =
         match
@@ -339,7 +339,7 @@ let format (type ext std) (ext_fg : ext Extended_ast.t)
             ; ("old ast", old_ast)
             ; ("new ast", new_ast) ]
             |> List.filter_map ~f:(fun (s, f_opt) ->
-                   Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)) )
+                Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)) )
           in
           if
             Normalize_std_ast.equal std_fg ~ignore_doc_comments:true conf

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -467,7 +467,7 @@ let is_in_listing_file ~listings ~filename =
               In_channel.input_lines ch
               |> Migrate_ast.Location.of_lines ~filename:listing_filename
               |> List.filter ~f:(fun Location.{txt= l; _} ->
-                     not (drop_line l) )
+                  not (drop_line l) )
             in
             List.find_map lines ~f:(fun {txt= line; loc} ->
                 match Fpath.of_string line with

--- a/test/passing/refs.ahrefs/attributes.ml.ref
+++ b/test/passing/refs.ahrefs/attributes.ml.ref
@@ -504,10 +504,10 @@ let () =
   let () =
     S.ntyp Cbor_type.Reserved
     @@ S.tok begin[@warning "-4"] fun ev ->
-         match ev with
-         | Cbor_event.Reserved int -> Some int
-         | _ -> None
-       end
+      match ev with
+      | Cbor_event.Reserved int -> Some int
+      | _ -> None
+    end
   in
   ()
 
@@ -518,7 +518,7 @@ let () =
           match ev with
           | Cbor_event.Reserved int -> Some int
           | _ -> None)
-       [@warning "-4"])
+    [@warning "-4"])
   in
   ()
 ;;

--- a/test/passing/refs.ahrefs/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ahrefs/exp_grouping-parens.ml.ref
@@ -540,11 +540,10 @@ let _ =
 let () =
   fooooo
   |>>>>> List.iter (fun a ->
-           let x =
-             some_really_really_really_long_name_that_doesn't_fit_on_the_line
-             $ y
-           in
-           fooooooooooo x)
+    let x =
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+    in
+    fooooooooooo x)
 
 let () =
   fooooo
@@ -559,11 +558,10 @@ let () =
 let () =
   fooooo
   |>>>>> List.iter (fun a ->
-           let x =
-             some_really_really_really_long_name_that_doesn't_fit_on_the_line
-             $ y
-           in
-           fooooooooooo x)
+    let x =
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+    in
+    fooooooooooo x)
 
 let () =
   fooooo

--- a/test/passing/refs.ahrefs/exp_grouping.ml.ref
+++ b/test/passing/refs.ahrefs/exp_grouping.ml.ref
@@ -620,12 +620,11 @@ let _ =
 let () =
   fooooo
   |>>>>> List.iter begin fun a ->
-           let x =
-             some_really_really_really_long_name_that_doesn't_fit_on_the_line
-             $ y
-           in
-           fooooooooooo x
-         end
+    let x =
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+    in
+    fooooooooooo x
+  end
 
 let () =
   fooooo
@@ -641,12 +640,11 @@ let () =
 let () =
   fooooo
   |>>>>> List.iter begin fun a ->
-           let x =
-             some_really_really_really_long_name_that_doesn't_fit_on_the_line
-             $ y
-           in
-           fooooooooooo x
-         end
+    let x =
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+    in
+    fooooooooooo x
+  end
 
 let () =
   fooooo

--- a/test/passing/refs.ahrefs/infix_arg_grouping.ml.err
+++ b/test/passing/refs.ahrefs/infix_arg_grouping.ml.err
@@ -1,2 +1,1 @@
-Warning: infix_arg_grouping.ml:31 exceeds the margin
-Warning: infix_arg_grouping.ml:89 exceeds the margin
+Warning: infix_arg_grouping.ml:87 exceeds the margin

--- a/test/passing/refs.ahrefs/infix_arg_grouping.ml.ref
+++ b/test/passing/refs.ahrefs/infix_arg_grouping.ml.ref
@@ -13,23 +13,21 @@ user_error
 hvbox 1
   (str "\""
   $ list_pn lines (fun ?prev curr ?next ->
-      let drop = function
-        | ' ' -> true
-        | _ -> false
+    let drop = function
+      | ' ' -> true
+      | _ -> false
+    in
+    let line = if Option.is_none prev then curr else String.lstrip ~drop curr in
+    fmt_line line
+    $ opt next (fun next ->
+      let spc =
+        match String.lfindi next ~f:(fun _ c -> not (drop c)) with
+        | Some 0 -> ""
+        | Some i -> escape_string (String.sub next 0 i)
+        | None -> escape_string next
       in
-      let line =
-        if Option.is_none prev then curr else String.lstrip ~drop curr
-      in
-      fmt_line line
-      $ opt next (fun next ->
-          let spc =
-            match String.lfindi next ~f:(fun _ c -> not (drop c)) with
-            | Some 0 -> ""
-            | Some i -> escape_string (String.sub next 0 i)
-            | None -> escape_string next
-          in
-          fmt "\\n"
-          $ fmt_if_k (not (String.is_empty next)) (str spc $ pre_break 0 "\\" 0)))
+      fmt "\\n"
+      $ fmt_if_k (not (String.is_empty next)) (str spc $ pre_break 0 "\\" 0)))
   $ str "\""
   $ Option.call ~f:epi)
 ;;
@@ -62,13 +60,13 @@ hvbox 0
   $ wrap "(" ")"
       (str txt
       $ opt mt (fun _ ->
-          fmt "@ : "
-          $ Option.call ~f:pro_t
-          $ psp_t
-          $ fmt "@;<1 2>"
-          $ bdy_t
-          $ esp_t
-          $ Option.call ~f:epi_t))
+        fmt "@ : "
+        $ Option.call ~f:pro_t
+        $ psp_t
+        $ fmt "@;<1 2>"
+        $ bdy_t
+        $ esp_t
+        $ Option.call ~f:epi_t))
   $ fmt " ->@ "
   $ Option.call ~f:pro_e
   $ psp_e

--- a/test/passing/refs.ahrefs/js_source.ml.ref
+++ b/test/passing/refs.ahrefs/js_source.ml.ref
@@ -316,16 +316,16 @@ let x =
 let x =
   some_value
   |> some_fun (fun x ->
-       do_something ();
-       do_something_else ();
-       return_this_value)
+    do_something ();
+    do_something_else ();
+    return_this_value)
 
 let x =
   some_value
   ^ some_fun (fun x ->
-      do_something ();
-      do_something_else ();
-      return_this_value)
+    do_something ();
+    do_something_else ();
+    return_this_value)
 
 let bind t ~f =
   unfold_step
@@ -425,20 +425,20 @@ let _ =
 let _ =
   foo
   |> List.map ~f:(fun x ->
-       do_something ();
-       do_something ();
-       do_something ();
-       do_something ();
-       do_something_else ())
+    do_something ();
+    do_something ();
+    do_something ();
+    do_something ();
+    do_something_else ())
 
 let _ =
   foo
   |> List.map ~f:(fun x ->
-       do_something ();
-       do_something ();
-       do_something ();
-       do_something ();
-       do_something_else ())
+    do_something ();
+    do_something ();
+    do_something ();
+    do_something ();
+    do_something_else ())
   |> bar
 
 let _ =
@@ -451,11 +451,11 @@ let _ = foo |> List.map (function A -> do_something ())
 let _ =
   foo
   |> List.map (function
-       | A -> do_something ()
-       | A -> do_something ()
-       | A -> do_something ()
-       | A -> do_something ()
-       | A -> do_something_else ())
+    | A -> do_something ()
+    | A -> do_something ()
+    | A -> do_something ()
+    | A -> do_something ()
+    | A -> do_something_else ())
   |> bar
 
 let _ =
@@ -495,15 +495,15 @@ end
 let _ =
   foo
   $$ (match group with
-     | [] -> impossible "previous match"
-     | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
+    | [] -> impossible "previous match"
+    | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
   $$ bar
 
 let _ =
   foo
   $$ (try group with
-     | [] -> impossible "previous match"
-     | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
+    | [] -> impossible "previous match"
+    | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
   $$ bar
 
 let _ =
@@ -791,7 +791,7 @@ let _ =
 let _ =
   fooooooooooooooooooooooooooooooo
   |> foooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (function
-       | foo -> bar)
+    | foo -> bar)
 
 let _ =
   fooooooooooooooooooooooooooooooo

--- a/test/passing/refs.ahrefs/list-space_around.ml.ref
+++ b/test/passing/refs.ahrefs/list-space_around.ml.ref
@@ -98,7 +98,7 @@ let _ =
   make_single_trace create_loc message
   :: make_single_trace create_loc create_message
   :: List.map call_chain ~f:(fun foooooooooooooooooooooooooooo ->
-       fooooooooooooooooooooooooooooooo foooooooooooo [])
+    fooooooooooooooooooooooooooooooo foooooooooooo [])
   :: foooooooo
   :: fooooooooooooooooo
 

--- a/test/passing/refs.ahrefs/list.ml.ref
+++ b/test/passing/refs.ahrefs/list.ml.ref
@@ -98,7 +98,7 @@ let _ =
   make_single_trace create_loc message
   :: make_single_trace create_loc create_message
   :: List.map call_chain ~f:(fun foooooooooooooooooooooooooooo ->
-       fooooooooooooooooooooooooooooooo foooooooooooo [])
+    fooooooooooooooooooooooooooooooo foooooooooooo [])
   :: foooooooo
   :: fooooooooooooooooo
 

--- a/test/passing/refs.ahrefs/max_indent.ml.ref
+++ b/test/passing/refs.ahrefs/max_indent.ml.ref
@@ -1,8 +1,8 @@
 let () =
   fooooo
   |> List.iter (fun x ->
-       let x = x $ y in
-       fooooooooooo x)
+    let x = x $ y in
+    fooooooooooo x)
 
 let () =
   fooooo
@@ -13,13 +13,21 @@ let () =
        in
        fooooooooooo x)
 
+let () =
+  List.iter
+    (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
+    let x =
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+    in
+    fooooooooooo x)
+
 let foooooooooo =
   foooooooooooooooooooooo
   |> Option.bind ~f:(function
-       | Pform.Expansion.Var (Values l) -> Some (static l)
-       | Macro (Ocaml_config, s) ->
-         Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
-       | Macro (Env, s) -> Option.map ~f:static (expand_env t var s))
+    | Pform.Expansion.Var (Values l) -> Some (static l)
+    | Macro (Ocaml_config, s) ->
+      Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
+    | Macro (Env, s) -> Option.map ~f:static (expand_env t var s))
 
 let fooooooooooooo =
   match lbls with
@@ -88,13 +96,13 @@ let x =
 let x =
   some_value
   |> some_fun (fun x ->
-       do_something ();
-       do_something_else ();
-       return_this_value)
+    do_something ();
+    do_something_else ();
+    return_this_value)
 
 let x =
   some_value
   ^ some_fun (fun x ->
-      do_something ();
-      do_something_else ();
-      return_this_value)
+    do_something ();
+    do_something_else ();
+    return_this_value)

--- a/test/passing/refs.default/attributes.ml.ref
+++ b/test/passing/refs.default/attributes.ml.ref
@@ -396,8 +396,8 @@ let () =
   let () =
     S.ntyp Cbor_type.Reserved
     @@ S.tok begin[@warning "-4"] fun ev ->
-           match ev with Cbor_event.Reserved int -> Some int | _ -> None
-         end
+        match ev with Cbor_event.Reserved int -> Some int | _ -> None
+      end
   in
   ()
 
@@ -406,7 +406,7 @@ let () =
     S.ntyp Cbor_type.Reserved
     @@ (S.tok (fun ev ->
             match ev with Cbor_event.Reserved int -> Some int | _ -> None)
-       [@warning "-4"])
+    [@warning "-4"])
   in
   ()
 ;;

--- a/test/passing/refs.default/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.default/exp_grouping-parens.ml.ref
@@ -557,11 +557,10 @@ let _ =
 let () =
   fooooo
   |>>>>> List.iter (fun a ->
-             let x =
-               some_really_really_really_long_name_that_doesn't_fit_on_the_line
-               $ y
-             in
-             fooooooooooo x)
+      let x =
+        some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+      in
+      fooooooooooo x)
 
 let () =
   fooooo
@@ -576,11 +575,10 @@ let () =
 let () =
   fooooo
   |>>>>> List.iter (fun a ->
-             let x =
-               some_really_really_really_long_name_that_doesn't_fit_on_the_line
-               $ y
-             in
-             fooooooooooo x)
+      let x =
+        some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+      in
+      fooooooooooo x)
 
 let () =
   fooooo

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -638,12 +638,11 @@ let _ =
 let () =
   fooooo
   |>>>>> List.iter begin fun a ->
-             let x =
-               some_really_really_really_long_name_that_doesn't_fit_on_the_line
-               $ y
-             in
-             fooooooooooo x
-           end
+      let x =
+        some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+      in
+      fooooooooooo x
+    end
 
 let () =
   fooooo
@@ -659,12 +658,11 @@ let () =
 let () =
   fooooo
   |>>>>> List.iter begin fun a ->
-             let x =
-               some_really_really_really_long_name_that_doesn't_fit_on_the_line
-               $ y
-             in
-             fooooooooooo x
-           end
+      let x =
+        some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+      in
+      fooooooooooo x
+    end
 
 let () =
   fooooo

--- a/test/passing/refs.default/infix_arg_grouping.ml.err
+++ b/test/passing/refs.default/infix_arg_grouping.ml.err
@@ -1,1 +1,2 @@
-Warning: infix_arg_grouping.ml:74 exceeds the margin
+Warning: infix_arg_grouping.ml:26 exceeds the margin
+Warning: infix_arg_grouping.ml:72 exceeds the margin

--- a/test/passing/refs.default/infix_arg_grouping.ml.ref
+++ b/test/passing/refs.default/infix_arg_grouping.ml.ref
@@ -11,22 +11,20 @@ user_error
 hvbox 1
   (str "\""
   $ list_pn lines (fun ?prev curr ?next ->
-        let drop = function ' ' -> true | _ -> false in
-        let line =
-          if Option.is_none prev then curr else String.lstrip ~drop curr
-        in
-        fmt_line line
-        $ opt next (fun next ->
-              let spc =
-                match String.lfindi next ~f:(fun _ c -> not (drop c)) with
-                | Some 0 -> ""
-                | Some i -> escape_string (String.sub next 0 i)
-                | None -> escape_string next
-              in
-              fmt "\\n"
-              $ fmt_if_k
-                  (not (String.is_empty next))
-                  (str spc $ pre_break 0 "\\" 0)))
+      let drop = function ' ' -> true | _ -> false in
+      let line =
+        if Option.is_none prev then curr else String.lstrip ~drop curr
+      in
+      fmt_line line
+      $ opt next (fun next ->
+          let spc =
+            match String.lfindi next ~f:(fun _ c -> not (drop c)) with
+            | Some 0 -> ""
+            | Some i -> escape_string (String.sub next 0 i)
+            | None -> escape_string next
+          in
+          fmt "\\n"
+          $ fmt_if_k (not (String.is_empty next)) (str spc $ pre_break 0 "\\" 0)))
   $ str "\"" $ Option.call ~f:epi)
 ;;
 
@@ -56,8 +54,8 @@ hvbox 0
   $ wrap "(" ")"
       (str txt
       $ opt mt (fun _ ->
-            fmt "@ : " $ Option.call ~f:pro_t $ psp_t $ fmt "@;<1 2>" $ bdy_t
-            $ esp_t $ Option.call ~f:epi_t))
+          fmt "@ : " $ Option.call ~f:pro_t $ psp_t $ fmt "@;<1 2>" $ bdy_t
+          $ esp_t $ Option.call ~f:epi_t))
   $ fmt " ->@ " $ Option.call ~f:pro_e $ psp_e $ bdy_e $ esp_e
   $ Option.call ~f:epi_e)
 ;;

--- a/test/passing/refs.default/js_source.ml.ref
+++ b/test/passing/refs.default/js_source.ml.ref
@@ -298,16 +298,16 @@ let x =
 let x =
   some_value
   |> some_fun (fun x ->
-         do_something ();
-         do_something_else ();
-         return_this_value)
+      do_something ();
+      do_something_else ();
+      return_this_value)
 
 let x =
   some_value
   ^ some_fun (fun x ->
-        do_something ();
-        do_something_else ();
-        return_this_value)
+      do_something ();
+      do_something_else ();
+      return_this_value)
 
 let bind t ~f =
   unfold_step
@@ -398,20 +398,20 @@ let _ =
 let _ =
   foo
   |> List.map ~f:(fun x ->
-         do_something ();
-         do_something ();
-         do_something ();
-         do_something ();
-         do_something_else ())
+      do_something ();
+      do_something ();
+      do_something ();
+      do_something ();
+      do_something_else ())
 
 let _ =
   foo
   |> List.map ~f:(fun x ->
-         do_something ();
-         do_something ();
-         do_something ();
-         do_something ();
-         do_something_else ())
+      do_something ();
+      do_something ();
+      do_something ();
+      do_something ();
+      do_something_else ())
   |> bar
 
 let _ =
@@ -424,11 +424,11 @@ let _ = foo |> List.map (function A -> do_something ())
 let _ =
   foo
   |> List.map (function
-       | A -> do_something ()
-       | A -> do_something ()
-       | A -> do_something ()
-       | A -> do_something ()
-       | A -> do_something_else ())
+    | A -> do_something ()
+    | A -> do_something ()
+    | A -> do_something ()
+    | A -> do_something ()
+    | A -> do_something_else ())
   |> bar
 
 let _ =
@@ -468,15 +468,15 @@ end
 let _ =
   foo
   $$ (match group with
-     | [] -> impossible "previous match"
-     | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
+    | [] -> impossible "previous match"
+    | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
   $$ bar
 
 let _ =
   foo
   $$ (try group with
-     | [] -> impossible "previous match"
-     | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
+    | [] -> impossible "previous match"
+    | [ cmt ] -> fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt)
   $$ bar
 
 let _ =
@@ -743,7 +743,7 @@ let _ =
 let _ =
   fooooooooooooooooooooooooooooooo
   |> foooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (function
-         | foo -> bar)
+      | foo -> bar)
 
 let _ =
   fooooooooooooooooooooooooooooooo

--- a/test/passing/refs.default/list-space_around.ml.ref
+++ b/test/passing/refs.default/list-space_around.ml.ref
@@ -72,7 +72,7 @@ let _ =
   make_single_trace create_loc message
   :: make_single_trace create_loc create_message
   :: List.map call_chain ~f:(fun foooooooooooooooooooooooooooo ->
-         fooooooooooooooooooooooooooooooo foooooooooooo [])
+      fooooooooooooooooooooooooooooooo foooooooooooo [])
   :: foooooooo :: fooooooooooooooooo
 
 let _ =

--- a/test/passing/refs.default/list.ml.ref
+++ b/test/passing/refs.default/list.ml.ref
@@ -72,7 +72,7 @@ let _ =
   make_single_trace create_loc message
   :: make_single_trace create_loc create_message
   :: List.map call_chain ~f:(fun foooooooooooooooooooooooooooo ->
-         fooooooooooooooooooooooooooooooo foooooooooooo [])
+      fooooooooooooooooooooooooooooooo foooooooooooo [])
   :: foooooooo :: fooooooooooooooooo
 
 let _ =

--- a/test/passing/refs.default/max_indent.ml.ref
+++ b/test/passing/refs.default/max_indent.ml.ref
@@ -1,8 +1,8 @@
 let () =
   fooooo
   |> List.iter (fun x ->
-       let x = x $ y in
-       fooooooooooo x)
+    let x = x $ y in
+    fooooooooooo x)
 
 let () =
   fooooo
@@ -13,13 +13,21 @@ let () =
        in
        fooooooooooo x)
 
+let () =
+  List.iter
+    (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
+    let x =
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+    in
+    fooooooooooo x)
+
 let foooooooooo =
   foooooooooooooooooooooo
   |> Option.bind ~f:(function
-       | Pform.Expansion.Var (Values l) -> Some (static l)
-       | Macro (Ocaml_config, s) ->
-         Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
-       | Macro (Env, s) -> Option.map ~f:static (expand_env t var s))
+    | Pform.Expansion.Var (Values l) -> Some (static l)
+    | Macro (Ocaml_config, s) ->
+      Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
+    | Macro (Env, s) -> Option.map ~f:static (expand_env t var s))
 
 let fooooooooooooo =
   match lbls with
@@ -88,13 +96,13 @@ let x =
 let x =
   some_value
   |> some_fun (fun x ->
-       do_something ();
-       do_something_else ();
-       return_this_value)
+    do_something ();
+    do_something_else ();
+    return_this_value)
 
 let x =
   some_value
   ^ some_fun (fun x ->
-      do_something ();
-      do_something_else ();
-      return_this_value)
+    do_something ();
+    do_something_else ();
+    return_this_value)

--- a/test/passing/refs.janestreet/max_indent.ml.err
+++ b/test/passing/refs.janestreet/max_indent.ml.err
@@ -1,1 +1,1 @@
-Warning: max_indent.ml:34 exceeds the margin
+Warning: max_indent.ml:40 exceeds the margin

--- a/test/passing/refs.janestreet/max_indent.ml.ref
+++ b/test/passing/refs.janestreet/max_indent.ml.ref
@@ -12,6 +12,12 @@ let () =
     fooooooooooo x)
 ;;
 
+let () =
+  List.iter (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
+    let x = some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y in
+    fooooooooooo x)
+;;
+
 let foooooooooo =
   foooooooooooooooooooooo
   |> Option.bind ~f:(function

--- a/test/passing/refs.ocamlformat/attributes.ml.ref
+++ b/test/passing/refs.ocamlformat/attributes.ml.ref
@@ -442,8 +442,8 @@ let () =
   let () =
     S.ntyp Cbor_type.Reserved
     @@ S.tok begin[@warning "-4"] fun ev ->
-           match ev with Cbor_event.Reserved int -> Some int | _ -> None
-         end
+        match ev with Cbor_event.Reserved int -> Some int | _ -> None
+      end
   in
   ()
 
@@ -452,7 +452,7 @@ let () =
     S.ntyp Cbor_type.Reserved
     @@ (S.tok (fun ev ->
             match ev with Cbor_event.Reserved int -> Some int | _ -> None )
-       [@warning "-4"] )
+    [@warning "-4"] )
   in
   ()
 ;;

--- a/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping-parens.ml.ref
@@ -561,11 +561,10 @@ let _ =
 let () =
   fooooo
   |>>>>> List.iter (fun a ->
-             let x =
-               some_really_really_really_long_name_that_doesn't_fit_on_the_line
-               $ y
-             in
-             fooooooooooo x )
+      let x =
+        some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+      in
+      fooooooooooo x )
 
 let () =
   fooooo
@@ -580,11 +579,10 @@ let () =
 let () =
   fooooo
   |>>>>> List.iter (fun a ->
-             let x =
-               some_really_really_really_long_name_that_doesn't_fit_on_the_line
-               $ y
-             in
-             fooooooooooo x )
+      let x =
+        some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+      in
+      fooooooooooo x )
 
 let () =
   fooooo

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -644,12 +644,11 @@ let _ =
 let () =
   fooooo
   |>>>>> List.iter begin fun a ->
-             let x =
-               some_really_really_really_long_name_that_doesn't_fit_on_the_line
-               $ y
-             in
-             fooooooooooo x
-           end
+      let x =
+        some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+      in
+      fooooooooooo x
+    end
 
 let () =
   fooooo
@@ -665,12 +664,11 @@ let () =
 let () =
   fooooo
   |>>>>> List.iter begin fun a ->
-             let x =
-               some_really_really_really_long_name_that_doesn't_fit_on_the_line
-               $ y
-             in
-             fooooooooooo x
-           end
+      let x =
+        some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+      in
+      fooooooooooo x
+    end
 
 let () =
   fooooo

--- a/test/passing/refs.ocamlformat/infix_arg_grouping.ml.err
+++ b/test/passing/refs.ocamlformat/infix_arg_grouping.ml.err
@@ -1,0 +1,1 @@
+Warning: infix_arg_grouping.ml:29 exceeds the margin

--- a/test/passing/refs.ocamlformat/infix_arg_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/infix_arg_grouping.ml.ref
@@ -11,25 +11,23 @@ user_error
 hvbox 1
   ( str "\""
   $ list_pn lines (fun ?prev curr ?next ->
-        let drop = function ' ' -> true | _ -> false in
-        let line =
-          if Option.is_none prev then curr else String.lstrip ~drop curr
-        in
-        fmt_line line
-        $ opt next (fun next ->
-              let spc =
-                match String.lfindi next ~f:(fun _ c -> not (drop c)) with
-                | Some 0 ->
-                    ""
-                | Some i ->
-                    escape_string (String.sub next 0 i)
-                | None ->
-                    escape_string next
-              in
-              fmt "\\n"
-              $ fmt_if_k
-                  (not (String.is_empty next))
-                  (str spc $ pre_break 0 "\\" 0) ) )
+      let drop = function ' ' -> true | _ -> false in
+      let line =
+        if Option.is_none prev then curr else String.lstrip ~drop curr
+      in
+      fmt_line line
+      $ opt next (fun next ->
+          let spc =
+            match String.lfindi next ~f:(fun _ c -> not (drop c)) with
+            | Some 0 ->
+                ""
+            | Some i ->
+                escape_string (String.sub next 0 i)
+            | None ->
+                escape_string next
+          in
+          fmt "\\n"
+          $ fmt_if_k (not (String.is_empty next)) (str spc $ pre_break 0 "\\" 0) ) )
   $ str "\"" $ Option.call ~f:epi )
 ;;
 
@@ -60,8 +58,8 @@ hvbox 0
   $ wrap "(" ")"
       ( str txt
       $ opt mt (fun _ ->
-            fmt "@ : " $ Option.call ~f:pro_t $ psp_t $ fmt "@;<1 2>" $ bdy_t
-            $ esp_t $ Option.call ~f:epi_t ) )
+          fmt "@ : " $ Option.call ~f:pro_t $ psp_t $ fmt "@;<1 2>" $ bdy_t
+          $ esp_t $ Option.call ~f:epi_t ) )
   $ fmt " ->@ " $ Option.call ~f:pro_e $ psp_e $ bdy_e $ esp_e
   $ Option.call ~f:epi_e )
 ;;

--- a/test/passing/refs.ocamlformat/js_source.ml.err
+++ b/test/passing/refs.ocamlformat/js_source.ml.err
@@ -5,5 +5,5 @@ Warning: js_source.ml:154 exceeds the margin
 Warning: js_source.ml:219 exceeds the margin
 Warning: js_source.ml:224 exceeds the margin
 Warning: js_source.ml:235 exceeds the margin
-Warning: js_source.ml:633 exceeds the margin
-Warning: js_source.ml:833 exceeds the margin
+Warning: js_source.ml:637 exceeds the margin
+Warning: js_source.ml:837 exceeds the margin

--- a/test/passing/refs.ocamlformat/js_source.ml.ref
+++ b/test/passing/refs.ocamlformat/js_source.ml.ref
@@ -289,12 +289,12 @@ let x =
 let x =
   some_value
   |> some_fun (fun x ->
-         do_something () ; do_something_else () ; return_this_value )
+      do_something () ; do_something_else () ; return_this_value )
 
 let x =
   some_value
   ^ some_fun (fun x ->
-        do_something () ; do_something_else () ; return_this_value )
+      do_something () ; do_something_else () ; return_this_value )
 
 let bind t ~f =
   unfold_step
@@ -391,20 +391,20 @@ let _ =
 let _ =
   foo
   |> List.map ~f:(fun x ->
-         do_something () ;
-         do_something () ;
-         do_something () ;
-         do_something () ;
-         do_something_else () )
+      do_something () ;
+      do_something () ;
+      do_something () ;
+      do_something () ;
+      do_something_else () )
 
 let _ =
   foo
   |> List.map ~f:(fun x ->
-         do_something () ;
-         do_something () ;
-         do_something () ;
-         do_something () ;
-         do_something_else () )
+      do_something () ;
+      do_something () ;
+      do_something () ;
+      do_something () ;
+      do_something_else () )
   |> bar
 
 let _ =
@@ -417,16 +417,16 @@ let _ = foo |> List.map (function A -> do_something ())
 let _ =
   foo
   |> List.map (function
-       | A ->
-           do_something ()
-       | A ->
-           do_something ()
-       | A ->
-           do_something ()
-       | A ->
-           do_something ()
-       | A ->
-           do_something_else () )
+    | A ->
+        do_something ()
+    | A ->
+        do_something ()
+    | A ->
+        do_something ()
+    | A ->
+        do_something ()
+    | A ->
+        do_something_else () )
   |> bar
 
 let _ =
@@ -466,25 +466,29 @@ end
 let _ =
   foo
   $$ ( match group with
-     | [] ->
-         impossible "previous match"
-     | [cmt] ->
-         fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt )
+    | [] ->
+        impossible "previous match"
+    | [cmt] ->
+        fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt )
   $$ bar
 
 let _ =
   foo
   $$ ( try group with
-     | [] ->
-         impossible "previous match"
-     | [cmt] ->
-         fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt )
+    | [] ->
+        impossible "previous match"
+    | [cmt] ->
+        fmt_cmt t conf cmt ~fmt_code $ maybe_newline ~next cmt )
   $$ bar
 
 let _ =
   x == exp
   ||
-  match x with {pexp_desc= Pexp_constraint (e, _); _} -> loop e | _ -> false
+  match x with
+  | {pexp_desc= Pexp_constraint (e, _); _} ->
+      loop e
+  | _ ->
+      false
 
 let _ =
   let module M = struct
@@ -751,7 +755,7 @@ let _ =
 let _ =
   fooooooooooooooooooooooooooooooo
   |> foooooooooooooooooooooooooooo ~fooooooooooooooooooooooooooooooo (function
-         | foo -> bar )
+      | foo -> bar )
 
 let _ =
   fooooooooooooooooooooooooooooooo

--- a/test/passing/refs.ocamlformat/list-space_around.ml.ref
+++ b/test/passing/refs.ocamlformat/list-space_around.ml.ref
@@ -79,7 +79,7 @@ let _ =
   make_single_trace create_loc message
   :: make_single_trace create_loc create_message
   :: List.map call_chain ~f:(fun foooooooooooooooooooooooooooo ->
-         fooooooooooooooooooooooooooooooo foooooooooooo [] )
+      fooooooooooooooooooooooooooooooo foooooooooooo [] )
   :: foooooooo :: fooooooooooooooooo
 
 let _ =

--- a/test/passing/refs.ocamlformat/list.ml.ref
+++ b/test/passing/refs.ocamlformat/list.ml.ref
@@ -77,7 +77,7 @@ let _ =
   make_single_trace create_loc message
   :: make_single_trace create_loc create_message
   :: List.map call_chain ~f:(fun foooooooooooooooooooooooooooo ->
-         fooooooooooooooooooooooooooooooo foooooooooooo [] )
+      fooooooooooooooooooooooooooooooo foooooooooooo [] )
   :: foooooooo :: fooooooooooooooooo
 
 let _ =

--- a/test/passing/refs.ocamlformat/max_indent.ml.ref
+++ b/test/passing/refs.ocamlformat/max_indent.ml.ref
@@ -1,8 +1,8 @@
 let () =
   fooooo
   |> List.iter (fun x ->
-       let x = x $ y in
-       fooooooooooo x )
+    let x = x $ y in
+    fooooooooooo x )
 
 let () =
   fooooo
@@ -13,15 +13,23 @@ let () =
        in
        fooooooooooo x )
 
+let () =
+  List.iter
+    (fun some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
+    let x =
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+    in
+    fooooooooooo x )
+
 let foooooooooo =
   foooooooooooooooooooooo
   |> Option.bind ~f:(function
-       | Pform.Expansion.Var (Values l) ->
-           Some (static l)
-       | Macro (Ocaml_config, s) ->
-           Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
-       | Macro (Env, s) ->
-           Option.map ~f:static (expand_env t var s) )
+    | Pform.Expansion.Var (Values l) ->
+        Some (static l)
+    | Macro (Ocaml_config, s) ->
+        Some (static (expand_ocaml_config (Lazy.force ocaml_config) var s))
+    | Macro (Env, s) ->
+        Option.map ~f:static (expand_env t var s) )
 
 let fooooooooooooo =
   match lbls with
@@ -84,9 +92,9 @@ let x =
 let x =
   some_value
   |> some_fun (fun x ->
-       do_something () ; do_something_else () ; return_this_value )
+    do_something () ; do_something_else () ; return_this_value )
 
 let x =
   some_value
   ^ some_fun (fun x ->
-      do_something () ; do_something_else () ; return_this_value )
+    do_something () ; do_something_else () ; return_this_value )

--- a/test/passing/tests/max_indent.ml
+++ b/test/passing/tests/max_indent.ml
@@ -14,6 +14,15 @@ let () =
        in
        fooooooooooo x )
 
+let () =
+  List.iter
+    (fun
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line ->
+    let x =
+      some_really_really_really_long_name_that_doesn't_fit_on_the_line $ y
+    in
+    fooooooooooo x )
+
 let foooooooooo =
   foooooooooooooooooooooo
   |> Option.bind ~f:(function

--- a/test/rpc/rpc_test.ml
+++ b/test/rpc/rpc_test.ml
@@ -67,21 +67,21 @@ let start ?versions () =
       state := Running (client, close) ;
       client
     with
-  | exception _ ->
-      Error
-        (`Msg
-           "OCamlFormat-RPC did not respond. Check that a compatible \
-            version of the OCamlFormat RPC server (ocamlformat-rpc >= \
-            0.18.0) is installed." )
-  | x -> x )
+    | exception _ ->
+        Error
+          (`Msg
+             "OCamlFormat-RPC did not respond. Check that a compatible \
+              version of the OCamlFormat RPC server (ocamlformat-rpc >= \
+              0.18.0) is installed." )
+    | x -> x )
   |> Result.map_error ~f:(fun (`Msg msg) ->
-         state := Errored ;
-         log
-           "An error occured while initializing and configuring ocamlformat:\n\
-            %s\n\
-            %!"
-           msg ;
-         `No_process )
+      state := Errored ;
+      log
+        "An error occured while initializing and configuring ocamlformat:\n\
+         %s\n\
+         %!"
+        msg ;
+      `No_process )
 
 let get_client ?versions () =
   match !state with

--- a/test/rpc/rpc_test_fail.ml
+++ b/test/rpc/rpc_test_fail.ml
@@ -65,21 +65,21 @@ let start () =
       state := Running (client, close) ;
       client
     with
-  | exception _ ->
-      Error
-        (`Msg
-           "OCamlFormat-RPC did not respond. Check that a compatible \
-            version of the OCamlFormat RPC server (ocamlformat-rpc >= \
-            0.18.0) is installed." )
-  | x -> x )
+    | exception _ ->
+        Error
+          (`Msg
+             "OCamlFormat-RPC did not respond. Check that a compatible \
+              version of the OCamlFormat RPC server (ocamlformat-rpc >= \
+              0.18.0) is installed." )
+    | x -> x )
   |> Result.map_error ~f:(fun (`Msg msg) ->
-         state := Errored ;
-         log
-           "An error occured while initializing and configuring ocamlformat:\n\
-            %s\n\
-            %!"
-           msg ;
-         `No_process )
+      state := Errored ;
+      log
+        "An error occured while initializing and configuring ocamlformat:\n\
+         %s\n\
+         %!"
+        msg ;
+      `No_process )
 
 let get_client () =
   match !state with

--- a/test/unit/test_translation_unit.ml
+++ b/test/unit/test_translation_unit.ml
@@ -14,8 +14,8 @@ let test_parse_and_format kind_name ~fg test_name ~input ~expected =
         Translation_unit.parse_and_format fg ~input_name:"<test>"
           ~source:input Conf.default
         |> Result.map_error ~f:(fun e ->
-               Translation_unit.Error.print Stdlib.Format.str_formatter e ;
-               Stdlib.Format.flush_str_formatter () )
+            Translation_unit.Error.print Stdlib.Format.str_formatter e ;
+            Stdlib.Format.flush_str_formatter () )
       in
       let expected = Result.map_error expected ~f:normalize_eol in
       Alcotest.(check (result string string)) test_name expected actual )


### PR DESCRIPTION
--ocp-indent-compat behaviour for `|> map ( fun` and `@@ match` is very good. This enables it for everyone.

Replaces #2689 and #2686 .

Should lead to vastly smaller indentation in a lot of cases where it was huge.