### PR TITLE
[bugfix] fix crash with inline record type variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,8 @@ profile. This started with version 0.26.0.
   contexts like `a ; fun ...`. A check for the syntax `let a = fun ... in ...`
   was made more precise. (#2705, @EmileTrotignon)
 
+- Fix a crash on `type 'a t = A : 'a. {a: 'a} -> 'a t`. (#2710, @EmileTrotignon)
+
 ### Changed
 
 - `|> begin`, `~arg:begin`, `begin if`, `lazy begin`, `begin match`,

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3649,6 +3649,9 @@ and fmt_constructor_arguments ?vars c ctx ~pre = function
       in
       pre $ vars $ typs
   | Pcstr_record (loc, lds) ->
+      let vars =
+        match vars with Some vars -> space_break $ vars | None -> noop
+      in
       let p = Params.get_record_type c.conf in
       let fmt_ld ~first ~last x =
         fmt_if (not first) p.sep_before
@@ -3658,7 +3661,7 @@ and fmt_constructor_arguments ?vars c ctx ~pre = function
             (str " ")
         $ fmt_if (not last) p.sep_after
       in
-      pre
+      pre $ vars
       $ Cmts.fmt c loc ~pro:(break 1 0) ~epi:noop
         @@ wrap p.docked_before p.docked_after
         @@ wrap p.break_before p.break_after

--- a/test/passing/refs.ahrefs/record-402.ml.ref
+++ b/test/passing/refs.ahrefs/record-402.ml.ref
@@ -119,3 +119,5 @@ let x = (A B).a
 let x = A (B).a
 
 let x = (1).a
+
+type 'a t = A : 'b. { a : 'a } -> 'a t

--- a/test/passing/refs.ahrefs/record-loose.ml.ref
+++ b/test/passing/refs.ahrefs/record-loose.ml.ref
@@ -119,3 +119,5 @@ let x = (A B).a
 let x = A (B).a
 
 let x = (1).a
+
+type 'a t = A : 'b. { a : 'a } -> 'a t

--- a/test/passing/refs.ahrefs/record-tight_decl.ml.ref
+++ b/test/passing/refs.ahrefs/record-tight_decl.ml.ref
@@ -119,3 +119,5 @@ let x = (A B).a
 let x = A (B).a
 
 let x = (1).a
+
+type 'a t = A : 'b. { a: 'a } -> 'a t

--- a/test/passing/refs.ahrefs/record.ml.ref
+++ b/test/passing/refs.ahrefs/record.ml.ref
@@ -119,3 +119,5 @@ let x = (A B).a
 let x = A (B).a
 
 let x = (1).a
+
+type 'a t = A : 'b. { a: 'a } -> 'a t

--- a/test/passing/refs.default/record-402.ml.ref
+++ b/test/passing/refs.default/record-402.ml.ref
@@ -79,3 +79,5 @@ let foo
 let x = (A B).a
 let x = A (B).a
 let x = (1).a
+
+type 'a t = A : 'b. { a : 'a } -> 'a t

--- a/test/passing/refs.default/record-loose.ml.ref
+++ b/test/passing/refs.default/record-loose.ml.ref
@@ -79,3 +79,5 @@ let foo
 let x = (A B).a
 let x = A (B).a
 let x = (1).a
+
+type 'a t = A : 'b. { a : 'a } -> 'a t

--- a/test/passing/refs.default/record-tight_decl.ml.ref
+++ b/test/passing/refs.default/record-tight_decl.ml.ref
@@ -79,3 +79,5 @@ let foo
 let x = (A B).a
 let x = A (B).a
 let x = (1).a
+
+type 'a t = A : 'b. { a: 'a } -> 'a t

--- a/test/passing/refs.default/record.ml.ref
+++ b/test/passing/refs.default/record.ml.ref
@@ -79,3 +79,5 @@ let foo
 let x = (A B).a
 let x = A (B).a
 let x = (1).a
+
+type 'a t = A : 'b. { a: 'a } -> 'a t

--- a/test/passing/refs.janestreet/record-402.ml.ref
+++ b/test/passing/refs.janestreet/record-402.ml.ref
@@ -103,3 +103,5 @@ let foo
 let x = (A B).a
 let x = A (B).a
 let x = (1).a
+
+type 'a t = A : 'b. { a : 'a } -> 'a t

--- a/test/passing/refs.janestreet/record-loose.ml.ref
+++ b/test/passing/refs.janestreet/record-loose.ml.ref
@@ -103,3 +103,5 @@ let foo
 let x = (A B).a
 let x = A (B).a
 let x = (1).a
+
+type 'a t = A : 'b. { a : 'a } -> 'a t

--- a/test/passing/refs.janestreet/record-tight_decl.ml.ref
+++ b/test/passing/refs.janestreet/record-tight_decl.ml.ref
@@ -103,3 +103,5 @@ let foo
 let x = (A B).a
 let x = A (B).a
 let x = (1).a
+
+type 'a t = A : 'b. { a: 'a } -> 'a t

--- a/test/passing/refs.janestreet/record.ml.ref
+++ b/test/passing/refs.janestreet/record.ml.ref
@@ -103,3 +103,5 @@ let foo
 let x = (A B).a
 let x = A (B).a
 let x = (1).a
+
+type 'a t = A : 'b. { a: 'a } -> 'a t

--- a/test/passing/refs.ocamlformat/record-402.ml.ref
+++ b/test/passing/refs.ocamlformat/record-402.ml.ref
@@ -80,3 +80,5 @@ let x = (A B).a
 let x = A (B).a
 
 let x = (1).a
+
+type 'a t = A : 'b. {a: 'a} -> 'a t

--- a/test/passing/refs.ocamlformat/record-loose.ml.ref
+++ b/test/passing/refs.ocamlformat/record-loose.ml.ref
@@ -80,3 +80,5 @@ let x = (A B).a
 let x = A (B).a
 
 let x = (1).a
+
+type 'a t = A : 'b. {a : 'a} -> 'a t

--- a/test/passing/refs.ocamlformat/record-tight_decl.ml.ref
+++ b/test/passing/refs.ocamlformat/record-tight_decl.ml.ref
@@ -80,3 +80,5 @@ let x = (A B).a
 let x = A (B).a
 
 let x = (1).a
+
+type 'a t = A : 'b. {a: 'a} -> 'a t

--- a/test/passing/refs.ocamlformat/record.ml.ref
+++ b/test/passing/refs.ocamlformat/record.ml.ref
@@ -80,3 +80,5 @@ let x = (A B).a
 let x = A (B).a
 
 let x = (1).a
+
+type 'a t = A : 'b. {a: 'a} -> 'a t

--- a/test/passing/tests/record.ml
+++ b/test/passing/tests/record.ml
@@ -89,3 +89,4 @@ let x = A(B).a
 
 let x = (1).a
 
+type 'a t = A : 'b. {a: 'a} -> 'a t


### PR DESCRIPTION
Fix a crash were 
```ocaml
type 'a t = A : 'b. {a: 'a} -> 'a t
```

was formatted as
```ocaml
type 'a t = A : {a: 'a} -> 'a t
```

documented in issue #2708 