### PR TITLE
Improved global configuration file lookup.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,9 @@ profile. This started with version 0.26.0.
 
 - Fix missing parentheses in `(a, ~b:(if .. then .. else ..))` (#2811, @Julow)
 
+- Fix configuration in `$XDG_CONFIG_HOME` was not used when
+  `--enable-outside-detected-project` was passed (#2816, @torimus)
+
 ## 0.29.0
 
 ### Highlight

--- a/lib/bin_conf/File_system.ml
+++ b/lib/bin_conf/File_system.ml
@@ -105,7 +105,14 @@ let make ~enable_outside_detected_project ~disable_conf_files
         (* Inside a detected project, configs are applied in top-down
            starting from the project root (i.e. excluding the global config
            file). *)
-        if is_project_root ~root dir then {fs with project_root= Some dir}
+        if is_project_root ~root dir then
+          (* If we are on project's root and still no config file is found,
+             invoke case for possible global one lookup, *)
+          if List.is_empty fs.configuration_files then aux fs ~segs:[]
+          (* otherwise actual project's root and config file(s) is the final
+             result. *)
+          else {fs with project_root= Some dir}
+        (* Continue with lookup in upper parts of path *)
         else aux fs ~segs:upper_segs
   in
   aux ~segs

--- a/lib/bin_conf/File_system.ml
+++ b/lib/bin_conf/File_system.ml
@@ -108,12 +108,13 @@ let make ~enable_outside_detected_project ~disable_conf_files
         if is_project_root ~root dir then
           (* If we are on project's root and still no config file is found,
              invoke case for possible global one lookup, *)
-          if List.is_empty fs.configuration_files then aux fs ~segs:[]
+          if List.is_empty fs.configuration_files then
+            aux {fs with project_root= Some dir} ~segs:[]
           (* otherwise actual project's root and config file(s) is the final
              result. *)
-          else {fs with project_root= Some dir}
+            else {fs with project_root= Some dir}
         (* Continue with lookup in upper parts of path *)
-        else aux fs ~segs:upper_segs
+          else aux fs ~segs:upper_segs
   in
   aux ~segs
     { ignore_files= []

--- a/lib/bin_conf/File_system.ml
+++ b/lib/bin_conf/File_system.ml
@@ -60,19 +60,7 @@ let make ~enable_outside_detected_project ~disable_conf_files
   let segs = Fpath.segs dir |> List.rev in
   let rec aux fs ~segs =
     match segs with
-    | [] | [""] ->
-        (* Outside of a detected project, only apply the global config file
-           when [--enable-outside-detected-project] is set and no
-           [.ocamlformat] file has been found. *)
-        assert (Option.is_none fs.project_root) ;
-        if
-          List.is_empty fs.configuration_files
-          && enable_outside_detected_project
-        then
-          match xdg_config () with
-          | Some xdg -> {fs with configuration_files= [Ocamlformat xdg]}
-          | None -> fs
-        else fs
+    | [] | [""] -> fs
     | "" :: upper_segs -> aux fs ~segs:upper_segs
     | _ :: upper_segs ->
         let sep = Fpath.dir_sep in
@@ -105,22 +93,25 @@ let make ~enable_outside_detected_project ~disable_conf_files
         (* Inside a detected project, configs are applied in top-down
            starting from the project root (i.e. excluding the global config
            file). *)
-        if is_project_root ~root dir then
-          (* If we are on project's root and still no config file is found,
-             invoke case for possible global one lookup, *)
-          if List.is_empty fs.configuration_files then
-            aux {fs with project_root= Some dir} ~segs:[]
-          (* otherwise actual project's root and config file(s) is the final
-             result. *)
-            else {fs with project_root= Some dir}
-        (* Continue with lookup in upper parts of path *)
-          else aux fs ~segs:upper_segs
+        if is_project_root ~root dir then {fs with project_root= Some dir}
+        else aux fs ~segs:upper_segs
   in
-  aux ~segs
-    { ignore_files= []
-    ; enable_files= []
-    ; configuration_files= []
-    ; project_root= None }
+  let fs =
+    aux ~segs
+      { ignore_files= []
+      ; enable_files= []
+      ; configuration_files= []
+      ; project_root= None }
+  in
+  (* Outside of a detected project, only apply the global config file when
+     [--enable-outside-detected-project] is set and no [.ocamlformat] file
+     has been found. *)
+  if List.is_empty fs.configuration_files && enable_outside_detected_project
+  then
+    match xdg_config () with
+    | Some xdg -> {fs with configuration_files= [Ocamlformat xdg]}
+    | None -> fs
+  else fs
 
 let has_ocamlformat_file fs =
   List.exists fs.configuration_files ~f:(function

--- a/test/cli/global_configuration.t
+++ b/test/cli/global_configuration.t
@@ -1,0 +1,29 @@
+The user's global configuration should be used when [--enable-outside-detected-project] is passed.
+
+  $ mkdir -p root xdg
+  $ export XDG_CONFIG_HOME=$PWD/xdg
+  $ echo 'break-cases = vertical' > xdg/ocamlformat
+
+  $ cd root
+  $ touch dune-project
+  $ echo 'let _=match x with A->()|B->()' > test.ml
+
+  $ ocamlformat --enable-outside-detected-project test.ml
+  let _ =
+    match x with
+    | A ->
+        ()
+    | B ->
+        ()
+
+No global configuration:
+
+  $ XDG_CONFIG_HOME= ocamlformat --enable-outside-detected-project test.ml
+  let _ = match x with A -> () | B -> ()
+
+No --enable-outside-detected-project:
+
+  $ ocamlformat test.ml
+  File "test.ml", line 1:
+  Warning: Ocamlformat disabled because [--enable-outside-detected-project] is not set and no [.ocamlformat] was found within the project (root: ../root)
+  let _=match x with A->()|B->()


### PR DESCRIPTION
Possible fix for issues #2509, #2223 and #2534 .

This patch adds a case when project's root is detected but no configuration file (`.ocamlformat`) has been found. It then attempts to use global configuration file, when lookup outside project's root is enabled.

It improves behavior described in existing documentation

> If  no  project  root and  no  ocamlformat  file  has  been  found, and if the option enable-out-side-detected-project is  set,  the  global  ocamlformat  file  defined  in $XDG_CONFIG_HOME  (or in $HOME/.config if $XDG_CONFIG_HOME is undefined) is used.

by allowing to use existing global configuration also when there is none present in a project.
I find it quite handy to have this option available when new projects are instantiated, without a need to do a tedious work to clone my preferred settings for each one.