### PR TITLE
Fix quadratic command-line parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,9 @@ profile. This started with version 0.26.0.
 - Fix a crash where `type%e nonrec t = t` was formatted as `type nonrec%e t = t`,
   which is invalid syntax. (#2712, @EmileTrotignon)
 
+- Fix commandline parsing being quadratic in the number of arguments 
+  (#2724, @let-def)
+
 ### Changed
 
 - `|> begin`, `~arg:begin`, `begin if`, `lazy begin`, `begin match`,
@@ -1801,3 +1804,4 @@ profile. This started with version 0.26.0.
 ## 0.1 (2017-10-19)
 
 - Initial release.
+

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -535,11 +535,13 @@ let global_lib_term =
         new_global.lib_conf )
     $ global_term )
 
+let global_lib_term_eval = lazy (
+  Cmd.eval_value ~err:discard_formatter ~help:discard_formatter
+    (Cmd.v info global_lib_term)
+)
+
 let update_using_cmdline config =
-  match
-    Cmd.eval_value ~err:discard_formatter ~help:discard_formatter
-      (Cmd.v info global_lib_term)
-  with
+  match Lazy.force global_lib_term_eval with
   | Ok (`Ok conf_modif) -> conf_modif config
   | Error _ | Ok (`Version | `Help) -> config
 

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -535,7 +535,7 @@ let global_lib_term =
         new_global.lib_conf )
     $ global_term )
 
-let update_using_cmdline info config =
+let update_using_cmdline config =
   match
     Cmd.eval_value ~err:discard_formatter ~help:discard_formatter
       (Cmd.v info global_lib_term)
@@ -559,7 +559,7 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
       read_config_file ~version_check:false ~disable_conf_attrs:false
     in
     List.fold fs.configuration_files ~init:Conf.default ~f:read_config_file
-    |> update_using_env |> update_using_cmdline info
+    |> update_using_env |> update_using_cmdline
   in
   let conf =
     let opr_opts =
@@ -571,7 +571,7 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
   in
   let conf =
     List.fold fs.configuration_files ~init:conf ~f:read_config_file
-    |> update_using_env |> update_using_cmdline info
+    |> update_using_env |> update_using_cmdline
   in
   if
     (not is_stdin)

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -535,10 +535,10 @@ let global_lib_term =
         new_global.lib_conf )
     $ global_term )
 
-let global_lib_term_eval = lazy (
-  Cmd.eval_value ~err:discard_formatter ~help:discard_formatter
-    (Cmd.v info global_lib_term)
-)
+let global_lib_term_eval =
+  lazy
+    (Cmd.eval_value ~err:discard_formatter ~help:discard_formatter
+       (Cmd.v info global_lib_term) )
 
 let update_using_cmdline config =
   match Lazy.force global_lib_term_eval with


### PR DESCRIPTION
Command‑line parsing occurs in two passes: one pass parses the actions, and a second pass parses the configuration.
Because the configuration parser is invoked for every input file, the overall parsing time grows quadratically with the number of files.

This patch memoizes the configuration so that the parser runs only once. The configuration changes are still applied to each input file, preserving the original ocamlformat behaviour while making the runtime independent of the number of inputs.

Below are two plots that illustrate the performance before and after the change. They show the time spent and the number of stat calls as functions of the number of input files, clearly demonstrating the quadratic behaviour that the patch removes.

![stat](https://github.com/user-attachments/assets/b2ddfea4-7459-44a4-a082-ec2678880960)
![time](https://github.com/user-attachments/assets/51c0c64c-0373-4d25-a0af-f1570abde192)
