### PR TITLE
Fix match in `if-then-else` branches expanding to vertical with `fit-or-vertical`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,11 @@ profile. This started with version 0.26.0.
 
 ### Fixed
 
-- Fix instability on long if-then-else with `if-then-else=fit-or-vertical`
+- Fix instability on long `if-then-else` with `if-then-else=fit-or-vertical`
   (#2797, @MisterDA)
+
+- Fix `match` in `if-then-else` branches expanding to vertical with
+  `fit-or-vertical` (#2798, @MisterDA)
 
 ## 0.29.0
 
@@ -1944,4 +1947,3 @@ profile. This started with version 0.26.0.
 ## 0.1 (2017-10-19)
 
 - Initial release.
-

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -382,7 +382,9 @@ module Exp = struct
   let match_inner_pro ~ctx0 ~parens =
     if parens then false
     else
-      match ctx0 with Exp {pexp_desc= Pexp_infix _; _} -> false | _ -> true
+      match ctx0 with
+      | Exp {pexp_desc= Pexp_infix _ | Pexp_ifthenelse _; _} -> false
+      | _ -> true
 
   let function_inner_pro ~has_cmts_outer ~ctx0 =
     if has_cmts_outer then false

--- a/test/passing/refs.ahrefs/ite-compact.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact.ml.ref
@@ -183,6 +183,17 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
@@ -200,6 +200,19 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+  else (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
@@ -219,6 +219,17 @@ let () =
   else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
@@ -228,6 +228,18 @@ let () =
   end else
         ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ()
+  ) else (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
@@ -219,6 +219,17 @@ let () =
   else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ahrefs/ite-kr.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr.ml.ref
@@ -257,6 +257,18 @@ let () =
   end else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ()
+  ) else (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
@@ -264,6 +264,18 @@ let () =
   end else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ()
+  ) else (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ahrefs/ite-kw_first.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first.ml.ref
@@ -213,6 +213,18 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true
+  then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
@@ -230,6 +230,20 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true
+  then (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+  else (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
@@ -213,6 +213,18 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true
+  then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
@@ -183,6 +183,17 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ahrefs/ite-vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-vertical.ml.ref
@@ -256,6 +256,17 @@ let () =
   else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ahrefs/ite.ml.ref
+++ b/test/passing/refs.ahrefs/ite.ml.ref
@@ -183,6 +183,17 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.default/ite-compact.ml.ref
+++ b/test/passing/refs.default/ite-compact.ml.ref
@@ -183,6 +183,11 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.default/ite-compact_closing.ml.ref
+++ b/test/passing/refs.default/ite-compact_closing.ml.ref
@@ -198,6 +198,11 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.default/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical.ml.ref
@@ -219,6 +219,17 @@ let () =
   else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then
+    match expr with
+    | true -> ()
+    | false -> ()
+  else
+    match expr with
+    | true -> ()
+    | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
@@ -228,6 +228,17 @@ let () =
   end else
         ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then
+    match expr with
+    | true -> ()
+    | false -> ()
+  else
+    match expr with
+    | true -> ()
+    | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
@@ -219,6 +219,17 @@ let () =
   else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then
+    match expr with
+    | true -> ()
+    | false -> ()
+  else
+    match expr with
+    | true -> ()
+    | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.default/ite-kr.ml.ref
+++ b/test/passing/refs.default/ite-kr.ml.ref
@@ -259,6 +259,13 @@ let () =
   end else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then
+    match expr with true -> () | false -> ()
+  else
+    match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.default/ite-kr_closing.ml.ref
+++ b/test/passing/refs.default/ite-kr_closing.ml.ref
@@ -266,6 +266,13 @@ let () =
   end else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then
+    match expr with true -> () | false -> ()
+  else
+    match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.default/ite-kw_first.ml.ref
+++ b/test/passing/refs.default/ite-kw_first.ml.ref
@@ -213,6 +213,12 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true
+  then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.default/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_closing.ml.ref
@@ -228,6 +228,12 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true
+  then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
@@ -213,6 +213,12 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true
+  then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.default/ite-no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-no_indicate.ml.ref
@@ -183,6 +183,11 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.default/ite-vertical.ml.ref
+++ b/test/passing/refs.default/ite-vertical.ml.ref
@@ -258,6 +258,17 @@ let () =
   else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then
+    match expr with
+    | true -> ()
+    | false -> ()
+  else
+    match expr with
+    | true -> ()
+    | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.default/ite.ml.ref
+++ b/test/passing/refs.default/ite.ml.ref
@@ -183,6 +183,11 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.janestreet/ite-compact.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact.ml.ref
@@ -185,6 +185,18 @@ let () =
   else ()
 ;;
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+;;
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then

--- a/test/passing/refs.janestreet/ite-compact_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact_closing.ml.ref
@@ -197,6 +197,20 @@ let () =
   else ()
 ;;
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+  else (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+;;
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then

--- a/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
@@ -234,6 +234,18 @@ let () =
     ()
 ;;
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+;;
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
@@ -244,6 +244,19 @@ let () =
     ()
 ;;
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ()
+  ) else (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+;;
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
@@ -234,6 +234,18 @@ let () =
     ()
 ;;
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+;;
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then

--- a/test/passing/refs.janestreet/ite-kr.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr.ml.ref
@@ -280,6 +280,19 @@ let () =
     ()
 ;;
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ()
+  ) else (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+;;
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then

--- a/test/passing/refs.janestreet/ite-kr_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr_closing.ml.ref
@@ -287,6 +287,19 @@ let () =
     ()
 ;;
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ()
+  ) else (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+;;
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then

--- a/test/passing/refs.janestreet/ite-kw_first.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first.ml.ref
@@ -213,6 +213,19 @@ let () =
   else ()
 ;;
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true
+  then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+;;
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
@@ -225,6 +225,21 @@ let () =
   else ()
 ;;
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true
+  then (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+  else (
+    match expr with
+    | true -> ()
+    | false -> ()
+  )
+;;
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
@@ -213,6 +213,19 @@ let () =
   else ()
 ;;
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true
+  then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+;;
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.janestreet/ite-no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-no_indicate.ml.ref
@@ -185,6 +185,18 @@ let () =
   else ()
 ;;
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+;;
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then

--- a/test/passing/refs.janestreet/ite-vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-vertical.ml.ref
@@ -278,6 +278,18 @@ let () =
     ()
 ;;
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+;;
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then

--- a/test/passing/refs.janestreet/ite.ml.ref
+++ b/test/passing/refs.janestreet/ite.ml.ref
@@ -185,6 +185,18 @@ let () =
   else ()
 ;;
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then (
+    match expr with
+    | true -> ()
+    | false -> ())
+  else (
+    match expr with
+    | true -> ()
+    | false -> ())
+;;
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t then

--- a/test/passing/refs.ocamlformat/ite-compact.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact.ml.ref
@@ -182,6 +182,11 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
@@ -192,6 +192,11 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
@@ -218,6 +218,21 @@ let () =
   else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then
+    match expr with
+    | true ->
+        ()
+    | false ->
+        ()
+  else
+    match expr with
+    | true ->
+        ()
+    | false ->
+        ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
@@ -223,6 +223,21 @@ let () =
   end else
         ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then
+    match expr with
+    | true ->
+        ()
+    | false ->
+        ()
+  else
+    match expr with
+    | true ->
+        ()
+    | false ->
+        ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
@@ -215,6 +215,21 @@ let () =
   else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then
+    match expr with
+    | true ->
+        ()
+    | false ->
+        ()
+  else
+    match expr with
+    | true ->
+        ()
+    | false ->
+        ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ocamlformat/ite-kr.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr.ml.ref
@@ -260,6 +260,13 @@ let () =
   end else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then
+    match expr with true -> () | false -> ()
+  else
+    match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
@@ -264,6 +264,13 @@ let () =
   end else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then
+    match expr with true -> () | false -> ()
+  else
+    match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
@@ -211,6 +211,12 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true
+  then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
@@ -221,6 +221,12 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true
+  then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
@@ -208,6 +208,12 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true
+  then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
@@ -179,6 +179,11 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ocamlformat/ite-vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-vertical.ml.ref
@@ -259,6 +259,21 @@ let () =
   else
     ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then
+    match expr with
+    | true ->
+        ()
+    | false ->
+        ()
+  else
+    match expr with
+    | true ->
+        ()
+    | false ->
+        ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/refs.ocamlformat/ite.ml.ref
+++ b/test/passing/refs.ocamlformat/ite.ml.ref
@@ -182,6 +182,11 @@ let () =
   end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then match expr with true -> () | false -> ()
+  else match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if long_function_name_to_force_break a b c d e f g h i j k l m n o p q r s t

--- a/test/passing/tests/ite.ml
+++ b/test/passing/tests/ite.ml
@@ -181,6 +181,13 @@ let () =
     end
   else ()
 
+(* Match in if-then-else branches should fit on one line *)
+let name =
+  if true then
+    match expr with true -> () | false -> ()
+  else
+    match expr with true -> () | false -> ()
+
 (* Long condition with comment after then keyword *)
 let test =
   if


### PR DESCRIPTION
When a `match expr with` appeared as a branch of `if-then-else` with `if-then-else=fit-or-vertical`, the match keyword, scrutinee, and `with` were broken onto separate lines even when they easily fit on one line:

```ocaml
if true then
  match
    expr
  with
  | true -> ()
  | false -> ()
```

The regression was introduced by 8056fa50 ("Overhaul begin match formatting"), which changed `fmt_match` to wrap `pro` inside a nested `hvbox 0 (pro_inner $ keyword)`. When the match is inside an if-then-else branch, the `pro` carries a `break_unless_newline 1000 2` (from the Fit_or_vertical branch_pro). This inflates the inner hvbox's size to 1000+, causing the Format engine to classify the parent hovbox as non-fitting, which forces all breaks in the `match .. expr .. with` box to break.

Fix: in `match_inner_pro`, return `false` for `Pexp_ifthenelse` context (same as already done for `Pexp_infix`), so that `pro` is placed outside the match's inner hvbox as `pro_outer`, where it does not interfere with the match keyword/expr/with fitting on one line.

Fix #2766. This fix was vibe-clauded.