### PR TITLE
Add neocaml-mode support to ocamlformat-before-save

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -129,6 +129,11 @@ profile. This started with version 0.26.0.
      M.foo)
     ```
 
+### Emacs mode
+
+- Add `neocaml-mode` support to `ocamlformat-before-save`
+  (#2787, @bbatsov)
+
 ## 0.28.1
 
 ### Highlight

--- a/emacs/ocamlformat.el
+++ b/emacs/ocamlformat.el
@@ -101,7 +101,8 @@ nil (default)."
 \(add-hook \\='before-save-hook \\='ocamlformat-before-save)."
   (interactive)
   (when
-      (memq major-mode '(tuareg-mode caml-mode ocaml-ts-mode ocamli-ts-mode))
+      (memq major-mode '(tuareg-mode caml-mode ocaml-ts-mode ocamli-ts-mode
+                          neocaml-mode neocaml-interface-mode))
     (ocamlformat)))
 
 (defun ocamlformat--goto-line (line)


### PR DESCRIPTION
[neocaml](https://github.com/bbatsov/neocaml) is a new tree-sitter based OCaml major mode for Emacs. This adds `neocaml-mode` and `neocaml-interface-mode` to the mode whitelist in `ocamlformat-before-save` so format-on-save works in neocaml buffers.

Currently users who switch from tuareg-mode to neocaml-mode lose format-on-save silently because the `memq` check doesn't recognize the new modes.