### PR TITLE
More `if-then-else=fit-or-vertical` fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@ profile. This started with version 0.26.0.
 
 ### Fixed
 
+- Fix `begin match … end` (and `begin if … end`) branch with
+  `if-then-else=fit-or-vertical`: the `match … with` header no longer splits
+  over several lines, and `end` is aligned with `begin`.
+  (#2810, @MisterDA)
+
 - Fix indentation of a bare `match`/`function`/`try` branch preceded by a
   comment with `if-then-else=fit-or-vertical`: the branch is no longer
   indented relative to the comment's end column.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@ profile. This started with version 0.26.0.
 
 ### Fixed
 
+- Fix indentation of a bare `match`/`function`/`try` branch preceded by a
+  comment with `if-then-else=fit-or-vertical`: the branch is no longer
+  indented relative to the comment's end column.
+  (#2810, @MisterDA)
+
 - Fix formatting oscillation with `if-then-else=fit-or-vertical` and
   `begin...end`.
   (#2800, @MisterDA)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,13 @@ profile. This started with version 0.26.0.
 
 ### Fixed
 
+- Fix `begin match … end` (and `begin if … end`) branches: with
+  `if-then-else=fit-or-vertical` the `match … with` header no longer splits
+  over several lines and `end` is aligned with `begin`; and a leading comment
+  on the body no longer reindents it — `begin` keeps the body one indent in
+  instead of gluing the keyword to the comment.
+  (#2810, @MisterDA)
+
 - Fix indentation of a bare `match`/`function`/`try` branch preceded by a
   comment with `if-then-else=fit-or-vertical`: the branch is no longer
   indented relative to the comment's end column.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,11 +8,6 @@ profile. This started with version 0.26.0.
 
 ### Fixed
 
-- Fix `begin match … end` (and `begin if … end`) branch with
-  `if-then-else=fit-or-vertical`: the `match … with` header no longer splits
-  over several lines, and `end` is aligned with `begin`.
-  (#2810, @MisterDA)
-
 - Fix indentation of a bare `match`/`function`/`try` branch preceded by a
   comment with `if-then-else=fit-or-vertical`: the branch is no longer
   indented relative to the comment's end column.

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2593,7 +2593,12 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                          let branch_pro =
                            match raw_cmts_after_kw with
                            | Some cmts ->
-                               Params.raw_cmts_branch_pro c.conf cmts
+                               let bare_branch =
+                                 Params.is_bare_branch ~parens_bch
+                                   xbch.ast.pexp_desc
+                               in
+                               Params.raw_cmts_branch_pro ~bare_branch c.conf
+                                 cmts
                            | None -> p.branch_pro
                          in
                          let wrap_beginend =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2581,6 +2581,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                          in
                          let p =
                            Params.get_if_then_else c.conf ~cmts_before_opt
+                             ~has_cmts_before:(Cmts.has_before c.cmts)
                              ~pro:(fmt_if first pro_inner) ~first ~last
                              ~parens_bch ~parens_prev_bch:!parens_prev_bch
                              ~xcond ~xbch ~expr_loc:pexp_loc
@@ -3039,11 +3040,23 @@ and fmt_beginend c ~loc ?(box = true) ?(pro = noop) ~ctx ~ctx0 ~fmt_atrs
   $
   match e.pexp_desc with
   | Pexp_match _ | Pexp_try _ | Pexp_function _ | Pexp_ifthenelse _ ->
-      beginend_box
-        (fmt_expression c
-           ~pro:(pro $ begin_ $ str " ")
-           ~box:false ?eol ~parens:false ~indent_wrap (sub_exp ~ctx e) )
-      $ end_
+      (* In an [if-then-else] branch the branch break indents [begin] one
+         level in (e.g. [fit-or-vertical], whose branch box is [hovbox 0]),
+         while [end] follows the branch box; wrap the body and [end] together
+         so [end] lines up with [begin]. Other contexts (e.g. [map x begin
+         fun … end] as an application argument) must keep their own
+         indentation. *)
+      let box =
+        match ctx0 with
+        | Exp {pexp_desc= Pexp_ifthenelse _; _} -> hvbox 0
+        | _ -> Fn.id
+      in
+      box
+        ( beginend_box
+            (fmt_expression c
+               ~pro:(pro $ begin_ $ str " ")
+               ~box:false ?eol ~parens:false ~indent_wrap (sub_exp ~ctx e) )
+        $ end_ )
   | _ ->
       beginend_box
         ( hvbox 0 (pro $ begin_)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3038,12 +3038,25 @@ and fmt_beginend c ~loc ?(box = true) ?(pro = noop) ~ctx ~ctx0 ~fmt_atrs
   cmts_before
   $
   match e.pexp_desc with
-  | Pexp_match _ | Pexp_try _ | Pexp_function _ | Pexp_ifthenelse _ ->
-      beginend_box
-        (fmt_expression c
-           ~pro:(pro $ begin_ $ str " ")
-           ~box:false ?eol ~parens:false ~indent_wrap (sub_exp ~ctx e) )
-      $ end_
+  | Pexp_match _ | Pexp_try _ | Pexp_function _ | Pexp_ifthenelse _ -> (
+      let body ~pro =
+        beginend_box
+          (fmt_expression c
+             ~pro:(pro $ begin_ $ str " ")
+             ~box:false ?eol ~parens:false ~indent_wrap (sub_exp ~ctx e) )
+      in
+      match ctx0 with
+      | Exp {pexp_desc= Pexp_ifthenelse _; _} ->
+          (* In an [if-then-else] branch [pro] is the branch break, which for
+             [if-then-else=fit-or-vertical] is a wide [break_unless_newline].
+             Threading it into the inner expression's [pro] would inflate the
+             header box's width and wrongly break it (e.g. [begin match] /
+             [x] / [with]); the branch break already placed us, so emit it
+             outside. The [begin] is then indented by the branch break while
+             [end] would follow the enclosing box, so wrap both in a box to
+             keep [end] aligned with [begin]. *)
+          pro $ hvbox 0 (body ~pro:noop $ end_)
+      | _ -> body ~pro $ end_ )
   | _ ->
       beginend_box
         ( hvbox 0 (pro $ begin_)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3038,25 +3038,12 @@ and fmt_beginend c ~loc ?(box = true) ?(pro = noop) ~ctx ~ctx0 ~fmt_atrs
   cmts_before
   $
   match e.pexp_desc with
-  | Pexp_match _ | Pexp_try _ | Pexp_function _ | Pexp_ifthenelse _ -> (
-      let body ~pro =
-        beginend_box
-          (fmt_expression c
-             ~pro:(pro $ begin_ $ str " ")
-             ~box:false ?eol ~parens:false ~indent_wrap (sub_exp ~ctx e) )
-      in
-      match ctx0 with
-      | Exp {pexp_desc= Pexp_ifthenelse _; _} ->
-          (* In an [if-then-else] branch [pro] is the branch break, which for
-             [if-then-else=fit-or-vertical] is a wide [break_unless_newline].
-             Threading it into the inner expression's [pro] would inflate the
-             header box's width and wrongly break it (e.g. [begin match] /
-             [x] / [with]); the branch break already placed us, so emit it
-             outside. The [begin] is then indented by the branch break while
-             [end] would follow the enclosing box, so wrap both in a box to
-             keep [end] aligned with [begin]. *)
-          pro $ hvbox 0 (body ~pro:noop $ end_)
-      | _ -> body ~pro $ end_ )
+  | Pexp_match _ | Pexp_try _ | Pexp_function _ | Pexp_ifthenelse _ ->
+      beginend_box
+        (fmt_expression c
+           ~pro:(pro $ begin_ $ str " ")
+           ~box:false ?eol ~parens:false ~indent_wrap (sub_exp ~ctx e) )
+      $ end_
   | _ ->
       beginend_box
         ( hvbox 0 (pro $ begin_)

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -516,9 +516,22 @@ let is_special_or_nested_special_beginend = function
   | Pexp_beginend ({pexp_desc; _}, _) -> is_special_beginend pexp_desc
   | exp -> is_special_beginend exp
 
-let raw_cmts_branch_pro (c : Conf.t) cmts =
+(* An if-then-else branch is rendered "bare" when it is neither wrapped in
+   [begin]/[end] (including the [begin match end] shortcut, a
+   [Pexp_beginend]) nor parenthesized. *)
+let is_bare_branch ~parens_bch desc =
+  (not parens_bch) && match desc with Pexp_beginend _ -> false | _ -> true
+
+let raw_cmts_branch_pro ?(bare_branch = false) (c : Conf.t) cmts =
   match c.fmt_opts.if_then_else.v with
   | `Compact -> break 1000 0 $ cmts $ break 1000 0
+  (* A bare [match]/[function]/[try]/[if] branch breaks before its own body
+     with a [break_unless_newline], which is a no-op unless we are already at
+     the beginning of a line; without a trailing break here the branch box
+     would open at the comment's end column and indent the body relative to
+     it. A [begin]/[end]- or paren-wrapped branch instead emits its opening
+     delimiter right after the comment, so we leave the break to it. *)
+  | _ when bare_branch -> break 1000 2 $ cmts $ break 1000 2
   | _ -> break 1000 2 $ cmts
 
 type cases =
@@ -878,6 +891,7 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
     | _ -> (None, None, xbch)
   in
   let has_beginend = Option.is_some beginend_loc in
+  let bare_branch = is_bare_branch ~parens_bch xbch.ast.pexp_desc in
   let wrap_parens ~wrap_breaks k =
     if has_beginend then
       let infix_ext_attrs_beginend =
@@ -942,13 +956,13 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
       && (not has_cmts_after_kw) && guard
     then
       match cmts_before_opt xbch.ast.pexp_loc with
-      | Some cmts -> raw_cmts_branch_pro c cmts
+      | Some cmts -> raw_cmts_branch_pro ~bare_branch c cmts
       | None -> (
         match xbch.ast.pexp_desc with
         | Pexp_beginend ({pexp_loc; pexp_desc; _}, _)
           when is_special_beginend pexp_desc -> (
           match cmts_before_opt pexp_loc with
-          | Some cmts -> raw_cmts_branch_pro c cmts
+          | Some cmts -> raw_cmts_branch_pro ~bare_branch c cmts
           | None -> default )
         | _ -> default )
     else default

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -929,31 +929,40 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
     | None when parens_bch -> str " "
     | None -> break 1 indent
   in
+  (* When a comment precedes a multi-line
+     [match]/[function]/[try]/[if-then-else] branch body (or a [begin]/[end]
+     wrapping one), emit it from [branch_pro] with forced breaks, so the
+     branch indentation stays stable regardless of where the comment was
+     initially attached. [default] is the comment-less [branch_pro] for the
+     current mode, [guard] an extra mode-specific applicability condition. *)
+  let branch_pro_with_cmts ~default ~guard =
+    if
+      (not has_beginend)
+      && (not (Location.is_single_line expr_loc c.fmt_opts.margin.v))
+      && (not has_cmts_after_kw) && guard
+    then
+      match cmts_before_opt xbch.ast.pexp_loc with
+      | Some cmts -> raw_cmts_branch_pro c cmts
+      | None -> (
+        match xbch.ast.pexp_desc with
+        | Pexp_beginend ({pexp_loc; pexp_desc; _}, _)
+          when is_special_beginend pexp_desc -> (
+          match cmts_before_opt pexp_loc with
+          | Some cmts -> raw_cmts_branch_pro c cmts
+          | None -> default )
+        | _ -> default )
+    else default
+  in
   match c.fmt_opts.if_then_else.v with
   | `Compact ->
-      let branch_pro_with_cmts =
-        if
-          (not has_beginend) && (not parens_bch)
-          && (not (Location.is_single_line expr_loc c.fmt_opts.margin.v))
-          && (not has_cmts_after_kw)
-          && is_special_or_nested_special_beginend xbch.ast.pexp_desc
-        then
-          match cmts_before_opt xbch.ast.pexp_loc with
-          | Some cmts -> break 1000 0 $ cmts $ break 1000 0
-          | None -> (
-            match xbch.ast.pexp_desc with
-            | Pexp_beginend ({pexp_loc; pexp_desc; _}, _)
-              when is_special_beginend pexp_desc -> (
-              match cmts_before_opt pexp_loc with
-              | Some cmts -> break 1000 0 $ cmts $ break 1000 0
-              | None -> branch_pro ~indent:0 () )
-            | _ -> branch_pro ~indent:0 () )
-        else branch_pro ~indent:0 ()
-      in
       { box_branch= hovbox ~name:"Params.get_if_then_else `Compact" 2
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
-      ; branch_pro= branch_pro_with_cmts
+      ; branch_pro=
+          branch_pro_with_cmts ~default:(branch_pro ~indent:0 ())
+            ~guard:
+              ( (not parens_bch)
+              && is_special_or_nested_special_beginend xbch.ast.pexp_desc )
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:
@@ -982,24 +991,6 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
       ; space_between_branches= fmt_if (has_beginend || parens_bch) (str " ")
       }
   | `Fit_or_vertical ->
-      let branch_pro_with_cmts =
-        if
-          (not has_beginend)
-          && (not (Location.is_single_line expr_loc c.fmt_opts.margin.v))
-          && not has_cmts_after_kw
-        then
-          match cmts_before_opt xbch.ast.pexp_loc with
-          | Some cmts -> break 1000 2 $ cmts
-          | None -> (
-            match xbch.ast.pexp_desc with
-            | Pexp_beginend ({pexp_loc; pexp_desc; _}, _)
-              when is_special_beginend pexp_desc -> (
-              match cmts_before_opt pexp_loc with
-              | Some cmts -> break 1000 2 $ cmts
-              | None -> branch_pro ~begin_end_offset:0 () )
-            | _ -> branch_pro ~begin_end_offset:0 () )
-        else branch_pro ~begin_end_offset:0 ()
-      in
       { box_branch=
           hovbox
             ( match imd with
@@ -1007,7 +998,10 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
             | _ -> 0 )
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
-      ; branch_pro= branch_pro_with_cmts
+      ; branch_pro=
+          branch_pro_with_cmts
+            ~default:(branch_pro ~begin_end_offset:0 ())
+            ~guard:true
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -871,15 +871,22 @@ type if_then_else =
   ; break_end_branch: Fmt.t
   ; space_between_branches: Fmt.t }
 
-let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
-    ~parens_bch ~parens_prev_bch ~xcond ~xbch ~expr_loc ~fmt_infix_ext_attrs
-    ~infix_ext_attrs ~fmt_cond ~cmts_before_kw ~cmts_after_kw =
+let get_if_then_else (c : Conf.t) ~cmts_before_opt ~has_cmts_before ~pro
+    ~first ~last ~parens_bch ~parens_prev_bch ~xcond ~xbch ~expr_loc
+    ~fmt_infix_ext_attrs ~infix_ext_attrs ~fmt_cond ~cmts_before_kw
+    ~cmts_after_kw =
   let imd = c.fmt_opts.indicate_multiline_delimiters.v in
   let beginend_loc, infix_ext_attrs_beginend, branch_expr =
     let ast = xbch.Ast.ast in
     match ast with
-    | {pexp_desc= Pexp_beginend ({pexp_desc; _}, _); _}
-      when is_special_beginend pexp_desc ->
+    | {pexp_desc= Pexp_beginend (nested_exp, _); _}
+      when is_special_beginend nested_exp.pexp_desc
+           && not (has_cmts_before nested_exp.pexp_loc) ->
+        (* [begin match/try/function/if … end] shortcut: keep [begin] glued
+           to the body keyword. A leading comment on the body breaks the
+           glue, so fall through to the plain [begin]/[end] machinery below,
+           which puts [begin] on its own line and the body (comment included)
+           one indent in. *)
         (None, None, xbch)
     | { pexp_desc= Pexp_beginend (nested_exp, infix_ext_attrs)
       ; pexp_attributes= []
@@ -891,6 +898,18 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
     | _ -> (None, None, xbch)
   in
   let has_beginend = Option.is_some beginend_loc in
+  (* A [begin]/[end] branch whose body is a [match]/[try]/[function]/[if]
+     (the [begin match … end] shortcut, or its plain form when a leading
+     comment de-glues [begin] from the body). Such a body has a header
+     ([match … with], [if … then]) that the branch [break_unless_newline
+     1000] would wrongly split, so it provides its own break after [begin]
+     instead. Simple-bodied [begin … end] keeps the regular branch break. *)
+  let is_special_beginend_branch =
+    match xbch.ast.pexp_desc with
+    | Pexp_beginend (nested_exp, _) ->
+        is_special_beginend nested_exp.pexp_desc
+    | _ -> false
+  in
   let bare_branch = is_bare_branch ~parens_bch xbch.ast.pexp_desc in
   let wrap_parens ~wrap_breaks k =
     if has_beginend then
@@ -996,7 +1015,7 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
       ; branch_pro= branch_pro ~begin_end_offset:0 ()
       ; wrap_parens= wrap_parens ~wrap_breaks:(wrap (break 1000 2) noop)
       ; beginend_loc
-      ; box_expr= Some has_beginend
+      ; box_expr= Some (has_beginend && not is_special_beginend_branch)
       ; expr_pro= None
       ; expr_eol= Some (break 1 2)
       ; branch_expr
@@ -1024,10 +1043,13 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
       ; beginend_loc
       ; box_expr= Some false
       ; expr_pro=
-          Some
-            (fmt_if
-               (not (Location.is_single_line expr_loc c.fmt_opts.margin.v))
-               (break_unless_newline 1000 2) )
+          ( if is_special_beginend_branch then None
+            else
+              Some
+                (fmt_if
+                   (not
+                      (Location.is_single_line expr_loc c.fmt_opts.margin.v) )
+                   (break_unless_newline 1000 2) ) )
       ; expr_eol= Some (break 1 2)
       ; branch_expr
       ; break_end_branch= noop
@@ -1048,7 +1070,9 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~pro ~first ~last
                  ~cls_hint:((1, 0), (1000, 0)) )
       ; beginend_loc
       ; box_expr= None
-      ; expr_pro= Some (break_unless_newline 1000 2)
+      ; expr_pro=
+          ( if is_special_beginend_branch then None
+            else Some (break_unless_newline 1000 2) )
       ; expr_eol= None
       ; branch_expr
       ; break_end_branch= noop

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -242,10 +242,18 @@ val is_special_or_nested_special_beginend : expression_desc -> bool
     the keyword should be extracted without breaks (raw) to prevent oscillation
     between "after keyword" and "before expression" placements. *)
 
-val raw_cmts_branch_pro : Conf.t -> Fmt.t -> Fmt.t
+val is_bare_branch : parens_bch:bool -> expression_desc -> bool
+(** [is_bare_branch ~parens_bch desc] is whether an if-then-else branch with
+    expression description [desc] is rendered "bare", i.e. neither wrapped in
+    [begin]/[end] (including the [begin match end] shortcut) nor parenthesized. *)
+
+val raw_cmts_branch_pro : ?bare_branch:bool -> Conf.t -> Fmt.t -> Fmt.t
 (** [raw_cmts_branch_pro c cmts] returns the branch_pro for raw comments
     extracted after a keyword, using the correct indentation for the current
-    if-then-else mode. *)
+    if-then-else mode. [bare_branch] (default [false]) indicates the branch is
+    a bare [match]/[function]/[try]/[if] (not wrapped in [begin]/[end] or
+    parentheses); such a branch needs a forced break after the comment so that
+    its body is not indented relative to the comment's end column. *)
 
 val match_indent : ?default:int -> Conf.t -> parens:bool -> ctx:Ast.t -> int
 (** [match_indent c ~ctx ~default] returns the indentation used for the

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -221,6 +221,7 @@ type if_then_else =
 val get_if_then_else :
      Conf.t
   -> cmts_before_opt:(Location.t -> Fmt.t option)
+  -> has_cmts_before:(Location.t -> bool)
   -> pro:Fmt.t
   -> first:bool
   -> last:bool

--- a/test/passing/refs.ahrefs/ite-compact.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact.ml.ref
@@ -230,3 +230,13 @@ let _ =
         iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b)

--- a/test/passing/refs.ahrefs/ite-compact.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact.ml.ref
@@ -240,3 +240,14 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-compact.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact.ml.ref
@@ -240,14 +240,3 @@ let _ =
     match e with
     | A -> a
     | B -> b)
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.ahrefs/ite-compact.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact.ml.ref
@@ -207,10 +207,10 @@ let test =
 let f =
   match x with
   | A ->
-    if gf then
+    if gf then begin
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if a then b
-      end
+      if a then b
+    end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -240,3 +240,14 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
@@ -250,3 +250,14 @@ let _ =
         iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b
+  )

--- a/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
@@ -226,10 +226,10 @@ let test =
 let f =
   match x with
   | A ->
-    if gf then
+    if gf then begin
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if a then b
-      end
+      if a then b
+    end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -261,3 +261,14 @@ let _ =
     | A -> a
     | B -> b
   )
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
@@ -261,3 +261,14 @@ let _ =
     | A -> a
     | B -> b
   )
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
@@ -261,14 +261,3 @@ let _ =
     | A -> a
     | B -> b
   )
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.err
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.err
@@ -2,4 +2,4 @@ Warning: ite-fit_or_vertical.ml:116 exceeds the margin
 Warning: ite-fit_or_vertical.ml:121 exceeds the margin
 Warning: ite-fit_or_vertical.ml:126 exceeds the margin
 Warning: ite-fit_or_vertical.ml:247 exceeds the margin
-Warning: ite-fit_or_vertical.ml:260 exceeds the margin
+Warning: ite-fit_or_vertical.ml:257 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.err
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.err
@@ -2,4 +2,4 @@ Warning: ite-fit_or_vertical.ml:116 exceeds the margin
 Warning: ite-fit_or_vertical.ml:121 exceeds the margin
 Warning: ite-fit_or_vertical.ml:126 exceeds the margin
 Warning: ite-fit_or_vertical.ml:247 exceeds the margin
-Warning: ite-fit_or_vertical.ml:257 exceeds the margin
+Warning: ite-fit_or_vertical.ml:260 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
@@ -246,11 +246,8 @@ let f =
   | A ->
     if gf then
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-    begin if
-      a
-    then
-      b
-    end
+      begin if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -284,3 +281,15 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
@@ -244,12 +244,9 @@ let test =
 let f =
   match x with
   | A ->
-    if gf then
+    if gf then begin
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-    begin if
-      a
-    then
-      b
+      if a then b
     end
 
 (* Long comment before match in else branch (regression test for
@@ -284,3 +281,15 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
@@ -246,8 +246,11 @@ let f =
   | A ->
     if gf then
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if a then b
-      end
+    begin if
+      a
+    then
+      b
+    end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -281,15 +284,3 @@ let _ =
     match e with
     | A -> a
     | B -> b)
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
@@ -273,3 +273,14 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)(
+    match e with
+    | A -> a
+    | B -> b)

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.err
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.err
@@ -1,2 +1,2 @@
 Warning: ite-fit_or_vertical_closing.ml:257 exceeds the margin
-Warning: ite-fit_or_vertical_closing.ml:270 exceeds the margin
+Warning: ite-fit_or_vertical_closing.ml:267 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.err
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.err
@@ -1,2 +1,2 @@
 Warning: ite-fit_or_vertical_closing.ml:257 exceeds the margin
-Warning: ite-fit_or_vertical_closing.ml:267 exceeds the margin
+Warning: ite-fit_or_vertical_closing.ml:270 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
@@ -256,8 +256,11 @@ let f =
   | A ->
     if gf then
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if a then b
-      end
+    begin if
+      a
+    then
+      b
+    end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -293,15 +296,3 @@ let _ =
     | A -> a
     | B -> b
   )
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
@@ -256,11 +256,8 @@ let f =
   | A ->
     if gf then
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-    begin if
-      a
-    then
-      b
-    end
+      begin if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -296,3 +293,15 @@ let _ =
     | A -> a
     | B -> b
   )
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
@@ -284,3 +284,15 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)(
+    match e with
+    | A -> a
+    | B -> b
+  )

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
@@ -254,12 +254,9 @@ let test =
 let f =
   match x with
   | A ->
-    if gf then
+    if gf then begin
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-    begin if
-      a
-    then
-      b
+      if a then b
     end
 
 (* Long comment before match in else branch (regression test for
@@ -296,3 +293,15 @@ let _ =
     | A -> a
     | B -> b
   )
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.err
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.err
@@ -2,4 +2,4 @@ Warning: ite-fit_or_vertical_no_indicate.ml:116 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:121 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:126 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:247 exceeds the margin
-Warning: ite-fit_or_vertical_no_indicate.ml:260 exceeds the margin
+Warning: ite-fit_or_vertical_no_indicate.ml:257 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.err
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.err
@@ -2,4 +2,4 @@ Warning: ite-fit_or_vertical_no_indicate.ml:116 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:121 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:126 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:247 exceeds the margin
-Warning: ite-fit_or_vertical_no_indicate.ml:257 exceeds the margin
+Warning: ite-fit_or_vertical_no_indicate.ml:260 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
@@ -246,11 +246,8 @@ let f =
   | A ->
     if gf then
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-    begin if
-      a
-    then
-      b
-    end
+      begin if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -284,3 +281,15 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
@@ -244,12 +244,9 @@ let test =
 let f =
   match x with
   | A ->
-    if gf then
+    if gf then begin
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-    begin if
-      a
-    then
-      b
+      if a then b
     end
 
 (* Long comment before match in else branch (regression test for
@@ -284,3 +281,15 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
@@ -246,8 +246,11 @@ let f =
   | A ->
     if gf then
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if a then b
-      end
+    begin if
+      a
+    then
+      b
+    end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -281,15 +284,3 @@ let _ =
     match e with
     | A -> a
     | B -> b)
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
@@ -273,3 +273,14 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)(
+    match e with
+    | A -> a
+    | B -> b)

--- a/test/passing/refs.ahrefs/ite-kr.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr.ml.ref
@@ -283,9 +283,9 @@ let test =
 let f =
   match x with
   | A ->
-    if gf then
+    if gf then begin
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if a then b
+      if a then b
     end
 
 (* Long comment before match in else branch (regression test for
@@ -322,3 +322,15 @@ let _ =
     | A -> a
     | B -> b
   )
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-kr.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr.ml.ref
@@ -286,7 +286,7 @@ let f =
     if gf then
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
       begin if a then b
-      end
+    end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -322,15 +322,3 @@ let _ =
     | A -> a
     | B -> b
   )
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.ahrefs/ite-kr.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr.ml.ref
@@ -286,7 +286,7 @@ let f =
     if gf then
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
       begin if a then b
-    end
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -322,3 +322,15 @@ let _ =
     | A -> a
     | B -> b
   )
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-kr.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr.ml.ref
@@ -310,3 +310,15 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else (
+    (* a comment *)
+      match e with
+    | A -> a
+    | B -> b
+  )

--- a/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
@@ -293,7 +293,7 @@ let f =
     if gf then
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
       begin if a then b
-      end
+    end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -329,15 +329,3 @@ let _ =
     | A -> a
     | B -> b
   )
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
@@ -290,9 +290,9 @@ let test =
 let f =
   match x with
   | A ->
-    if gf then
+    if gf then begin
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if a then b
+      if a then b
     end
 
 (* Long comment before match in else branch (regression test for
@@ -329,3 +329,15 @@ let _ =
     | A -> a
     | B -> b
   )
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
@@ -317,3 +317,15 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else (
+    (* a comment *)
+      match e with
+    | A -> a
+    | B -> b
+  )

--- a/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
@@ -293,7 +293,7 @@ let f =
     if gf then
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
       begin if a then b
-    end
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -329,3 +329,15 @@ let _ =
     | A -> a
     | B -> b
   )
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-kw_first.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first.ml.ref
@@ -276,3 +276,15 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-kw_first.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first.ml.ref
@@ -239,10 +239,10 @@ let f =
   match x with
   | A ->
     if gf
-    then
+    then begin
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if a then b
-      end
+      if a then b
+    end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -276,3 +276,15 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-kw_first.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first.ml.ref
@@ -265,3 +265,14 @@ let _ =
       then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond
+  then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b)

--- a/test/passing/refs.ahrefs/ite-kw_first.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first.ml.ref
@@ -276,15 +276,3 @@ let _ =
     match e with
     | A -> a
     | B -> b)
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond
-  then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
@@ -297,3 +297,15 @@ let _ =
     | A -> a
     | B -> b
   )
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
@@ -258,10 +258,10 @@ let f =
   match x with
   | A ->
     if gf
-    then
+    then begin
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if a then b
-      end
+      if a then b
+    end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -297,3 +297,15 @@ let _ =
     | A -> a
     | B -> b
   )
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
@@ -285,3 +285,15 @@ let _ =
       then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond
+  then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b
+  )

--- a/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
@@ -297,15 +297,3 @@ let _ =
     | A -> a
     | B -> b
   )
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond
-  then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
@@ -276,3 +276,15 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
@@ -239,10 +239,10 @@ let f =
   match x with
   | A ->
     if gf
-    then
+    then begin
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if a then b
-      end
+      if a then b
+    end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -276,3 +276,15 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
@@ -265,3 +265,14 @@ let _ =
       then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond
+  then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b)

--- a/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
@@ -276,15 +276,3 @@ let _ =
     match e with
     | A -> a
     | B -> b)
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond
-  then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
@@ -230,3 +230,13 @@ let _ =
         iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b)

--- a/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
@@ -240,3 +240,14 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
@@ -240,14 +240,3 @@ let _ =
     match e with
     | A -> a
     | B -> b)
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
@@ -207,10 +207,10 @@ let test =
 let f =
   match x with
   | A ->
-    if gf then
+    if gf then begin
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if a then b
-      end
+      if a then b
+    end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -240,3 +240,14 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-vertical.ml.err
+++ b/test/passing/refs.ahrefs/ite-vertical.ml.err
@@ -2,4 +2,4 @@ Warning: ite-vertical.ml:131 exceeds the margin
 Warning: ite-vertical.ml:136 exceeds the margin
 Warning: ite-vertical.ml:141 exceeds the margin
 Warning: ite-vertical.ml:284 exceeds the margin
-Warning: ite-vertical.ml:297 exceeds the margin
+Warning: ite-vertical.ml:295 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-vertical.ml.err
+++ b/test/passing/refs.ahrefs/ite-vertical.ml.err
@@ -2,4 +2,4 @@ Warning: ite-vertical.ml:131 exceeds the margin
 Warning: ite-vertical.ml:136 exceeds the margin
 Warning: ite-vertical.ml:141 exceeds the margin
 Warning: ite-vertical.ml:284 exceeds the margin
-Warning: ite-vertical.ml:295 exceeds the margin
+Warning: ite-vertical.ml:297 exceeds the margin

--- a/test/passing/refs.ahrefs/ite-vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-vertical.ml.ref
@@ -310,3 +310,14 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b)

--- a/test/passing/refs.ahrefs/ite-vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-vertical.ml.ref
@@ -283,7 +283,9 @@ let f =
   | A ->
     if gf then
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if a then
+      begin if
+        a
+      then
         b
       end
 
@@ -319,15 +321,3 @@ let _ =
     match e with
     | A -> a
     | B -> b)
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.ahrefs/ite-vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-vertical.ml.ref
@@ -283,9 +283,7 @@ let f =
   | A ->
     if gf then
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
+      begin if a then
         b
       end
 
@@ -321,3 +319,15 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite-vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-vertical.ml.ref
@@ -281,13 +281,11 @@ let test =
 let f =
   match x with
   | A ->
-    if gf then
+    if gf then begin
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
+      if a then
         b
-      end
+    end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -321,3 +319,15 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite.ml.ref
+++ b/test/passing/refs.ahrefs/ite.ml.ref
@@ -230,3 +230,13 @@ let _ =
         iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b)

--- a/test/passing/refs.ahrefs/ite.ml.ref
+++ b/test/passing/refs.ahrefs/ite.ml.ref
@@ -240,3 +240,14 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.ahrefs/ite.ml.ref
+++ b/test/passing/refs.ahrefs/ite.ml.ref
@@ -240,14 +240,3 @@ let _ =
     match e with
     | A -> a
     | B -> b)
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.ahrefs/ite.ml.ref
+++ b/test/passing/refs.ahrefs/ite.ml.ref
@@ -207,10 +207,10 @@ let test =
 let f =
   match x with
   | A ->
-    if gf then
+    if gf then begin
       (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if a then b
-      end
+      if a then b
+    end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -240,3 +240,14 @@ let _ =
     match e with
     | A -> a
     | B -> b)
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-compact.ml.ref
+++ b/test/passing/refs.default/ite-compact.ml.ref
@@ -223,3 +223,11 @@ let _ =
         iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    match e with A -> a | B -> b

--- a/test/passing/refs.default/ite-compact.ml.ref
+++ b/test/passing/refs.default/ite-compact.ml.ref
@@ -201,10 +201,10 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -231,3 +231,14 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-compact.ml.ref
+++ b/test/passing/refs.default/ite-compact.ml.ref
@@ -231,3 +231,14 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-compact.ml.ref
+++ b/test/passing/refs.default/ite-compact.ml.ref
@@ -231,14 +231,3 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.default/ite-compact_closing.ml.ref
+++ b/test/passing/refs.default/ite-compact_closing.ml.ref
@@ -216,10 +216,10 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -246,3 +246,14 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-compact_closing.ml.ref
+++ b/test/passing/refs.default/ite-compact_closing.ml.ref
@@ -246,3 +246,14 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-compact_closing.ml.ref
+++ b/test/passing/refs.default/ite-compact_closing.ml.ref
@@ -238,3 +238,11 @@ let _ =
         iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    match e with A -> a | B -> b

--- a/test/passing/refs.default/ite-compact_closing.ml.ref
+++ b/test/passing/refs.default/ite-compact_closing.ml.ref
@@ -246,14 +246,3 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.default/ite-fit_or_vertical.ml.err
+++ b/test/passing/refs.default/ite-fit_or_vertical.ml.err
@@ -2,4 +2,4 @@ Warning: ite-fit_or_vertical.ml:115 exceeds the margin
 Warning: ite-fit_or_vertical.ml:120 exceeds the margin
 Warning: ite-fit_or_vertical.ml:125 exceeds the margin
 Warning: ite-fit_or_vertical.ml:247 exceeds the margin
-Warning: ite-fit_or_vertical.ml:260 exceeds the margin
+Warning: ite-fit_or_vertical.ml:257 exceeds the margin

--- a/test/passing/refs.default/ite-fit_or_vertical.ml.err
+++ b/test/passing/refs.default/ite-fit_or_vertical.ml.err
@@ -2,4 +2,4 @@ Warning: ite-fit_or_vertical.ml:115 exceeds the margin
 Warning: ite-fit_or_vertical.ml:120 exceeds the margin
 Warning: ite-fit_or_vertical.ml:125 exceeds the margin
 Warning: ite-fit_or_vertical.ml:247 exceeds the margin
-Warning: ite-fit_or_vertical.ml:257 exceeds the margin
+Warning: ite-fit_or_vertical.ml:260 exceeds the margin

--- a/test/passing/refs.default/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical.ml.ref
@@ -246,8 +246,11 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+      begin if
+        a
+      then
+        b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -281,15 +284,3 @@ let _ =
     match e with
     | A -> a
     | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.default/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical.ml.ref
@@ -244,12 +244,9 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
-        b
+        if a then b
       end
 
 (* Long comment before match in else branch (regression test for
@@ -284,3 +281,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical.ml.ref
@@ -259,8 +259,8 @@ let _ =
     b
   else
     (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-  match x with
-  | A -> f
+    match x with
+    | A -> f
 
 (* Comment before nested if in then branch - Compact mode oscillation *)
 let _ =
@@ -273,3 +273,14 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b

--- a/test/passing/refs.default/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical.ml.ref
@@ -246,11 +246,8 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
-        b
-      end
+        begin if a then b
+        end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -284,3 +281,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-fit_or_vertical_closing.ml.err
+++ b/test/passing/refs.default/ite-fit_or_vertical_closing.ml.err
@@ -1,2 +1,2 @@
 Warning: ite-fit_or_vertical_closing.ml:256 exceeds the margin
-Warning: ite-fit_or_vertical_closing.ml:266 exceeds the margin
+Warning: ite-fit_or_vertical_closing.ml:269 exceeds the margin

--- a/test/passing/refs.default/ite-fit_or_vertical_closing.ml.err
+++ b/test/passing/refs.default/ite-fit_or_vertical_closing.ml.err
@@ -1,2 +1,2 @@
 Warning: ite-fit_or_vertical_closing.ml:256 exceeds the margin
-Warning: ite-fit_or_vertical_closing.ml:269 exceeds the margin
+Warning: ite-fit_or_vertical_closing.ml:266 exceeds the margin

--- a/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
@@ -268,8 +268,8 @@ let _ =
     b
   else
     (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-  match x with
-  | A -> f
+    match x with
+    | A -> f
 
 (* Comment before nested if in then branch - Compact mode oscillation *)
 let _ =
@@ -282,3 +282,14 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b

--- a/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
@@ -255,11 +255,8 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
-        b
-      end
+        begin if a then b
+        end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -293,3 +290,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
@@ -253,12 +253,9 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
-        b
+        if a then b
       end
 
 (* Long comment before match in else branch (regression test for
@@ -293,3 +290,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
@@ -255,8 +255,11 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+      begin if
+        a
+      then
+        b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -290,15 +293,3 @@ let _ =
     match e with
     | A -> a
     | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.err
+++ b/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.err
@@ -2,4 +2,4 @@ Warning: ite-fit_or_vertical_no_indicate.ml:115 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:120 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:125 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:247 exceeds the margin
-Warning: ite-fit_or_vertical_no_indicate.ml:257 exceeds the margin
+Warning: ite-fit_or_vertical_no_indicate.ml:260 exceeds the margin

--- a/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.err
+++ b/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.err
@@ -2,4 +2,4 @@ Warning: ite-fit_or_vertical_no_indicate.ml:115 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:120 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:125 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:247 exceeds the margin
-Warning: ite-fit_or_vertical_no_indicate.ml:260 exceeds the margin
+Warning: ite-fit_or_vertical_no_indicate.ml:257 exceeds the margin

--- a/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
@@ -246,8 +246,11 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+      begin if
+        a
+      then
+        b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -281,15 +284,3 @@ let _ =
     match e with
     | A -> a
     | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
@@ -244,12 +244,9 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
-        b
+        if a then b
       end
 
 (* Long comment before match in else branch (regression test for
@@ -284,3 +281,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
@@ -259,8 +259,8 @@ let _ =
     b
   else
     (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-  match x with
-  | A -> f
+    match x with
+    | A -> f
 
 (* Comment before nested if in then branch - Compact mode oscillation *)
 let _ =
@@ -273,3 +273,14 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b

--- a/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
@@ -246,11 +246,8 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
-        b
-      end
+        begin if a then b
+        end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -284,3 +281,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-kr.ml.ref
+++ b/test/passing/refs.default/ite-kr.ml.ref
@@ -306,3 +306,11 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *) match e with A -> a | B -> b

--- a/test/passing/refs.default/ite-kr.ml.ref
+++ b/test/passing/refs.default/ite-kr.ml.ref
@@ -283,7 +283,7 @@ let f =
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
         begin if a then b
-      end
+        end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -314,3 +314,15 @@ let _ =
     x
   else
     (* a comment *) match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-kr.ml.ref
+++ b/test/passing/refs.default/ite-kr.ml.ref
@@ -283,7 +283,7 @@ let f =
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
         begin if a then b
-        end
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -314,15 +314,3 @@ let _ =
     x
   else
     (* a comment *) match e with A -> a | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.default/ite-kr.ml.ref
+++ b/test/passing/refs.default/ite-kr.ml.ref
@@ -280,9 +280,9 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
+        if a then b
       end
 
 (* Long comment before match in else branch (regression test for
@@ -314,3 +314,15 @@ let _ =
     x
   else
     (* a comment *) match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-kr_closing.ml.ref
+++ b/test/passing/refs.default/ite-kr_closing.ml.ref
@@ -290,7 +290,7 @@ let f =
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
         begin if a then b
-      end
+        end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -321,3 +321,15 @@ let _ =
     x
   else
     (* a comment *) match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-kr_closing.ml.ref
+++ b/test/passing/refs.default/ite-kr_closing.ml.ref
@@ -290,7 +290,7 @@ let f =
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
         begin if a then b
-        end
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -321,15 +321,3 @@ let _ =
     x
   else
     (* a comment *) match e with A -> a | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.default/ite-kr_closing.ml.ref
+++ b/test/passing/refs.default/ite-kr_closing.ml.ref
@@ -313,3 +313,11 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *) match e with A -> a | B -> b

--- a/test/passing/refs.default/ite-kr_closing.ml.ref
+++ b/test/passing/refs.default/ite-kr_closing.ml.ref
@@ -287,9 +287,9 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
+        if a then b
       end
 
 (* Long comment before match in else branch (regression test for
@@ -321,3 +321,15 @@ let _ =
     x
   else
     (* a comment *) match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-kw_first.ml.ref
+++ b/test/passing/refs.default/ite-kw_first.ml.ref
@@ -233,10 +233,10 @@ let f =
   match x with
   | A ->
       if gf
-      then
+      then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -270,3 +270,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-kw_first.ml.ref
+++ b/test/passing/refs.default/ite-kw_first.ml.ref
@@ -270,3 +270,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-kw_first.ml.ref
+++ b/test/passing/refs.default/ite-kw_first.ml.ref
@@ -270,15 +270,3 @@ let _ =
     match e with
     | A -> a
     | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond
-  then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.default/ite-kw_first.ml.ref
+++ b/test/passing/refs.default/ite-kw_first.ml.ref
@@ -259,3 +259,14 @@ let _ =
       then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b

--- a/test/passing/refs.default/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_closing.ml.ref
@@ -274,3 +274,14 @@ let _ =
       then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b

--- a/test/passing/refs.default/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_closing.ml.ref
@@ -285,15 +285,3 @@ let _ =
     match e with
     | A -> a
     | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond
-  then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.default/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_closing.ml.ref
@@ -248,10 +248,10 @@ let f =
   match x with
   | A ->
       if gf
-      then
+      then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -285,3 +285,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_closing.ml.ref
@@ -285,3 +285,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
@@ -233,10 +233,10 @@ let f =
   match x with
   | A ->
       if gf
-      then
+      then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -270,3 +270,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
@@ -270,3 +270,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
@@ -270,15 +270,3 @@ let _ =
     match e with
     | A -> a
     | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond
-  then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
@@ -259,3 +259,14 @@ let _ =
       then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b

--- a/test/passing/refs.default/ite-no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-no_indicate.ml.ref
@@ -223,3 +223,11 @@ let _ =
         iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    match e with A -> a | B -> b

--- a/test/passing/refs.default/ite-no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-no_indicate.ml.ref
@@ -201,10 +201,10 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -231,3 +231,14 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-no_indicate.ml.ref
@@ -231,3 +231,14 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-no_indicate.ml.ref
@@ -231,14 +231,3 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.default/ite-vertical.ml.err
+++ b/test/passing/refs.default/ite-vertical.ml.err
@@ -2,4 +2,4 @@ Warning: ite-vertical.ml:131 exceeds the margin
 Warning: ite-vertical.ml:136 exceeds the margin
 Warning: ite-vertical.ml:141 exceeds the margin
 Warning: ite-vertical.ml:286 exceeds the margin
-Warning: ite-vertical.ml:299 exceeds the margin
+Warning: ite-vertical.ml:297 exceeds the margin

--- a/test/passing/refs.default/ite-vertical.ml.err
+++ b/test/passing/refs.default/ite-vertical.ml.err
@@ -2,4 +2,4 @@ Warning: ite-vertical.ml:131 exceeds the margin
 Warning: ite-vertical.ml:136 exceeds the margin
 Warning: ite-vertical.ml:141 exceeds the margin
 Warning: ite-vertical.ml:286 exceeds the margin
-Warning: ite-vertical.ml:297 exceeds the margin
+Warning: ite-vertical.ml:299 exceeds the margin

--- a/test/passing/refs.default/ite-vertical.ml.ref
+++ b/test/passing/refs.default/ite-vertical.ml.ref
@@ -312,3 +312,14 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b

--- a/test/passing/refs.default/ite-vertical.ml.ref
+++ b/test/passing/refs.default/ite-vertical.ml.ref
@@ -283,13 +283,11 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if
-          a
-        then
+        if a then
           b
-        end
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -323,3 +321,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-vertical.ml.ref
+++ b/test/passing/refs.default/ite-vertical.ml.ref
@@ -285,9 +285,7 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if
-          a
-        then
+        begin if a then
           b
         end
 
@@ -323,3 +321,15 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite-vertical.ml.ref
+++ b/test/passing/refs.default/ite-vertical.ml.ref
@@ -285,7 +285,9 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then
+        begin if
+          a
+        then
           b
         end
 
@@ -321,15 +323,3 @@ let _ =
     match e with
     | A -> a
     | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.default/ite.ml.ref
+++ b/test/passing/refs.default/ite.ml.ref
@@ -223,3 +223,11 @@ let _ =
         iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    match e with A -> a | B -> b

--- a/test/passing/refs.default/ite.ml.ref
+++ b/test/passing/refs.default/ite.ml.ref
@@ -201,10 +201,10 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -231,3 +231,14 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite.ml.ref
+++ b/test/passing/refs.default/ite.ml.ref
@@ -231,3 +231,14 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+    end

--- a/test/passing/refs.default/ite.ml.ref
+++ b/test/passing/refs.default/ite.ml.ref
@@ -231,14 +231,3 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else
-    begin match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-    end

--- a/test/passing/refs.janestreet/ite-compact.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact.ml.ref
@@ -246,14 +246,3 @@ let _ =
     | A -> a
     | B -> b)
 ;;
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else (
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b)
-;;

--- a/test/passing/refs.janestreet/ite-compact.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact.ml.ref
@@ -235,3 +235,14 @@ let _ =
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
 ;;
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite-compact.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact.ml.ref
@@ -246,3 +246,14 @@ let _ =
     | A -> a
     | B -> b)
 ;;
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else (
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite-compact_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact_closing.ml.ref
@@ -262,15 +262,3 @@ let _ =
     | B -> b
   )
 ;;
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else (
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-  )
-;;

--- a/test/passing/refs.janestreet/ite-compact_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact_closing.ml.ref
@@ -250,3 +250,15 @@ let _ =
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
 ;;
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b
+  )
+;;

--- a/test/passing/refs.janestreet/ite-compact_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact_closing.ml.ref
@@ -262,3 +262,15 @@ let _ =
     | B -> b
   )
 ;;
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else (
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+  )
+;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
@@ -300,3 +300,15 @@ let _ =
     | A -> a
     | B -> b)
 ;;
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else (
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
@@ -300,15 +300,3 @@ let _ =
     | A -> a
     | B -> b)
 ;;
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else (
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b)
-;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
@@ -288,3 +288,15 @@ let _ =
     else
       g
 ;;
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)(
+    match e with
+    | A -> a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
@@ -313,16 +313,3 @@ let _ =
     | B -> b
   )
 ;;
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else (
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-  )
-;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
@@ -300,3 +300,16 @@ let _ =
     else
       g
 ;;
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)(
+    match e with
+    | A -> a
+    | B -> b
+  )
+;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
@@ -313,3 +313,16 @@ let _ =
     | B -> b
   )
 ;;
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else (
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+  )
+;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
@@ -300,3 +300,15 @@ let _ =
     | A -> a
     | B -> b)
 ;;
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else (
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
@@ -300,15 +300,3 @@ let _ =
     | A -> a
     | B -> b)
 ;;
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else (
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b)
-;;

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
@@ -288,3 +288,15 @@ let _ =
     else
       g
 ;;
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)(
+    match e with
+    | A -> a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite-kr.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr.ml.ref
@@ -336,3 +336,16 @@ let _ =
     else
       g
 ;;
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else (
+    (* a comment *)
+      match e with
+      | A -> a
+      | B -> b
+  )
+;;

--- a/test/passing/refs.janestreet/ite-kr.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr.ml.ref
@@ -349,16 +349,3 @@ let _ =
       | B -> b
   )
 ;;
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else (
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-  )
-;;

--- a/test/passing/refs.janestreet/ite-kr.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr.ml.ref
@@ -349,3 +349,16 @@ let _ =
       | B -> b
   )
 ;;
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else (
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+  )
+;;

--- a/test/passing/refs.janestreet/ite-kr_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr_closing.ml.ref
@@ -356,3 +356,16 @@ let _ =
       | B -> b
   )
 ;;
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else (
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+  )
+;;

--- a/test/passing/refs.janestreet/ite-kr_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr_closing.ml.ref
@@ -343,3 +343,16 @@ let _ =
     else
       g
 ;;
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else (
+    (* a comment *)
+      match e with
+      | A -> a
+      | B -> b
+  )
+;;

--- a/test/passing/refs.janestreet/ite-kr_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr_closing.ml.ref
@@ -356,16 +356,3 @@ let _ =
       | B -> b
   )
 ;;
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else (
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-  )
-;;

--- a/test/passing/refs.janestreet/ite-kw_first.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first.ml.ref
@@ -281,15 +281,3 @@ let _ =
     | A -> a
     | B -> b)
 ;;
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond
-  then x
-  else (
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b)
-;;

--- a/test/passing/refs.janestreet/ite-kw_first.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first.ml.ref
@@ -281,3 +281,15 @@ let _ =
     | A -> a
     | B -> b)
 ;;
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else (
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite-kw_first.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first.ml.ref
@@ -269,3 +269,15 @@ let _ =
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
 ;;
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond
+  then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
@@ -297,16 +297,3 @@ let _ =
     | B -> b
   )
 ;;
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond
-  then x
-  else (
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-  )
-;;

--- a/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
@@ -284,3 +284,16 @@ let _ =
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
 ;;
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond
+  then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b
+  )
+;;

--- a/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
@@ -297,3 +297,16 @@ let _ =
     | B -> b
   )
 ;;
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else (
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+  )
+;;

--- a/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
@@ -281,15 +281,3 @@ let _ =
     | A -> a
     | B -> b)
 ;;
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond
-  then x
-  else (
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b)
-;;

--- a/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
@@ -281,3 +281,15 @@ let _ =
     | A -> a
     | B -> b)
 ;;
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else (
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
@@ -269,3 +269,15 @@ let _ =
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
 ;;
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond
+  then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite-no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-no_indicate.ml.ref
@@ -246,14 +246,3 @@ let _ =
     | A -> a
     | B -> b)
 ;;
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else (
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b)
-;;

--- a/test/passing/refs.janestreet/ite-no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-no_indicate.ml.ref
@@ -235,3 +235,14 @@ let _ =
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
 ;;
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite-no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-no_indicate.ml.ref
@@ -246,3 +246,14 @@ let _ =
     | A -> a
     | B -> b)
 ;;
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else (
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite-vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-vertical.ml.ref
@@ -345,15 +345,3 @@ let _ =
     | A -> a
     | B -> b)
 ;;
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else (
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b)
-;;

--- a/test/passing/refs.janestreet/ite-vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-vertical.ml.ref
@@ -345,3 +345,15 @@ let _ =
     | A -> a
     | B -> b)
 ;;
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else (
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite-vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-vertical.ml.ref
@@ -333,3 +333,15 @@ let _ =
     else
       g
 ;;
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite.ml.ref
+++ b/test/passing/refs.janestreet/ite.ml.ref
@@ -246,14 +246,3 @@ let _ =
     | A -> a
     | B -> b)
 ;;
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else (
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b)
-;;

--- a/test/passing/refs.janestreet/ite.ml.ref
+++ b/test/passing/refs.janestreet/ite.ml.ref
@@ -235,3 +235,14 @@ let _ =
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
 ;;
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else (
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b)
+;;

--- a/test/passing/refs.janestreet/ite.ml.ref
+++ b/test/passing/refs.janestreet/ite.ml.ref
@@ -246,3 +246,14 @@ let _ =
     | A -> a
     | B -> b)
 ;;
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else (
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b)
+;;

--- a/test/passing/refs.ocamlformat/ite-compact.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact.ml.ref
@@ -200,10 +200,10 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -230,3 +230,16 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-compact.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact.ml.ref
@@ -222,3 +222,11 @@ let _ =
         iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    match e with A -> a | B -> b

--- a/test/passing/refs.ocamlformat/ite-compact.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact.ml.ref
@@ -230,3 +230,16 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-compact.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact.ml.ref
@@ -230,16 +230,3 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else
-    begin match e with
-    | A ->
-        function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B ->
-        b
-    end

--- a/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
@@ -240,16 +240,3 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else
-    begin match e with
-    | A ->
-        function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B ->
-        b
-    end

--- a/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
@@ -232,3 +232,11 @@ let _ =
         iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    match e with A -> a | B -> b

--- a/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
@@ -210,10 +210,10 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -240,3 +240,16 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
@@ -240,3 +240,16 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.err
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.err
@@ -1,2 +1,2 @@
 Warning: ite-fit_or_vertical.ml:250 exceeds the margin
-Warning: ite-fit_or_vertical.ml:263 exceeds the margin
+Warning: ite-fit_or_vertical.ml:260 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.err
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.err
@@ -1,2 +1,2 @@
 Warning: ite-fit_or_vertical.ml:250 exceeds the margin
-Warning: ite-fit_or_vertical.ml:260 exceeds the margin
+Warning: ite-fit_or_vertical.ml:263 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
@@ -262,9 +262,9 @@ let _ =
     b
   else
     (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-  match x with
-  | A ->
-      f
+    match x with
+    | A ->
+        f
 
 (* Comment before nested if in then branch - Compact mode oscillation *)
 let _ =
@@ -277,3 +277,16 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    match e with
+    | A ->
+        a
+    | B ->
+        b

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
@@ -247,12 +247,9 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
-        b
+        if a then b
       end
 
 (* Long comment before match in else branch (regression test for
@@ -290,3 +287,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
@@ -249,8 +249,11 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+      begin if
+        a
+      then
+        b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -287,17 +290,3 @@ let _ =
         a
     | B ->
         b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A ->
-        function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B ->
-        b
-    end

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
@@ -249,11 +249,8 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
-        b
-      end
+        begin if a then b
+        end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -290,3 +287,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.err
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.err
@@ -1,2 +1,2 @@
 Warning: ite-fit_or_vertical_closing.ml:255 exceeds the margin
-Warning: ite-fit_or_vertical_closing.ml:268 exceeds the margin
+Warning: ite-fit_or_vertical_closing.ml:265 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.err
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.err
@@ -1,2 +1,2 @@
 Warning: ite-fit_or_vertical_closing.ml:255 exceeds the margin
-Warning: ite-fit_or_vertical_closing.ml:265 exceeds the margin
+Warning: ite-fit_or_vertical_closing.ml:268 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
@@ -254,11 +254,8 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
-        b
-      end
+        begin if a then b
+        end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -295,3 +292,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
@@ -267,9 +267,9 @@ let _ =
     b
   else
     (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-  match x with
-  | A ->
-      f
+    match x with
+    | A ->
+        f
 
 (* Comment before nested if in then branch - Compact mode oscillation *)
 let _ =
@@ -282,3 +282,16 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    match e with
+    | A ->
+        a
+    | B ->
+        b

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
@@ -254,8 +254,11 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+      begin if
+        a
+      then
+        b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -292,17 +295,3 @@ let _ =
         a
     | B ->
         b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A ->
-        function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B ->
-        b
-    end

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
@@ -252,12 +252,9 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
-        b
+        if a then b
       end
 
 (* Long comment before match in else branch (regression test for
@@ -295,3 +292,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.err
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.err
@@ -2,4 +2,4 @@ Warning: ite-fit_or_vertical_no_indicate.ml:110 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:115 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:120 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:247 exceeds the margin
-Warning: ite-fit_or_vertical_no_indicate.ml:260 exceeds the margin
+Warning: ite-fit_or_vertical_no_indicate.ml:257 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.err
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.err
@@ -2,4 +2,4 @@ Warning: ite-fit_or_vertical_no_indicate.ml:110 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:115 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:120 exceeds the margin
 Warning: ite-fit_or_vertical_no_indicate.ml:247 exceeds the margin
-Warning: ite-fit_or_vertical_no_indicate.ml:257 exceeds the margin
+Warning: ite-fit_or_vertical_no_indicate.ml:260 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
@@ -244,12 +244,9 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
-        b
+        if a then b
       end
 
 (* Long comment before match in else branch (regression test for
@@ -287,3 +284,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
@@ -259,9 +259,9 @@ let _ =
     b
   else
     (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-  match x with
-  | A ->
-      f
+    match x with
+    | A ->
+        f
 
 (* Comment before nested if in then branch - Compact mode oscillation *)
 let _ =
@@ -274,3 +274,16 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    match e with
+    | A ->
+        a
+    | B ->
+        b

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
@@ -246,11 +246,8 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-      begin if
-        a
-      then
-        b
-      end
+        begin if a then b
+        end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -287,3 +284,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
@@ -246,8 +246,11 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+      begin if
+        a
+      then
+        b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -284,17 +287,3 @@ let _ =
         a
     | B ->
         b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A ->
-        function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B ->
-        b
-    end

--- a/test/passing/refs.ocamlformat/ite-kr.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr.ml.ref
@@ -308,3 +308,11 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *) match e with A -> a | B -> b

--- a/test/passing/refs.ocamlformat/ite-kr.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr.ml.ref
@@ -284,7 +284,7 @@ let f =
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
         begin if a then b
-        end
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -316,17 +316,3 @@ let _ =
     x
   else
     (* a comment *) match e with A -> a | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A ->
-        function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B ->
-        b
-    end

--- a/test/passing/refs.ocamlformat/ite-kr.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr.ml.ref
@@ -284,7 +284,7 @@ let f =
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
         begin if a then b
-      end
+        end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -316,3 +316,17 @@ let _ =
     x
   else
     (* a comment *) match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-kr.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr.ml.ref
@@ -281,9 +281,9 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
+        if a then b
       end
 
 (* Long comment before match in else branch (regression test for
@@ -316,3 +316,17 @@ let _ =
     x
   else
     (* a comment *) match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
@@ -285,9 +285,9 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
+        if a then b
       end
 
 (* Long comment before match in else branch (regression test for
@@ -320,3 +320,17 @@ let _ =
     x
   else
     (* a comment *) match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
@@ -288,7 +288,7 @@ let f =
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
         begin if a then b
-        end
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -320,17 +320,3 @@ let _ =
     x
   else
     (* a comment *) match e with A -> a | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A ->
-        function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B ->
-        b
-    end

--- a/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
@@ -312,3 +312,11 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *) match e with A -> a | B -> b

--- a/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
@@ -288,7 +288,7 @@ let f =
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
         begin if a then b
-      end
+        end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -320,3 +320,17 @@ let _ =
     x
   else
     (* a comment *) match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
@@ -271,3 +271,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
@@ -271,17 +271,3 @@ let _ =
         a
     | B ->
         b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond
-  then x
-  else
-    begin match e with
-    | A ->
-        function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B ->
-        b
-    end

--- a/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
@@ -258,3 +258,16 @@ let _ =
       then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    match e with
+    | A ->
+        a
+    | B ->
+        b

--- a/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
@@ -231,10 +231,10 @@ let f =
   match x with
   | A ->
       if gf
-      then
+      then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -271,3 +271,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
@@ -281,3 +281,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
@@ -241,10 +241,10 @@ let f =
   match x with
   | A ->
       if gf
-      then
+      then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -281,3 +281,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
@@ -281,17 +281,3 @@ let _ =
         a
     | B ->
         b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond
-  then x
-  else
-    begin match e with
-    | A ->
-        function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B ->
-        b
-    end

--- a/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
@@ -268,3 +268,16 @@ let _ =
       then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    match e with
+    | A ->
+        a
+    | B ->
+        b

--- a/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
@@ -268,3 +268,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
@@ -228,10 +228,10 @@ let f =
   match x with
   | A ->
       if gf
-      then
+      then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -268,3 +268,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
@@ -255,3 +255,16 @@ let _ =
       then iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    match e with
+    | A ->
+        a
+    | B ->
+        b

--- a/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
@@ -268,17 +268,3 @@ let _ =
         a
     | B ->
         b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond
-  then x
-  else
-    begin match e with
-    | A ->
-        function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B ->
-        b
-    end

--- a/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
@@ -197,10 +197,10 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -227,3 +227,16 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
@@ -219,3 +219,11 @@ let _ =
         iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    match e with A -> a | B -> b

--- a/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
@@ -227,3 +227,16 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
@@ -227,16 +227,3 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else
-    begin match e with
-    | A ->
-        function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B ->
-        b
-    end

--- a/test/passing/refs.ocamlformat/ite-vertical.ml.err
+++ b/test/passing/refs.ocamlformat/ite-vertical.ml.err
@@ -1,2 +1,2 @@
 Warning: ite-vertical.ml:291 exceeds the margin
-Warning: ite-vertical.ml:302 exceeds the margin
+Warning: ite-vertical.ml:304 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-vertical.ml.err
+++ b/test/passing/refs.ocamlformat/ite-vertical.ml.err
@@ -1,2 +1,2 @@
 Warning: ite-vertical.ml:291 exceeds the margin
-Warning: ite-vertical.ml:304 exceeds the margin
+Warning: ite-vertical.ml:302 exceeds the margin

--- a/test/passing/refs.ocamlformat/ite-vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-vertical.ml.ref
@@ -290,7 +290,9 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then
+        begin if
+          a
+        then
           b
         end
 
@@ -329,17 +331,3 @@ let _ =
         a
     | B ->
         b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then
-    x
-  else
-    begin match e with
-    | A ->
-        function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B ->
-        b
-    end

--- a/test/passing/refs.ocamlformat/ite-vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-vertical.ml.ref
@@ -290,9 +290,7 @@ let f =
   | A ->
       if gf then
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if
-          a
-        then
+        begin if a then
           b
         end
 
@@ -331,3 +329,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite-vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-vertical.ml.ref
@@ -318,3 +318,16 @@ let _ =
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else
       g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    match e with
+    | A ->
+        a
+    | B ->
+        b

--- a/test/passing/refs.ocamlformat/ite-vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-vertical.ml.ref
@@ -288,13 +288,11 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if
-          a
-        then
+        if a then
           b
-        end
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -331,3 +329,17 @@ let _ =
         a
     | B ->
         b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then
+    x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite.ml.ref
+++ b/test/passing/refs.ocamlformat/ite.ml.ref
@@ -200,10 +200,10 @@ let test =
 let f =
   match x with
   | A ->
-      if gf then
+      if gf then begin
         (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
-        begin if a then b
-        end
+        if a then b
+      end
 
 (* Long comment before match in else branch (regression test for
    formatting oscillation) *)
@@ -230,3 +230,16 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite.ml.ref
+++ b/test/passing/refs.ocamlformat/ite.ml.ref
@@ -222,3 +222,11 @@ let _ =
         iter (i + 1) ~a:s ~b:a ~c:b ~d:c ~fa:fs ~fb:fa ~fc:fb mflag
       else iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
     else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    match e with A -> a | B -> b

--- a/test/passing/refs.ocamlformat/ite.ml.ref
+++ b/test/passing/refs.ocamlformat/ite.ml.ref
@@ -230,3 +230,16 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else
+    begin match e with
+    | A ->
+        function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B ->
+        b
+    end

--- a/test/passing/refs.ocamlformat/ite.ml.ref
+++ b/test/passing/refs.ocamlformat/ite.ml.ref
@@ -230,16 +230,3 @@ let _ =
   else
     (* a comment *)
     match e with A -> a | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else
-    begin match e with
-    | A ->
-        function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B ->
-        b
-    end

--- a/test/passing/tests/ite.ml
+++ b/test/passing/tests/ite.ml
@@ -227,3 +227,13 @@ let _ =
       else
         iter (i + 1) ~a ~b:s ~c:b ~d:c ~fa ~fb:fs ~fc:fb mflag
   else g
+
+(* Short comment before a bare match in the else branch: the match must stay
+   indented under the comment, not pushed to its end column (regression test) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    match e with
+    | A -> a
+    | B -> b

--- a/test/passing/tests/ite.ml
+++ b/test/passing/tests/ite.ml
@@ -237,3 +237,14 @@ let _ =
     match e with
     | A -> a
     | B -> b
+
+(* A bare [begin match ... end] branch must keep [match ... with] on one line,
+   not split it as [begin match] / scrutinee / [with], and must align [end]
+   with [begin] (regression test) *)
+let _ =
+  if cond then x
+  else begin
+    match e with
+    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
+    | B -> b
+  end

--- a/test/passing/tests/ite.ml
+++ b/test/passing/tests/ite.ml
@@ -237,14 +237,3 @@ let _ =
     match e with
     | A -> a
     | B -> b
-
-(* A bare [begin match ... end] branch must keep [match ... with] on one line,
-   not split it as [begin match] / scrutinee / [with], and must align [end]
-   with [begin] (regression test) *)
-let _ =
-  if cond then x
-  else begin
-    match e with
-    | A -> function_with_a_long_enough_name_to_force_a_vertical_break a
-    | B -> b
-  end


### PR DESCRIPTION
- Fix `begin match … end` (and `begin if … end`) branch with `if-then-else=fit-or-vertical`: the `match … with` header no longer splits over several lines, and `end` is aligned with `begin`.

- Fix indentation of a bare `match`/`function`/`try` branch preceded by a comment with `if-then-else=fit-or-vertical`: the branch is no longer indented relative to the comment's end column.
