### PR TITLE
Fix formatting oscillation in if-then-else branches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@ profile. This started with version 0.26.0.
 
 ### Fixed
 
+- Fix formatting oscillation with `if-then-else=fit-or-vertical` and
+  `begin...end`.
+  (#2800, @MisterDA)
+
 - Fix instability on long `if-then-else` with `if-then-else=fit-or-vertical`
   (#2797, @MisterDA)
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2562,7 +2562,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                          let cmts_after_kw, raw_cmts_after_kw =
                            if Cmts.has_after c.cmts keyword_loc then
                              if
-                               Params.needs_raw_cmts_after_kw
+                               Params.is_special_or_nested_special_beginend
                                  xbch.ast.pexp_desc
                              then
                                ( None

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2559,10 +2559,18 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                          let cmts_before_kw =
                            Cmts.fmt_before c keyword_loc
                          in
-                         let cmts_after_kw =
+                         let cmts_after_kw, raw_cmts_after_kw =
                            if Cmts.has_after c.cmts keyword_loc then
-                             Some (Cmts.fmt_after c keyword_loc)
-                           else None
+                             if
+                               Params.needs_raw_cmts_after_kw
+                                 xbch.ast.pexp_desc
+                             then
+                               ( None
+                               , Some
+                                   (Cmts.fmt_after ~pro:noop ~epi:noop c
+                                      keyword_loc ) )
+                             else (Some (Cmts.fmt_after c keyword_loc), None)
+                           else (None, None)
                          in
                          let cmts_before_opt loc =
                            if Cmts.has_before c.cmts loc then
@@ -2582,6 +2590,12 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                              ~fmt_cond:(fmt_expression ~box:false c)
                              ~cmts_before_kw ~cmts_after_kw
                          in
+                         let branch_pro =
+                           match raw_cmts_after_kw with
+                           | Some cmts ->
+                               Params.raw_cmts_branch_pro c.conf cmts
+                           | None -> p.branch_pro
+                         in
                          let wrap_beginend =
                            match p.beginend_loc with
                            | Some loc -> Cmts.fmt c loc
@@ -2591,7 +2605,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                          p.box_branch
                            ( p.cond
                            $ p.box_keyword_and_expr
-                               ( p.branch_pro
+                               ( branch_pro
                                $ wrap_beginend
                                    (p.wrap_parens
                                       ( fmt_expression c ?box:p.box_expr

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -512,6 +512,21 @@ let is_special_beginend exp =
   | Pexp_match _ | Pexp_try _ | Pexp_function _ | Pexp_ifthenelse _ -> true
   | _ -> false
 
+let needs_raw_cmts_after_kw = function
+  | Pexp_beginend
+      ( { pexp_desc=
+            Pexp_match _ | Pexp_try _ | Pexp_function _ | Pexp_ifthenelse _
+        ; _ }
+      , _ )
+   |Pexp_match _ | Pexp_try _ | Pexp_function _ | Pexp_ifthenelse _ ->
+      true
+  | _ -> false
+
+let raw_cmts_branch_pro (c : Conf.t) cmts =
+  match c.fmt_opts.if_then_else.v with
+  | `Compact -> break 1000 0 $ cmts $ break 1000 0
+  | _ -> break 1000 2 $ cmts
+
 type cases =
   { leading_space: Fmt.t
   ; bar: Fmt.t
@@ -922,10 +937,29 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
   in
   match c.fmt_opts.if_then_else.v with
   | `Compact ->
+      let branch_pro_with_cmts =
+        if
+          (not has_beginend) && (not parens_bch)
+          && (not (Location.is_single_line expr_loc c.fmt_opts.margin.v))
+          && (not has_cmts_after_kw)
+          && needs_raw_cmts_after_kw xbch.ast.pexp_desc
+        then
+          match cmts_before_opt xbch.ast.pexp_loc with
+          | Some cmts -> break 1000 0 $ cmts $ break 1000 0
+          | None -> (
+            match xbch.ast.pexp_desc with
+            | Pexp_beginend ({pexp_loc; pexp_desc; _}, _)
+              when is_special_beginend pexp_desc -> (
+              match cmts_before_opt pexp_loc with
+              | Some cmts -> break 1000 0 $ cmts $ break 1000 0
+              | None -> branch_pro ~indent:0 () )
+            | _ -> branch_pro ~indent:0 () )
+        else branch_pro ~indent:0 ()
+      in
       { box_branch= hovbox ~name:"Params.get_if_then_else `Compact" 2
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
-      ; branch_pro= branch_pro ~indent:0 ()
+      ; branch_pro= branch_pro_with_cmts
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:
@@ -954,6 +988,24 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
       ; space_between_branches= fmt_if (has_beginend || parens_bch) (str " ")
       }
   | `Fit_or_vertical ->
+      let branch_pro_with_cmts =
+        if
+          (not has_beginend)
+          && (not (Location.is_single_line expr_loc c.fmt_opts.margin.v))
+          && not has_cmts_after_kw
+        then
+          match cmts_before_opt xbch.ast.pexp_loc with
+          | Some cmts -> break 1000 2 $ cmts
+          | None -> (
+            match xbch.ast.pexp_desc with
+            | Pexp_beginend ({pexp_loc; pexp_desc; _}, _)
+              when is_special_beginend pexp_desc -> (
+              match cmts_before_opt pexp_loc with
+              | Some cmts -> break 1000 2 $ cmts
+              | None -> branch_pro ~begin_end_offset:0 () )
+            | _ -> branch_pro ~begin_end_offset:0 () )
+        else branch_pro ~begin_end_offset:0 ()
+      in
       { box_branch=
           hovbox
             ( match imd with
@@ -961,15 +1013,7 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
             | _ -> 0 )
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
-      ; branch_pro=
-          ( if
-              (not has_beginend) && (not has_cmts_after_kw)
-              && not (Location.is_single_line expr_loc c.fmt_opts.margin.v)
-            then
-              match cmts_before_opt xbch.ast.pexp_loc with
-              | Some cmts -> break 1000 2 $ cmts
-              | None -> branch_pro ~begin_end_offset:0 ()
-            else branch_pro ~begin_end_offset:0 () )
+      ; branch_pro= branch_pro_with_cmts
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -512,15 +512,9 @@ let is_special_beginend exp =
   | Pexp_match _ | Pexp_try _ | Pexp_function _ | Pexp_ifthenelse _ -> true
   | _ -> false
 
-let needs_raw_cmts_after_kw = function
-  | Pexp_beginend
-      ( { pexp_desc=
-            Pexp_match _ | Pexp_try _ | Pexp_function _ | Pexp_ifthenelse _
-        ; _ }
-      , _ )
-   |Pexp_match _ | Pexp_try _ | Pexp_function _ | Pexp_ifthenelse _ ->
-      true
-  | _ -> false
+let is_special_or_nested_special_beginend = function
+  | Pexp_beginend ({pexp_desc; _}, _) -> is_special_beginend pexp_desc
+  | exp -> is_special_beginend exp
 
 let raw_cmts_branch_pro (c : Conf.t) cmts =
   match c.fmt_opts.if_then_else.v with
@@ -942,7 +936,7 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
           (not has_beginend) && (not parens_bch)
           && (not (Location.is_single_line expr_loc c.fmt_opts.margin.v))
           && (not has_cmts_after_kw)
-          && needs_raw_cmts_after_kw xbch.ast.pexp_desc
+          && is_special_or_nested_special_beginend xbch.ast.pexp_desc
         then
           match cmts_before_opt xbch.ast.pexp_loc with
           | Some cmts -> break 1000 0 $ cmts $ break 1000 0

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -237,9 +237,9 @@ val get_if_then_else :
   -> if_then_else
 (** [cmts_before_opt] return the comment before the given location with no breaks around it. *)
 
-val needs_raw_cmts_after_kw : expression_desc -> bool
-(** [needs_raw_cmts_after_kw desc] returns [true] when comments after the
-    keyword should be extracted without breaks (raw) to prevent oscillation
+val is_special_or_nested_special_beginend : expression_desc -> bool
+(** [is_special_or_nested_special_beginend] returns [true] when comments after
+    the keyword should be extracted without breaks (raw) to prevent oscillation
     between "after keyword" and "before expression" placements. *)
 
 val raw_cmts_branch_pro : Conf.t -> Fmt.t -> Fmt.t

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -237,6 +237,16 @@ val get_if_then_else :
   -> if_then_else
 (** [cmts_before_opt] return the comment before the given location with no breaks around it. *)
 
+val needs_raw_cmts_after_kw : expression_desc -> bool
+(** [needs_raw_cmts_after_kw desc] returns [true] when comments after the
+    keyword should be extracted without breaks (raw) to prevent oscillation
+    between "after keyword" and "before expression" placements. *)
+
+val raw_cmts_branch_pro : Conf.t -> Fmt.t -> Fmt.t
+(** [raw_cmts_branch_pro c cmts] returns the branch_pro for raw comments
+    extracted after a keyword, using the correct indentation for the current
+    if-then-else mode. *)
+
 val match_indent : ?default:int -> Conf.t -> parens:bool -> ctx:Ast.t -> int
 (** [match_indent c ~ctx ~default] returns the indentation used for the
     pattern-matching in context [ctx], depending on the `match-indent-nested`

--- a/test/passing/refs.ahrefs/ite-compact.ml.err
+++ b/test/passing/refs.ahrefs/ite-compact.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-compact.ml:95 exceeds the margin
 Warning: ite-compact.ml:100 exceeds the margin
 Warning: ite-compact.ml:105 exceeds the margin
+Warning: ite-compact.ml:210 exceeds the margin
+Warning: ite-compact.ml:219 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-compact.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact.ml.ref
@@ -201,3 +201,32 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if a then b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f)
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.ahrefs/ite-compact_closing.ml.err
+++ b/test/passing/refs.ahrefs/ite-compact_closing.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-compact_closing.ml:229 exceeds the margin
+Warning: ite-compact_closing.ml:238 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
@@ -220,3 +220,33 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if a then b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f
+  )
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.err
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-fit_or_vertical.ml:116 exceeds the margin
 Warning: ite-fit_or_vertical.ml:121 exceeds the margin
 Warning: ite-fit_or_vertical.ml:126 exceeds the margin
+Warning: ite-fit_or_vertical.ml:247 exceeds the margin
+Warning: ite-fit_or_vertical.ml:260 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
@@ -238,3 +238,38 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    begin if
+      a
+    then
+      b
+    end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)(
+    match x with
+    | A -> f)
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.err
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-fit_or_vertical_closing.ml:257 exceeds the margin
+Warning: ite-fit_or_vertical_closing.ml:270 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
@@ -248,3 +248,39 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    begin if
+      a
+    then
+      b
+    end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)(
+    match x with
+    | A -> f
+  )
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.err
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-fit_or_vertical_no_indicate.ml:116 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:121 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:126 exceeds the margin
+Warning: ite-fit_or_vertical_no_indicate.ml:247 exceeds the margin
+Warning: ite-fit_or_vertical_no_indicate.ml:260 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
@@ -238,3 +238,38 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    begin if
+      a
+    then
+      b
+    end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)(
+    match x with
+    | A -> f)
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.ahrefs/ite-kr.ml.err
+++ b/test/passing/refs.ahrefs/ite-kr.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-kr.ml:286 exceeds the margin
+Warning: ite-kr.ml:296 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-kr.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr.ml.ref
@@ -277,3 +277,36 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if a then b
+    end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      match x with
+    | A -> f
+  )
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.ahrefs/ite-kr_closing.ml.err
+++ b/test/passing/refs.ahrefs/ite-kr_closing.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-kr_closing.ml:293 exceeds the margin
+Warning: ite-kr_closing.ml:303 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
@@ -284,3 +284,36 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if a then b
+    end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      match x with
+    | A -> f
+  )
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.ahrefs/ite-kw_first.ml.err
+++ b/test/passing/refs.ahrefs/ite-kw_first.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-kw_first.ml:110 exceeds the margin
 Warning: ite-kw_first.ml:116 exceeds the margin
 Warning: ite-kw_first.ml:121 exceeds the margin
+Warning: ite-kw_first.ml:242 exceeds the margin
+Warning: ite-kw_first.ml:252 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-kw_first.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first.ml.ref
@@ -232,3 +232,36 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf
+    then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if a then b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a
+  then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f)
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa
+  then
+    if bbbbb
+    then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs
+      then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.ahrefs/ite-kw_first_closing.ml.err
+++ b/test/passing/refs.ahrefs/ite-kw_first_closing.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-kw_first_closing.ml:261 exceeds the margin
+Warning: ite-kw_first_closing.ml:271 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
@@ -251,3 +251,37 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf
+    then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if a then b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a
+  then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f
+  )
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa
+  then
+    if bbbbb
+    then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs
+      then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.err
+++ b/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-kw_first_no_indicate.ml:110 exceeds the margin
 Warning: ite-kw_first_no_indicate.ml:116 exceeds the margin
 Warning: ite-kw_first_no_indicate.ml:121 exceeds the margin
+Warning: ite-kw_first_no_indicate.ml:242 exceeds the margin
+Warning: ite-kw_first_no_indicate.ml:252 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
@@ -232,3 +232,36 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf
+    then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if a then b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a
+  then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f)
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa
+  then
+    if bbbbb
+    then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs
+      then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.ahrefs/ite-no_indicate.ml.err
+++ b/test/passing/refs.ahrefs/ite-no_indicate.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-no_indicate.ml:95 exceeds the margin
 Warning: ite-no_indicate.ml:100 exceeds the margin
 Warning: ite-no_indicate.ml:105 exceeds the margin
+Warning: ite-no_indicate.ml:210 exceeds the margin
+Warning: ite-no_indicate.ml:219 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
@@ -201,3 +201,32 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if a then b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f)
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.ahrefs/ite-vertical.ml.err
+++ b/test/passing/refs.ahrefs/ite-vertical.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-vertical.ml:131 exceeds the margin
 Warning: ite-vertical.ml:136 exceeds the margin
 Warning: ite-vertical.ml:141 exceeds the margin
+Warning: ite-vertical.ml:284 exceeds the margin
+Warning: ite-vertical.ml:297 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-vertical.ml.ref
@@ -275,3 +275,38 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if
+        a
+      then
+        b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f)
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.ahrefs/ite.ml.err
+++ b/test/passing/refs.ahrefs/ite.ml.err
@@ -1,3 +1,5 @@
 Warning: ite.ml:95 exceeds the margin
 Warning: ite.ml:100 exceeds the margin
 Warning: ite.ml:105 exceeds the margin
+Warning: ite.ml:210 exceeds the margin
+Warning: ite.ml:219 exceeds the margin

--- a/test/passing/refs.ahrefs/ite.ml.ref
+++ b/test/passing/refs.ahrefs/ite.ml.ref
@@ -201,3 +201,32 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if a then b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f)
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.default/ite-compact.ml.err
+++ b/test/passing/refs.default/ite-compact.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-compact.ml:94 exceeds the margin
 Warning: ite-compact.ml:99 exceeds the margin
 Warning: ite-compact.ml:104 exceeds the margin
+Warning: ite-compact.ml:204 exceeds the margin
+Warning: ite-compact.ml:213 exceeds the margin

--- a/test/passing/refs.default/ite-compact.ml.ref
+++ b/test/passing/refs.default/ite-compact.ml.ref
@@ -195,3 +195,31 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.default/ite-compact_closing.ml.err
+++ b/test/passing/refs.default/ite-compact_closing.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-compact_closing.ml:219 exceeds the margin
+Warning: ite-compact_closing.ml:228 exceeds the margin

--- a/test/passing/refs.default/ite-compact_closing.ml.ref
+++ b/test/passing/refs.default/ite-compact_closing.ml.ref
@@ -210,3 +210,31 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.default/ite-fit_or_vertical.ml.err
+++ b/test/passing/refs.default/ite-fit_or_vertical.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-fit_or_vertical.ml:115 exceeds the margin
 Warning: ite-fit_or_vertical.ml:120 exceeds the margin
 Warning: ite-fit_or_vertical.ml:125 exceeds the margin
+Warning: ite-fit_or_vertical.ml:247 exceeds the margin
+Warning: ite-fit_or_vertical.ml:260 exceeds the margin

--- a/test/passing/refs.default/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical.ml.ref
@@ -238,3 +238,38 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if
+        a
+      then
+        b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+  match x with
+  | A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.default/ite-fit_or_vertical_closing.ml.err
+++ b/test/passing/refs.default/ite-fit_or_vertical_closing.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-fit_or_vertical_closing.ml:256 exceeds the margin
+Warning: ite-fit_or_vertical_closing.ml:269 exceeds the margin

--- a/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
@@ -247,3 +247,38 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if
+        a
+      then
+        b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+  match x with
+  | A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.err
+++ b/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-fit_or_vertical_no_indicate.ml:115 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:120 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:125 exceeds the margin
+Warning: ite-fit_or_vertical_no_indicate.ml:247 exceeds the margin
+Warning: ite-fit_or_vertical_no_indicate.ml:260 exceeds the margin

--- a/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
@@ -238,3 +238,38 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if
+        a
+      then
+        b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+  match x with
+  | A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.default/ite-kr.ml.err
+++ b/test/passing/refs.default/ite-kr.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-kr.ml:283 exceeds the margin
+Warning: ite-kr.ml:293 exceeds the margin

--- a/test/passing/refs.default/ite-kr.ml.ref
+++ b/test/passing/refs.default/ite-kr.ml.ref
@@ -274,3 +274,35 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      match x with
+    | A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.default/ite-kr_closing.ml.err
+++ b/test/passing/refs.default/ite-kr_closing.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-kr_closing.ml:290 exceeds the margin
+Warning: ite-kr_closing.ml:300 exceeds the margin

--- a/test/passing/refs.default/ite-kr_closing.ml.ref
+++ b/test/passing/refs.default/ite-kr_closing.ml.ref
@@ -281,3 +281,35 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      match x with
+    | A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.default/ite-kw_first.ml.err
+++ b/test/passing/refs.default/ite-kw_first.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-kw_first.ml:109 exceeds the margin
 Warning: ite-kw_first.ml:115 exceeds the margin
 Warning: ite-kw_first.ml:120 exceeds the margin
+Warning: ite-kw_first.ml:236 exceeds the margin
+Warning: ite-kw_first.ml:246 exceeds the margin

--- a/test/passing/refs.default/ite-kw_first.ml.ref
+++ b/test/passing/refs.default/ite-kw_first.ml.ref
@@ -226,3 +226,36 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf
+      then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a
+  then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa
+  then
+    if bbbbb
+    then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs
+      then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.default/ite-kw_first_closing.ml.err
+++ b/test/passing/refs.default/ite-kw_first_closing.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-kw_first_closing.ml:251 exceeds the margin
+Warning: ite-kw_first_closing.ml:261 exceeds the margin

--- a/test/passing/refs.default/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_closing.ml.ref
@@ -241,3 +241,36 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf
+      then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a
+  then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa
+  then
+    if bbbbb
+    then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs
+      then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.default/ite-kw_first_no_indicate.ml.err
+++ b/test/passing/refs.default/ite-kw_first_no_indicate.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-kw_first_no_indicate.ml:109 exceeds the margin
 Warning: ite-kw_first_no_indicate.ml:115 exceeds the margin
 Warning: ite-kw_first_no_indicate.ml:120 exceeds the margin
+Warning: ite-kw_first_no_indicate.ml:236 exceeds the margin
+Warning: ite-kw_first_no_indicate.ml:246 exceeds the margin

--- a/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
@@ -226,3 +226,36 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf
+      then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a
+  then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa
+  then
+    if bbbbb
+    then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs
+      then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.default/ite-no_indicate.ml.err
+++ b/test/passing/refs.default/ite-no_indicate.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-no_indicate.ml:94 exceeds the margin
 Warning: ite-no_indicate.ml:99 exceeds the margin
 Warning: ite-no_indicate.ml:104 exceeds the margin
+Warning: ite-no_indicate.ml:204 exceeds the margin
+Warning: ite-no_indicate.ml:213 exceeds the margin

--- a/test/passing/refs.default/ite-no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-no_indicate.ml.ref
@@ -195,3 +195,31 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.default/ite-vertical.ml.err
+++ b/test/passing/refs.default/ite-vertical.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-vertical.ml:131 exceeds the margin
 Warning: ite-vertical.ml:136 exceeds the margin
 Warning: ite-vertical.ml:141 exceeds the margin
+Warning: ite-vertical.ml:286 exceeds the margin
+Warning: ite-vertical.ml:299 exceeds the margin

--- a/test/passing/refs.default/ite-vertical.ml.ref
+++ b/test/passing/refs.default/ite-vertical.ml.ref
@@ -277,3 +277,38 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if
+          a
+        then
+          b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.default/ite.ml.err
+++ b/test/passing/refs.default/ite.ml.err
@@ -1,3 +1,5 @@
 Warning: ite.ml:94 exceeds the margin
 Warning: ite.ml:99 exceeds the margin
 Warning: ite.ml:104 exceeds the margin
+Warning: ite.ml:204 exceeds the margin
+Warning: ite.ml:213 exceeds the margin

--- a/test/passing/refs.default/ite.ml.ref
+++ b/test/passing/refs.default/ite.ml.ref
@@ -195,3 +195,31 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.janestreet/ite-compact.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact.ml.ref
@@ -204,3 +204,34 @@ let test =
     1
   else 2
 ;;
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then b
+;;
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f)
+;;
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g
+;;

--- a/test/passing/refs.janestreet/ite-compact_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact_closing.ml.ref
@@ -218,3 +218,35 @@ let test =
     1
   else 2
 ;;
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then b
+;;
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f
+  )
+;;
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g
+;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
@@ -254,3 +254,37 @@ let test =
   else
     2
 ;;
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then b
+;;
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)(
+    match x with
+    | A -> f)
+;;
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g
+;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
@@ -265,3 +265,38 @@ let test =
   else
     2
 ;;
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then b
+;;
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)(
+    match x with
+    | A -> f
+  )
+;;
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g
+;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
@@ -254,3 +254,37 @@ let test =
   else
     2
 ;;
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then b
+;;
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)(
+    match x with
+    | A -> f)
+;;
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g
+;;

--- a/test/passing/refs.janestreet/ite-kr.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr.ml.ref
@@ -301,3 +301,38 @@ let test =
   else
     2
 ;;
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then b
+;;
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      match x with
+      | A -> f
+  )
+;;
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g
+;;

--- a/test/passing/refs.janestreet/ite-kr_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr_closing.ml.ref
@@ -308,3 +308,38 @@ let test =
   else
     2
 ;;
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then b
+;;
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      match x with
+      | A -> f
+  )
+;;
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g
+;;

--- a/test/passing/refs.janestreet/ite-kw_first.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first.ml.ref
@@ -234,3 +234,38 @@ let test =
     1
   else 2
 ;;
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf
+    then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then b
+;;
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a
+  then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f)
+;;
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa
+  then
+    if bbbbb
+    then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs
+      then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g
+;;

--- a/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
@@ -248,3 +248,39 @@ let test =
     1
   else 2
 ;;
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf
+    then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then b
+;;
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a
+  then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f
+  )
+;;
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa
+  then
+    if bbbbb
+    then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs
+      then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g
+;;

--- a/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
@@ -234,3 +234,38 @@ let test =
     1
   else 2
 ;;
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf
+    then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then b
+;;
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a
+  then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f)
+;;
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa
+  then
+    if bbbbb
+    then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs
+      then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g
+;;

--- a/test/passing/refs.janestreet/ite-no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-no_indicate.ml.ref
@@ -204,3 +204,34 @@ let test =
     1
   else 2
 ;;
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then b
+;;
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f)
+;;
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g
+;;

--- a/test/passing/refs.janestreet/ite-vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-vertical.ml.ref
@@ -298,3 +298,38 @@ let test =
   else
     2
 ;;
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then
+        b
+;;
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f)
+;;
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g
+;;

--- a/test/passing/refs.janestreet/ite.ml.ref
+++ b/test/passing/refs.janestreet/ite.ml.ref
@@ -204,3 +204,34 @@ let test =
     1
   else 2
 ;;
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then b
+;;
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else (
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f)
+;;
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g
+;;

--- a/test/passing/refs.ocamlformat/ite-compact.ml.err
+++ b/test/passing/refs.ocamlformat/ite-compact.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-compact.ml:203 exceeds the margin
+Warning: ite-compact.ml:212 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-compact.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact.ml.ref
@@ -194,3 +194,31 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.ocamlformat/ite-compact_closing.ml.err
+++ b/test/passing/refs.ocamlformat/ite-compact_closing.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-compact_closing.ml:213 exceeds the margin
+Warning: ite-compact_closing.ml:222 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
@@ -204,3 +204,31 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.err
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-fit_or_vertical.ml:250 exceeds the margin
+Warning: ite-fit_or_vertical.ml:263 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
@@ -241,3 +241,39 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if
+        a
+      then
+        b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+  match x with
+  | A ->
+      f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.err
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-fit_or_vertical_closing.ml:255 exceeds the margin
+Warning: ite-fit_or_vertical_closing.ml:268 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
@@ -246,3 +246,39 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if
+        a
+      then
+        b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+  match x with
+  | A ->
+      f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.err
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-fit_or_vertical_no_indicate.ml:110 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:115 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:120 exceeds the margin
+Warning: ite-fit_or_vertical_no_indicate.ml:247 exceeds the margin
+Warning: ite-fit_or_vertical_no_indicate.ml:260 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
@@ -238,3 +238,39 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      begin if
+        a
+      then
+        b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+  match x with
+  | A ->
+      f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.ocamlformat/ite-kr.ml.err
+++ b/test/passing/refs.ocamlformat/ite-kr.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-kr.ml:284 exceeds the margin
+Warning: ite-kr.ml:294 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-kr.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr.ml.ref
@@ -275,3 +275,36 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      match x with
+    | A ->
+        f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.ocamlformat/ite-kr_closing.ml.err
+++ b/test/passing/refs.ocamlformat/ite-kr_closing.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-kr_closing.ml:288 exceeds the margin
+Warning: ite-kr_closing.ml:298 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
@@ -279,3 +279,36 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+      end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      match x with
+    | A ->
+        f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.ocamlformat/ite-kw_first.ml.err
+++ b/test/passing/refs.ocamlformat/ite-kw_first.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-kw_first.ml:234 exceeds the margin
+Warning: ite-kw_first.ml:244 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
@@ -224,3 +224,37 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf
+      then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a
+  then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A ->
+        f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa
+  then
+    if bbbbb
+    then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs
+      then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.err
+++ b/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-kw_first_closing.ml:244 exceeds the margin
+Warning: ite-kw_first_closing.ml:254 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
@@ -234,3 +234,37 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf
+      then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a
+  then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A ->
+        f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa
+  then
+    if bbbbb
+    then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs
+      then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.err
+++ b/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-kw_first_no_indicate.ml:103 exceeds the margin
 Warning: ite-kw_first_no_indicate.ml:109 exceeds the margin
 Warning: ite-kw_first_no_indicate.ml:114 exceeds the margin
+Warning: ite-kw_first_no_indicate.ml:231 exceeds the margin
+Warning: ite-kw_first_no_indicate.ml:241 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
@@ -221,3 +221,37 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf
+      then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a
+  then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A ->
+        f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa
+  then
+    if bbbbb
+    then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs
+      then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.ocamlformat/ite-no_indicate.ml.err
+++ b/test/passing/refs.ocamlformat/ite-no_indicate.ml.err
@@ -1,3 +1,5 @@
 Warning: ite-no_indicate.ml:89 exceeds the margin
 Warning: ite-no_indicate.ml:94 exceeds the margin
 Warning: ite-no_indicate.ml:99 exceeds the margin
+Warning: ite-no_indicate.ml:200 exceeds the margin
+Warning: ite-no_indicate.ml:209 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
@@ -191,3 +191,31 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/refs.ocamlformat/ite-vertical.ml.err
+++ b/test/passing/refs.ocamlformat/ite-vertical.ml.err
@@ -1,0 +1,2 @@
+Warning: ite-vertical.ml:291 exceeds the margin
+Warning: ite-vertical.ml:304 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-vertical.ml.ref
@@ -282,3 +282,39 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if
+          a
+        then
+          b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then
+    b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A ->
+        f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else
+      g

--- a/test/passing/refs.ocamlformat/ite.ml.err
+++ b/test/passing/refs.ocamlformat/ite.ml.err
@@ -1,0 +1,2 @@
+Warning: ite.ml:203 exceeds the margin
+Warning: ite.ml:212 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite.ml.ref
+++ b/test/passing/refs.ocamlformat/ite.ml.ref
@@ -194,3 +194,31 @@ let test =
     (* comment *)
     1
   else 2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+      if gf then
+        (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+        begin if a then b
+        end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+    else g

--- a/test/passing/tests/ite.ml
+++ b/test/passing/tests/ite.ml
@@ -197,3 +197,33 @@ let test =
     1
   else
     2
+
+(* Begin-end with long comment before nested if (regression test for
+   formatting oscillation) *)
+let f =
+  match x with
+  | A ->
+    if gf then begin
+      (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+      if a then b
+    end
+
+(* Long comment before match in else branch (regression test for
+   formatting oscillation) *)
+let _ =
+  if a then b
+  else
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    match x with
+    | A -> f
+
+(* Comment before nested if in then branch - Compact mode oscillation *)
+let _ =
+  if aaaa then
+    if bbbbb then
+      (* in this case, b <- s *)
+      if abs_float fa < abs_float fs then
+        iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
+      else
+        iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
+  else g


### PR DESCRIPTION
When a comment sits between a keyword (then/else) and certain branch
expressions (begin...end wrapping match/try/function/ifthenelse, or bare
match/try/function/ifthenelse), the comment would alternate between
"after keyword" and "before expression" placements across formatting
iterations. This caused branch_pro to compute different indentation each
time, producing "formatting did not stabilize after 10 iterations".

The fix detects these oscillation-prone patterns and ensures stable
formatting regardless of the initial comment placement:

- In Fmt_ast, when a branch matches `needs_raw_cmts_after_kw`, extract
  "after keyword" comments without breaks and override branch_pro using
  `Params.raw_cmts_branch_pro` (which computes mode-appropriate
  break+indent+comment output).

- In Params, `branch_pro_with_cmts` detects comments "before expression"
  (the alternate placement) and forces a break, producing the same layout
  as the "after keyword" path.

- For begin...end branches, `branch_pro` checks for comments before the
  inner expression (not just the begin...end node) to handle the case
  where the comment migrates inside the begin...end scope.

Affected modes: Fit_or_vertical, Compact (profile=conventional).

Closes #2799.