### PR TITLE
Fix missing parentheses around labelled tuple argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ profile. This started with version 0.26.0.
 - Fix lexer error on Windows when an Odoc code block contains CRLF line
   endings (@hhugo)
 
+- Fix missing parentheses in `(a, ~b:(if .. then .. else ..))` (#2811, @Julow)
+
 ## 0.29.0
 
 ### Highlight

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2106,7 +2106,9 @@ end = struct
     memo
 
   let last_tuple_and_simple f l =
-    match List.last_exn l with Lte_simple l -> f l.lte_elt | _ -> false
+    match List.last_exn l with
+    | Lte_simple {lte_label= None; lte_elt} -> f lte_elt
+    | _ -> false
 
   (** [exposed cls exp] holds if there is a right-most subexpression of [exp]
       which satisfies [Exp.mem_cls cls] and is not parenthesized. *)

--- a/test/passing/refs.ahrefs/labeled_tuples.ml.ref
+++ b/test/passing/refs.ahrefs/labeled_tuples.ml.ref
@@ -637,3 +637,11 @@ module type T = sig
     a ->
     'b
 end
+
+let func cond a b1 b2 = ~a, ~b:(if cond then b1 else b2)
+
+let func cond a b1 b2 =
+  ( a,
+    ~b:(match cond with
+       | true -> b1
+       | false -> b2) )

--- a/test/passing/refs.default/labeled_tuples.ml.ref
+++ b/test/passing/refs.default/labeled_tuples.ml.ref
@@ -576,3 +576,6 @@ module type T = sig
     a ->
     'b
 end
+
+let func cond a b1 b2 = (~a, ~b:(if cond then b1 else b2))
+let func cond a b1 b2 = (a, ~b:(match cond with true -> b1 | false -> b2))

--- a/test/passing/refs.janestreet/labeled_tuples.ml.ref
+++ b/test/passing/refs.janestreet/labeled_tuples.ml.ref
@@ -636,3 +636,12 @@ module type T = sig
     -> a
     -> 'b
 end
+
+let func cond a b1 b2 = ~a, ~b:(if cond then b1 else b2)
+
+let func cond a b1 b2 =
+  ( a
+  , ~b:(match cond with
+        | true -> b1
+        | false -> b2) )
+;;

--- a/test/passing/refs.ocamlformat/labeled_tuples.ml.ref
+++ b/test/passing/refs.ocamlformat/labeled_tuples.ml.ref
@@ -643,3 +643,7 @@ module type T = sig
     -> a
     -> 'b
 end
+
+let func cond a b1 b2 = (~a, ~b:(if cond then b1 else b2))
+
+let func cond a b1 b2 = (a, ~b:(match cond with true -> b1 | false -> b2))

--- a/test/passing/tests/labeled_tuples.ml
+++ b/test/passing/tests/labeled_tuples.ml
@@ -665,3 +665,9 @@ module type T = sig
     -> a
     -> 'b
 end
+
+let func cond a b1 b2 =
+  (~a, ~b:(if cond then b1 else b2))
+
+let func cond a b1 b2 =
+  (a, ~b:(match cond with true -> b1 | false -> b2))


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/2806