### PR TITLE
make `map ~a:(fun` and `map (fun`  consistent

### DIFF
--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -176,17 +176,10 @@ module Exp = struct
       | Some ((Labelled _ | Optional _), _, _) -> true
       | _ -> false
     in
-    let is_ctx_beginend =
-      match ctx0 with
-      | Exp {pexp_desc= Pexp_beginend _; _} -> true
-      | _ -> false
-    in
     if Conf.(c.fmt_opts.ocp_indent_compat.v) then
       if last_arg || is_labelled_arg then break 1 2 else str " "
     else if is_labelled_arg then break 1 2
-    else if last_arg then break 1 0
-    else if is_ctx_beginend then break 1 0
-    else str " "
+    else break 1 0
 
   let box_fun_decl_args ~ctx ~ctx0 ?(last_arg = false) ?epi c ~parens ~kw
       ~args ~annot =
@@ -217,11 +210,8 @@ module Exp = struct
             match ctx_is_apply_and_exp_is_arg ~ctx ~ctx0 with
             | Some (_, _, true) ->
                 (* Is last arg. *) hvbox ~name (if parens then 0 else 2)
-            | Some (Nolabel, _, false) ->
-                (* TODO: Inconsistent formatting of fun args. *)
-                hovbox ~name 0
-            | Some ((Labelled _ | Optional _), _, false) -> hvbox ~name 0
-            | None -> Fn.id
+            | Some (_, _, false) -> hvbox ~name 0
+            | None -> hvbox ~name 0
         in
         (box, not c.fmt_opts.wrap_fun_args.v)
     in

--- a/test/passing/refs.ahrefs/break_fun_decl-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ahrefs/break_fun_decl-fit_or_vertical.ml.ref
@@ -136,8 +136,12 @@ let f
 
 let new_specialised_args =
   Variable.Map.mapi
-    (fun new_inner_var______ (definition : Definition.t) :
-         Flambda.specialised_to -> ())
+    (fun
+      new_inner_var______
+      (definition : Definition.t)
+      :
+      Flambda.specialised_to
+    -> ())
     foo
 
 let new_specialised_args =

--- a/test/passing/refs.ahrefs/break_fun_decl-smart.ml.ref
+++ b/test/passing/refs.ahrefs/break_fun_decl-smart.ml.ref
@@ -129,8 +129,12 @@ let f
 
 let new_specialised_args =
   Variable.Map.mapi
-    (fun new_inner_var______ (definition : Definition.t) :
-         Flambda.specialised_to -> ())
+    (fun
+      new_inner_var______
+      (definition : Definition.t)
+      :
+      Flambda.specialised_to
+    -> ())
     foo
 
 let new_specialised_args =

--- a/test/passing/refs.ahrefs/break_fun_decl-wrap.ml.ref
+++ b/test/passing/refs.ahrefs/break_fun_decl-wrap.ml.ref
@@ -110,8 +110,12 @@ let f (module Store : Irmin.Generic_key.S with type repo = repo)
 
 let new_specialised_args =
   Variable.Map.mapi
-    (fun new_inner_var______ (definition : Definition.t) :
-         Flambda.specialised_to -> ())
+    (fun
+      new_inner_var______
+      (definition : Definition.t)
+      :
+      Flambda.specialised_to
+    -> ())
     foo
 
 let new_specialised_args =

--- a/test/passing/refs.ahrefs/break_fun_decl.ml.ref
+++ b/test/passing/refs.ahrefs/break_fun_decl.ml.ref
@@ -110,8 +110,12 @@ let f (module Store : Irmin.Generic_key.S with type repo = repo)
 
 let new_specialised_args =
   Variable.Map.mapi
-    (fun new_inner_var______ (definition : Definition.t) :
-         Flambda.specialised_to -> ())
+    (fun
+      new_inner_var______
+      (definition : Definition.t)
+      :
+      Flambda.specialised_to
+    -> ())
     foo
 
 let new_specialised_args =

--- a/test/passing/refs.ahrefs/class_expr.ml.ref
+++ b/test/passing/refs.ahrefs/class_expr.ml.ref
@@ -9,7 +9,8 @@ class c (* xx *) i (* yy *) = x
 class c =
   object
     method class_infos : 'a. ('a -> 'res) -> 'a class_infos -> 'res =
-      fun _a
+      fun
+        _a
         { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } ->
         let pci_virt = self#virtual_flag pci_virt in
         let pci_params = self#list in

--- a/test/passing/refs.ahrefs/exp_grouping.ml.ref
+++ b/test/passing/refs.ahrefs/exp_grouping.ml.ref
@@ -394,9 +394,7 @@ let v =
 let v =
   map x
     begin fun
-      x
-      arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-    ->
+      x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
     y
   end
 
@@ -457,10 +455,7 @@ let _ =
 
 let _ =
   lazy begin fun
-         xxxxxxxxxxxxxxxxxxxxxxx
-         yyyyyyyyyyyyyyyyyyy
-         zzzzzzzzzzzzzzzzzzzzzzzz
-       ->
+         xxxxxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzzzzz ->
     print_endline xxxxxxxxx;
     f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
   end

--- a/test/passing/refs.ahrefs/fun_decl-no-wrap-fun-args.ml.err
+++ b/test/passing/refs.ahrefs/fun_decl-no-wrap-fun-args.ml.err
@@ -1,1 +1,1 @@
-Warning: fun_decl-no-wrap-fun-args.ml:39 exceeds the margin
+Warning: fun_decl-no-wrap-fun-args.ml:41 exceeds the margin

--- a/test/passing/refs.ahrefs/fun_decl-no-wrap-fun-args.ml.ref
+++ b/test/passing/refs.ahrefs/fun_decl-no-wrap-fun-args.ml.ref
@@ -5,25 +5,27 @@ let _ = fun (x : int) : int -> (some_large_computation : int)
 let fooo = List.foooo ~f:(fun foooo foooo : bool -> foooooooooooooooooooooo)
 
 let _ =
- fun (x : int)
-     (x : int)
-     (x : int)
-     (x : int)
-     (x : int)
-     :
-     fooooooooooooooooooooooooooo foooooooooooooo foooooooooo ->
+ fun
+   (x : int)
+   (x : int)
+   (x : int)
+   (x : int)
+   (x : int)
+   :
+   fooooooooooooooooooooooooooo foooooooooooooo foooooooooo ->
   some_large_computation
 
 let _ =
- fun (x : int)
-     (x : int)
-     (x : int)
-     (x : int)
-     (x : int)
-     (x : int)
-     (x : int)
-     :
-     fooooooooooooooooooooooooooo foooooooooooooo foooooooooo ->
+ fun
+   (x : int)
+   (x : int)
+   (x : int)
+   (x : int)
+   (x : int)
+   (x : int)
+   (x : int)
+   :
+   fooooooooooooooooooooooooooo foooooooooooooo foooooooooo ->
   some_large_computation
 
 let () =
@@ -94,17 +96,19 @@ let _ =
 
 let _ =
   let _ = () in
-  fun (context : Context.t)
-      ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
-    ->
+  fun
+    (context : Context.t)
+    ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
+  ->
     let _ = () in
     ()
 
 let _ =
   print_endline "foo";
-  fun (context : Context.t)
-      ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
-    ->
+  fun
+    (context : Context.t)
+    ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
+  ->
     let _ = () in
     ()
 

--- a/test/passing/refs.ahrefs/fun_decl.ml.ref
+++ b/test/passing/refs.ahrefs/fun_decl.ml.ref
@@ -82,7 +82,8 @@ let _ =
 
 let _ =
   let _ = () in
-  fun (context : Context.t)
+  fun
+    (context : Context.t)
     ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
   ->
     let _ = () in
@@ -90,7 +91,8 @@ let _ =
 
 let _ =
   print_endline "foo";
-  fun (context : Context.t)
+  fun
+    (context : Context.t)
     ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
   ->
     let _ = () in

--- a/test/passing/refs.ahrefs/js_source.ml.err
+++ b/test/passing/refs.ahrefs/js_source.ml.err
@@ -2,4 +2,4 @@ Warning: js_source.ml:136 exceeds the margin
 Warning: js_source.ml:170 exceeds the margin
 Warning: js_source.ml:243 exceeds the margin
 Warning: js_source.ml:255 exceeds the margin
-Warning: js_source.ml:862 exceeds the margin
+Warning: js_source.ml:864 exceeds the margin

--- a/test/passing/refs.ahrefs/js_source.ml.ref
+++ b/test/passing/refs.ahrefs/js_source.ml.ref
@@ -587,7 +587,8 @@ let _ =
 
 let _ =
   let x = x in
-  fun foooooooooooooooooo
+  fun
+    foooooooooooooooooo
     foooooooooooooooooo
     foooooooooooooooooo
     foooooooooooooooooo
@@ -645,7 +646,8 @@ module M =
 
 let _ =
   Some
-    (fun fooooooooooooooooooooooooooooooo
+    (fun
+      fooooooooooooooooooooooooooooooo
       fooooooooooooooooooooooooooooooo
       fooooooooooooooooooooooooooooooo
     -> foo)

--- a/test/passing/refs.default/break_fun_decl-fit_or_vertical.ml.ref
+++ b/test/passing/refs.default/break_fun_decl-fit_or_vertical.ml.ref
@@ -136,8 +136,12 @@ let f
 
 let new_specialised_args =
   Variable.Map.mapi
-    (fun new_inner_var______ (definition : Definition.t) :
-         Flambda.specialised_to -> ())
+    (fun
+      new_inner_var______
+      (definition : Definition.t)
+      :
+      Flambda.specialised_to
+    -> ())
     foo
 
 let new_specialised_args =

--- a/test/passing/refs.default/break_fun_decl-smart.ml.ref
+++ b/test/passing/refs.default/break_fun_decl-smart.ml.ref
@@ -129,8 +129,12 @@ let f
 
 let new_specialised_args =
   Variable.Map.mapi
-    (fun new_inner_var______ (definition : Definition.t) :
-         Flambda.specialised_to -> ())
+    (fun
+      new_inner_var______
+      (definition : Definition.t)
+      :
+      Flambda.specialised_to
+    -> ())
     foo
 
 let new_specialised_args =

--- a/test/passing/refs.default/break_fun_decl-wrap.ml.ref
+++ b/test/passing/refs.default/break_fun_decl-wrap.ml.ref
@@ -110,8 +110,12 @@ let f (module Store : Irmin.Generic_key.S with type repo = repo)
 
 let new_specialised_args =
   Variable.Map.mapi
-    (fun new_inner_var______ (definition : Definition.t) :
-         Flambda.specialised_to -> ())
+    (fun
+      new_inner_var______
+      (definition : Definition.t)
+      :
+      Flambda.specialised_to
+    -> ())
     foo
 
 let new_specialised_args =

--- a/test/passing/refs.default/break_fun_decl.ml.ref
+++ b/test/passing/refs.default/break_fun_decl.ml.ref
@@ -110,8 +110,12 @@ let f (module Store : Irmin.Generic_key.S with type repo = repo)
 
 let new_specialised_args =
   Variable.Map.mapi
-    (fun new_inner_var______ (definition : Definition.t) :
-         Flambda.specialised_to -> ())
+    (fun
+      new_inner_var______
+      (definition : Definition.t)
+      :
+      Flambda.specialised_to
+    -> ())
     foo
 
 let new_specialised_args =

--- a/test/passing/refs.default/class_expr.ml.err
+++ b/test/passing/refs.default/class_expr.ml.err
@@ -1,1 +1,1 @@
-Warning: class_expr.ml:9 exceeds the margin
+Warning: class_expr.ml:10 exceeds the margin

--- a/test/passing/refs.default/class_expr.ml.ref
+++ b/test/passing/refs.default/class_expr.ml.ref
@@ -6,7 +6,8 @@ class c (* xx *) i (* yy *) = x
 class c =
   object
     method class_infos : 'a. ('a -> 'res) -> 'a class_infos -> 'res =
-      fun _a
+      fun
+          _a
           { pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes } ->
         let pci_virt = self#virtual_flag pci_virt in
         let pci_params = self#list in

--- a/test/passing/refs.default/exp_grouping.ml.ref
+++ b/test/passing/refs.default/exp_grouping.ml.ref
@@ -411,9 +411,7 @@ let v =
 let v =
   map x
     begin fun
-      x
-      arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-    ->
+      x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
       y
     end
 
@@ -474,10 +472,7 @@ let _ =
 
 let _ =
   lazy begin fun
-         xxxxxxxxxxxxxxxxxxxxxxx
-         yyyyyyyyyyyyyyyyyyy
-         zzzzzzzzzzzzzzzzzzzzzzzz
-       ->
+         xxxxxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzzzzz ->
     print_endline xxxxxxxxx;
     f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
   end

--- a/test/passing/refs.default/fun_decl-no-wrap-fun-args.ml.ref
+++ b/test/passing/refs.default/fun_decl-no-wrap-fun-args.ml.ref
@@ -3,7 +3,8 @@ let _ = fun (x : int) : int -> (some_large_computation : int)
 let fooo = List.foooo ~f:(fun foooo foooo : bool -> foooooooooooooooooooooo)
 
 let _ =
- fun (x : int)
+ fun
+     (x : int)
      (x : int)
      (x : int)
      (x : int)
@@ -13,7 +14,8 @@ let _ =
   some_large_computation
 
 let _ =
- fun (x : int)
+ fun
+     (x : int)
      (x : int)
      (x : int)
      (x : int)
@@ -94,17 +96,19 @@ let _ =
 
 let _ =
   let _ = () in
-  fun (context : Context.t)
-      ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
-    ->
+  fun
+    (context : Context.t)
+    ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
+  ->
     let _ = () in
     ()
 
 let _ =
   print_endline "foo";
-  fun (context : Context.t)
-      ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
-    ->
+  fun
+    (context : Context.t)
+    ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
+  ->
     let _ = () in
     ()
 

--- a/test/passing/refs.default/fun_decl.ml.ref
+++ b/test/passing/refs.default/fun_decl.ml.ref
@@ -80,7 +80,8 @@ let _ =
 
 let _ =
   let _ = () in
-  fun (context : Context.t)
+  fun
+    (context : Context.t)
     ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
   ->
     let _ = () in
@@ -88,7 +89,8 @@ let _ =
 
 let _ =
   print_endline "foo";
-  fun (context : Context.t)
+  fun
+    (context : Context.t)
     ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
   ->
     let _ = () in

--- a/test/passing/refs.default/js_source.ml.err
+++ b/test/passing/refs.default/js_source.ml.err
@@ -4,4 +4,4 @@ Warning: js_source.ml:224 exceeds the margin
 Warning: js_source.ml:229 exceeds the margin
 Warning: js_source.ml:240 exceeds the margin
 Warning: js_source.ml:328 exceeds the margin
-Warning: js_source.ml:814 exceeds the margin
+Warning: js_source.ml:816 exceeds the margin

--- a/test/passing/refs.default/js_source.ml.ref
+++ b/test/passing/refs.default/js_source.ml.ref
@@ -560,7 +560,8 @@ let _ =
 
 let _ =
   let x = x in
-  fun foooooooooooooooooo
+  fun
+    foooooooooooooooooo
     foooooooooooooooooo
     foooooooooooooooooo
     foooooooooooooooooo
@@ -613,7 +614,8 @@ module M =
 
 let _ =
   Some
-    (fun fooooooooooooooooooooooooooooooo
+    (fun
+      fooooooooooooooooooooooooooooooo
       fooooooooooooooooooooooooooooooo
       fooooooooooooooooooooooooooooooo
     -> foo)

--- a/test/passing/refs.ocamlformat/break_fun_decl-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/break_fun_decl-fit_or_vertical.ml.ref
@@ -136,8 +136,12 @@ let f
 
 let new_specialised_args =
   Variable.Map.mapi
-    (fun new_inner_var______ (definition : Definition.t) :
-         Flambda.specialised_to -> () )
+    (fun
+      new_inner_var______
+      (definition : Definition.t)
+      :
+      Flambda.specialised_to
+    -> () )
     foo
 
 let new_specialised_args =

--- a/test/passing/refs.ocamlformat/break_fun_decl-smart.ml.ref
+++ b/test/passing/refs.ocamlformat/break_fun_decl-smart.ml.ref
@@ -129,8 +129,12 @@ let f
 
 let new_specialised_args =
   Variable.Map.mapi
-    (fun new_inner_var______ (definition : Definition.t) :
-         Flambda.specialised_to -> () )
+    (fun
+      new_inner_var______
+      (definition : Definition.t)
+      :
+      Flambda.specialised_to
+    -> () )
     foo
 
 let new_specialised_args =

--- a/test/passing/refs.ocamlformat/break_fun_decl-wrap.ml.ref
+++ b/test/passing/refs.ocamlformat/break_fun_decl-wrap.ml.ref
@@ -110,8 +110,12 @@ let f (module Store : Irmin.Generic_key.S with type repo = repo)
 
 let new_specialised_args =
   Variable.Map.mapi
-    (fun new_inner_var______ (definition : Definition.t) :
-         Flambda.specialised_to -> () )
+    (fun
+      new_inner_var______
+      (definition : Definition.t)
+      :
+      Flambda.specialised_to
+    -> () )
     foo
 
 let new_specialised_args =

--- a/test/passing/refs.ocamlformat/break_fun_decl.ml.ref
+++ b/test/passing/refs.ocamlformat/break_fun_decl.ml.ref
@@ -110,8 +110,12 @@ let f (module Store : Irmin.Generic_key.S with type repo = repo)
 
 let new_specialised_args =
   Variable.Map.mapi
-    (fun new_inner_var______ (definition : Definition.t) :
-         Flambda.specialised_to -> () )
+    (fun
+      new_inner_var______
+      (definition : Definition.t)
+      :
+      Flambda.specialised_to
+    -> () )
     foo
 
 let new_specialised_args =

--- a/test/passing/refs.ocamlformat/class_expr.ml.ref
+++ b/test/passing/refs.ocamlformat/class_expr.ml.ref
@@ -9,7 +9,8 @@ class c (* xx *) i (* yy *) = x
 class c =
   object
     method class_infos : 'a. ('a -> 'res) -> 'a class_infos -> 'res =
-      fun _a
+      fun
+          _a
           {pci_virt; pci_params; pci_name; pci_expr; pci_loc; pci_attributes} ->
         let pci_virt = self#virtual_flag pci_virt in
         let pci_params = self#list in

--- a/test/passing/refs.ocamlformat/exp_grouping.ml.ref
+++ b/test/passing/refs.ocamlformat/exp_grouping.ml.ref
@@ -412,9 +412,7 @@ let v =
 let v =
   map x
     begin fun
-      x
-      arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-    ->
+      x arggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg ->
       y
     end
 
@@ -472,10 +470,7 @@ let _ =
 
 let _ =
   lazy begin fun
-         xxxxxxxxxxxxxxxxxxxxxxx
-         yyyyyyyyyyyyyyyyyyy
-         zzzzzzzzzzzzzzzzzzzzzzzz
-       ->
+         xxxxxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzzzzz ->
     print_endline xxxxxxxxx ;
     f xxxxxxxxxx yyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzzzz
   end

--- a/test/passing/refs.ocamlformat/fun_decl-no-wrap-fun-args.ml.ref
+++ b/test/passing/refs.ocamlformat/fun_decl-no-wrap-fun-args.ml.ref
@@ -5,7 +5,8 @@ let _ = fun (x : int) : int -> (some_large_computation : int)
 let fooo = List.foooo ~f:(fun foooo foooo : bool -> foooooooooooooooooooooo)
 
 let _ =
- fun (x : int)
+ fun
+     (x : int)
      (x : int)
      (x : int)
      (x : int)
@@ -15,7 +16,8 @@ let _ =
   some_large_computation
 
 let _ =
- fun (x : int)
+ fun
+     (x : int)
      (x : int)
      (x : int)
      (x : int)
@@ -100,17 +102,19 @@ let _ =
 
 let _ =
   let _ = () in
-  fun (context : Context.t)
-      ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
-    ->
+  fun
+    (context : Context.t)
+    ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
+  ->
     let _ = () in
     ()
 
 let _ =
   print_endline "foo" ;
-  fun (context : Context.t)
-      ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
-    ->
+  fun
+    (context : Context.t)
+    ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
+  ->
     let _ = () in
     ()
 

--- a/test/passing/refs.ocamlformat/fun_decl.ml.ref
+++ b/test/passing/refs.ocamlformat/fun_decl.ml.ref
@@ -86,7 +86,8 @@ let _ =
 
 let _ =
   let _ = () in
-  fun (context : Context.t)
+  fun
+    (context : Context.t)
     ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
   ->
     let _ = () in
@@ -94,7 +95,8 @@ let _ =
 
 let _ =
   print_endline "foo" ;
-  fun (context : Context.t)
+  fun
+    (context : Context.t)
     ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t)
   ->
     let _ = () in

--- a/test/passing/refs.ocamlformat/js_source.ml.err
+++ b/test/passing/refs.ocamlformat/js_source.ml.err
@@ -5,5 +5,5 @@ Warning: js_source.ml:154 exceeds the margin
 Warning: js_source.ml:219 exceeds the margin
 Warning: js_source.ml:224 exceeds the margin
 Warning: js_source.ml:235 exceeds the margin
-Warning: js_source.ml:633 exceeds the margin
-Warning: js_source.ml:833 exceeds the margin
+Warning: js_source.ml:635 exceeds the margin
+Warning: js_source.ml:835 exceeds the margin

--- a/test/passing/refs.ocamlformat/js_source.ml.ref
+++ b/test/passing/refs.ocamlformat/js_source.ml.ref
@@ -568,7 +568,8 @@ let _ =
 
 let _ =
   let x = x in
-  fun foooooooooooooooooo
+  fun
+    foooooooooooooooooo
     foooooooooooooooooo
     foooooooooooooooooo
     foooooooooooooooooo
@@ -623,7 +624,8 @@ module M =
 
 let _ =
   Some
-    (fun fooooooooooooooooooooooooooooooo
+    (fun
+      fooooooooooooooooooooooooooooooo
       fooooooooooooooooooooooooooooooo
       fooooooooooooooooooooooooooooooo
     -> foo )


### PR DESCRIPTION
There used to be two formatting for these two syntaxes.

This makes them consistent. I picked the syntax of `~a:(fun` because it was the nicest one in my opinion. `(fun` without label has slightly less indentation. 

I would like fun exprs to always be formatted like 
```ocaml
fun
  args
->
  body
```
because
```ocaml
fun
  args ->
  body
```
is just not readable: its quite hard to see were the arg ends and where the body starts.
As a comparison, we never ever do

```ocaml
if
  cond then
  body
```
I realize this is probably to large of a diff overall, but achieving it would also be both nice and make the code a lot simpler.