### PR TITLE
type nonrec infix ext bugfix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,9 @@ profile. This started with version 0.26.0.
 
 - Fix a crash on `type 'a t = A : 'a. {a: 'a} -> 'a t`. (#2710, @EmileTrotignon)
 
+- Fix a crash where `type%e nonrec t = t` was formatted as `type nonrec%e t = t`,
+  which is invalid syntax. (#2712, @EmileTrotignon)
+
 ### Changed
 
 - `|> begin`, `~arg:begin`, `begin if`, `lazy begin`, `begin match`,

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3457,7 +3457,7 @@ and fmt_class_params c ctx params =
        ( wrap_fits_breaks c.conf "[" "]" (list_fl params fmt_param)
        $ space_break ) )
 
-and fmt_type_declaration c ?(pre = "") ?name ?(eq = "=") {ast= decl; _} =
+and fmt_type_declaration c ?(kw = "") ?(nonrec_kw="") ?name ?(eq = "=") {ast= decl; _} =
   protect c (Td decl)
   @@
   let { ptype_name= {txt; loc}
@@ -3497,9 +3497,10 @@ and fmt_type_declaration c ?(pre = "") ?name ?(eq = "=") {ast= decl; _} =
   in
   let box_manifest k =
     hvbox c.conf.fmt_opts.type_decl_indent.v
-      ( str pre
+      ( str kw
       $ fmt_extension_suffix c ext
       $ fmt_attributes c attrs_before
+      $ str nonrec_kw
       $ str " "
       $ hvbox_if
           (not (List.is_empty ptype_params))
@@ -4265,12 +4266,12 @@ and fmt_module_statement c ~attributes ?keyword mod_expr =
 
 and fmt_with_constraint c ctx ~pre = function
   | Pwith_type (lid, td) ->
-      fmt_type_declaration ~pre:(pre ^ " type") c ~name:lid (sub_td ~ctx td)
+      fmt_type_declaration ~kw:(pre ^ " type") c ~name:lid (sub_td ~ctx td)
   | Pwith_module (m1, m2) ->
       str pre $ str " module " $ fmt_longident_loc c m1 $ str " = "
       $ fmt_longident_loc c m2
   | Pwith_typesubst (lid, td) ->
-      fmt_type_declaration ~pre:(pre ^ " type") c ~eq:":=" ~name:lid
+      fmt_type_declaration ~kw:(pre ^ " type") c ~eq:":=" ~name:lid
         (sub_td ~ctx td)
   | Pwith_modsubst (m1, m2) ->
       str pre $ str " module " $ fmt_longident_loc c m1 $ str " := "
@@ -4550,10 +4551,10 @@ and fmt_type c ?eq rec_flag decls ctx =
   let is_rec = Asttypes.is_recursive rec_flag in
   let fmt_decl c ctx ~prev ~next:_ decl =
     let first = Option.is_none prev in
-    let pre =
-      if first then if is_rec then "type" else "type nonrec" else "and"
+    let kw, nonrec_kw =
+      if first then if is_rec then ("type", None) else ("type", Some " nonrec") else ("and", None)
     in
-    fmt_type_declaration c ~pre ?eq (sub_td ~ctx decl)
+    fmt_type_declaration c ~kw ?nonrec_kw ?eq (sub_td ~ctx decl)
   in
   let ast x = Td x in
   fmt_item_list c ctx update_config ast fmt_decl decls

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3457,7 +3457,8 @@ and fmt_class_params c ctx params =
        ( wrap_fits_breaks c.conf "[" "]" (list_fl params fmt_param)
        $ space_break ) )
 
-and fmt_type_declaration c ?(kw = "") ?(nonrec_kw="") ?name ?(eq = "=") {ast= decl; _} =
+and fmt_type_declaration c ?(kw = "") ?(nonrec_kw = "") ?name ?(eq = "=")
+    {ast= decl; _} =
   protect c (Td decl)
   @@
   let { ptype_name= {txt; loc}
@@ -3500,8 +3501,7 @@ and fmt_type_declaration c ?(kw = "") ?(nonrec_kw="") ?name ?(eq = "=") {ast= de
       ( str kw
       $ fmt_extension_suffix c ext
       $ fmt_attributes c attrs_before
-      $ str nonrec_kw
-      $ str " "
+      $ str nonrec_kw $ str " "
       $ hvbox_if
           (not (List.is_empty ptype_params))
           0
@@ -4552,7 +4552,9 @@ and fmt_type c ?eq rec_flag decls ctx =
   let fmt_decl c ctx ~prev ~next:_ decl =
     let first = Option.is_none prev in
     let kw, nonrec_kw =
-      if first then if is_rec then ("type", None) else ("type", Some " nonrec") else ("and", None)
+      if first then
+        if is_rec then ("type", None) else ("type", Some " nonrec")
+      else ("and", None)
     in
     fmt_type_declaration c ~kw ?nonrec_kw ?eq (sub_td ~ctx decl)
   in

--- a/test/passing/refs.ahrefs/extensions-indent.ml.ref
+++ b/test/passing/refs.ahrefs/extensions-indent.ml.ref
@@ -553,3 +553,5 @@ let xxxxxx =
   { zzzzzzzzzzzzz }
 
 type%e nonrec t = t
+
+type%e[@a] nonrec t = t

--- a/test/passing/refs.ahrefs/extensions-indent.ml.ref
+++ b/test/passing/refs.ahrefs/extensions-indent.ml.ref
@@ -551,3 +551,5 @@ let xxxxxx =
     yyyyyyyy
   in
   { zzzzzzzzzzzzz }
+
+type%e nonrec t = t

--- a/test/passing/refs.ahrefs/extensions.ml.ref
+++ b/test/passing/refs.ahrefs/extensions.ml.ref
@@ -553,3 +553,5 @@ let xxxxxx =
   { zzzzzzzzzzzzz }
 
 type%e nonrec t = t
+
+type%e[@a] nonrec t = t

--- a/test/passing/refs.ahrefs/extensions.ml.ref
+++ b/test/passing/refs.ahrefs/extensions.ml.ref
@@ -551,3 +551,5 @@ let xxxxxx =
     yyyyyyyy
   in
   { zzzzzzzzzzzzz }
+
+type%e nonrec t = t

--- a/test/passing/refs.default/extensions-indent.ml.ref
+++ b/test/passing/refs.default/extensions-indent.ml.ref
@@ -465,3 +465,5 @@ let xxxxxx =
     yyyyyyyy
   in
   { zzzzzzzzzzzzz }
+
+type%e nonrec t = t

--- a/test/passing/refs.default/extensions-indent.ml.ref
+++ b/test/passing/refs.default/extensions-indent.ml.ref
@@ -467,3 +467,4 @@ let xxxxxx =
   { zzzzzzzzzzzzz }
 
 type%e nonrec t = t
+type%e[@a] nonrec t = t

--- a/test/passing/refs.default/extensions.ml.ref
+++ b/test/passing/refs.default/extensions.ml.ref
@@ -465,3 +465,5 @@ let xxxxxx =
     yyyyyyyy
   in
   { zzzzzzzzzzzzz }
+
+type%e nonrec t = t

--- a/test/passing/refs.default/extensions.ml.ref
+++ b/test/passing/refs.default/extensions.ml.ref
@@ -467,3 +467,4 @@ let xxxxxx =
   { zzzzzzzzzzzzz }
 
 type%e nonrec t = t
+type%e[@a] nonrec t = t

--- a/test/passing/refs.janestreet/extensions-indent.ml.ref
+++ b/test/passing/refs.janestreet/extensions-indent.ml.ref
@@ -699,3 +699,4 @@ let xxxxxx =
 ;;
 
 type%e nonrec t = t
+type%e[@a] nonrec t = t

--- a/test/passing/refs.janestreet/extensions-indent.ml.ref
+++ b/test/passing/refs.janestreet/extensions-indent.ml.ref
@@ -697,3 +697,5 @@ let xxxxxx =
              __________ *) () = yyyyyyyy in
   { zzzzzzzzzzzzz }
 ;;
+
+type%e nonrec t = t

--- a/test/passing/refs.janestreet/extensions.ml.ref
+++ b/test/passing/refs.janestreet/extensions.ml.ref
@@ -699,3 +699,4 @@ let xxxxxx =
 ;;
 
 type%e nonrec t = t
+type%e[@a] nonrec t = t

--- a/test/passing/refs.janestreet/extensions.ml.ref
+++ b/test/passing/refs.janestreet/extensions.ml.ref
@@ -697,3 +697,5 @@ let xxxxxx =
              __________ *) () = yyyyyyyy in
   { zzzzzzzzzzzzz }
 ;;
+
+type%e nonrec t = t

--- a/test/passing/refs.ocamlformat/extensions-indent.ml.ref
+++ b/test/passing/refs.ocamlformat/extensions-indent.ml.ref
@@ -511,3 +511,5 @@ let xxxxxx =
   {zzzzzzzzzzzzz}
 
 type%e nonrec t = t
+
+type%e[@a] nonrec t = t

--- a/test/passing/refs.ocamlformat/extensions-indent.ml.ref
+++ b/test/passing/refs.ocamlformat/extensions-indent.ml.ref
@@ -509,3 +509,5 @@ let xxxxxx =
     yyyyyyyy
   in
   {zzzzzzzzzzzzz}
+
+type%e nonrec t = t

--- a/test/passing/refs.ocamlformat/extensions.ml.ref
+++ b/test/passing/refs.ocamlformat/extensions.ml.ref
@@ -511,3 +511,5 @@ let xxxxxx =
   {zzzzzzzzzzzzz}
 
 type%e nonrec t = t
+
+type%e[@a] nonrec t = t

--- a/test/passing/refs.ocamlformat/extensions.ml.ref
+++ b/test/passing/refs.ocamlformat/extensions.ml.ref
@@ -509,3 +509,5 @@ let xxxxxx =
     yyyyyyyy
   in
   {zzzzzzzzzzzzz}
+
+type%e nonrec t = t

--- a/test/passing/tests/extensions.ml
+++ b/test/passing/tests/extensions.ml
@@ -390,3 +390,5 @@ let xxxxxx =
   let%map (* _____________________________
              __________ *)()            = yyyyyyyy in
   { zzzzzzzzzzzzz }
+
+type%e nonrec t = t

--- a/test/passing/tests/extensions.ml
+++ b/test/passing/tests/extensions.ml
@@ -392,3 +392,5 @@ let xxxxxx =
   { zzzzzzzzzzzzz }
 
 type%e nonrec t = t
+
+type%e [@a] nonrec t = t


### PR DESCRIPTION
`type%e nonrec t = t` was formatted as `type nonrec%e t = t` which is invalid syntax. This is now fixed.