### PR TITLE
avoid command line parsing in a the middle of a library

### DIFF
--- a/bin/ocamlformat-rpc/main.ml
+++ b/bin/ocamlformat-rpc/main.ml
@@ -73,6 +73,6 @@ let info =
   Cmd.info "ocamlformat-rpc" ~version:Ocamlformat_lib.Version.current ~doc
     ~man
 
-let rpc_main_t = Term.(const Ocamlformat_rpc.run $ const ())
+let rpc_main_t = Term.(const (Ocamlformat_rpc.run ~global_conf:None) $ const ())
 
 let () = Stdlib.exit @@ Cmd.eval_result (Cmd.v info rpc_main_t)

--- a/bin/ocamlformat/main.ml
+++ b/bin/ocamlformat/main.ml
@@ -87,7 +87,7 @@ let run_action action =
   | Print_config conf -> Conf.print_config conf ; Ok ()
 ;;
 
-match Bin_conf.action () with
+match Cmdliner.Cmd.eval_value Bin_conf.term with
 | Ok (`Ok action) -> (
   match run_action action with
   | Ok () -> Stdlib.exit 0

--- a/lib/bin_conf/Bin_conf.mli
+++ b/lib/bin_conf/Bin_conf.mli
@@ -9,11 +9,14 @@
 (*                                                                        *)
 (**************************************************************************)
 
+type global_conf
 val build_config :
      enable_outside_detected_project:bool
   -> root:Fpath.t option
   -> file:string
   -> is_stdin:bool
+  -> ?global_conf:global_conf
+  -> unit
   -> (Ocamlformat_lib.Conf.t, string) Result.t
 
 type file = Stdin | File of string
@@ -35,5 +38,4 @@ type action =
   | Print_config of Ocamlformat_lib.Conf.t
       (** Print the configuration and exit. *)
 
-val action :
-  unit -> (action Cmdliner.Cmd.eval_ok, Cmdliner.Cmd.eval_error) Result.t
+val term : action Cmdliner.Cmd.t


### PR DESCRIPTION
As discussed in #2736.

The change wouldn't make sense to merge as is (for instance, this new `Bin_conf.global_conf` type in the interface cannot be constructed from outside the module), this was more written to see how information flows. It'd need a bit of cleanup.

The rpc server exe might change behavior slightly (not sure): it doesn't doesn't parse the command line at all. I think any command line flag would have been rejected by the outermost call to cmdliner anyway, but if Cmdliner terms consults environment variables, maybe something could be different here ?

Also the behavior of `update_using_cmdline` is perhaps different, not sure either. Specifically, the old code is doing something like `global_conf := apply_cli {!global_conf with lib_conf}` vs after `let new_value = global_conf.apply_cli { default with lib_conf }`. I think this repeated mutations of `global_conf` is not necessary, but I'm not 100% sure.