### PR TITLE
break-struct for sig fix

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3806,6 +3806,13 @@ and fmt_module_type c ?(rec_ = false) ({ast= mty; _} as xmty) =
         bdy= fmt_longident_loc c lid
       ; epi= Some (fmt_attributes c pmty_attributes ~pre:(Break (1, 0))) }
   | Pmty_signature s ->
+      let is_signature_multiline =
+        match s with
+        | [] -> false
+        | _ :: _ ->
+            (List.hd_exn s).psig_loc.loc_start.pos_lnum
+            <> (List.last_exn s).psig_loc.loc_start.pos_lnum
+      in
       let empty = List.is_empty s && not (Cmts.has_within c.cmts pmty_loc) in
       let before = Cmts.fmt_before c pmty_loc in
       let within = Cmts.fmt_within c ~pro:noop pmty_loc in
@@ -3820,7 +3827,8 @@ and fmt_module_type c ?(rec_ = false) ({ast= mty; _} as xmty) =
       ; cls= noop
       ; esp=
           fmt_if (not empty)
-            ( if c.conf.fmt_opts.break_struct.v then force_break
+            ( if c.conf.fmt_opts.break_struct.v || is_signature_multiline then
+                force_break
               else break 1 0 )
       ; epi=
           Some

--- a/test/passing/refs.ahrefs/break_struct.ml.ref
+++ b/test/passing/refs.ahrefs/break_struct.ml.ref
@@ -94,18 +94,21 @@ module type Module_type_fail = sig
 
   module F : functor (_ : T) -> sig end
 
-  include S end
+  include S
+end
 
 module A : sig
   type a
 
-  type b end =
+  type b
+end =
   B
 
 module A : sig
   type a
 
-  type b end = struct
+  type b
+end = struct
   type a
 
   type b

--- a/test/passing/refs.ahrefs/break_struct.ml.ref
+++ b/test/passing/refs.ahrefs/break_struct.ml.ref
@@ -68,3 +68,52 @@ include (
       include Ast_407
     end
     with module Location := Ast_407.Location)
+
+module type S = sig
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd end
+
+module S : sig
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd end = struct
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd
+end
+
+module type Module_type_fail = sig
+  include S
+
+  module F : functor (_ : T) -> sig end
+
+  include S end
+
+module A : sig
+  type a
+
+  type b end =
+  B
+
+module A : sig
+  type a
+
+  type b end = struct
+  type a
+
+  type b
+end
+
+module type S = sig
+  module Make (Config : sig
+    val blah : string
+
+    val boo : int
+  end) : S end

--- a/test/passing/refs.default/break_struct.ml.ref
+++ b/test/passing/refs.default/break_struct.ml.ref
@@ -75,3 +75,32 @@ include (
       include Ast_407
     end
     with module Location := Ast_407.Location)
+
+module type S = sig
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd end
+
+module S : sig
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd end = struct
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd
+end
+
+module type Module_type_fail = sig
+  include S module F : functor (_ : T) -> sig end include S end
+
+module A : sig type a type b end = B
+module A : sig type a type b end = struct type a type b end
+
+module type S = sig
+  module Make (Config : sig val blah : string val boo : int end) : S end

--- a/test/passing/refs.janestreet/break_struct.ml.ref
+++ b/test/passing/refs.janestreet/break_struct.ml.ref
@@ -84,3 +84,31 @@ end
 include (
   Ast_407 :
     module type of struct include Ast_407 end with module Location := Ast_407.Location)
+
+module type S = sig
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd end
+
+module S : sig
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd end = struct
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd
+end
+
+module type Module_type_fail = sig
+  include S module F : functor (_ : T) -> sig end include S end
+
+module A : sig type a type b end = B
+module A : sig type a type b end = struct type a type b end
+
+module type S = sig module Make (Config : sig val blah : string val boo : int end) : S end

--- a/test/passing/refs.ocamlformat/break_struct.ml.ref
+++ b/test/passing/refs.ocamlformat/break_struct.ml.ref
@@ -83,3 +83,52 @@ include (
       include Ast_407
     end
     with module Location := Ast_407.Location )
+
+module type S = sig
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd end
+
+module S : sig
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd end = struct
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd
+end
+
+module type Module_type_fail = sig
+  include S
+
+  module F : functor (_ : T) -> sig end
+
+  include S end
+
+module A : sig
+  type a
+
+  type b end =
+  B
+
+module A : sig
+  type a
+
+  type b end = struct
+  type a
+
+  type b
+end
+
+module type S = sig
+  module Make (Config : sig
+    val blah : string
+
+    val boo : int
+  end) : S end

--- a/test/passing/refs.ocamlformat/break_struct.ml.ref
+++ b/test/passing/refs.ocamlformat/break_struct.ml.ref
@@ -109,18 +109,21 @@ module type Module_type_fail = sig
 
   module F : functor (_ : T) -> sig end
 
-  include S end
+  include S
+end
 
 module A : sig
   type a
 
-  type b end =
+  type b
+end =
   B
 
 module A : sig
   type a
 
-  type b end = struct
+  type b
+end = struct
   type a
 
   type b

--- a/test/passing/tests/break_struct.ml
+++ b/test/passing/tests/break_struct.ml
@@ -88,3 +88,58 @@ include (
     module type of struct include Ast_407
     end
     with module Location := Ast_407.Location )
+
+module type S = sig
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd
+end
+
+module S : sig
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd
+end = struct
+  type t =
+    | AAaaaaaaaaaaaaaaaaaa
+    | Bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    | Ccccccccccccccccccccccc
+    | Dddddddddddddddddd
+end
+
+module type Module_type_fail = sig
+  include S
+
+  module F : functor (_ : T) -> sig end
+
+  include S
+end
+
+module A : sig
+  type a
+
+  type b
+end =
+  B
+
+module A : sig
+  type a
+
+  type b
+end = struct
+  type a
+
+  type b
+end
+
+module type S = sig
+  module Make (Config : sig
+    val blah : string
+
+    val boo : int
+  end) : S
+end


### PR DESCRIPTION
There was a bug in my #2682 PR to apply break-struct=natural to `sig ... end`. 

This fixes that bug. The bug was that the box structure did not put the `end` on a new line:

```ocaml
module type T = sig
  type a
  type b end
```

The implem is a bit hacking, but I tried modifying the box structure to do something cleaner, but it was very hard to do without making diffs all over the place. I can't just copy the `struct ... end` boxes because of the following:

```ocaml
module S : sig
  type a
  type b
end = struct
  type a = int
  type b = string
end
```
The code for `struct ... end` simply handles less cases.