### PR TITLE
Params: deduplicate branch_pro_with_cmts across if-then-else modes

### DIFF
--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -929,31 +929,40 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
     | None when parens_bch -> str " "
     | None -> break 1 indent
   in
+  (* When a comment precedes a multi-line
+     [match]/[function]/[try]/[if-then-else] branch body (or a [begin]/[end]
+     wrapping one), emit it from [branch_pro] with forced breaks, so the
+     branch indentation stays stable regardless of where the comment was
+     initially attached. [default] is the comment-less [branch_pro] for the
+     current mode, [guard] an extra mode-specific applicability condition. *)
+  let branch_pro_with_cmts ~default ~guard =
+    if
+      (not has_beginend)
+      && (not (Location.is_single_line expr_loc c.fmt_opts.margin.v))
+      && (not has_cmts_after_kw) && guard
+    then
+      match cmts_before_opt xbch.ast.pexp_loc with
+      | Some cmts -> raw_cmts_branch_pro c cmts
+      | None -> (
+        match xbch.ast.pexp_desc with
+        | Pexp_beginend ({pexp_loc; pexp_desc; _}, _)
+          when is_special_beginend pexp_desc -> (
+          match cmts_before_opt pexp_loc with
+          | Some cmts -> raw_cmts_branch_pro c cmts
+          | None -> default )
+        | _ -> default )
+    else default
+  in
   match c.fmt_opts.if_then_else.v with
   | `Compact ->
-      let branch_pro_with_cmts =
-        if
-          (not has_beginend) && (not parens_bch)
-          && (not (Location.is_single_line expr_loc c.fmt_opts.margin.v))
-          && (not has_cmts_after_kw)
-          && is_special_or_nested_special_beginend xbch.ast.pexp_desc
-        then
-          match cmts_before_opt xbch.ast.pexp_loc with
-          | Some cmts -> break 1000 0 $ cmts $ break 1000 0
-          | None -> (
-            match xbch.ast.pexp_desc with
-            | Pexp_beginend ({pexp_loc; pexp_desc; _}, _)
-              when is_special_beginend pexp_desc -> (
-              match cmts_before_opt pexp_loc with
-              | Some cmts -> break 1000 0 $ cmts $ break 1000 0
-              | None -> branch_pro ~indent:0 () )
-            | _ -> branch_pro ~indent:0 () )
-        else branch_pro ~indent:0 ()
-      in
       { box_branch= hovbox ~name:"Params.get_if_then_else `Compact" 2
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
-      ; branch_pro= branch_pro_with_cmts
+      ; branch_pro=
+          branch_pro_with_cmts ~default:(branch_pro ~indent:0 ())
+            ~guard:
+              ( (not parens_bch)
+              && is_special_or_nested_special_beginend xbch.ast.pexp_desc )
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:
@@ -982,24 +991,6 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
       ; space_between_branches= fmt_if (has_beginend || parens_bch) (str " ")
       }
   | `Fit_or_vertical ->
-      let branch_pro_with_cmts =
-        if
-          (not has_beginend)
-          && (not (Location.is_single_line expr_loc c.fmt_opts.margin.v))
-          && not has_cmts_after_kw
-        then
-          match cmts_before_opt xbch.ast.pexp_loc with
-          | Some cmts -> break 1000 2 $ cmts
-          | None -> (
-            match xbch.ast.pexp_desc with
-            | Pexp_beginend ({pexp_loc; pexp_desc; _}, _)
-              when is_special_beginend pexp_desc -> (
-              match cmts_before_opt pexp_loc with
-              | Some cmts -> break 1000 2 $ cmts
-              | None -> branch_pro ~begin_end_offset:0 () )
-            | _ -> branch_pro ~begin_end_offset:0 () )
-        else branch_pro ~begin_end_offset:0 ()
-      in
       { box_branch=
           hovbox
             ( match imd with
@@ -1007,7 +998,10 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
             | _ -> 0 )
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
-      ; branch_pro= branch_pro_with_cmts
+      ; branch_pro=
+          branch_pro_with_cmts
+            ~default:(branch_pro ~begin_end_offset:0 ())
+            ~guard:true
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:


### PR DESCRIPTION
The `Compact` and `Fit_or_vertical` arms of `get_if_then_else` each carried a near-identical block computing `branch_pro` for the case of a comment preceding a special branch body, and their inline break expressions (`break 1000 0 $ cmts $ break 1000 0` and `break 1000 2 $ cmts`) duplicated exactly what `raw_cmts_branch_pro` already computes per mode.

Extract a single `branch_pro_with_cmts ~default ~guard` helper that reuses `raw_cmts_branch_pro`, parameterized by each mode's comment-less `branch_pro` and its extra applicability guard. Behavior is unchanged (the full test suite passes with no ref changes).