### PR TITLE
more compact formatting for while-loops with no body

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ profile. This started with version 0.26.0.
 
 ## unreleased
 
+### Changed
+
+- Empty bodies of while loops will be formatted on one line: `do () done`.
+  (#2812, @v-gb)
+
 ### Fixed
 
 - Fix `begin match … end` (and `begin if … end`) branches: with

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2920,6 +2920,14 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                  $ fmt_core_type c (sub_typ ~ctx t2) )
              $ fmt_atrs ) )
   | Pexp_while (e1, e2, infix_ext_attrs) ->
+      let break_around_body =
+        match e2 with
+        | { pexp_desc= Pexp_construct ({txt= Lident "()"; _}, None)
+          ; pexp_attributes= []
+          ; _ } ->
+            str " "
+        | _ -> force_break
+      in
       pro
       $ hvbox 0
           (Params.Exp.wrap c.conf ~parens
@@ -2931,9 +2939,9 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                          $ break 1 2
                          $ fmt_expression c (sub_exp ~ctx e1)
                          $ space_break $ str "do" )
-                     $ force_break
+                     $ break_around_body
                      $ fmt_expression c (sub_exp ~ctx e2) )
-                 $ force_break $ str "done" )
+                 $ break_around_body $ str "done" )
              $ fmt_atrs ) )
   | Pexp_unreachable -> pro $ str "."
   | Pexp_send (exp, meth) ->

--- a/test/passing/refs.ahrefs/extensions-indent.ml.err
+++ b/test/passing/refs.ahrefs/extensions-indent.ml.err
@@ -1,1 +1,1 @@
-Warning: extensions-indent.ml:545 exceeds the margin
+Warning: extensions-indent.ml:541 exceeds the margin

--- a/test/passing/refs.ahrefs/extensions-indent.ml.ref
+++ b/test/passing/refs.ahrefs/extensions-indent.ml.ref
@@ -99,17 +99,13 @@ let _ =
     (for i = 0 to 1 do
        ()
      done)
-    (while true do
-       ()
-     done)
+    (while true do () done)
 let _ =
   f
     (for%ext i = 0 to 1 do
        ()
      done)
-    (while%ext true do
-       ()
-     done)
+    (while%ext true do () done)
 
 let _ = function%ext
   | x -> x

--- a/test/passing/refs.ahrefs/extensions.ml.err
+++ b/test/passing/refs.ahrefs/extensions.ml.err
@@ -1,1 +1,1 @@
-Warning: extensions.ml:545 exceeds the margin
+Warning: extensions.ml:541 exceeds the margin

--- a/test/passing/refs.ahrefs/extensions.ml.ref
+++ b/test/passing/refs.ahrefs/extensions.ml.ref
@@ -99,17 +99,13 @@ let _ =
     (for i = 0 to 1 do
        ()
      done)
-    (while true do
-       ()
-     done)
+    (while true do () done)
 let _ =
   f
     (for%ext i = 0 to 1 do
        ()
      done)
-    (while%ext true do
-       ()
-     done)
+    (while%ext true do () done)
 
 let _ = function%ext
   | x -> x

--- a/test/passing/refs.ahrefs/for_while.ml.ref
+++ b/test/passing/refs.ahrefs/for_while.ml.ref
@@ -1,13 +1,13 @@
 let () =
   foo
     (for i = 1 to 10 do
-       ()
+       print_endline ()
      done)
 
 let () =
   foo
     (while true do
-       ()
+       print_endline ()
      done)
 
 let _ =
@@ -48,3 +48,9 @@ let _ =
   do
     test this
   done
+
+let _ =
+  while
+    some biggggggggggggggggggggggggggggggggg
+      expressionnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+  do () done

--- a/test/passing/refs.ahrefs/kw_extentions.ml.ref
+++ b/test/passing/refs.ahrefs/kw_extentions.ml.ref
@@ -15,9 +15,7 @@ let () =
   for%ext i = 1 to 10 do
     ()
   done;
-  while%ext false do
-    ()
-  done;
+  while%ext false do () done;
   match%ext x with
   | _ -> ()
 

--- a/test/passing/refs.ahrefs/shortcut_ext_attr.ml.ref
+++ b/test/passing/refs.ahrefs/shortcut_ext_attr.ml.ref
@@ -12,11 +12,7 @@ let () =
     | x -> ()];
   [%foo try[@foo] () with _ -> ()];
   [%foo if[@foo] () then () else ()];
-  [%foo
-    while () do
-      ()
-    done
-    [@foo]];
+  [%foo while () do () done [@foo]];
   [%foo
     for x = () to () do
       ()

--- a/test/passing/refs.ahrefs/source.ml.err
+++ b/test/passing/refs.ahrefs/source.ml.err
@@ -1,4 +1,4 @@
-Warning: source.ml:3417 exceeds the margin
-Warning: source.ml:6551 exceeds the margin
-Warning: source.ml:6985 exceeds the margin
-Warning: source.ml:7817 exceeds the margin
+Warning: source.ml:3415 exceeds the margin
+Warning: source.ml:6549 exceeds the margin
+Warning: source.ml:6983 exceeds the margin
+Warning: source.ml:7815 exceeds the margin

--- a/test/passing/refs.ahrefs/source.ml.ref
+++ b/test/passing/refs.ahrefs/source.ml.ref
@@ -87,9 +87,7 @@ let () =
   | x -> ());
   (try%foo[@foo] () with _ -> ());
   if%foo[@foo] () then () else ();
-  while%foo[@foo] () do
-    ()
-  done;
+  while%foo[@foo] () do () done;
   for%foo[@foo] x = () to () do
     ()
   done;

--- a/test/passing/refs.default/extensions-indent.ml.err
+++ b/test/passing/refs.default/extensions-indent.ml.err
@@ -1,1 +1,1 @@
-Warning: extensions-indent.ml:459 exceeds the margin
+Warning: extensions-indent.ml:455 exceeds the margin

--- a/test/passing/refs.default/extensions-indent.ml.ref
+++ b/test/passing/refs.default/extensions-indent.ml.ref
@@ -87,18 +87,14 @@ let _ =
     (for i = 0 to 1 do
        ()
      done)
-    (while true do
-       ()
-     done)
+    (while true do () done)
 
 let _ =
   f
     (for%ext i = 0 to 1 do
        ()
      done)
-    (while%ext true do
-       ()
-     done)
+    (while%ext true do () done)
 
 let _ = function%ext x -> x
 let _ = f (function%ext x -> x)

--- a/test/passing/refs.default/extensions.ml.err
+++ b/test/passing/refs.default/extensions.ml.err
@@ -1,1 +1,1 @@
-Warning: extensions.ml:459 exceeds the margin
+Warning: extensions.ml:455 exceeds the margin

--- a/test/passing/refs.default/extensions.ml.ref
+++ b/test/passing/refs.default/extensions.ml.ref
@@ -87,18 +87,14 @@ let _ =
     (for i = 0 to 1 do
        ()
      done)
-    (while true do
-       ()
-     done)
+    (while true do () done)
 
 let _ =
   f
     (for%ext i = 0 to 1 do
        ()
      done)
-    (while%ext true do
-       ()
-     done)
+    (while%ext true do () done)
 
 let _ = function%ext x -> x
 let _ = f (function%ext x -> x)

--- a/test/passing/refs.default/for_while.ml.ref
+++ b/test/passing/refs.default/for_while.ml.ref
@@ -1,13 +1,13 @@
 let () =
   foo
     (for i = 1 to 10 do
-       ()
+       print_endline ()
      done)
 
 let () =
   foo
     (while true do
-       ()
+       print_endline ()
      done)
 
 let _ =
@@ -48,3 +48,9 @@ let _ =
   do
     test this
   done
+
+let _ =
+  while
+    some biggggggggggggggggggggggggggggggggg
+      expressionnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+  do () done

--- a/test/passing/refs.default/kw_extentions.ml.ref
+++ b/test/passing/refs.default/kw_extentions.ml.ref
@@ -15,9 +15,7 @@ let () =
   for%ext i = 1 to 10 do
     ()
   done;
-  while%ext false do
-    ()
-  done;
+  while%ext false do () done;
   match%ext x with _ -> ()
 
 let () =

--- a/test/passing/refs.default/shortcut_ext_attr.ml.ref
+++ b/test/passing/refs.default/shortcut_ext_attr.ml.ref
@@ -9,11 +9,7 @@ let () =
   [%foo function[@foo] x -> ()];
   [%foo try[@foo] () with _ -> ()];
   [%foo if[@foo] () then () else ()];
-  [%foo
-    while () do
-      ()
-    done
-    [@foo]];
+  [%foo while () do () done [@foo]];
   [%foo
     for x = () to () do
       ()

--- a/test/passing/refs.default/source.ml.err
+++ b/test/passing/refs.default/source.ml.err
@@ -1,4 +1,4 @@
-Warning: source.ml:917 exceeds the margin
-Warning: source.ml:992 exceeds the margin
-Warning: source.ml:6638 exceeds the margin
-Warning: source.ml:7097 exceeds the margin
+Warning: source.ml:915 exceeds the margin
+Warning: source.ml:990 exceeds the margin
+Warning: source.ml:6636 exceeds the margin
+Warning: source.ml:7095 exceeds the margin

--- a/test/passing/refs.default/source.ml.ref
+++ b/test/passing/refs.default/source.ml.ref
@@ -89,9 +89,7 @@ let () =
   (function%foo[@foo] x -> ());
   (try%foo[@foo] () with _ -> ());
   if%foo[@foo] () then () else ();
-  while%foo[@foo] () do
-    ()
-  done;
+  while%foo[@foo] () do () done;
   for%foo[@foo] x = () to () do
     ()
   done;

--- a/test/passing/refs.janestreet/extensions-indent.ml.ref
+++ b/test/passing/refs.janestreet/extensions-indent.ml.ref
@@ -97,9 +97,7 @@ let _ =
     (for i = 0 to 1 do
        ()
      done)
-    (while true do
-       ()
-     done)
+    (while true do () done)
 ;;
 
 let _ =
@@ -107,9 +105,7 @@ let _ =
     (for%ext i = 0 to 1 do
        ()
      done)
-    (while%ext true do
-       ()
-     done)
+    (while%ext true do () done)
 ;;
 
 let _ = function%ext

--- a/test/passing/refs.janestreet/extensions.ml.ref
+++ b/test/passing/refs.janestreet/extensions.ml.ref
@@ -97,9 +97,7 @@ let _ =
     (for i = 0 to 1 do
        ()
      done)
-    (while true do
-       ()
-     done)
+    (while true do () done)
 ;;
 
 let _ =
@@ -107,9 +105,7 @@ let _ =
     (for%ext i = 0 to 1 do
        ()
      done)
-    (while%ext true do
-       ()
-     done)
+    (while%ext true do () done)
 ;;
 
 let _ = function%ext

--- a/test/passing/refs.janestreet/for_while.ml.ref
+++ b/test/passing/refs.janestreet/for_while.ml.ref
@@ -1,14 +1,14 @@
 let () =
   foo
     (for i = 1 to 10 do
-       ()
+       print_endline ()
      done)
 ;;
 
 let () =
   foo
     (while true do
-       ()
+       print_endline ()
      done)
 ;;
 
@@ -52,4 +52,12 @@ let _ =
   while some bigggggggggggggggggggggg expressionnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn do
     test this
   done
+;;
+
+let _ =
+  while
+    some
+      biggggggggggggggggggggggggggggggggg
+      expressionnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+  do () done
 ;;

--- a/test/passing/refs.janestreet/kw_extentions.ml.ref
+++ b/test/passing/refs.janestreet/kw_extentions.ml.ref
@@ -17,9 +17,7 @@ let () =
   for%ext i = 1 to 10 do
     ()
   done;
-  while%ext false do
-    ()
-  done;
+  while%ext false do () done;
   match%ext x with
   | _ -> ()
 ;;

--- a/test/passing/refs.janestreet/shortcut_ext_attr.ml.ref
+++ b/test/passing/refs.janestreet/shortcut_ext_attr.ml.ref
@@ -14,11 +14,7 @@ let () =
     try[@foo] () with
     | _ -> ()];
   [%foo if[@foo] () then () else ()];
-  [%foo
-    while () do
-      ()
-    done
-    [@foo]];
+  [%foo while () do () done [@foo]];
   [%foo
     for x = () to () do
       ()

--- a/test/passing/refs.janestreet/source.ml.ref
+++ b/test/passing/refs.janestreet/source.ml.ref
@@ -91,9 +91,7 @@ let () =
   (try%foo[@foo] () with
    | _ -> ());
   if%foo[@foo] () then () else ();
-  while%foo[@foo] () do
-    ()
-  done;
+  while%foo[@foo] () do () done;
   for%foo[@foo] x = () to () do
     ()
   done;

--- a/test/passing/refs.ocamlformat/extensions-indent.ml.err
+++ b/test/passing/refs.ocamlformat/extensions-indent.ml.err
@@ -1,1 +1,1 @@
-Warning: extensions-indent.ml:503 exceeds the margin
+Warning: extensions-indent.ml:499 exceeds the margin

--- a/test/passing/refs.ocamlformat/extensions-indent.ml.ref
+++ b/test/passing/refs.ocamlformat/extensions-indent.ml.ref
@@ -88,18 +88,14 @@ let _ =
     ( for i = 0 to 1 do
         ()
       done )
-    ( while true do
-        ()
-      done )
+    (while true do () done)
 
 let _ =
   f
     ( for%ext i = 0 to 1 do
         ()
       done )
-    ( while%ext true do
-        ()
-      done )
+    (while%ext true do () done)
 
 let _ = function%ext x -> x
 

--- a/test/passing/refs.ocamlformat/extensions.ml.err
+++ b/test/passing/refs.ocamlformat/extensions.ml.err
@@ -1,1 +1,1 @@
-Warning: extensions.ml:503 exceeds the margin
+Warning: extensions.ml:499 exceeds the margin

--- a/test/passing/refs.ocamlformat/extensions.ml.ref
+++ b/test/passing/refs.ocamlformat/extensions.ml.ref
@@ -88,18 +88,14 @@ let _ =
     ( for i = 0 to 1 do
         ()
       done )
-    ( while true do
-        ()
-      done )
+    (while true do () done)
 
 let _ =
   f
     ( for%ext i = 0 to 1 do
         ()
       done )
-    ( while%ext true do
-        ()
-      done )
+    (while%ext true do () done)
 
 let _ = function%ext x -> x
 

--- a/test/passing/refs.ocamlformat/for_while.ml.ref
+++ b/test/passing/refs.ocamlformat/for_while.ml.ref
@@ -1,13 +1,13 @@
 let () =
   foo
     ( for i = 1 to 10 do
-        ()
+        print_endline ()
       done )
 
 let () =
   foo
     ( while true do
-        ()
+        print_endline ()
       done )
 
 let _ =
@@ -48,3 +48,9 @@ let _ =
   do
     test this
   done
+
+let _ =
+  while
+    some biggggggggggggggggggggggggggggggggg
+      expressionnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+  do () done

--- a/test/passing/refs.ocamlformat/kw_extentions.ml.ref
+++ b/test/passing/refs.ocamlformat/kw_extentions.ml.ref
@@ -15,9 +15,7 @@ let () =
   for%ext i = 1 to 10 do
     ()
   done ;
-  while%ext false do
-    ()
-  done ;
+  while%ext false do () done ;
   match%ext x with _ -> ()
 
 let () =

--- a/test/passing/refs.ocamlformat/shortcut_ext_attr.ml.ref
+++ b/test/passing/refs.ocamlformat/shortcut_ext_attr.ml.ref
@@ -9,11 +9,7 @@ let () =
   [%foo function[@foo] x -> ()] ;
   [%foo try[@foo] () with _ -> ()] ;
   [%foo if[@foo] () then () else ()] ;
-  [%foo
-    while () do
-      ()
-    done
-    [@foo]] ;
+  [%foo while () do () done [@foo]] ;
   [%foo
     for x = () to () do
       ()

--- a/test/passing/refs.ocamlformat/source.ml.err
+++ b/test/passing/refs.ocamlformat/source.ml.err
@@ -1,3 +1,3 @@
-Warning: source.ml:6495 exceeds the margin
-Warning: source.ml:7369 exceeds the margin
-Warning: source.ml:7887 exceeds the margin
+Warning: source.ml:6493 exceeds the margin
+Warning: source.ml:7367 exceeds the margin
+Warning: source.ml:7885 exceeds the margin

--- a/test/passing/refs.ocamlformat/source.ml.ref
+++ b/test/passing/refs.ocamlformat/source.ml.ref
@@ -98,9 +98,7 @@ let () =
   (function%foo[@foo] x -> ()) ;
   (try%foo[@foo] () with _ -> ()) ;
   if%foo[@foo] () then () else () ;
-  while%foo[@foo] () do
-    ()
-  done ;
+  while%foo[@foo] () do () done ;
   for%foo[@foo] x = () to () do
     ()
   done ;

--- a/test/passing/tests/for_while.ml
+++ b/test/passing/tests/for_while.ml
@@ -1,13 +1,13 @@
 let () =
   foo
     ( for i = 1 to 10 do
-        ()
+        print_endline ()
       done )
 
 let () =
   foo
     ( while true do
-        ()
+        print_endline ()
       done )
 
 let _ =
@@ -50,3 +50,9 @@ let _ =
   do
     test this
   done
+
+let _ =
+  while
+    some biggggggggggggggggggggggggggggggggg
+      expressionnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+  do () done


### PR DESCRIPTION
Concretely, this is what changes:

```diff
 while
   loooong
     condition
-do
-  ()
-done
+do () done
```

A real example where I wished for a more compact formatting:

https://github.com/ocaml/ocaml-re/pull/599/commits/59198dd3dd379bbc5325a4443b96c10b9e2f02d7#diff-a91a869b078e8995843c8b377da588505468c962166d62d7029893c27be32833R70-R80

To explain a bit: while-loops are fairly inexpressive in ocaml due to the absence of `break`.  In a decent number of cases, it's nicer to give up on the separation between condition and body, by moving the body into the condition. In that case, it's a bit silly to waste 3 lines on the empty body.

For instance, if you wanted to write a loop where the first iteration always runs, like a do-while in C, the obvious thing to do (without auxiliary functions) is:

```ocaml
let first = ref true in
while !first || condition; do first := false; body done
```

but the simpler version is:

```ocaml
while body; condition do () done
```

Or iterating through a stack:

```ocaml
while not (Stack.is_empty s) do f (Stack.pop_exn s) done
```

can be done without double-checking that the stack is empty:

```ocaml
while
  match Stack.pop s with
  | None -> false
  | Some elt -> f elt; true
do () done
```