### PR TITLE
Fix formatting instability on long if conditions with `if-then-else=fit-or-vertical`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,13 @@ Items marked with an asterisk (\*) are changes that are likely to format
 existing code differently from the previous release when using the default
 profile. This started with version 0.26.0.
 
+## unreleased
+
+### Fixed
+
+- Fix instability on long if-then-else with `if-then-else=fit-or-vertical`
+  (#2797, @MisterDA)
+
 ## 0.29.0
 
 ### Highlight

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2571,9 +2571,6 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                                   c loc )
                            else None
                          in
-                         let has_cmts_before_body =
-                           Cmts.has_before c.cmts xbch.ast.pexp_loc
-                         in
                          let p =
                            Params.get_if_then_else c.conf ~cmts_before_opt
                              ~pro:(fmt_if first pro_inner) ~first ~last
@@ -2584,7 +2581,6 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                              ~infix_ext_attrs
                              ~fmt_cond:(fmt_expression ~box:false c)
                              ~cmts_before_kw ~cmts_after_kw
-                             ~has_cmts_before_body
                          in
                          let wrap_beginend =
                            match p.beginend_loc with

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2571,6 +2571,9 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                                   c loc )
                            else None
                          in
+                         let has_cmts_before_body =
+                           Cmts.has_before c.cmts xbch.ast.pexp_loc
+                         in
                          let p =
                            Params.get_if_then_else c.conf ~cmts_before_opt
                              ~pro:(fmt_if first pro_inner) ~first ~last
@@ -2581,6 +2584,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                              ~infix_ext_attrs
                              ~fmt_cond:(fmt_expression ~box:false c)
                              ~cmts_before_kw ~cmts_after_kw
+                             ~has_cmts_before_body
                          in
                          let wrap_beginend =
                            match p.beginend_loc with

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -849,7 +849,8 @@ type if_then_else =
 
 let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
     ~parens_bch ~parens_prev_bch ~xcond ~xbch ~expr_loc ~fmt_infix_ext_attrs
-    ~infix_ext_attrs ~fmt_cond ~cmts_before_kw ~cmts_after_kw =
+    ~infix_ext_attrs ~fmt_cond ~cmts_before_kw ~cmts_after_kw
+    ~has_cmts_before_body =
   let imd = c.fmt_opts.indicate_multiline_delimiters.v in
   let beginend_loc, infix_ext_attrs_beginend, branch_expr =
     let ast = xbch.Ast.ast in
@@ -959,7 +960,12 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
             | _ -> 0 )
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
-      ; branch_pro= branch_pro ~begin_end_offset:0 ()
+      ; branch_pro=
+          ( if
+              has_cmts_before_body && (not has_cmts_after_kw)
+              && not (Location.is_single_line expr_loc c.fmt_opts.margin.v)
+            then break 1000 2
+            else branch_pro ~begin_end_offset:0 () )
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -849,8 +849,7 @@ type if_then_else =
 
 let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
     ~parens_bch ~parens_prev_bch ~xcond ~xbch ~expr_loc ~fmt_infix_ext_attrs
-    ~infix_ext_attrs ~fmt_cond ~cmts_before_kw ~cmts_after_kw
-    ~has_cmts_before_body =
+    ~infix_ext_attrs ~fmt_cond ~cmts_before_kw ~cmts_after_kw =
   let imd = c.fmt_opts.indicate_multiline_delimiters.v in
   let beginend_loc, infix_ext_attrs_beginend, branch_expr =
     let ast = xbch.Ast.ast in
@@ -962,9 +961,12 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
       ; box_keyword_and_expr= Fn.id
       ; branch_pro=
           ( if
-              has_cmts_before_body && (not has_cmts_after_kw)
+              (not has_beginend) && (not has_cmts_after_kw)
               && not (Location.is_single_line expr_loc c.fmt_opts.margin.v)
-            then break 1000 2
+            then
+              match cmts_before_opt xbch.ast.pexp_loc with
+              | Some cmts -> break 1000 2 $ cmts
+              | None -> branch_pro ~begin_end_offset:0 ()
             else branch_pro ~begin_end_offset:0 () )
       ; wrap_parens=
           wrap_parens

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -234,6 +234,7 @@ val get_if_then_else :
   -> fmt_cond:(expression Ast.xt -> Fmt.t)
   -> cmts_before_kw:Fmt.t
   -> cmts_after_kw:Fmt.t option
+  -> has_cmts_before_body:bool
   -> if_then_else
 (** [cmts_before_opt] return the comment before the given location with no breaks around it. *)
 

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -234,7 +234,6 @@ val get_if_then_else :
   -> fmt_cond:(expression Ast.xt -> Fmt.t)
   -> cmts_before_kw:Fmt.t
   -> cmts_after_kw:Fmt.t option
-  -> has_cmts_before_body:bool
   -> if_then_else
 (** [cmts_before_opt] return the comment before the given location with no breaks around it. *)
 

--- a/test/passing/refs.ahrefs/ite-compact.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact.ml.ref
@@ -182,3 +182,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
@@ -199,3 +199,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
@@ -218,3 +218,12 @@ let () =
   end
   else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
@@ -227,3 +227,12 @@ let () =
     ()
   end else
         ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
@@ -218,3 +218,12 @@ let () =
   end
   else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.ahrefs/ite-kr.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr.ml.ref
@@ -256,3 +256,12 @@ let () =
     ()
   end else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
@@ -263,3 +263,12 @@ let () =
     ()
   end else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.ahrefs/ite-kw_first.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first.ml.ref
@@ -212,3 +212,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
@@ -229,3 +229,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
@@ -212,3 +212,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
@@ -182,3 +182,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.ahrefs/ite-vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-vertical.ml.ref
@@ -255,3 +255,12 @@ let () =
   end
   else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.ahrefs/ite.ml.ref
+++ b/test/passing/refs.ahrefs/ite.ml.ref
@@ -182,3 +182,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.default/ite-compact.ml.ref
+++ b/test/passing/refs.default/ite-compact.ml.ref
@@ -182,3 +182,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.default/ite-compact_closing.ml.ref
+++ b/test/passing/refs.default/ite-compact_closing.ml.ref
@@ -197,3 +197,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.default/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical.ml.ref
@@ -218,3 +218,12 @@ let () =
   end
   else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
@@ -227,3 +227,12 @@ let () =
     ()
   end else
         ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
@@ -218,3 +218,12 @@ let () =
   end
   else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.default/ite-kr.ml.ref
+++ b/test/passing/refs.default/ite-kr.ml.ref
@@ -258,3 +258,12 @@ let () =
     ()
   end else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.default/ite-kr_closing.ml.ref
+++ b/test/passing/refs.default/ite-kr_closing.ml.ref
@@ -265,3 +265,12 @@ let () =
     ()
   end else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.default/ite-kw_first.ml.ref
+++ b/test/passing/refs.default/ite-kw_first.ml.ref
@@ -212,3 +212,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.default/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_closing.ml.ref
@@ -227,3 +227,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
@@ -212,3 +212,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.default/ite-no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-no_indicate.ml.ref
@@ -182,3 +182,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.default/ite-vertical.ml.ref
+++ b/test/passing/refs.default/ite-vertical.ml.ref
@@ -257,3 +257,12 @@ let () =
   end
   else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.default/ite.ml.ref
+++ b/test/passing/refs.default/ite.ml.ref
@@ -182,3 +182,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.janestreet/ite-compact.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact.ml.ref
@@ -184,3 +184,11 @@ let () =
     ()
   else ()
 ;;
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then
+    (* comment *)
+    1
+  else 2
+;;

--- a/test/passing/refs.janestreet/ite-compact_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact_closing.ml.ref
@@ -196,3 +196,11 @@ let () =
     ()
   else ()
 ;;
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then
+    (* comment *)
+    1
+  else 2
+;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
@@ -233,3 +233,12 @@ let () =
   else
     ()
 ;;
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then
+    (* comment *)
+    1
+  else
+    2
+;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
@@ -243,3 +243,12 @@ let () =
   else
     ()
 ;;
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then
+    (* comment *)
+    1
+  else
+    2
+;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
@@ -233,3 +233,12 @@ let () =
   else
     ()
 ;;
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then
+    (* comment *)
+    1
+  else
+    2
+;;

--- a/test/passing/refs.janestreet/ite-kr.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr.ml.ref
@@ -279,3 +279,12 @@ let () =
   else
     ()
 ;;
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then
+    (* comment *)
+    1
+  else
+    2
+;;

--- a/test/passing/refs.janestreet/ite-kr_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr_closing.ml.ref
@@ -286,3 +286,12 @@ let () =
   else
     ()
 ;;
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then
+    (* comment *)
+    1
+  else
+    2
+;;

--- a/test/passing/refs.janestreet/ite-kw_first.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first.ml.ref
@@ -212,3 +212,12 @@ let () =
     ()
   else ()
 ;;
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2
+;;

--- a/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
@@ -224,3 +224,12 @@ let () =
     ()
   else ()
 ;;
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2
+;;

--- a/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
@@ -212,3 +212,12 @@ let () =
     ()
   else ()
 ;;
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2
+;;

--- a/test/passing/refs.janestreet/ite-no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-no_indicate.ml.ref
@@ -184,3 +184,11 @@ let () =
     ()
   else ()
 ;;
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then
+    (* comment *)
+    1
+  else 2
+;;

--- a/test/passing/refs.janestreet/ite-vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-vertical.ml.ref
@@ -277,3 +277,12 @@ let () =
   else
     ()
 ;;
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then
+    (* comment *)
+    1
+  else
+    2
+;;

--- a/test/passing/refs.janestreet/ite.ml.ref
+++ b/test/passing/refs.janestreet/ite.ml.ref
@@ -184,3 +184,11 @@ let () =
     ()
   else ()
 ;;
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then
+    (* comment *)
+    1
+  else 2
+;;

--- a/test/passing/refs.ocamlformat/ite-compact.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact.ml.ref
@@ -181,3 +181,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
@@ -191,3 +191,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
@@ -217,3 +217,12 @@ let () =
   end
   else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
@@ -222,3 +222,12 @@ let () =
     ()
   end else
         ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
@@ -214,3 +214,12 @@ let () =
   end
   else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.ocamlformat/ite-kr.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr.ml.ref
@@ -259,3 +259,12 @@ let () =
     ()
   end else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
@@ -263,3 +263,12 @@ let () =
     ()
   end else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
@@ -210,3 +210,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
@@ -220,3 +220,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
@@ -207,3 +207,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
@@ -178,3 +178,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/refs.ocamlformat/ite-vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-vertical.ml.ref
@@ -258,3 +258,12 @@ let () =
   end
   else
     ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2

--- a/test/passing/refs.ocamlformat/ite.ml.ref
+++ b/test/passing/refs.ocamlformat/ite.ml.ref
@@ -181,3 +181,11 @@ let () =
     ()
   end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else 2

--- a/test/passing/tests/ite.ml
+++ b/test/passing/tests/ite.ml
@@ -180,3 +180,13 @@ let () =
       ()
     end
   else ()
+
+(* Long condition with comment after then keyword *)
+let test =
+  if
+    long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t
+  then
+    (* comment *)
+    1
+  else
+    2


### PR DESCRIPTION
I vibe-clauded a fix for #2770, which is an annoying blocker for me.