### PR TITLE
opam: Bump the minimum OCaml version to 4.14

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -41,7 +41,7 @@
   "OCamlFormat is a tool to automatically format OCaml code in a uniform style.")
  (depends
   (ocaml
-   (>= 4.08))
+   (>= 4.14))
   (alcotest
    (and
     :with-test
@@ -94,7 +94,7 @@
   "**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.\n\n- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.\n- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.\n- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.\n- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code.")
  (depends
   (ocaml
-   (>= 4.08))
+   (>= 4.14))
   (cmdliner
    (or
     (and

--- a/ocamlformat-lib.opam
+++ b/ocamlformat-lib.opam
@@ -18,7 +18,7 @@ authors: [
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.14"}
   "alcotest" {with-test & >= "1.3.0"}
   "base" {>= "v0.12.0"}
   "cmdliner" {>= "1.1.0"}

--- a/ocamlformat.opam
+++ b/ocamlformat.opam
@@ -23,7 +23,7 @@ authors: [
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.14"}
   "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
   "csexp" {>= "1.4.0"}
   "dune" {>= "2.8"}


### PR DESCRIPTION
This was caught by opam-repository CI and caused by the vendored modules from the compiler's source.