### PR TITLE
Additional fixes on top of #2810

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ profile. This started with version 0.26.0.
   over several lines and `end` is aligned with `begin`; and a leading comment
   on the body no longer reindents it — `begin` keeps the body one indent in
   instead of gluing the keyword to the comment.
-  (#2810, @MisterDA)
+  (#2810, #2815, @MisterDA, @yakobowski)
 
 - Fix indentation of a bare `match`/`function`/`try` branch preceded by a
   comment with `if-then-else=fit-or-vertical`: the branch is no longer

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2591,16 +2591,20 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                              ~fmt_cond:(fmt_expression ~box:false c)
                              ~cmts_before_kw ~cmts_after_kw
                          in
-                         let branch_pro =
+                         let branch_pro, wrap_parens =
                            match raw_cmts_after_kw with
                            | Some cmts ->
-                               let bare_branch =
-                                 Params.is_bare_branch ~parens_bch
-                                   xbch.ast.pexp_desc
+                               let bp =
+                                 Params.raw_cmts_branch_pro c.conf cmts
                                in
-                               Params.raw_cmts_branch_pro ~bare_branch c.conf
-                                 cmts
-                           | None -> p.branch_pro
+                               if
+                                 parens_bch
+                                 && Params
+                                    .is_special_or_nested_special_beginend
+                                      xbch.ast.pexp_desc
+                               then (bp $ str "(", fun k -> k $ str ")")
+                               else (bp, p.wrap_parens)
+                           | None -> (p.branch_pro, p.wrap_parens)
                          in
                          let wrap_beginend =
                            match p.beginend_loc with
@@ -2613,7 +2617,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                            $ p.box_keyword_and_expr
                                ( branch_pro
                                $ wrap_beginend
-                                   (p.wrap_parens
+                                   (wrap_parens
                                       ( fmt_expression c ?box:p.box_expr
                                           ~parens:false ?pro:p.expr_pro
                                           ?eol:p.expr_eol p.branch_expr

--- a/lib/Params.ml
+++ b/lib/Params.ml
@@ -516,23 +516,10 @@ let is_special_or_nested_special_beginend = function
   | Pexp_beginend ({pexp_desc; _}, _) -> is_special_beginend pexp_desc
   | exp -> is_special_beginend exp
 
-(* An if-then-else branch is rendered "bare" when it is neither wrapped in
-   [begin]/[end] (including the [begin match end] shortcut, a
-   [Pexp_beginend]) nor parenthesized. *)
-let is_bare_branch ~parens_bch desc =
-  (not parens_bch) && match desc with Pexp_beginend _ -> false | _ -> true
-
-let raw_cmts_branch_pro ?(bare_branch = false) (c : Conf.t) cmts =
+let raw_cmts_branch_pro (c : Conf.t) cmts =
   match c.fmt_opts.if_then_else.v with
   | `Compact -> break 1000 0 $ cmts $ break 1000 0
-  (* A bare [match]/[function]/[try]/[if] branch breaks before its own body
-     with a [break_unless_newline], which is a no-op unless we are already at
-     the beginning of a line; without a trailing break here the branch box
-     would open at the comment's end column and indent the body relative to
-     it. A [begin]/[end]- or paren-wrapped branch instead emits its opening
-     delimiter right after the comment, so we leave the break to it. *)
-  | _ when bare_branch -> break 1000 2 $ cmts $ break 1000 2
-  | _ -> break 1000 2 $ cmts
+  | _ -> break 1000 2 $ cmts $ break 1000 2
 
 type cases =
   { leading_space: Fmt.t
@@ -910,7 +897,6 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~has_cmts_before ~pro
         is_special_beginend nested_exp.pexp_desc
     | _ -> false
   in
-  let bare_branch = is_bare_branch ~parens_bch xbch.ast.pexp_desc in
   let wrap_parens ~wrap_breaks k =
     if has_beginend then
       let infix_ext_attrs_beginend =
@@ -967,7 +953,9 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~has_cmts_before ~pro
      wrapping one), emit it from [branch_pro] with forced breaks, so the
      branch indentation stays stable regardless of where the comment was
      initially attached. [default] is the comment-less [branch_pro] for the
-     current mode, [guard] an extra mode-specific applicability condition. *)
+     current mode, [guard] an extra mode-specific applicability condition.
+     Returns [(branch_pro, has_cmts_before)] where [has_cmts_before] is true
+     when a comment was consumed into [branch_pro]. *)
   let branch_pro_with_cmts ~default ~guard =
     if
       (not has_beginend)
@@ -975,27 +963,29 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~has_cmts_before ~pro
       && (not has_cmts_after_kw) && guard
     then
       match cmts_before_opt xbch.ast.pexp_loc with
-      | Some cmts -> raw_cmts_branch_pro ~bare_branch c cmts
+      | Some cmts -> (raw_cmts_branch_pro c cmts, true)
       | None -> (
         match xbch.ast.pexp_desc with
         | Pexp_beginend ({pexp_loc; pexp_desc; _}, _)
           when is_special_beginend pexp_desc -> (
           match cmts_before_opt pexp_loc with
-          | Some cmts -> raw_cmts_branch_pro ~bare_branch c cmts
-          | None -> default )
-        | _ -> default )
-    else default
+          | Some cmts -> (raw_cmts_branch_pro c cmts, true)
+          | None -> (default, false) )
+        | _ -> (default, false) )
+    else (default, false)
   in
   match c.fmt_opts.if_then_else.v with
   | `Compact ->
+      let branch_pro, _has_cmts =
+        branch_pro_with_cmts ~default:(branch_pro ~indent:0 ())
+          ~guard:
+            ( (not parens_bch)
+            && is_special_or_nested_special_beginend xbch.ast.pexp_desc )
+      in
       { box_branch= hovbox ~name:"Params.get_if_then_else `Compact" 2
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
-      ; branch_pro=
-          branch_pro_with_cmts ~default:(branch_pro ~indent:0 ())
-            ~guard:
-              ( (not parens_bch)
-              && is_special_or_nested_special_beginend xbch.ast.pexp_desc )
+      ; branch_pro
       ; wrap_parens=
           wrap_parens
             ~wrap_breaks:
@@ -1024,6 +1014,30 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~has_cmts_before ~pro
       ; space_between_branches= fmt_if (has_beginend || parens_bch) (str " ")
       }
   | `Fit_or_vertical ->
+      let branch_pro_default, has_cmts =
+        branch_pro_with_cmts
+          ~default:(branch_pro ~begin_end_offset:0 ())
+          ~guard:true
+      in
+      let paren_glue =
+        has_cmts && parens_bch
+        && is_special_or_nested_special_beginend xbch.ast.pexp_desc
+      in
+      let branch_pro, wrap_parens =
+        if paren_glue then
+          let cls =
+            match imd with
+            | `Closing_on_separate_line -> break 1000 0 $ str ")"
+            | _ -> str ")"
+          in
+          (branch_pro_default $ str "(", fun k -> k $ cls)
+        else
+          ( branch_pro_default
+          , wrap_parens
+              ~wrap_breaks:
+                (get_parens_breaks ~opn_hint_indent:2
+                   ~cls_hint:((1, 0), (1000, 0)) ) )
+      in
       { box_branch=
           hovbox
             ( match imd with
@@ -1031,19 +1045,12 @@ let get_if_then_else (c : Conf.t) ~cmts_before_opt ~has_cmts_before ~pro
             | _ -> 0 )
       ; cond= cond ()
       ; box_keyword_and_expr= Fn.id
-      ; branch_pro=
-          branch_pro_with_cmts
-            ~default:(branch_pro ~begin_end_offset:0 ())
-            ~guard:true
-      ; wrap_parens=
-          wrap_parens
-            ~wrap_breaks:
-              (get_parens_breaks ~opn_hint_indent:2
-                 ~cls_hint:((1, 0), (1000, 0)) )
+      ; branch_pro
+      ; wrap_parens
       ; beginend_loc
       ; box_expr= Some false
       ; expr_pro=
-          ( if is_special_beginend_branch then None
+          ( if is_special_beginend_branch || paren_glue then None
             else
               Some
                 (fmt_if

--- a/lib/Params.mli
+++ b/lib/Params.mli
@@ -243,18 +243,10 @@ val is_special_or_nested_special_beginend : expression_desc -> bool
     the keyword should be extracted without breaks (raw) to prevent oscillation
     between "after keyword" and "before expression" placements. *)
 
-val is_bare_branch : parens_bch:bool -> expression_desc -> bool
-(** [is_bare_branch ~parens_bch desc] is whether an if-then-else branch with
-    expression description [desc] is rendered "bare", i.e. neither wrapped in
-    [begin]/[end] (including the [begin match end] shortcut) nor parenthesized. *)
-
-val raw_cmts_branch_pro : ?bare_branch:bool -> Conf.t -> Fmt.t -> Fmt.t
+val raw_cmts_branch_pro : Conf.t -> Fmt.t -> Fmt.t
 (** [raw_cmts_branch_pro c cmts] returns the branch_pro for raw comments
     extracted after a keyword, using the correct indentation for the current
-    if-then-else mode. [bare_branch] (default [false]) indicates the branch is
-    a bare [match]/[function]/[try]/[if] (not wrapped in [begin]/[end] or
-    parentheses); such a branch needs a forced break after the comment so that
-    its body is not indented relative to the comment's end column. *)
+    if-then-else mode. *)
 
 val match_indent : ?default:int -> Conf.t -> parens:bool -> ctx:Ast.t -> int
 (** [match_indent c ~ctx ~default] returns the indentation used for the

--- a/test/passing/refs.ahrefs/ite-compact.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact.ml.ref
@@ -241,6 +241,17 @@ let _ =
     | A -> a
     | B -> b)
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-compact_closing.ml.ref
@@ -262,6 +262,17 @@ let _ =
     | B -> b
   )
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
@@ -282,6 +282,18 @@ let _ =
      | A -> a
      | B -> b)
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical.ml.ref
@@ -255,9 +255,9 @@ let _ =
   if a then
     b
   else
-    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)(
-    match x with
-    | A -> f)
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    (match x with
+     | A -> f)
 
 (* Comment before nested if in then branch - Compact mode oscillation *)
 let _ =
@@ -277,10 +277,10 @@ let _ =
   if cond then
     x
   else
-    (* a comment *)(
-    match e with
-    | A -> a
-    | B -> b)
+    (* a comment *)
+    (match e with
+     | A -> a
+     | B -> b)
 
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
@@ -265,9 +265,9 @@ let _ =
   if a then
     b
   else
-    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)(
-    match x with
-    | A -> f
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    (match x with
+     | A -> f
   )
 
 (* Comment before nested if in then branch - Compact mode oscillation *)
@@ -288,10 +288,10 @@ let _ =
   if cond then
     x
   else
-    (* a comment *)(
-    match e with
-    | A -> a
-    | B -> b
+    (* a comment *)
+    (match e with
+     | A -> a
+     | B -> b
   )
 
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_closing.ml.ref
@@ -294,6 +294,18 @@ let _ =
      | B -> b
   )
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
@@ -282,6 +282,18 @@ let _ =
      | A -> a
      | B -> b)
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-fit_or_vertical_no_indicate.ml.ref
@@ -255,9 +255,9 @@ let _ =
   if a then
     b
   else
-    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)(
-    match x with
-    | A -> f)
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    (match x with
+     | A -> f)
 
 (* Comment before nested if in then branch - Compact mode oscillation *)
 let _ =
@@ -277,10 +277,10 @@ let _ =
   if cond then
     x
   else
-    (* a comment *)(
-    match e with
-    | A -> a
-    | B -> b)
+    (* a comment *)
+    (match e with
+     | A -> a
+     | B -> b)
 
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]

--- a/test/passing/refs.ahrefs/ite-kr.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr.ml.ref
@@ -323,6 +323,18 @@ let _ =
     | B -> b
   )
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kr_closing.ml.ref
@@ -330,6 +330,18 @@ let _ =
     | B -> b
   )
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ahrefs/ite-kw_first.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first.ml.ref
@@ -277,6 +277,18 @@ let _ =
     | A -> a
     | B -> b)
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_closing.ml.ref
@@ -298,6 +298,18 @@ let _ =
     | B -> b
   )
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-kw_first_no_indicate.ml.ref
@@ -277,6 +277,18 @@ let _ =
     | A -> a
     | B -> b)
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ahrefs/ite-no_indicate.ml.ref
@@ -241,6 +241,17 @@ let _ =
     | A -> a
     | B -> b)
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ahrefs/ite-vertical.ml.ref
+++ b/test/passing/refs.ahrefs/ite-vertical.ml.ref
@@ -320,6 +320,18 @@ let _ =
     | A -> a
     | B -> b)
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ahrefs/ite.ml.ref
+++ b/test/passing/refs.ahrefs/ite.ml.ref
@@ -241,6 +241,17 @@ let _ =
     | A -> a
     | B -> b)
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.default/ite-compact.ml.ref
+++ b/test/passing/refs.default/ite-compact.ml.ref
@@ -232,6 +232,15 @@ let _ =
     (* a comment *)
     match e with A -> a | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.default/ite-compact_closing.ml.ref
+++ b/test/passing/refs.default/ite-compact_closing.ml.ref
@@ -247,6 +247,15 @@ let _ =
     (* a comment *)
     match e with A -> a | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.default/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical.ml.ref
@@ -282,6 +282,16 @@ let _ =
     | A -> a
     | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_closing.ml.ref
@@ -291,6 +291,16 @@ let _ =
     | A -> a
     | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-fit_or_vertical_no_indicate.ml.ref
@@ -282,6 +282,16 @@ let _ =
     | A -> a
     | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.default/ite-kr.ml.ref
+++ b/test/passing/refs.default/ite-kr.ml.ref
@@ -315,6 +315,16 @@ let _ =
   else
     (* a comment *) match e with A -> a | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.default/ite-kr_closing.ml.ref
+++ b/test/passing/refs.default/ite-kr_closing.ml.ref
@@ -322,6 +322,16 @@ let _ =
   else
     (* a comment *) match e with A -> a | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.default/ite-kw_first.ml.ref
+++ b/test/passing/refs.default/ite-kw_first.ml.ref
@@ -271,6 +271,16 @@ let _ =
     | A -> a
     | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.default/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_closing.ml.ref
@@ -286,6 +286,16 @@ let _ =
     | A -> a
     | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-kw_first_no_indicate.ml.ref
@@ -271,6 +271,16 @@ let _ =
     | A -> a
     | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.default/ite-no_indicate.ml.ref
+++ b/test/passing/refs.default/ite-no_indicate.ml.ref
@@ -232,6 +232,15 @@ let _ =
     (* a comment *)
     match e with A -> a | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.default/ite-vertical.ml.ref
+++ b/test/passing/refs.default/ite-vertical.ml.ref
@@ -322,6 +322,16 @@ let _ =
     | A -> a
     | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.default/ite.ml.ref
+++ b/test/passing/refs.default/ite.ml.ref
@@ -232,6 +232,15 @@ let _ =
     (* a comment *)
     match e with A -> a | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.janestreet/ite-compact.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact.ml.ref
@@ -247,6 +247,17 @@ let _ =
     | B -> b)
 ;;
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else (
+    (* a comment *)
+    match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b)
+;;
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.janestreet/ite-compact_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-compact_closing.ml.ref
@@ -263,6 +263,18 @@ let _ =
   )
 ;;
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else (
+    (* a comment *)
+    match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+  )
+;;
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
@@ -271,9 +271,9 @@ let _ =
   if a then
     b
   else
-    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)(
-    match x with
-    | A -> f)
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    (match x with
+     | A -> f)
 ;;
 
 (* Comment before nested if in then branch - Compact mode oscillation *)
@@ -295,10 +295,10 @@ let _ =
   if cond then
     x
   else
-    (* a comment *)(
-    match e with
-    | A -> a
-    | B -> b)
+    (* a comment *)
+    (match e with
+     | A -> a
+     | B -> b)
 ;;
 
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,

--- a/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical.ml.ref
@@ -301,6 +301,18 @@ let _ =
      | B -> b)
 ;;
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    (match some_long_scrutinee_expression with
+     | A -> a
+     | B -> b)
+;;
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
@@ -282,9 +282,9 @@ let _ =
   if a then
     b
   else
-    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)(
-    match x with
-    | A -> f
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    (match x with
+     | A -> f
   )
 ;;
 
@@ -307,10 +307,10 @@ let _ =
   if cond then
     x
   else
-    (* a comment *)(
-    match e with
-    | A -> a
-    | B -> b
+    (* a comment *)
+    (match e with
+     | A -> a
+     | B -> b
   )
 ;;
 

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_closing.ml.ref
@@ -314,6 +314,19 @@ let _ =
   )
 ;;
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    (match some_long_scrutinee_expression with
+     | A -> a
+     | B -> b
+  )
+;;
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
@@ -271,9 +271,9 @@ let _ =
   if a then
     b
   else
-    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)(
-    match x with
-    | A -> f)
+    (* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *)
+    (match x with
+     | A -> f)
 ;;
 
 (* Comment before nested if in then branch - Compact mode oscillation *)
@@ -295,10 +295,10 @@ let _ =
   if cond then
     x
   else
-    (* a comment *)(
-    match e with
-    | A -> a
-    | B -> b)
+    (* a comment *)
+    (match e with
+     | A -> a
+     | B -> b)
 ;;
 
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,

--- a/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-fit_or_vertical_no_indicate.ml.ref
@@ -301,6 +301,18 @@ let _ =
      | B -> b)
 ;;
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    (match some_long_scrutinee_expression with
+     | A -> a
+     | B -> b)
+;;
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.janestreet/ite-kr.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr.ml.ref
@@ -350,6 +350,19 @@ let _ =
   )
 ;;
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else (
+    (* a comment *)
+      match some_long_scrutinee_expression with
+      | A -> a
+      | B -> b
+  )
+;;
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.janestreet/ite-kr_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kr_closing.ml.ref
@@ -357,6 +357,19 @@ let _ =
   )
 ;;
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else (
+    (* a comment *)
+      match some_long_scrutinee_expression with
+      | A -> a
+      | B -> b
+  )
+;;
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.janestreet/ite-kw_first.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first.ml.ref
@@ -282,6 +282,18 @@ let _ =
     | B -> b)
 ;;
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond
+  then x
+  else (
+    (* a comment *)
+    match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b)
+;;
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_closing.ml.ref
@@ -298,6 +298,19 @@ let _ =
   )
 ;;
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond
+  then x
+  else (
+    (* a comment *)
+    match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+  )
+;;
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-kw_first_no_indicate.ml.ref
@@ -282,6 +282,18 @@ let _ =
     | B -> b)
 ;;
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond
+  then x
+  else (
+    (* a comment *)
+    match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b)
+;;
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.janestreet/ite-no_indicate.ml.ref
+++ b/test/passing/refs.janestreet/ite-no_indicate.ml.ref
@@ -247,6 +247,17 @@ let _ =
     | B -> b)
 ;;
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else (
+    (* a comment *)
+    match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b)
+;;
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.janestreet/ite-vertical.ml.ref
+++ b/test/passing/refs.janestreet/ite-vertical.ml.ref
@@ -346,6 +346,18 @@ let _ =
     | B -> b)
 ;;
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else (
+    (* a comment *)
+    match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b)
+;;
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.janestreet/ite.ml.ref
+++ b/test/passing/refs.janestreet/ite.ml.ref
@@ -247,6 +247,17 @@ let _ =
     | B -> b)
 ;;
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else (
+    (* a comment *)
+    match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b)
+;;
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ocamlformat/ite-compact.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact.ml.ref
@@ -231,6 +231,15 @@ let _ =
     (* a comment *)
     match e with A -> a | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-compact_closing.ml.ref
@@ -241,6 +241,15 @@ let _ =
     (* a comment *)
     match e with A -> a | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical.ml.ref
@@ -288,6 +288,16 @@ let _ =
     | B ->
         b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_closing.ml.ref
@@ -293,6 +293,16 @@ let _ =
     | B ->
         b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-fit_or_vertical_no_indicate.ml.ref
@@ -285,6 +285,16 @@ let _ =
     | B ->
         b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ocamlformat/ite-kr.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr.ml.ref
@@ -317,6 +317,16 @@ let _ =
   else
     (* a comment *) match e with A -> a | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kr_closing.ml.ref
@@ -321,6 +321,16 @@ let _ =
   else
     (* a comment *) match e with A -> a | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first.ml.ref
@@ -272,6 +272,16 @@ let _ =
     | B ->
         b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_closing.ml.ref
@@ -282,6 +282,16 @@ let _ =
     | B ->
         b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-kw_first_no_indicate.ml.ref
@@ -269,6 +269,16 @@ let _ =
     | B ->
         b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond
+  then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-no_indicate.ml.ref
@@ -228,6 +228,15 @@ let _ =
     (* a comment *)
     match e with A -> a | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ocamlformat/ite-vertical.ml.ref
+++ b/test/passing/refs.ocamlformat/ite-vertical.ml.ref
@@ -330,6 +330,16 @@ let _ =
     | B ->
         b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then
+    x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/refs.ocamlformat/ite.ml.ref
+++ b/test/passing/refs.ocamlformat/ite.ml.ref
@@ -231,6 +231,15 @@ let _ =
     (* a comment *)
     match e with A -> a | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with A -> a | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)

--- a/test/passing/tests/ite.ml
+++ b/test/passing/tests/ite.ml
@@ -238,6 +238,17 @@ let _ =
     | A -> a
     | B -> b
 
+(* Comment before [begin match ... end]: comment must not glue to [begin]
+   (regression test for paren-glue in profiles with exp_grouping=parens) *)
+let _ =
+  if cond then x
+  else
+    (* a comment *)
+    begin match some_long_scrutinee_expression with
+    | A -> a
+    | B -> b
+    end
+
 (* A bare [begin match ... end] branch must keep [match ... with] on one line,
    not split it as [begin match] / scrutinee / [with], and must align [end]
    with [begin] (regression test) *)


### PR DESCRIPTION
This MR fixes a few additional problems for the `if-then-else=fit-or-vertical` mode. It is stacked on top of #2180.

The first commit partially reverts some changes (`bare_branch` logic) in order to fix some additional less-than-ideal reformatting found on our codebase. I have added testcases, but I was not able to add the more interesting ones in a standalone commit, as ocamlformat without the fix does not stabilize in some configurations. (See the last commit.)