### PR TITLE
Fix gen_manpage unstable output with dune-pkg

### DIFF
--- a/doc/dune
+++ b/doc/dune
@@ -5,7 +5,11 @@
  (action
   (with-stdout-to
    manpage_ocamlformat.mld.gen
-   (run ../tools/gen_manpage/gen_manpage.exe %{bin:ocamlformat} --help=plain))))
+   (run
+    ../tools/gen_manpage/gen_manpage.exe
+    ocamlformat
+    %{bin:ocamlformat}
+    --help=plain))))
 
 (rule
  (alias gen_manpage)
@@ -19,6 +23,7 @@
    manpage_ocamlformat_rpc.mld.gen
    (run
     ../tools/gen_manpage/gen_manpage.exe
+    ocamlformat-rpc
     %{bin:ocamlformat-rpc}
     --help=plain))))
 

--- a/tools/gen_manpage/gen_manpage.ml
+++ b/tools/gen_manpage/gen_manpage.ml
@@ -1,12 +1,13 @@
+(** See [doc/dune] for usage. *)
+
 let pf = Printf.printf
 
 let () =
   match Array.to_list Sys.argv with
-  | _ :: exe :: args ->
-      pf "{0 Manpage: %s}\n\n{v\n%!" (Filename.basename exe) ;
+  | _ :: prog_name :: cmd ->
+      pf "{0 Manpage: %s}\n\n{v\n%!" prog_name ;
       let s =
-        Sys.command
-          (String.concat " " (List.map Filename.quote (exe :: args)))
+        Sys.command (String.concat " " (List.map Filename.quote cmd))
       in
       if s <> 0 then exit s ;
       pf "v}\n%!"


### PR DESCRIPTION
With dune-pkg, the executable could be named "ocamlformat.exe" and "main.exe", creating a diff in the generated manpage.